### PR TITLE
feat(pms): add owner barcode rows and align scan entry

### DIFF
--- a/alembic/versions/1ebda503789f_seed_pms_item_barcodes_page.py
+++ b/alembic/versions/1ebda503789f_seed_pms_item_barcodes_page.py
@@ -1,0 +1,110 @@
+"""seed_pms_item_barcodes_page
+
+Revision ID: 1ebda503789f
+Revises: 32b08d41971c
+Create Date: 2026-04-09 21:37:15.802489
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "1ebda503789f"
+down_revision: Union[str, Sequence[str], None] = "32b08d41971c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+
+    op.execute(
+        """
+        INSERT INTO page_registry (
+          code,
+          name,
+          parent_code,
+          level,
+          domain_code,
+          show_in_topbar,
+          show_in_sidebar,
+          inherit_permissions,
+          read_permission_id,
+          write_permission_id,
+          sort_order,
+          is_active
+        )
+        VALUES (
+          'pms.item_barcodes',
+          '商品条码',
+          'pms',
+          2,
+          'pms',
+          FALSE,
+          TRUE,
+          TRUE,
+          NULL,
+          NULL,
+          15,
+          TRUE
+        )
+        ON CONFLICT (code) DO UPDATE
+        SET
+          name = EXCLUDED.name,
+          parent_code = EXCLUDED.parent_code,
+          level = EXCLUDED.level,
+          domain_code = EXCLUDED.domain_code,
+          show_in_topbar = EXCLUDED.show_in_topbar,
+          show_in_sidebar = EXCLUDED.show_in_sidebar,
+          inherit_permissions = EXCLUDED.inherit_permissions,
+          read_permission_id = EXCLUDED.read_permission_id,
+          write_permission_id = EXCLUDED.write_permission_id,
+          sort_order = EXCLUDED.sort_order,
+          is_active = EXCLUDED.is_active
+        """
+    )
+
+    op.execute(
+        """
+        INSERT INTO page_route_prefixes (
+          page_code,
+          route_prefix,
+          sort_order,
+          is_active
+        )
+        VALUES (
+          'pms.item_barcodes',
+          '/item-barcodes',
+          10,
+          TRUE
+        )
+        ON CONFLICT (route_prefix) DO UPDATE
+        SET
+          page_code = EXCLUDED.page_code,
+          sort_order = EXCLUDED.sort_order,
+          is_active = EXCLUDED.is_active
+        """
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+
+    op.execute(
+        """
+        DELETE FROM page_route_prefixes
+        WHERE route_prefix = '/item-barcodes'
+           OR page_code = 'pms.item_barcodes'
+        """
+    )
+
+    op.execute(
+        """
+        DELETE FROM page_registry
+        WHERE code = 'pms.item_barcodes'
+        """
+    )

--- a/app/pms/items/routers/item_barcodes.py
+++ b/app/pms/items/routers/item_barcodes.py
@@ -1,6 +1,7 @@
 # app/pms/items/routers/item_barcodes.py
 from __future__ import annotations
 
+from datetime import datetime
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -9,6 +10,7 @@ from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 
 from app.db.deps import get_db
+from app.models.item import Item
 from app.models.item_barcode import ItemBarcode
 from app.models.item_uom import ItemUOM
 
@@ -53,6 +55,33 @@ class ItemBarcodeOut(BaseModel):
     is_primary: bool
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class ItemBarcodeCompositeRow(BaseModel):
+    """
+    商品条码页 owner 复合只读行：
+    - 一行 = 一个商品 + 一个单位 + 一条码
+    - 页面用它直接渲染，不再让前端分别请求 /item-barcodes 与 /item-uoms 后自行 join
+    """
+
+    barcode_id: int
+    item_id: int
+    item_uom_id: int
+
+    sku: str
+    item_name: str
+
+    uom: str
+    display_name: Optional[str]
+    ratio_to_base: int
+    is_base: bool
+    is_purchase_default: bool
+
+    barcode: str
+    symbology: str
+    is_primary: bool
+    active: bool
+    updated_at: datetime
 
 
 @router.post("", response_model=ItemBarcodeOut, status_code=status.HTTP_201_CREATED)
@@ -100,6 +129,64 @@ def list_barcodes_for_items(
 
     rows = db.execute(stmt.order_by(ItemBarcode.item_id.asc(), ItemBarcode.id.asc())).scalars().all()
     return list(rows)
+
+
+@router.get("/item/{item_id}/rows", response_model=List[ItemBarcodeCompositeRow])
+def list_barcode_rows_for_item(
+    item_id: int,
+    active_only: bool = Query(False, description="true 时仅返回 active=true 的条码行"),
+    db: Session = Depends(get_db),
+):
+    """
+    Owner 读模型：
+    - 返回“一个商品、一个单位、一行条码”的复合结果
+    - 供 PMS 商品条码页直接渲染当前商品条码表
+    """
+    if item_id <= 0:
+        raise HTTPException(400, "invalid item_id")
+
+    stmt = (
+        select(ItemBarcode, ItemUOM, Item)
+        .join(
+            ItemUOM,
+            (ItemUOM.id == ItemBarcode.item_uom_id)
+            & (ItemUOM.item_id == ItemBarcode.item_id),
+        )
+        .join(Item, Item.id == ItemBarcode.item_id)
+        .where(ItemBarcode.item_id == item_id)
+    )
+
+    if active_only:
+        stmt = stmt.where(ItemBarcode.active.is_(True))
+
+    rows = db.execute(
+        stmt.order_by(
+            ItemUOM.ratio_to_base.asc(),
+            ItemUOM.id.asc(),
+            ItemBarcode.id.asc(),
+        )
+    ).all()
+
+    return [
+        ItemBarcodeCompositeRow(
+            barcode_id=int(bc.id),
+            item_id=int(item.id),
+            item_uom_id=int(uom.id),
+            sku=str(item.sku),
+            item_name=str(item.name),
+            uom=str(uom.uom),
+            display_name=str(uom.display_name).strip() if uom.display_name is not None else None,
+            ratio_to_base=int(uom.ratio_to_base),
+            is_base=bool(uom.is_base),
+            is_purchase_default=bool(uom.is_purchase_default),
+            barcode=str(bc.barcode),
+            symbology=str(bc.symbology),
+            is_primary=bool(bc.is_primary),
+            active=bool(bc.active),
+            updated_at=bc.updated_at,
+        )
+        for bc, uom, item in rows
+    ]
 
 
 @router.get("/item/{item_id}", response_model=List[ItemBarcodeOut])

--- a/app/wms/reconciliation/contracts/scan.py
+++ b/app/wms/reconciliation/contracts/scan.py
@@ -128,7 +128,10 @@ class ScanResponse(BaseModel):
     source: str
 
     item_id: Optional[int] = None
+    item_uom_id: Optional[int] = None
+    ratio_to_base: Optional[int] = None
     qty: Optional[int] = None
+    qty_base: Optional[int] = None
 
     # ✅ 合同双轨：lot_code 正名 + batch_code 兼容
     lot_code: Optional[str] = None

--- a/app/wms/reconciliation/routers/scan_entrypoint.py
+++ b/app/wms/reconciliation/routers/scan_entrypoint.py
@@ -35,8 +35,12 @@ def register(router: APIRouter) -> None:
         # ★ item_id：优先 orchestrator，其次请求体
         item_id = result.get("item_id") or req.item_id
 
-        # qty / lot_code/batch_code 仍以请求体为主（count 模式下 actual 单独返回）
+        item_uom_id = result.get("item_uom_id")
+        ratio_to_base = result.get("ratio_to_base")
+
+        # qty 继续作为输入单位数量回显
         qty = req.qty
+        qty_base = result.get("qty_base")
 
         # 合同双轨：对外返回两者对齐；内部仍沿用 batch_code 作为 key
         lot_code = req.lot_code or req.batch_code
@@ -70,7 +74,10 @@ def register(router: APIRouter) -> None:
             event_id=result.get("event_id"),
             source=result.get("source") or "scan_orchestrator",
             item_id=item_id,
+            item_uom_id=item_uom_id,
+            ratio_to_base=ratio_to_base,
             qty=qty,
+            qty_base=qty_base,
             lot_code=lot_code,
             batch_code=batch_code,
             warehouse_id=warehouse_id,

--- a/app/wms/reconciliation/services/scan_orchestrator_ingest.py
+++ b/app/wms/reconciliation/services/scan_orchestrator_ingest.py
@@ -53,6 +53,51 @@ def _build_scan_ref(*, mode: str, scan_session_id: str) -> str:
     return f"scan:{str(mode).strip().lower()}:dev:{scan_session_id}"
 
 
+def _coerce_optional_int(value: Any) -> Optional[int]:
+    if value is None or value == "":
+        return None
+    return int(value)
+
+
+def _build_qty_base(
+    *,
+    mode: str,
+    qty: int,
+    ratio_to_base: Optional[int],
+) -> Optional[int]:
+    """
+    仅 receive / pick 进入“执行单位基础化”：
+    - qty：仍代表输入单位数量
+    - qty_base：代表真正下送 handler 的 base qty
+
+    count 暂不改语义：
+    - count_handler 的 actual 是“盘点后的绝对量”，不是增量
+    - 因此这里先返回 None，不参与 count 执行
+    """
+    if mode not in {"receive", "pick"}:
+        return None
+
+    ratio = int(ratio_to_base or 1)
+    if ratio <= 0:
+        raise ValueError("ratio_to_base 必须 >= 1")
+
+    return int(qty) * int(ratio)
+
+
+def _attach_scan_passthrough(
+    result: Dict[str, Any],
+    *,
+    item_uom_id: Optional[int],
+    ratio_to_base: Optional[int],
+    qty_base: Optional[int],
+) -> Dict[str, Any]:
+    out = dict(result)
+    out["item_uom_id"] = item_uom_id
+    out["ratio_to_base"] = ratio_to_base
+    out["qty_base"] = qty_base
+    return out
+
+
 async def ingest(scan: Dict[str, Any], session: Optional[AsyncSession]) -> Dict[str, Any]:
     """
     v2 扫描编排器（receive / pick / count；历史 putaway 已下线）：
@@ -83,6 +128,9 @@ async def ingest(scan: Dict[str, Any], session: Optional[AsyncSession]) -> Dict[
             "evidence": [],
             "errors": [{"stage": "ingest", "error": "missing session"}],
             "item_id": None,
+            "item_uom_id": None,
+            "ratio_to_base": None,
+            "qty_base": None,
         }
 
     (
@@ -96,6 +144,14 @@ async def ingest(scan: Dict[str, Any], session: Optional[AsyncSession]) -> Dict[
         production_date,
         expiry_date,
     ) = await parse_scan(scan_mut, session)
+
+    item_uom_id = _coerce_optional_int(parsed.get("item_uom_id"))
+    ratio_to_base = _coerce_optional_int(parsed.get("ratio_to_base"))
+    qty_base = _build_qty_base(
+        mode=mode,
+        qty=int(qty),
+        ratio_to_base=ratio_to_base,
+    )
 
     # ✅ 关键：确保 scan_ref 一定含 mode（哪怕调用方没传、parse_scan 推导了）
     scan_with_mode: Dict[str, Any] = dict(scan_mut or {})
@@ -122,6 +178,9 @@ async def ingest(scan: Dict[str, Any], session: Optional[AsyncSession]) -> Dict[
             "evidence": [{"source": "scan_feature_disabled", "db": True}],
             "errors": [{"stage": "ingest", "error": f"FEATURE_DISABLED: unsupported_mode:{mode}"}],
             "item_id": item_id,
+            "item_uom_id": item_uom_id,
+            "ratio_to_base": ratio_to_base,
+            "qty_base": qty_base,
         }
 
     base_kwargs: Dict[str, Any] = {
@@ -135,7 +194,7 @@ async def ingest(scan: Dict[str, Any], session: Optional[AsyncSession]) -> Dict[
 
     try:
         if mode == "count":
-            return await run_count_flow(
+            result = await run_count_flow(
                 session=session,
                 audit=AUDIT,
                 scan_ref_norm=scan_ref_norm,
@@ -149,34 +208,54 @@ async def ingest(scan: Dict[str, Any], session: Optional[AsyncSession]) -> Dict[
                 expiry_date=expiry_date,
                 evidence=evidence,
             )
+            return _attach_scan_passthrough(
+                result,
+                item_uom_id=item_uom_id,
+                ratio_to_base=ratio_to_base,
+                qty_base=qty_base,
+            )
 
         if mode == "receive":
-            return await run_receive_flow(
+            exec_qty = int(qty_base if qty_base is not None else qty)
+            result = await run_receive_flow(
                 session=session,
                 audit=AUDIT,
                 scan_ref_norm=scan_ref_norm,
                 probe=probe,
                 base_kwargs=base_kwargs,
-                qty=qty,
+                qty=exec_qty,
                 item_id=item_id,
                 evidence=evidence,
             )
+            return _attach_scan_passthrough(
+                result,
+                item_uom_id=item_uom_id,
+                ratio_to_base=ratio_to_base,
+                qty_base=exec_qty,
+            )
 
         # pick
-        return await run_pick_flow(
+        exec_qty = int(qty_base if qty_base is not None else qty)
+        result = await run_pick_flow(
             session=session,
             audit=AUDIT,
             scan_ref_norm=scan_ref_norm,
             probe=probe,
             parsed=parsed,
             base_kwargs=base_kwargs,
-            qty=qty,
+            qty=exec_qty,
             item_id=item_id,
             wh_id=wh_id,
             batch_code=batch_code,
             production_date=production_date,
             expiry_date=expiry_date,
             evidence=evidence,
+        )
+        return _attach_scan_passthrough(
+            result,
+            item_uom_id=item_uom_id,
+            ratio_to_base=ratio_to_base,
+            qty_base=exec_qty,
         )
 
     except Exception as e:
@@ -190,4 +269,7 @@ async def ingest(scan: Dict[str, Any], session: Optional[AsyncSession]) -> Dict[
             "evidence": evidence,
             "errors": [{"stage": mode, "error": str(e)}],
             "item_id": item_id,
+            "item_uom_id": item_uom_id,
+            "ratio_to_base": ratio_to_base,
+            "qty_base": qty_base,
         }

--- a/tests/api/test_user_navigation_api.py
+++ b/tests/api/test_user_navigation_api.py
@@ -251,6 +251,25 @@ async def test_my_navigation_masterdata_and_wms_warehouses_domain_codes_are_corr
 
 
 @pytest.mark.asyncio
+async def test_my_navigation_item_barcodes_page_is_under_pms(client: AsyncClient) -> None:
+    headers = await _login_admin_headers(client)
+
+    r = await client.get("/users/me/navigation", headers=headers)
+    assert r.status_code == 200, r.text
+
+    data = r.json()
+    nodes = _walk_pages(data["pages"])
+
+    item_barcodes = nodes.get("pms.item_barcodes")
+    assert item_barcodes is not None, "pms.item_barcodes should exist"
+
+    assert item_barcodes["parent_code"] == "pms"
+    assert item_barcodes["domain_code"] == "pms"
+    assert item_barcodes["effective_read_permission"] == "page.pms.read"
+    assert item_barcodes["effective_write_permission"] == "page.pms.write"
+
+
+@pytest.mark.asyncio
 async def test_my_navigation_route_prefix_mapping_and_effective_permissions(client: AsyncClient) -> None:
     headers = await _login_admin_headers(client)
 
@@ -314,6 +333,26 @@ async def test_my_navigation_route_prefix_mapping_and_effective_permissions(clie
 
     assert warehouses_route["effective_read_permission"] == "page.wms.read"
     assert warehouses_route["effective_write_permission"] == "page.wms.write"
+
+
+@pytest.mark.asyncio
+async def test_my_navigation_item_barcodes_route_prefix_mapping_and_permissions(
+    client: AsyncClient,
+) -> None:
+    headers = await _login_admin_headers(client)
+
+    r = await client.get("/users/me/navigation", headers=headers)
+    assert r.status_code == 200, r.text
+
+    data = r.json()
+    route_map = _index_route_prefixes(data["route_prefixes"])
+
+    item_barcodes_route = route_map.get("/item-barcodes")
+    assert item_barcodes_route is not None, "/item-barcodes should exist in route_prefixes"
+
+    assert item_barcodes_route["page_code"] == "pms.item_barcodes"
+    assert item_barcodes_route["effective_read_permission"] == "page.pms.read"
+    assert item_barcodes_route["effective_write_permission"] == "page.pms.write"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add owner composite readonly barcode rows endpoint
- align scan entry contract to item barcode page flow
- seed pms item barcodes page

## Validation
- python3 -m compileall target files