### PR TITLE
feat(pms,wms): add public barcode probe and reuse in scan parsing

### DIFF
--- a/app/pms/public/items/__init__.py
+++ b/app/pms/public/items/__init__.py
@@ -1,12 +1,25 @@
 # app/pms/public/items/__init__.py
 from __future__ import annotations
 
-from .contracts import ItemBasic, ItemPolicy, ItemReadQuery
-from .services import ItemReadService
+from .contracts import (
+    BarcodeProbeError,
+    BarcodeProbeIn,
+    BarcodeProbeOut,
+    BarcodeProbeStatus,
+    ItemBasic,
+    ItemPolicy,
+    ItemReadQuery,
+)
+from .services import BarcodeProbeService, ItemReadService
 
 __all__ = [
+    "BarcodeProbeError",
+    "BarcodeProbeIn",
+    "BarcodeProbeOut",
+    "BarcodeProbeStatus",
     "ItemBasic",
     "ItemPolicy",
     "ItemReadQuery",
+    "BarcodeProbeService",
     "ItemReadService",
 ]

--- a/app/pms/public/items/contracts/__init__.py
+++ b/app/pms/public/items/contracts/__init__.py
@@ -1,11 +1,21 @@
 # app/pms/public/items/contracts/__init__.py
 from __future__ import annotations
 
+from .barcode_probe import (
+    BarcodeProbeError,
+    BarcodeProbeIn,
+    BarcodeProbeOut,
+    BarcodeProbeStatus,
+)
 from .item_basic import ItemBasic
 from .item_policy import ItemPolicy
 from .item_query import ItemReadQuery
 
 __all__ = [
+    "BarcodeProbeError",
+    "BarcodeProbeIn",
+    "BarcodeProbeOut",
+    "BarcodeProbeStatus",
     "ItemBasic",
     "ItemPolicy",
     "ItemReadQuery",

--- a/app/pms/public/items/contracts/barcode_probe.py
+++ b/app/pms/public/items/contracts/barcode_probe.py
@@ -1,0 +1,54 @@
+# app/pms/public/items/contracts/barcode_probe.py
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from app.pms.public.items.contracts.item_basic import ItemBasic
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+    )
+
+
+class BarcodeProbeStatus(str, Enum):
+    BOUND = "BOUND"
+    UNBOUND = "UNBOUND"
+    ERROR = "ERROR"
+
+
+class BarcodeProbeIn(_Base):
+    barcode: str = Field(..., min_length=1, max_length=128)
+
+    @field_validator("barcode", mode="before")
+    @classmethod
+    def _trim_barcode(cls, v: object) -> object:
+        if isinstance(v, str):
+            return v.strip()
+        return v
+
+
+class BarcodeProbeError(_Base):
+    stage: str
+    error: str
+
+
+class BarcodeProbeOut(_Base):
+    ok: bool
+    status: BarcodeProbeStatus
+    barcode: str
+
+    item_id: int | None = None
+    item_uom_id: int | None = None
+    ratio_to_base: int | None = None
+
+    symbology: str | None = None
+    active: bool | None = None
+
+    item_basic: ItemBasic | None = None
+
+    errors: list[BarcodeProbeError] = Field(default_factory=list)

--- a/app/pms/public/items/routers/barcode_probe.py
+++ b/app/pms/public/items/routers/barcode_probe.py
@@ -1,0 +1,23 @@
+# app/pms/public/items/routers/barcode_probe.py
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.db.deps import get_db
+from app.pms.public.items.contracts.barcode_probe import BarcodeProbeIn, BarcodeProbeOut
+from app.pms.public.items.services.barcode_probe_service import BarcodeProbeService
+
+router = APIRouter(tags=["pms-public-items"])
+
+
+def get_barcode_probe_service(db: Session = Depends(get_db)) -> BarcodeProbeService:
+    return BarcodeProbeService(db)
+
+
+@router.post("/items/barcode-probe", response_model=BarcodeProbeOut)
+def probe_barcode(
+    body: BarcodeProbeIn,
+    service: BarcodeProbeService = Depends(get_barcode_probe_service),
+) -> BarcodeProbeOut:
+    return service.probe(barcode=body.barcode)

--- a/app/pms/public/items/routers/items_read.py
+++ b/app/pms/public/items/routers/items_read.py
@@ -1,0 +1,46 @@
+# app/pms/public/items/routers/items_read.py
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.db.deps import get_db
+from app.pms.public.items.contracts.item_basic import ItemBasic
+from app.pms.public.items.contracts.item_query import ItemReadQuery
+from app.pms.public.items.services.item_read_service import ItemReadService
+
+router = APIRouter(prefix="/public/items", tags=["pms-public-items"])
+
+
+def get_item_read_service(db: Session = Depends(get_db)) -> ItemReadService:
+    return ItemReadService(db)
+
+
+@router.get("", response_model=list[ItemBasic], status_code=status.HTTP_200_OK)
+def list_public_items(
+    supplier_id: Optional[int] = Query(None, ge=1, description="按供应商过滤"),
+    enabled: Optional[bool] = Query(None, description="按启用状态过滤"),
+    q: Optional[str] = Query(None, description="关键词搜索（sku/name）"),
+    limit: Optional[int] = Query(None, ge=1, le=200, description="限制返回条数（默认 50，最大 200）"),
+    service: ItemReadService = Depends(get_item_read_service),
+) -> list[ItemBasic]:
+    query = ItemReadQuery(
+        supplier_id=supplier_id,
+        enabled=enabled,
+        q=q,
+        limit=limit,
+    )
+    return service.list_basic(query=query)
+
+
+@router.get("/{item_id}", response_model=ItemBasic, status_code=status.HTTP_200_OK)
+def get_public_item_by_id(
+    item_id: int,
+    service: ItemReadService = Depends(get_item_read_service),
+) -> ItemBasic:
+    obj = service.get_basic_by_id(item_id=int(item_id))
+    if obj is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Item not found")
+    return obj

--- a/app/pms/public/items/services/__init__.py
+++ b/app/pms/public/items/services/__init__.py
@@ -1,6 +1,7 @@
 # app/pms/public/items/services/__init__.py
 from __future__ import annotations
 
+from .barcode_probe_service import BarcodeProbeService
 from .item_read_service import ItemReadService
 
-__all__ = ["ItemReadService"]
+__all__ = ["BarcodeProbeService", "ItemReadService"]

--- a/app/pms/public/items/services/barcode_probe_service.py
+++ b/app/pms/public/items/services/barcode_probe_service.py
@@ -1,0 +1,131 @@
+# app/pms/public/items/services/barcode_probe_service.py
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
+
+from app.models.item_barcode import ItemBarcode
+from app.models.item_uom import ItemUOM
+from app.pms.public.items.contracts.barcode_probe import (
+    BarcodeProbeError,
+    BarcodeProbeOut,
+    BarcodeProbeStatus,
+)
+from app.pms.public.items.services.item_read_service import ItemReadService
+
+
+class BarcodeProbeService:
+    """
+    PMS public barcode probe service。
+
+    职责：
+    - 解析 barcode 是否绑定
+    - 返回 item_id / item_uom_id / ratio_to_base
+    - 补充最小 item_basic 读模型
+
+    边界：
+    - 这是 PMS 主数据探针，不承载 WMS /scan 的作业语义
+    - 不返回 committed / scan_ref / event_id / qty / batch_code 等仓内字段
+    """
+
+    def __init__(self, db: Session | AsyncSession) -> None:
+        self.db = db
+
+    def _require_sync_db(self) -> Session:
+        if isinstance(self.db, AsyncSession):
+            raise TypeError("BarcodeProbeService sync API requires Session, got AsyncSession")
+        if not isinstance(self.db, Session):
+            raise TypeError(f"BarcodeProbeService expected Session, got {type(self.db)!r}")
+        return self.db
+
+    def _require_async_db(self) -> AsyncSession:
+        if not isinstance(self.db, AsyncSession):
+            raise TypeError("BarcodeProbeService async API requires AsyncSession")
+        return self.db
+
+    def probe(self, *, barcode: str) -> BarcodeProbeOut:
+        db = self._require_sync_db()
+        code = (barcode or "").strip()
+        if not code:
+            return BarcodeProbeOut(
+                ok=False,
+                status=BarcodeProbeStatus.ERROR,
+                barcode="",
+                errors=[BarcodeProbeError(stage="probe", error="barcode is required")],
+            )
+
+        stmt = (
+            select(ItemBarcode, ItemUOM)
+            .join(
+                ItemUOM,
+                (ItemUOM.id == ItemBarcode.item_uom_id)
+                & (ItemUOM.item_id == ItemBarcode.item_id),
+            )
+            .where(ItemBarcode.barcode == code)
+            .order_by(ItemBarcode.active.desc(), ItemBarcode.id.asc())
+        )
+        row = db.execute(stmt).first()
+        if row is None:
+            return BarcodeProbeOut(
+                ok=True,
+                status=BarcodeProbeStatus.UNBOUND,
+                barcode=code,
+            )
+
+        bc, uom = row
+        item_basic = ItemReadService(db).get_basic_by_id(item_id=int(bc.item_id))
+        return BarcodeProbeOut(
+            ok=True,
+            status=BarcodeProbeStatus.BOUND,
+            barcode=code,
+            item_id=int(bc.item_id),
+            item_uom_id=int(bc.item_uom_id),
+            ratio_to_base=int(uom.ratio_to_base),
+            symbology=str(bc.symbology),
+            active=bool(bc.active),
+            item_basic=item_basic,
+        )
+
+    async def aprobe(self, *, barcode: str) -> BarcodeProbeOut:
+        db = self._require_async_db()
+        code = (barcode or "").strip()
+        if not code:
+            return BarcodeProbeOut(
+                ok=False,
+                status=BarcodeProbeStatus.ERROR,
+                barcode="",
+                errors=[BarcodeProbeError(stage="probe", error="barcode is required")],
+            )
+
+        stmt = (
+            select(ItemBarcode, ItemUOM)
+            .join(
+                ItemUOM,
+                (ItemUOM.id == ItemBarcode.item_uom_id)
+                & (ItemUOM.item_id == ItemBarcode.item_id),
+            )
+            .where(ItemBarcode.barcode == code)
+            .order_by(ItemBarcode.active.desc(), ItemBarcode.id.asc())
+        )
+        row = (await db.execute(stmt)).first()
+        if row is None:
+            return BarcodeProbeOut(
+                ok=True,
+                status=BarcodeProbeStatus.UNBOUND,
+                barcode=code,
+            )
+
+        bc, uom = row
+        item_basic = await ItemReadService(db).aget_basic_by_id(item_id=int(bc.item_id))
+        return BarcodeProbeOut(
+            ok=True,
+            status=BarcodeProbeStatus.BOUND,
+            barcode=code,
+            item_id=int(bc.item_id),
+            item_uom_id=int(bc.item_uom_id),
+            ratio_to_base=int(uom.ratio_to_base),
+            symbology=str(bc.symbology),
+            active=bool(bc.active),
+            item_basic=item_basic,
+        )

--- a/app/router_mount.py
+++ b/app/router_mount.py
@@ -25,6 +25,8 @@ def mount_routers(app: FastAPI, *, enable_dev_routes: bool) -> None:
     from app.pms.items.routers.item_barcodes import router as item_barcodes_router
     from app.pms.items.routers.item_uoms import router as item_uoms_router
     from app.pms.items.routers.items import router as items_router
+    from app.pms.public.items.routers.barcode_probe import router as pms_public_barcode_probe_router
+    from app.pms.public.items.routers.items_read import router as pms_public_items_read_router
     from app.wms.analysis.routers.ledger_reconcile_v2 import router as ledger_reconcile_v2_router
     from app.wms.ledger.routers.ledger_timeline import router as ledger_timeline_router
     from app.diagnostics.routers.lifecycle import router as lifecycle_router
@@ -117,7 +119,12 @@ def mount_routers(app: FastAPI, *, enable_dev_routes: bool) -> None:
 
     app.include_router(warehouses_router)
 
-    # 商品相关
+    # 商品相关：
+    # - PMS public 读面先挂
+    # - /items/barcode-probe 先于 /items/{id}
+    # - /public/items 独立前缀，不与 owner /items 冲突
+    app.include_router(pms_public_items_read_router)
+    app.include_router(pms_public_barcode_probe_router)
     app.include_router(items_router)
     app.include_router(item_barcodes_router)
     app.include_router(item_uoms_router)

--- a/app/wms/reconciliation/services/scan_orchestrator_item_resolver.py
+++ b/app/wms/reconciliation/services/scan_orchestrator_item_resolver.py
@@ -1,37 +1,74 @@
 # app/wms/reconciliation/services/scan_orchestrator_item_resolver.py
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Optional
 
-import sqlalchemy as sa
 from sqlalchemy import text as SA
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.item_barcode import ItemBarcode
+from app.pms.public.items.services.barcode_probe_service import BarcodeProbeService
 
 
-async def resolve_item_id_from_barcode(session: AsyncSession, barcode: str) -> Optional[int]:
+@dataclass(frozen=True)
+class ScanBarcodeResolved:
+    item_id: int
+    item_uom_id: int | None
+    ratio_to_base: int | None
+    symbology: str | None
+    active: bool | None
+
+
+async def probe_item_from_barcode(
+    session: AsyncSession,
+    barcode: str,
+) -> Optional[ScanBarcodeResolved]:
+    """
+    WMS scan 读取链复用 PMS public barcode probe：
+
+    - 不再直接查询 item_barcodes
+    - 从 PMS BarcodeProbeService 获取主数据解析结果
+    - 当前返回 richer 结构，供 parse_scan 后续阶段继续透传
+    """
     code = (barcode or "").strip()
     if not code:
         return None
 
-    stmt = (
-        sa.select(ItemBarcode.item_id)
-        .where(ItemBarcode.barcode == code)
-        .order_by(ItemBarcode.active.desc(), ItemBarcode.id.asc())
-    )
-
     try:
-        row = await session.execute(stmt)
-        item_id = row.scalar_one_or_none()
-        if item_id is None:
+        probe = await BarcodeProbeService(session).aprobe(barcode=code)
+        if probe.status != "BOUND":
             return None
-        try:
-            return int(item_id)
-        except Exception:
+        if probe.item_id is None:
             return None
+
+        return ScanBarcodeResolved(
+            item_id=int(probe.item_id),
+            item_uom_id=(
+                int(probe.item_uom_id) if probe.item_uom_id is not None else None
+            ),
+            ratio_to_base=(
+                int(probe.ratio_to_base) if probe.ratio_to_base is not None else None
+            ),
+            symbology=(str(probe.symbology) if probe.symbology is not None else None),
+            active=probe.active if probe.active is not None else None,
+        )
     except Exception:
         return None
+
+
+async def resolve_item_id_from_barcode(
+    session: AsyncSession,
+    barcode: str,
+) -> Optional[int]:
+    """
+    兼容壳：
+    - 现阶段 parse_scan 仍只消费 item_id
+    - 后续阶段将逐步改为直接消费 probe_item_from_barcode 的 richer 结果
+    """
+    resolved = await probe_item_from_barcode(session, barcode)
+    if resolved is None:
+        return None
+    return int(resolved.item_id)
 
 
 async def resolve_item_id_from_sku(session: AsyncSession, sku: str) -> Optional[int]:

--- a/app/wms/reconciliation/services/scan_orchestrator_parse.py
+++ b/app/wms/reconciliation/services/scan_orchestrator_parse.py
@@ -11,12 +11,31 @@ from app.utils.gs1 import parse_gs1
 
 from app.wms.reconciliation.services.scan_orchestrator_dates import coerce_date
 from app.wms.reconciliation.services.scan_orchestrator_item_resolver import (
-    resolve_item_id_from_barcode,
+    probe_item_from_barcode,
     resolve_item_id_from_sku,
 )
 from app.wms.reconciliation.services.scan_orchestrator_tokens import parse_tokens
 
 _BARCODE_RESOLVER = BarcodeResolver()
+
+
+def _apply_barcode_probe(parsed: Dict[str, Any], resolved: object) -> None:
+    """
+    把 PMS public barcode probe 的 richer 结果并入 parsed。
+    当前阶段只做“写入 parsed”，不改变 parse_scan 的返回 tuple 形状。
+    """
+    item_id = getattr(resolved, "item_id", None)
+    item_uom_id = getattr(resolved, "item_uom_id", None)
+    ratio_to_base = getattr(resolved, "ratio_to_base", None)
+
+    if item_id is not None and not parsed.get("item_id"):
+        parsed["item_id"] = int(item_id)
+
+    if item_uom_id is not None and not parsed.get("item_uom_id"):
+        parsed["item_uom_id"] = int(item_uom_id)
+
+    if ratio_to_base is not None and not parsed.get("ratio_to_base"):
+        parsed["ratio_to_base"] = int(ratio_to_base)
 
 
 async def parse_scan(
@@ -41,6 +60,11 @@ async def parse_scan(
     Phase M-4 governance：
     - 对外新增 lot_code（正名），但 orchestrator 内部 key 仍使用 batch_code（历史兼容）
     - 因此：若请求带 lot_code 且 batch_code 为空，会映射到 parsed['batch_code']
+
+    当前阶段（PMS probe 接入）：
+    - 条码解析已通过 PMS public barcode probe 获取 richer 结果
+    - richer 字段（item_uom_id / ratio_to_base）先写入 parsed
+    - 暂不改变 parse_scan 的返回 tuple 形状
     """
     # 1) 从 barcode 字符串里解析 KV token：ITM: / QTY: / B: / PD: / EXP: / WH:
     raw = str(scan.get("barcode") or (scan.get("tokens") or {}).get("barcode") or "")
@@ -66,11 +90,11 @@ async def parse_scan(
     if not parsed.get("batch_code") and parsed.get("lot_code"):
         parsed["batch_code"] = parsed.get("lot_code")
 
-    # 3) 使用 item_barcodes 反查 item_id
+    # 3) 使用 PMS public barcode probe 反查 item_id，并把 richer 字段写入 parsed
     if raw and parsed.get("item_id") is None:
-        item_id_from_barcode = await resolve_item_id_from_barcode(session, raw)
-        if item_id_from_barcode:
-            parsed["item_id"] = item_id_from_barcode
+        resolved = await probe_item_from_barcode(session, raw)
+        if resolved is not None:
+            _apply_barcode_probe(parsed, resolved)
 
     # 4) 使用 BarcodeResolver（SKU / GTIN / 批次 / 到期）
     if raw:
@@ -86,11 +110,11 @@ async def parse_scan(
                 if iid:
                     parsed["item_id"] = iid
 
-            # GTIN → item_id
+            # GTIN → richer probe
             if getattr(r, "gtin", None) and parsed.get("item_id") is None:
-                iid2 = await resolve_item_id_from_barcode(session, r.gtin)  # type: ignore[arg-type]
-                if iid2:
-                    parsed["item_id"] = iid2
+                resolved_gtin = await probe_item_from_barcode(session, r.gtin)  # type: ignore[arg-type]
+                if resolved_gtin is not None:
+                    _apply_barcode_probe(parsed, resolved_gtin)
 
             # 批次 / 到期
             if getattr(r, "batch", None) and not parsed.get("batch_code"):


### PR DESCRIPTION
## Summary
- add PMS public barcode probe contracts, router, and service
- mount PMS public barcode probe in router entry
- reuse PMS barcode probe capability in WMS scan item resolving/parsing

## Testing
- python3 -m compileall app/pms/public/items app/wms/reconciliation/services
- manual API verification for /items/barcode-probe and /scan probe