### PR TITLE
refactor(pms): complete item weight cutover backend

### DIFF
--- a/alembic/versions/5542b7decf4b_add_net_weight_kg_to_item_uoms.py
+++ b/alembic/versions/5542b7decf4b_add_net_weight_kg_to_item_uoms.py
@@ -1,0 +1,37 @@
+# alembic/versions/5542b7decf4b_add_net_weight_kg_to_item_uoms.py
+"""add net_weight_kg to item_uoms
+
+Revision ID: 5542b7decf4b
+Revises: 1ebda503789f
+Create Date: 2026-04-10 12:02:32.038483
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "5542b7decf4b"
+down_revision: Union[str, Sequence[str], None] = "1ebda503789f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add net_weight_kg column to item_uoms."""
+    op.add_column(
+        "item_uoms",
+        sa.Column(
+            "net_weight_kg",
+            sa.Numeric(10, 3),
+            nullable=True,
+            comment="净重（kg）。基础包装为真相源；非基础包装默认可按 ratio_to_base 推导；不含包材。",
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop net_weight_kg column from item_uoms."""
+    op.drop_column("item_uoms", "net_weight_kg")

--- a/alembic/versions/6994653cf477_backfill_base_uom_net_weight_kg_from_.py
+++ b/alembic/versions/6994653cf477_backfill_base_uom_net_weight_kg_from_.py
@@ -1,0 +1,47 @@
+# alembic/versions/6994653cf477_backfill_base_uom_net_weight_kg_from_.py
+"""backfill base uom net_weight_kg from items
+
+Revision ID: 6994653cf477
+Revises: 5542b7decf4b
+Create Date: 2026-04-10 12:08:26.636116
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "6994653cf477"
+down_revision: Union[str, Sequence[str], None] = "5542b7decf4b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Backfill base item_uoms.net_weight_kg from items.weight_kg."""
+    op.execute(
+        """
+        UPDATE item_uoms AS u
+           SET net_weight_kg = i.weight_kg
+          FROM items AS i
+         WHERE u.item_id = i.id
+           AND u.is_base = true
+           AND i.weight_kg IS NOT NULL
+           AND u.net_weight_kg IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    """Clear backfilled base item_uoms.net_weight_kg values."""
+    op.execute(
+        """
+        UPDATE item_uoms AS u
+           SET net_weight_kg = NULL
+          FROM items AS i
+         WHERE u.item_id = i.id
+           AND u.is_base = true
+           AND i.weight_kg IS NOT NULL
+        """
+    )

--- a/alembic/versions/d810ee4649c6_drop_items_weight_kg_after_uom_weight_.py
+++ b/alembic/versions/d810ee4649c6_drop_items_weight_kg_after_uom_weight_.py
@@ -1,0 +1,36 @@
+"""drop items weight_kg after uom weight migration
+
+Revision ID: d810ee4649c6
+Revises: 6994653cf477
+Create Date: 2026-04-10 13:22:55.680687
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d810ee4649c6"
+down_revision: Union[str, Sequence[str], None] = "6994653cf477"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.drop_column("items", "weight_kg")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.add_column(
+        "items",
+        sa.Column(
+            "weight_kg",
+            sa.Numeric(10, 3),
+            nullable=True,
+            comment="单件净重（kg），用于运费预估，不含包材",
+        ),
+    )

--- a/app/models/item.py
+++ b/app/models/item.py
@@ -5,7 +5,7 @@ import enum
 from datetime import datetime
 from typing import TYPE_CHECKING, List, Optional
 
-from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Integer, Numeric, String, text
+from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Integer, String, text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
@@ -41,6 +41,10 @@ class Item(Base):
     Phase M-5（unit_governance 二阶段）：
     - items.uom 已物理移除
     - base_uom 的事实口径 = item_uoms.is_base=true（结构层）
+
+    Phase M-6（item weight cutover）：
+    - items.weight_kg 已物理删除
+    - 运行时 weight_kg = base item_uom.net_weight_kg
     """
 
     __tablename__ = "items"
@@ -83,12 +87,6 @@ class Item(Base):
     derivation_allowed: Mapped[bool] = mapped_column(Boolean, nullable=False)
     uom_governance_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False)
 
-    weight_kg: Mapped[Optional[float]] = mapped_column(
-        Numeric(10, 3),
-        nullable=True,
-        comment="单件净重（kg），用于运费预估，不含包材",
-    )
-
     shelf_life_value: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     shelf_life_unit: Mapped[Optional[str]] = mapped_column(String(16), nullable=True)
 
@@ -117,6 +115,21 @@ class Item(Base):
         if base is None or not getattr(base, "uom", None):
             raise RuntimeError(f"item missing base item_uom (is_base=true): item_id={int(self.id)}")
         return str(getattr(base, "uom"))
+
+    @property
+    def weight_kg(self) -> Optional[float]:
+        """
+        Phase M-6：只读输出投影
+        - items.weight_kg 已物理删除
+        - 运行时真相源 = base item_uom.net_weight_kg
+        """
+        base = self.get_base_uom()
+        if base is None:
+            return None
+        raw = getattr(base, "net_weight_kg", None)
+        if raw is None:
+            return None
+        return float(raw)
 
     @property
     def barcode(self) -> Optional[str]:

--- a/app/models/item_uom.py
+++ b/app/models/item_uom.py
@@ -5,7 +5,17 @@ from datetime import datetime
 from typing import Optional, TYPE_CHECKING
 
 import sqlalchemy as sa
-from sqlalchemy import Boolean, CheckConstraint, DateTime, ForeignKey, Index, Integer, String, text
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    Numeric,
+    String,
+    text,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
 
@@ -23,6 +33,7 @@ class ItemUOM(Base):
     - 一个 item 可以有多个 uom（PCS/箱/盒/...）
     - ratio_to_base：1 uom = ratio_to_base * base_uom（base_uom 真相源 = item_uoms.is_base）
     - is_base：每个 item 恰好一个 base（用 partial unique index 强制）
+    - net_weight_kg：净重（kg）。基础包装为真相源；非基础包装默认可按 ratio_to_base 推导；不含包材。
 
     Phase M-5（二阶段）：
     - 强化默认单位唯一性（purchase/inbound/outbound）——DB 用 partial unique index 强制
@@ -46,6 +57,13 @@ class ItemUOM(Base):
 
     # 展示名（可选）：如“箱”“盒”
     display_name: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+
+    # 净重（kg）。基础包装为真相源；非基础包装默认可按 ratio_to_base 推导；不含包材。
+    net_weight_kg: Mapped[Optional[float]] = mapped_column(
+        Numeric(10, 3),
+        nullable=True,
+        comment="净重（kg）。基础包装为真相源；非基础包装默认可按 ratio_to_base 推导；不含包材。",
+    )
 
     is_base: Mapped[bool] = mapped_column(
         Boolean,
@@ -125,5 +143,6 @@ class ItemUOM(Base):
         return (
             f"<ItemUOM id={self.id} item_id={self.item_id} "
             f"uom={self.uom!r} ratio_to_base={self.ratio_to_base} "
+            f"net_weight_kg={self.net_weight_kg} "
             f"is_base={self.is_base}>"
         )

--- a/app/pms/items/contracts/item.py
+++ b/app/pms/items/contracts/item.py
@@ -55,6 +55,7 @@ class ItemBase(_Base):
     shelf_life_value: Annotated[int | None, Field(default=None, gt=0)] = None
     shelf_life_unit: Annotated[ShelfLifeUnit | None, Field(default=None)] = None
 
+    # 兼容输出字段：事实来源已切到 base item_uom.net_weight_kg
     weight_kg: Annotated[float | None, Field(default=None, ge=0)] = None
 
     @field_validator(
@@ -77,6 +78,7 @@ class ItemCreate(_Base):
     Create Item（统一由后端生成 SKU）：
     - 不接受 sku 输入
     - 不接受 barcode 输入；主条码请走 /item-barcodes
+    - 不接受 weight_kg 输入；基础包装净重请走 item_uoms（base uom）
 
     Phase M-3：
     - items.case_ratio/case_uom 已删除；包装单位请走 item_uoms
@@ -104,8 +106,6 @@ class ItemCreate(_Base):
     shelf_life_value: Annotated[int | None, Field(default=None, gt=0)] = None
     shelf_life_unit: Annotated[ShelfLifeUnit | None, Field(default=None)] = None
 
-    weight_kg: Annotated[float | None, Field(default=None, ge=0)] = None
-
     @field_validator(
         "name",
         "spec",
@@ -124,6 +124,7 @@ class ItemUpdate(_Base):
 
     - 不开放 sku 变更
     - 不接受 barcode / has_shelf_life
+    - 不接受 weight_kg；基础包装净重请改 item_uoms
     - nullable 字段支持显式传 null 清空
     """
 
@@ -148,8 +149,6 @@ class ItemUpdate(_Base):
 
     shelf_life_value: Annotated[int | None, Field(default=None, gt=0)] = None
     shelf_life_unit: Annotated[ShelfLifeUnit | None, Field(default=None)] = None
-
-    weight_kg: Annotated[float | None, Field(default=None, ge=0)] = None
 
     @field_validator(
         "name",
@@ -179,6 +178,7 @@ class ItemCreateById(_Base):
     说明：
     - 本轮主线不收这个例外通道
     - 仅把 shelf_life 的合同口径对齐到真实 DB
+    - 不接受 weight_kg；基础包装净重请改 item_uoms
     """
 
     id: Annotated[int, Field(gt=0)]
@@ -201,8 +201,6 @@ class ItemCreateById(_Base):
 
     shelf_life_value: Annotated[int | None, Field(default=None, gt=0)] = None
     shelf_life_unit: Annotated[ShelfLifeUnit | None, Field(default=None)] = None
-
-    weight_kg: Annotated[float | None, Field(default=None, ge=0)] = None
 
 
 class ItemOut(ItemBase):

--- a/app/pms/items/contracts/item_uom.py
+++ b/app/pms/items/contracts/item_uom.py
@@ -1,3 +1,4 @@
+# app/pms/items/contracts/item_uom.py
 from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -8,6 +9,7 @@ class ItemUomCreate(BaseModel):
     uom: str = Field(..., min_length=1, max_length=16)
     ratio_to_base: int = Field(..., ge=1)
     display_name: Optional[str] = Field(None, max_length=32)
+    net_weight_kg: Optional[float] = Field(None, ge=0)
     is_base: bool = False
     is_purchase_default: bool = False
     is_inbound_default: bool = False
@@ -18,6 +20,7 @@ class ItemUomUpdate(BaseModel):
     uom: Optional[str] = Field(None, min_length=1, max_length=16)
     ratio_to_base: Optional[int] = Field(None, ge=1)
     display_name: Optional[str] = Field(None, max_length=32)
+    net_weight_kg: Optional[float] = Field(None, ge=0)
     is_base: Optional[bool] = None
     is_purchase_default: Optional[bool] = None
     is_inbound_default: Optional[bool] = None
@@ -32,6 +35,7 @@ class ItemUomOut(BaseModel):
     uom: str
     ratio_to_base: int
     display_name: Optional[str]
+    net_weight_kg: Optional[float]
     is_base: bool
     is_purchase_default: bool
     is_inbound_default: bool

--- a/app/pms/items/routers/item_barcodes.py
+++ b/app/pms/items/routers/item_barcodes.py
@@ -29,6 +29,25 @@ def _get_item_uom_or_404(db: Session, item_uom_id: int) -> ItemUOM:
     return obj
 
 
+def _ensure_item_uom_barcode_vacant(
+    db: Session,
+    *,
+    item_id: int,
+    item_uom_id: int,
+    exclude_barcode_id: int | None = None,
+) -> None:
+    stmt = select(ItemBarcode.id).where(
+        ItemBarcode.item_id == int(item_id),
+        ItemBarcode.item_uom_id == int(item_uom_id),
+    )
+    if exclude_barcode_id is not None:
+        stmt = stmt.where(ItemBarcode.id != int(exclude_barcode_id))
+
+    exists = db.execute(stmt.limit(1)).scalar_one_or_none()
+    if exists is not None:
+        raise HTTPException(409, "Current item_uom already bound to a barcode")
+
+
 class ItemBarcodeCreate(BaseModel):
     item_uom_id: int
     barcode: str
@@ -37,8 +56,9 @@ class ItemBarcodeCreate(BaseModel):
 
 
 class ItemBarcodeUpdate(BaseModel):
-    """PATCH 更新条码：可用于切主条码/启用/停用/修改码制/修改条码值"""
+    """PATCH 更新条码：可用于改绑包装 / 改条码 / 改码制 / 切主条码"""
 
+    item_uom_id: Optional[int] = None
     barcode: Optional[str] = None
     symbology: Optional[str] = None
     active: Optional[bool] = None
@@ -98,6 +118,12 @@ def create_barcode(
     exists = db.execute(select(ItemBarcode).where(ItemBarcode.barcode == code)).scalars().first()
     if exists:
         raise HTTPException(409, "Barcode already exists")
+
+    _ensure_item_uom_barcode_vacant(
+        db,
+        item_id=int(uom.item_id),
+        item_uom_id=int(uom.id),
+    )
 
     obj = ItemBarcode(
         item_id=int(uom.item_id),
@@ -231,6 +257,19 @@ def update_barcode(id: int, body: ItemBarcodeUpdate, db: Session = Depends(get_d
     bc = db.get(ItemBarcode, id)
     if not bc:
         raise HTTPException(404, "Barcode not found")
+
+    if body.item_uom_id is not None:
+        target_uom = _get_item_uom_or_404(db, body.item_uom_id)
+        if int(target_uom.item_id) != int(bc.item_id):
+            raise HTTPException(400, "item_uom_id does not belong to current item")
+
+        _ensure_item_uom_barcode_vacant(
+            db,
+            item_id=int(bc.item_id),
+            item_uom_id=int(target_uom.id),
+            exclude_barcode_id=int(bc.id),
+        )
+        bc.item_uom_id = int(target_uom.id)
 
     if body.barcode is not None:
         code = body.barcode.strip()

--- a/app/pms/items/routers/item_uoms.py
+++ b/app/pms/items/routers/item_uoms.py
@@ -1,10 +1,13 @@
 # app/pms/items/routers/item_uoms.py
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_session
+from app.models.inbound_receipt import InboundReceiptLine
+from app.models.item_barcode import ItemBarcode
 from app.models.item_uom import ItemUOM
+from app.models.purchase_order_line import PurchaseOrderLine
 from app.pms.items.contracts.item_uom import (
     ItemUomCreate,
     ItemUomOut,
@@ -12,6 +15,66 @@ from app.pms.items.contracts.item_uom import (
 )
 
 router = APIRouter(prefix="/item-uoms", tags=["item-uoms"])
+
+
+async def _get_item_uom_or_404(session: AsyncSession, item_uom_id: int) -> ItemUOM:
+    obj = await session.get(ItemUOM, int(item_uom_id))
+    if not obj:
+        raise HTTPException(status_code=404, detail="ItemUom not found")
+    return obj
+
+
+async def _has_barcode_refs(
+    session: AsyncSession,
+    *,
+    item_id: int,
+    item_uom_id: int,
+) -> bool:
+    stmt = (
+        select(ItemBarcode.id)
+        .where(
+            ItemBarcode.item_id == int(item_id),
+            ItemBarcode.item_uom_id == int(item_uom_id),
+        )
+        .limit(1)
+    )
+    return (await session.execute(stmt)).scalar_one_or_none() is not None
+
+
+async def _has_po_line_refs(session: AsyncSession, *, item_uom_id: int) -> bool:
+    stmt = (
+        select(PurchaseOrderLine.id)
+        .where(PurchaseOrderLine.purchase_uom_id_snapshot == int(item_uom_id))
+        .limit(1)
+    )
+    return (await session.execute(stmt)).scalar_one_or_none() is not None
+
+
+async def _has_receipt_line_refs(session: AsyncSession, *, item_uom_id: int) -> bool:
+    stmt = (
+        select(InboundReceiptLine.id)
+        .where(InboundReceiptLine.uom_id == int(item_uom_id))
+        .limit(1)
+    )
+    return (await session.execute(stmt)).scalar_one_or_none() is not None
+
+
+async def _find_base_uom(
+    session: AsyncSession,
+    *,
+    item_id: int,
+    exclude_id: int,
+) -> ItemUOM | None:
+    stmt = (
+        select(ItemUOM)
+        .where(
+            ItemUOM.item_id == int(item_id),
+            ItemUOM.is_base.is_(True),
+            ItemUOM.id != int(exclude_id),
+        )
+        .limit(1)
+    )
+    return (await session.execute(stmt)).scalars().first()
 
 
 @router.post("", response_model=ItemUomOut)
@@ -66,14 +129,63 @@ async def update_item_uom(
     return obj
 
 
-@router.delete("/{id}")
+@router.delete("/{id}", status_code=status.HTTP_200_OK)
 async def delete_item_uom(
     id: int,
     session: AsyncSession = Depends(get_session),
 ):
-    obj = await session.get(ItemUOM, id)
-    if not obj:
-        raise HTTPException(status_code=404, detail="ItemUom not found")
+    obj = await _get_item_uom_or_404(session, id)
+
+    if bool(obj.is_base):
+        raise HTTPException(
+            status_code=400,
+            detail="基础包装不能删除",
+        )
+
+    if await _has_barcode_refs(
+        session,
+        item_id=int(obj.item_id),
+        item_uom_id=int(obj.id),
+    ):
+        raise HTTPException(
+            status_code=409,
+            detail="当前包装已绑定条码，不能删除；请先修改条码绑定",
+        )
+
+    if await _has_po_line_refs(session, item_uom_id=int(obj.id)):
+        raise HTTPException(
+            status_code=409,
+            detail="当前包装已被采购单引用，不能删除",
+        )
+
+    if await _has_receipt_line_refs(session, item_uom_id=int(obj.id)):
+        raise HTTPException(
+            status_code=409,
+            detail="当前包装已被收货记录引用，不能删除",
+        )
+
+    need_fallback_default = bool(
+        obj.is_purchase_default or obj.is_inbound_default or obj.is_outbound_default
+    )
+
+    if need_fallback_default:
+        base = await _find_base_uom(
+            session,
+            item_id=int(obj.item_id),
+            exclude_id=int(obj.id),
+        )
+        if base is None:
+            raise HTTPException(
+                status_code=409,
+                detail="缺少基础包装，无法安全删除当前包装",
+            )
+
+        if obj.is_purchase_default:
+            base.is_purchase_default = True
+        if obj.is_inbound_default:
+            base.is_inbound_default = True
+        if obj.is_outbound_default:
+            base.is_outbound_default = True
 
     await session.delete(obj)
     await session.commit()

--- a/app/pms/items/routers/items.py
+++ b/app/pms/items/routers/items.py
@@ -50,7 +50,6 @@ def create_item(
             ),
             shelf_life_value=item_in.shelf_life_value,
             shelf_life_unit=item_in.shelf_life_unit,
-            weight_kg=item_in.weight_kg,
         )
     except ValueError as e:
         detail = str(e)
@@ -153,8 +152,6 @@ def update_item(
             shelf_life_value_set=("shelf_life_value" in fields_set),
             shelf_life_unit=data.get("shelf_life_unit"),
             shelf_life_unit_set=("shelf_life_unit" in fields_set),
-            weight_kg=data.get("weight_kg"),
-            weight_kg_set=("weight_kg" in fields_set),
             brand=data.get("brand"),
             brand_set=("brand" in fields_set),
             category=data.get("category"),

--- a/app/pms/items/services/item_maintenance_service.py
+++ b/app/pms/items/services/item_maintenance_service.py
@@ -27,6 +27,10 @@ class ItemMaintenanceService:
     - items.uom 已物理移除；此通道不再接收/写入 uom
     - 必须补齐 items 的 NOT NULL 策略字段
     - 若要写入主条码，必须先存在 base item_uom（不再做隐式兜底）
+
+    Phase M-6：
+    - 此通道不再接收/写入 items.weight_kg
+    - 基础包装净重请改走 item_uoms（base uom）
     """
 
     def __init__(self, db: Session) -> None:
@@ -48,7 +52,6 @@ class ItemMaintenanceService:
         has_shelf_life: Optional[bool] = None,
         shelf_life_value: Optional[int] = None,
         shelf_life_unit: Optional[str] = None,
-        weight_kg: Optional[float] = None,
     ) -> Item:
         if not _allow_create_item_by_id():
             raise ValueError(
@@ -96,7 +99,6 @@ class ItemMaintenanceService:
             # shelf_life params
             shelf_life_value=shelf_life_value,
             shelf_life_unit=shelf_life_unit,
-            weight_kg=weight_kg,
         )
 
         self.db.add(obj)

--- a/app/pms/items/services/item_service.py
+++ b/app/pms/items/services/item_service.py
@@ -26,6 +26,10 @@ class ItemService:
 
     Phase M-5：
     - items.uom 已物理移除；单位治理完全由 item_uoms 承载
+
+    Phase M-6：
+    - items.weight_kg 不再作为写入真相源
+    - PMS 主合同的净重读写转移到 base item_uom.net_weight_kg
     """
 
     def __init__(self, db: Session) -> None:
@@ -84,7 +88,6 @@ class ItemService:
         supplier_id: Optional[int] = None,
         shelf_life_value: Optional[int] = None,
         shelf_life_unit: Optional[str] = None,
-        weight_kg: Optional[float] = None,
         lot_source_policy: Optional[str] = None,
         expiry_policy: Optional[str] = None,
         derivation_allowed: Optional[bool] = None,
@@ -99,7 +102,6 @@ class ItemService:
             supplier_id=supplier_id,
             shelf_life_value=shelf_life_value,
             shelf_life_unit=shelf_life_unit,
-            weight_kg=weight_kg,
             lot_source_policy=lot_source_policy,
             expiry_policy=expiry_policy,
             derivation_allowed=derivation_allowed,
@@ -124,7 +126,6 @@ class ItemService:
         has_shelf_life: Optional[bool] = None,
         shelf_life_value: Optional[int] = None,
         shelf_life_unit: Optional[str] = None,
-        weight_kg: Optional[float] = None,
     ) -> Item:
         obj = self._maintenance.create_item_by_id(
             id=id,
@@ -139,7 +140,6 @@ class ItemService:
             has_shelf_life=has_shelf_life,
             shelf_life_value=shelf_life_value,
             shelf_life_unit=shelf_life_unit,
-            weight_kg=weight_kg,
         )
         out = self._present.present_item(item=obj)
         assert out is not None
@@ -183,8 +183,6 @@ class ItemService:
         shelf_life_value_set: bool = False,
         shelf_life_unit: Optional[str] = None,
         shelf_life_unit_set: bool = False,
-        weight_kg: Optional[float] = None,
-        weight_kg_set: bool = False,
         brand: Optional[str] = None,
         category: Optional[str] = None,
         brand_set: bool = False,
@@ -212,8 +210,6 @@ class ItemService:
             shelf_life_value_set=shelf_life_value_set,
             shelf_life_unit=shelf_life_unit,
             shelf_life_unit_set=shelf_life_unit_set,
-            weight_kg=weight_kg,
-            weight_kg_set=weight_kg_set,
             brand=brand,
             category=category,
             brand_set=brand_set,

--- a/app/pms/items/services/item_write_service.py
+++ b/app/pms/items/services/item_write_service.py
@@ -110,6 +110,10 @@ class ItemWriteService:
 
     Phase M-5：
     - items.uom 已物理移除；单位治理完全由 item_uoms 结构层承载
+
+    Phase M-6：
+    - items.weight_kg 不再作为写入真相源
+    - 基础包装净重请通过 item_uoms（base uom）维护
     """
 
     def __init__(self, db: Session) -> None:
@@ -129,7 +133,6 @@ class ItemWriteService:
         supplier_id: Optional[int] = None,
         shelf_life_value: Optional[int] = None,
         shelf_life_unit: Optional[str] = None,
-        weight_kg: Optional[float] = None,
         lot_source_policy: Optional[str] = None,
         expiry_policy: Optional[str] = None,
         derivation_allowed: Optional[bool] = None,
@@ -183,7 +186,6 @@ class ItemWriteService:
             uom_governance_enabled=uom_gov,
             shelf_life_value=sl_value,
             shelf_life_unit=sl_unit,
-            weight_kg=weight_kg,
         )
 
         add_item(self.db, obj)
@@ -216,8 +218,6 @@ class ItemWriteService:
         shelf_life_value_set: bool = False,
         shelf_life_unit: Optional[str] = None,
         shelf_life_unit_set: bool = False,
-        weight_kg: Optional[float] = None,
-        weight_kg_set: bool = False,
         brand: Optional[str] = None,
         category: Optional[str] = None,
         brand_set: bool = False,
@@ -282,10 +282,6 @@ class ItemWriteService:
             if uom_governance_enabled is None:
                 raise ValueError("uom_governance_enabled 不能为空")
             obj.uom_governance_enabled = bool(uom_governance_enabled)
-            changed = True
-
-        if weight_kg_set:
-            obj.weight_kg = weight_kg
             changed = True
 
         if brand_set:

--- a/tests/api/test_items_main_contract_api.py
+++ b/tests/api/test_items_main_contract_api.py
@@ -33,7 +33,6 @@ async def _create_item(
         "uom_governance_enabled": False,
         "shelf_life_value": 12,
         "shelf_life_unit": "MONTH",
-        "weight_kg": 1.25,
     }
     payload.update(overrides)
     r = await client.post("/items", json=payload, headers=headers)
@@ -62,6 +61,18 @@ async def test_items_create_rejects_has_shelf_life_field(client: httpx.AsyncClie
     payload = {
         "name": f"UT-ITEM-{uuid4().hex[:8]}",
         "has_shelf_life": True,
+    }
+    r = await client.post("/items", json=payload, headers=headers)
+    assert r.status_code == 422, r.text
+
+
+@pytest.mark.asyncio
+async def test_items_create_rejects_weight_kg_field(client: httpx.AsyncClient) -> None:
+    headers = await _login_admin_headers(client)
+
+    payload = {
+        "name": f"UT-ITEM-{uuid4().hex[:8]}",
+        "weight_kg": 1.25,
     }
     r = await client.post("/items", json=payload, headers=headers)
     assert r.status_code == 422, r.text
@@ -107,7 +118,6 @@ async def test_items_patch_explicit_null_clears_nullable_fields(client: httpx.As
         headers,
         spec="SPEC-TO-CLEAR",
         supplier_id=1,
-        weight_kg=2.5,
         expiry_policy="REQUIRED",
         shelf_life_value=9,
         shelf_life_unit="YEAR",
@@ -117,7 +127,6 @@ async def test_items_patch_explicit_null_clears_nullable_fields(client: httpx.As
     patch_payload = {
         "spec": None,
         "supplier_id": None,
-        "weight_kg": None,
         "shelf_life_value": None,
         "shelf_life_unit": None,
     }
@@ -127,7 +136,6 @@ async def test_items_patch_explicit_null_clears_nullable_fields(client: httpx.As
 
     assert patched["spec"] is None
     assert patched["supplier_id"] is None
-    assert patched["weight_kg"] is None
     assert patched["shelf_life_value"] is None
     assert patched["shelf_life_unit"] is None
 
@@ -137,9 +145,29 @@ async def test_items_patch_explicit_null_clears_nullable_fields(client: httpx.As
 
     assert fetched["spec"] is None
     assert fetched["supplier_id"] is None
-    assert fetched["weight_kg"] is None
     assert fetched["shelf_life_value"] is None
     assert fetched["shelf_life_unit"] is None
+
+
+@pytest.mark.asyncio
+async def test_items_patch_rejects_weight_kg_field(client: httpx.AsyncClient) -> None:
+    headers = await _login_admin_headers(client)
+
+    created = await _create_item(
+        client,
+        headers,
+        expiry_policy="REQUIRED",
+        shelf_life_value=30,
+        shelf_life_unit="DAY",
+    )
+    item_id = int(created["id"])
+
+    r_patch = await client.patch(
+        f"/items/{item_id}",
+        json={"weight_kg": None},
+        headers=headers,
+    )
+    assert r_patch.status_code == 422, r_patch.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- complete backend cutover of item weight from items.weight_kg to base item_uoms.net_weight_kg
- remove remaining write-path and ORM dependency on items.weight_kg
- add and wire migrations for item_uoms weight field, backfill, and final drop of items.weight_kg
- tighten main contract tests to reject weight_kg writes

## Validation
- python3 -m compileall app/models/item.py tests/api/test_items_main_contract_api.py alembic/versions/d810ee4649c6_drop_items_weight_kg_after_uom_weight_.py
- make test TESTS="tests/api/test_items_main_contract_api.py"
- alembic upgrade-dev
- make alembic-check