### PR TITLE
feat(pms): bind item barcodes to item uoms

### DIFF
--- a/alembic/versions/32b08d41971c_bind_item_barcodes_to_item_uoms.py
+++ b/alembic/versions/32b08d41971c_bind_item_barcodes_to_item_uoms.py
@@ -1,0 +1,213 @@
+"""bind_item_barcodes_to_item_uoms
+
+Revision ID: 32b08d41971c
+Revises: 4a0e3e897c4f
+Create Date: 2026-04-09 16:37:38.385129
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "32b08d41971c"
+down_revision: Union[str, Sequence[str], None] = "4a0e3e897c4f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+
+    # 1) 先让 item_uoms 具备可被复合外键引用的唯一键
+    op.create_unique_constraint(
+        "uq_item_uoms_id_item_id",
+        "item_uoms",
+        ["id", "item_id"],
+    )
+
+    # 2) item_barcodes 新增终态字段（先 nullable，回填后再收紧）
+    op.add_column(
+        "item_barcodes",
+        sa.Column("item_uom_id", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "item_barcodes",
+        sa.Column(
+            "symbology",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'CUSTOM'"),
+            comment="条码码制/来源：EAN13 / EAN8 / UPC / UPC12 / GS1 / CUSTOM ...",
+        ),
+    )
+    op.create_index(
+        "ix_item_barcodes_item_uom_id",
+        "item_barcodes",
+        ["item_uom_id"],
+        unique=False,
+    )
+
+    # 3) item_barcodes.item_id 类型对齐到 items.id / item_uoms.item_id（integer）
+    op.drop_constraint(
+        "item_barcodes_item_id_fkey",
+        "item_barcodes",
+        type_="foreignkey",
+    )
+    op.alter_column(
+        "item_barcodes",
+        "item_id",
+        existing_type=sa.BigInteger(),
+        type_=sa.Integer(),
+        existing_nullable=False,
+        postgresql_using="item_id::integer",
+    )
+    op.create_foreign_key(
+        "item_barcodes_item_id_fkey",
+        "item_barcodes",
+        "items",
+        ["item_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    # 4) symbology 回填：旧 kind 里只有“码制/来源”保留，其它脏语义降级为 CUSTOM
+    op.execute(
+        """
+        UPDATE item_barcodes
+           SET symbology = CASE
+             WHEN upper(btrim(kind)) IN ('EAN8', 'UPC', 'UPC12', 'EAN13', 'GS1', 'CUSTOM', 'ITF14')
+               THEN upper(btrim(kind))
+             ELSE 'CUSTOM'
+           END
+        """
+    )
+
+    # 5) item_uom_id 回填到各 item 的 base uom
+    op.execute(
+        """
+        UPDATE item_barcodes AS b
+           SET item_uom_id = u.id
+          FROM item_uoms AS u
+         WHERE u.item_id = b.item_id
+           AND u.is_base = true
+           AND b.item_uom_id IS NULL
+        """
+    )
+
+    # 6) 严格校验：不允许存在无法绑定 base uom 的历史条码
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF EXISTS (
+            SELECT 1
+              FROM item_barcodes
+             WHERE item_uom_id IS NULL
+          ) THEN
+            RAISE EXCEPTION 'item_barcodes.item_uom_id backfill failed: some rows have no base item_uom';
+          END IF;
+        END
+        $$;
+        """
+    )
+
+    # 7) 复合外键：强制 item_uom_id 必须属于同一个 item
+    op.create_foreign_key(
+        "fk_item_barcodes_item_uom_pair",
+        "item_barcodes",
+        "item_uoms",
+        ["item_uom_id", "item_id"],
+        ["id", "item_id"],
+    )
+
+    # 8) 收紧为终态
+    op.alter_column(
+        "item_barcodes",
+        "item_uom_id",
+        existing_type=sa.Integer(),
+        nullable=False,
+    )
+    op.alter_column(
+        "item_barcodes",
+        "symbology",
+        existing_type=sa.Text(),
+        nullable=False,
+        server_default=None,
+    )
+
+    # 9) 退役旧脏字段 kind
+    op.drop_column("item_barcodes", "kind")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+
+    # 1) 恢复旧字段 kind
+    op.add_column(
+        "item_barcodes",
+        sa.Column(
+            "kind",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'CUSTOM'"),
+            comment="条码类型：EAN13 / UPC / INNER / CUSTOM ...",
+        ),
+    )
+
+    # 2) kind 近似恢复：从 symbology 回写
+    op.execute(
+        """
+        UPDATE item_barcodes
+           SET kind = CASE
+             WHEN upper(btrim(symbology)) IN ('EAN8', 'UPC', 'UPC12', 'EAN13', 'GS1', 'CUSTOM', 'ITF14')
+               THEN upper(btrim(symbology))
+             ELSE 'CUSTOM'
+           END
+        """
+    )
+
+    # 3) 先拆掉 uom 级绑定
+    op.drop_constraint(
+        "fk_item_barcodes_item_uom_pair",
+        "item_barcodes",
+        type_="foreignkey",
+    )
+    op.drop_index(
+        "ix_item_barcodes_item_uom_id",
+        table_name="item_barcodes",
+    )
+    op.drop_column("item_barcodes", "item_uom_id")
+    op.drop_column("item_barcodes", "symbology")
+
+    # 4) item_id 类型恢复成 bigint
+    op.drop_constraint(
+        "item_barcodes_item_id_fkey",
+        "item_barcodes",
+        type_="foreignkey",
+    )
+    op.alter_column(
+        "item_barcodes",
+        "item_id",
+        existing_type=sa.Integer(),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+        postgresql_using="item_id::bigint",
+    )
+    op.create_foreign_key(
+        "item_barcodes_item_id_fkey",
+        "item_barcodes",
+        "items",
+        ["item_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    # 5) 回滚 item_uoms 的复合唯一键
+    op.drop_constraint(
+        "uq_item_uoms_id_item_id",
+        "item_uoms",
+        type_="unique",
+    )

--- a/app/models/item_barcode.py
+++ b/app/models/item_barcode.py
@@ -3,7 +3,17 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import BigInteger, Boolean, DateTime, ForeignKey, Index, Text, text
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    Integer,
+    Text,
+    text,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
@@ -11,11 +21,12 @@ from app.db.base import Base
 
 class ItemBarcode(Base):
     """
-    商品条码表（v2 完整形态）
+    商品条码表（uom 级绑定终态）
 
     用途：
-    - 绑定商品 → barcode → item_id
-    - 用于 scan、采购、入库、盘点、出库等全链路
+    - 绑定条码 → item_id + item_uom_id
+    - 包装语义由 item_uom_id 表达（基准单位 / 盒 / 箱 / ...）
+    - 码制/来源由 symbology 表达（EAN13 / UPC / GS1 / CUSTOM ...）
     - 主条码用于 UI 显示（itemsStore.primaryBarcodes）
     """
 
@@ -28,8 +39,14 @@ class ItemBarcode(Base):
     )
 
     item_id: Mapped[int] = mapped_column(
-        BigInteger,
+        Integer,
         ForeignKey("items.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    item_uom_id: Mapped[int] = mapped_column(
+        Integer,
         nullable=False,
         index=True,
     )
@@ -39,11 +56,11 @@ class ItemBarcode(Base):
         nullable=False,
     )
 
-    kind: Mapped[str] = mapped_column(
+    symbology: Mapped[str] = mapped_column(
         Text,
         nullable=False,
         server_default=text("'CUSTOM'"),
-        comment="条码类型：EAN13 / UPC / INNER / CUSTOM ...",
+        comment="条码码制/来源：EAN13 / EAN8 / UPC / UPC12 / GS1 / CUSTOM ...",
     )
 
     active: Mapped[bool] = mapped_column(
@@ -72,6 +89,11 @@ class ItemBarcode(Base):
     )
 
     __table_args__ = (
+        ForeignKeyConstraint(
+            ["item_uom_id", "item_id"],
+            ["item_uoms.id", "item_uoms.item_id"],
+            name="fk_item_barcodes_item_uom_pair",
+        ),
         # 一个 item 只能有一个主条码（部分索引）
         Index(
             "uq_item_barcodes_primary",
@@ -85,6 +107,6 @@ class ItemBarcode(Base):
 
     def __repr__(self) -> str:
         return (
-            f"<ItemBarcode id={self.id} item={self.item_id} "
-            f"barcode={self.barcode!r} primary={self.is_primary}>"
+            f"<ItemBarcode id={self.id} item={self.item_id} item_uom_id={self.item_uom_id} "
+            f"barcode={self.barcode!r} symbology={self.symbology!r} primary={self.is_primary}>"
         )

--- a/app/pms/items/routers/item_barcodes.py
+++ b/app/pms/items/routers/item_barcodes.py
@@ -9,24 +9,36 @@ from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 
 from app.db.deps import get_db
-from app.models.item import Item
 from app.models.item_barcode import ItemBarcode
+from app.models.item_uom import ItemUOM
 
 router = APIRouter(prefix="/item-barcodes", tags=["item-barcodes"])
 
 
+def _normalize_symbology(v: str | None) -> str:
+    s = (v or "").strip().upper()
+    return s or "CUSTOM"
+
+
+def _get_item_uom_or_404(db: Session, item_uom_id: int) -> ItemUOM:
+    obj = db.get(ItemUOM, int(item_uom_id))
+    if not obj:
+        raise HTTPException(404, "ItemUom not found")
+    return obj
+
+
 class ItemBarcodeCreate(BaseModel):
-    item_id: int
+    item_uom_id: int
     barcode: str
-    kind: str = "CUSTOM"
+    symbology: str = "CUSTOM"
     active: bool = True
 
 
 class ItemBarcodeUpdate(BaseModel):
-    """PATCH 更新条码：可用于切主条码/启用/停用/修改类型"""
+    """PATCH 更新条码：可用于切主条码/启用/停用/修改码制/修改条码值"""
 
     barcode: Optional[str] = None
-    kind: Optional[str] = None
+    symbology: Optional[str] = None
     active: Optional[bool] = None
     is_primary: Optional[bool] = None
 
@@ -34,8 +46,9 @@ class ItemBarcodeUpdate(BaseModel):
 class ItemBarcodeOut(BaseModel):
     id: int
     item_id: int
+    item_uom_id: int
     barcode: str
-    kind: str
+    symbology: str
     active: bool
     is_primary: bool
 
@@ -47,9 +60,7 @@ def create_barcode(
     body: ItemBarcodeCreate,
     db: Session = Depends(get_db),
 ):
-    item = db.get(Item, body.item_id)
-    if not item:
-        raise HTTPException(404, "Item not found")
+    uom = _get_item_uom_or_404(db, body.item_uom_id)
 
     code = body.barcode.strip()
     if not code:
@@ -60,9 +71,10 @@ def create_barcode(
         raise HTTPException(409, "Barcode already exists")
 
     obj = ItemBarcode(
-        item_id=body.item_id,
+        item_id=int(uom.item_id),
+        item_uom_id=int(uom.id),
         barcode=code,
-        kind=body.kind.strip() or "CUSTOM",
+        symbology=_normalize_symbology(body.symbology),
         active=bool(body.active),
         is_primary=False,
     )
@@ -114,6 +126,7 @@ def set_primary(id: int, db: Session = Depends(get_db)):
     db.execute(
         update(ItemBarcode).where(ItemBarcode.item_id == bc.item_id).values(is_primary=False)
     )
+    bc.active = True
     bc.is_primary = True
     db.commit()
     db.refresh(bc)
@@ -132,17 +145,41 @@ def update_barcode(id: int, body: ItemBarcodeUpdate, db: Session = Depends(get_d
     if not bc:
         raise HTTPException(404, "Barcode not found")
 
-    if body.kind is not None:
-        bc.kind = body.kind
+    if body.barcode is not None:
+        code = body.barcode.strip()
+        if not code:
+            raise HTTPException(400, "barcode is required")
+        exists = (
+            db.execute(
+                select(ItemBarcode).where(
+                    ItemBarcode.barcode == code,
+                    ItemBarcode.id != bc.id,
+                )
+            )
+            .scalars()
+            .first()
+        )
+        if exists:
+            raise HTTPException(409, "Barcode already exists")
+        bc.barcode = code
+
+    if body.symbology is not None:
+        bc.symbology = _normalize_symbology(body.symbology)
 
     if body.active is not None:
-        bc.active = bool(body.active)
+        next_active = bool(body.active)
+        if (body.is_primary is True) or (body.is_primary is None and bc.is_primary and not next_active):
+            raise HTTPException(400, "primary barcode must be active")
+        bc.active = next_active
 
     if body.is_primary is True:
         db.execute(
             update(ItemBarcode).where(ItemBarcode.item_id == bc.item_id).values(is_primary=False)
         )
+        bc.active = True
         bc.is_primary = True
+    elif body.is_primary is False:
+        bc.is_primary = False
 
     db.commit()
     db.refresh(bc)

--- a/app/pms/items/services/item_barcode_service.py
+++ b/app/pms/items/services/item_barcode_service.py
@@ -7,6 +7,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.models.item_barcode import ItemBarcode
+from app.models.item_uom import ItemUOM
 
 
 class ItemBarcodeService:
@@ -16,10 +17,27 @@ class ItemBarcodeService:
     - 主条码真相：item_barcodes.is_primary = true AND active = true
     - 输出层投影：primary_barcode（以及兼容 alias barcode）
     - 写入层：创建 item 时可选写入一条主条码；后续更新主条码必须走 /item-barcodes
+    - 条码绑定终态：条码必须绑定到 item_uom_id；主条码默认绑定到 base item_uom
     """
 
     def __init__(self, db: Session) -> None:
         self.db = db
+
+    @staticmethod
+    def _normalize_symbology(v: str | None) -> str:
+        s = (v or "").strip().upper()
+        return s or "CUSTOM"
+
+    def _require_base_item_uom_id(self, *, item_id: int) -> int:
+        row = self.db.execute(
+            select(ItemUOM.id)
+            .where(ItemUOM.item_id == int(item_id))
+            .where(ItemUOM.is_base.is_(True))
+            .limit(1)
+        ).scalar_one_or_none()
+        if row is None:
+            raise ValueError(f"base item_uom missing for item_id={int(item_id)}")
+        return int(row)
 
     def load_primary_barcodes_map(self, *, item_ids: List[int]) -> dict[int, str]:
         ids = sorted({int(x) for x in item_ids if x is not None})
@@ -54,16 +72,25 @@ class ItemBarcodeService:
         if existing is not None:
             raise ValueError("barcode duplicate: already bound to an item")
 
-    def create_primary_for_item(self, *, item_id: int, barcode: str, kind: str = "EAN13") -> None:
+    def create_primary_for_item(
+        self,
+        *,
+        item_id: int,
+        barcode: str,
+        symbology: str = "EAN13",
+    ) -> None:
         code = (barcode or "").strip()
         if not code:
             return
         self.ensure_unique_or_raise(barcode=code)
 
+        base_uom_id = self._require_base_item_uom_id(item_id=int(item_id))
+
         b = ItemBarcode(
             item_id=int(item_id),
+            item_uom_id=int(base_uom_id),
             barcode=code,
-            kind=kind,
+            symbology=self._normalize_symbology(symbology),
             active=True,
             is_primary=True,
         )

--- a/app/pms/items/services/item_maintenance_service.py
+++ b/app/pms/items/services/item_maintenance_service.py
@@ -26,6 +26,7 @@ class ItemMaintenanceService:
     Phase M-5：
     - items.uom 已物理移除；此通道不再接收/写入 uom
     - 必须补齐 items 的 NOT NULL 策略字段
+    - 若要写入主条码，必须先存在 base item_uom（不再做隐式兜底）
     """
 
     def __init__(self, db: Session) -> None:
@@ -50,7 +51,9 @@ class ItemMaintenanceService:
         weight_kg: Optional[float] = None,
     ) -> Item:
         if not _allow_create_item_by_id():
-            raise ValueError("create_item_by_id disabled: set WMS_ALLOW_CREATE_ITEM_BY_ID=1 to enable for maintenance")
+            raise ValueError(
+                "create_item_by_id disabled: set WMS_ALLOW_CREATE_ITEM_BY_ID=1 to enable for maintenance"
+            )
 
         if not id or id <= 0:
             raise ValueError("id 必须为正整数")
@@ -102,7 +105,11 @@ class ItemMaintenanceService:
 
             code = (barcode or "").strip()
             if code:
-                self._barcodes.create_primary_for_item(item_id=int(obj.id), barcode=code, kind="EAN13")
+                self._barcodes.create_primary_for_item(
+                    item_id=int(obj.id),
+                    barcode=code,
+                    symbology="EAN13",
+                )
 
             self.db.commit()
         except IntegrityError as e:

--- a/tests/fixtures/base_seed.sql
+++ b/tests/fixtures/base_seed.sql
@@ -224,10 +224,20 @@ DO UPDATE SET
   is_inbound_default = EXCLUDED.is_inbound_default,
   is_outbound_default = EXCLUDED.is_outbound_default;
 
--- ===== item_barcodes (primary) =====
-INSERT INTO item_barcodes (item_id, barcode, kind, active, is_primary, created_at, updated_at)
+-- ===== item_barcodes (primary; bind to base item_uom) =====
+INSERT INTO item_barcodes (
+  item_id,
+  item_uom_id,
+  barcode,
+  symbology,
+  active,
+  is_primary,
+  created_at,
+  updated_at
+)
 SELECT
   i.id,
+  u.id,
   'AUTO-BC-' || i.id::text,
   'CUSTOM',
   true,
@@ -235,7 +245,14 @@ SELECT
   NOW(),
   NOW()
 FROM items i
-WHERE NOT EXISTS (SELECT 1 FROM item_barcodes b WHERE b.item_id = i.id);
+JOIN item_uoms u
+  ON u.item_id = i.id
+ AND u.is_base = true
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM item_barcodes b
+  WHERE b.item_id = i.id
+);
 
 -- ===== inbound_receipts (compat placeholder) =====
 -- 注意：当前 INTERNAL lot 的终态 identity 不应依赖 inbound_receipts。
@@ -301,7 +318,6 @@ SELECT setval(
   COALESCE((SELECT MAX(id) FROM shipping_provider_pricing_template_matrix), 0),
   true
 );
-
 
 SELECT setval(
   pg_get_serial_sequence('items','id'),


### PR DESCRIPTION
## Summary
- bind item_barcodes to concrete item_uoms at schema level
- add migration for item_uom barcode binding and symbology cleanup
- align barcode model, router, service, and maintenance path with uom-level barcode ownership

## Testing
- python3 -m compileall app/models/item_barcode.py app/pms/items/routers/item_barcodes.py app/pms/items/services/item_barcode_service.py app/pms/items/services/item_maintenance_service.py
- make alembic-check
- make upgrade-dev