### PR TITLE
chore: warm up status checks on main

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ Minimal skeleton: FastAPI + Docker Compose + GitHub Actions.
 # Test trigger CI at 2025年 09月 22日 星期一 20:31:00 CST
 # Trigger after permission change 2025年 09月 22日 星期一 20:34:03 CST
 # keepalive
+


### PR DESCRIPTION
This PR makes a trivial change to README in order to trigger CI on the `main` branch.
The goal is to ensure that the GitHub Actions workflow (CI / Build & Push) runs
successfully on `main`, so that it can be added as a required check in branch protection rules.
