### PR TITLE
feat(pms): align owner aggregate and suppliers contract

### DIFF
--- a/alembic/versions/fc982b78117a_pms_suppliers_allow_updating_code.py
+++ b/alembic/versions/fc982b78117a_pms_suppliers_allow_updating_code.py
@@ -1,0 +1,69 @@
+"""pms suppliers allow updating code
+
+Revision ID: fc982b78117a
+Revises: d810ee4649c6
+Create Date: 2026-04-10 19:00:35.830447
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "fc982b78117a"
+down_revision: Union[str, Sequence[str], None] = "d810ee4649c6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Allow suppliers.code to be updated.
+
+    Keep DB truth as:
+    - code is UNIQUE
+    - code is NONBLANK
+    - code is TRIMMED
+    - code is UPPERCASE
+    Only remove the immutable trigger/function.
+    """
+    op.execute(
+        """
+        DROP TRIGGER IF EXISTS trg_suppliers_code_immutable ON suppliers;
+        """
+    )
+    op.execute(
+        """
+        DROP FUNCTION IF EXISTS trg_forbid_update_suppliers_code();
+        """
+    )
+
+
+def downgrade() -> None:
+    """Restore suppliers.code immutability trigger/function."""
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION trg_forbid_update_suppliers_code()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+            IF NEW.code IS DISTINCT FROM OLD.code THEN
+                RAISE EXCEPTION 'suppliers.code is immutable';
+            END IF;
+            RETURN NEW;
+        END;
+        $$;
+        """
+    )
+    op.execute(
+        """
+        DROP TRIGGER IF EXISTS trg_suppliers_code_immutable ON suppliers;
+        CREATE TRIGGER trg_suppliers_code_immutable
+        BEFORE UPDATE ON suppliers
+        FOR EACH ROW
+        EXECUTE FUNCTION trg_forbid_update_suppliers_code();
+        """
+    )

--- a/app/models/supplier.py
+++ b/app/models/supplier.py
@@ -12,7 +12,6 @@ from sqlalchemy import (
     String,
     UniqueConstraint,
     func,
-    inspect as sa_inspect,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship, validates
 
@@ -27,26 +26,26 @@ class Supplier(Base):
     __table_args__ = (
         UniqueConstraint("name", name="uq_suppliers_name"),
         UniqueConstraint("code", name="uq_suppliers_code"),
-        # 供应商 code 作为业务身份：人工输入，但必须规范化且不可为空白
-        # 注意：这里声明 CHECK 约束，DB 侧仍需要通过 Alembic migration 实际落地。
+        # code：允许修改，但必须规范化且不可为空白
         CheckConstraint("btrim(code) <> ''", name="ck_suppliers_code_nonblank"),
+        CheckConstraint("code = btrim(code)", name="ck_suppliers_code_trimmed"),
         CheckConstraint("code = upper(code)", name="ck_suppliers_code_upper"),
-        # name 作为展示字段：不允许空白（避免 UI/报表出现“空名供应商”）
+        # name：展示字段，不允许空白，且统一 trim
         CheckConstraint("btrim(name) <> ''", name="ck_suppliers_name_nonblank"),
+        CheckConstraint("name = btrim(name)", name="ck_suppliers_name_trimmed"),
         {"info": {"skip_autogen": True}},
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
 
     name: Mapped[str] = mapped_column(String(255), nullable=False)
-    # 业务身份：创建时必须提供；创建后不可修改（模型层防线，DB 侧还会用 trigger 强制）
     code: Mapped[str] = mapped_column(String(64), nullable=False)
 
     website: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
 
     active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
 
-    contacts: Mapped[List[SupplierContact]] = relationship(
+    contacts: Mapped[List["SupplierContact"]] = relationship(
         "SupplierContact",
         back_populates="supplier",
         cascade="save-update, merge",
@@ -63,10 +62,10 @@ class Supplier(Base):
     @validates("code")
     def _validate_code(self, _key: str, value: str) -> str:
         """
-        业务身份：人工输入，但一旦创建后不可修改。
+        供应商编码：
         - 统一 trim + upper
         - 禁止空白
-        - 对已持久化对象，禁止改 code（应用层防线）
+        - 允许更新；唯一性由 DB UNIQUE 约束保证
         """
         if value is None:
             raise ValueError("supplier.code 不能为空")
@@ -74,13 +73,6 @@ class Supplier(Base):
         v = value.strip().upper()
         if v == "":
             raise ValueError("supplier.code 不能为空白")
-
-        state = sa_inspect(self)
-        # persistent：已落库对象；pending：新建未提交；transient：未关联 session
-        if state.persistent:
-            old = getattr(self, "code", None)
-            if old is not None and v != old:
-                raise ValueError("supplier.code 不允许修改（创建后不可变）")
 
         return v
 

--- a/app/pms/items/contracts/item_aggregate.py
+++ b/app/pms/items/contracts/item_aggregate.py
@@ -1,0 +1,175 @@
+# app/pms/items/contracts/item_aggregate.py
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from app.pms.items.contracts.item import (
+    ExpiryPolicy,
+    ItemOut,
+    LotSourcePolicy,
+    ShelfLifeUnit,
+)
+from app.pms.items.contracts.item_uom import ItemUomOut
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+
+def _norm_text(v: object) -> object:
+    return v.strip() if isinstance(v, str) else v
+
+
+class AggregateItemInput(_Base):
+    name: Annotated[str, Field(min_length=1, max_length=128)]
+    spec: Annotated[str | None, Field(default=None, max_length=128)] = None
+
+    brand: Annotated[str | None, Field(default=None, max_length=64)] = None
+    category: Annotated[str | None, Field(default=None, max_length=64)] = None
+
+    enabled: bool = True
+    supplier_id: int | None = None
+
+    lot_source_policy: LotSourcePolicy | None = None
+    expiry_policy: ExpiryPolicy | None = None
+    derivation_allowed: bool | None = None
+    uom_governance_enabled: bool | None = None
+
+    shelf_life_value: Annotated[int | None, Field(default=None, gt=0)] = None
+    shelf_life_unit: Annotated[ShelfLifeUnit | None, Field(default=None)] = None
+
+    @field_validator(
+        "name",
+        "spec",
+        "brand",
+        "category",
+        mode="before",
+    )
+    @classmethod
+    def _trim_text(cls, v: object) -> object:
+        return _norm_text(v)
+
+
+class AggregateUomInput(_Base):
+    id: int | None = None
+    uom_key: Annotated[str, Field(min_length=1, max_length=64)]
+
+    uom: Annotated[str, Field(min_length=1, max_length=16)]
+    ratio_to_base: Annotated[int, Field(ge=1)]
+    display_name: Annotated[str | None, Field(default=None, max_length=32)] = None
+    net_weight_kg: Annotated[float | None, Field(default=None, ge=0)] = None
+
+    is_base: bool = False
+    is_purchase_default: bool = False
+    is_inbound_default: bool = False
+    is_outbound_default: bool = False
+
+    @field_validator(
+        "uom_key",
+        "uom",
+        "display_name",
+        mode="before",
+    )
+    @classmethod
+    def _trim_text(cls, v: object) -> object:
+        return _norm_text(v)
+
+
+BarcodeSymbology = Literal["EAN13", "UPC", "UPC12", "EAN8", "GS1", "CUSTOM"]
+
+
+class AggregateBarcodeInput(_Base):
+    id: int | None = None
+
+    barcode: Annotated[str, Field(min_length=1, max_length=128)]
+    symbology: BarcodeSymbology = "CUSTOM"
+    active: bool = True
+    is_primary: bool = False
+
+    bind_uom_key: Annotated[str, Field(min_length=1, max_length=64)]
+
+    @field_validator(
+        "barcode",
+        "bind_uom_key",
+        mode="before",
+    )
+    @classmethod
+    def _trim_text(cls, v: object) -> object:
+        return _norm_text(v)
+
+    @model_validator(mode="after")
+    def _primary_must_be_active(self) -> "AggregateBarcodeInput":
+        if self.is_primary and not self.active:
+            raise ValueError("primary barcode must be active")
+        return self
+
+
+class ItemAggregatePayload(_Base):
+    item: AggregateItemInput
+    uoms: list[AggregateUomInput]
+    barcodes: list[AggregateBarcodeInput]
+
+    @model_validator(mode="after")
+    def _validate_shape(self) -> "ItemAggregatePayload":
+        if not self.uoms:
+            raise ValueError("uoms 不能为空")
+
+        uom_keys = [str(x.uom_key) for x in self.uoms]
+        if len(set(uom_keys)) != len(uom_keys):
+            raise ValueError("uom_key 不能重复")
+
+        base_rows = [x for x in self.uoms if x.is_base]
+        if len(base_rows) != 1:
+            raise ValueError("必须且只能提供一个基础包装")
+
+        base = base_rows[0]
+        if int(base.ratio_to_base) != 1:
+            raise ValueError("基础包装的 ratio_to_base 必须为 1")
+
+        purchase_defaults = [x for x in self.uoms if x.is_purchase_default]
+        inbound_defaults = [x for x in self.uoms if x.is_inbound_default]
+        outbound_defaults = [x for x in self.uoms if x.is_outbound_default]
+
+        if len(purchase_defaults) > 1:
+            raise ValueError("采购默认包装最多只能有一个")
+        if len(inbound_defaults) > 1:
+            raise ValueError("入库默认包装最多只能有一个")
+        if len(outbound_defaults) > 1:
+            raise ValueError("出库默认包装最多只能有一个")
+
+        valid_uom_keys = set(uom_keys)
+
+        primary_barcodes = [x for x in self.barcodes if x.is_primary]
+        if len(primary_barcodes) > 1:
+            raise ValueError("主条码最多只能有一个")
+
+        for bc in self.barcodes:
+            if str(bc.bind_uom_key) not in valid_uom_keys:
+                raise ValueError(f"barcode 绑定的 uom_key 不存在: {bc.bind_uom_key}")
+
+        return self
+
+
+class AggregateBarcodeOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    item_id: int
+    item_uom_id: int
+    barcode: str
+    symbology: str
+    active: bool
+    is_primary: bool
+
+
+class ItemAggregateOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    item: ItemOut
+    uoms: list[ItemUomOut]
+    barcodes: list[AggregateBarcodeOut]

--- a/app/pms/items/contracts/item_uom.py
+++ b/app/pms/items/contracts/item_uom.py
@@ -1,4 +1,7 @@
 # app/pms/items/contracts/item_uom.py
+from __future__ import annotations
+
+from datetime import datetime
 from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -40,3 +43,37 @@ class ItemUomOut(BaseModel):
     is_purchase_default: bool
     is_inbound_default: bool
     is_outbound_default: bool
+
+
+class ItemUomBarcodeRowOut(BaseModel):
+    """
+    owner 复合读模型：
+    - 一行 = 一个商品 + 一个包装 + 零/一条码
+    - 主权归 item_uoms，不归 item_barcodes
+    """
+
+    sku: str
+    item_name: str
+
+    item_id: int
+    item_uom_id: int
+
+    uom: str
+    display_name: Optional[str]
+    ratio_to_base: int
+    net_weight_kg: Optional[float]
+
+    is_base: bool
+    is_purchase_default: bool
+    is_inbound_default: bool
+    is_outbound_default: bool
+
+    barcode_id: Optional[int] = None
+    barcode: Optional[str] = None
+    symbology: Optional[str] = None
+    is_primary: bool = False
+    active: bool = False
+
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/app/pms/items/repos/item_barcode_repo.py
+++ b/app/pms/items/repos/item_barcode_repo.py
@@ -1,0 +1,225 @@
+# app/pms/items/repos/item_barcode_repo.py
+from __future__ import annotations
+
+from typing import Sequence
+
+from sqlalchemy import select, update
+from sqlalchemy.orm import Session
+
+from app.models.item import Item
+from app.models.item_barcode import ItemBarcode
+from app.models.item_uom import ItemUOM
+
+
+def get_item_barcode_by_id(db: Session, barcode_id: int) -> ItemBarcode | None:
+    if not barcode_id or barcode_id <= 0:
+        return None
+    return db.get(ItemBarcode, int(barcode_id))
+
+
+def get_item_barcode_by_code(
+    db: Session,
+    *,
+    barcode: str,
+    exclude_id: int | None = None,
+) -> ItemBarcode | None:
+    code = (barcode or "").strip()
+    if not code:
+        return None
+
+    stmt = select(ItemBarcode).where(ItemBarcode.barcode == code)
+    if exclude_id is not None:
+        stmt = stmt.where(ItemBarcode.id != int(exclude_id))
+
+    return db.execute(stmt).scalars().first()
+
+
+def list_item_barcodes_by_item_id(
+    db: Session,
+    *,
+    item_id: int,
+    active_only: bool | None = None,
+) -> list[ItemBarcode]:
+    if not item_id or item_id <= 0:
+        return []
+
+    stmt = select(ItemBarcode).where(ItemBarcode.item_id == int(item_id))
+    if active_only is True:
+        stmt = stmt.where(ItemBarcode.active.is_(True))
+
+    stmt = stmt.order_by(ItemBarcode.id.asc())
+    return db.execute(stmt).scalars().all()
+
+
+def list_item_barcodes_by_item_ids(
+    db: Session,
+    *,
+    item_ids: Sequence[int],
+    active_only: bool | None = None,
+) -> list[ItemBarcode]:
+    ids = sorted({int(x) for x in item_ids if int(x) > 0})
+    if not ids:
+        return []
+
+    stmt = select(ItemBarcode).where(ItemBarcode.item_id.in_(ids))
+    if active_only is True:
+        stmt = stmt.where(ItemBarcode.active.is_(True))
+
+    stmt = stmt.order_by(ItemBarcode.item_id.asc(), ItemBarcode.id.asc())
+    return db.execute(stmt).scalars().all()
+
+
+def load_primary_barcodes_map(
+    db: Session,
+    *,
+    item_ids: Sequence[int],
+) -> dict[int, str]:
+    ids = sorted({int(x) for x in item_ids if int(x) > 0})
+    if not ids:
+        return {}
+
+    rows = (
+        db.execute(
+            select(ItemBarcode.item_id, ItemBarcode.barcode)
+            .where(ItemBarcode.item_id.in_(ids))
+            .where(ItemBarcode.is_primary.is_(True))
+            .where(ItemBarcode.active.is_(True))
+        )
+        .all()
+    )
+
+    out: dict[int, str] = {}
+    for item_id, barcode in rows:
+        if item_id is None or barcode is None:
+            continue
+        out[int(item_id)] = str(barcode)
+    return out
+
+
+def has_barcode_bound_to_item_uom(
+    db: Session,
+    *,
+    item_id: int,
+    item_uom_id: int,
+    exclude_barcode_id: int | None = None,
+) -> bool:
+    stmt = select(ItemBarcode.id).where(
+        ItemBarcode.item_id == int(item_id),
+        ItemBarcode.item_uom_id == int(item_uom_id),
+    )
+    if exclude_barcode_id is not None:
+        stmt = stmt.where(ItemBarcode.id != int(exclude_barcode_id))
+
+    return db.execute(stmt.limit(1)).scalar_one_or_none() is not None
+
+
+def add_item_barcode(db: Session, obj: ItemBarcode) -> None:
+    db.add(obj)
+
+
+def create_item_barcode(
+    db: Session,
+    *,
+    item_id: int,
+    item_uom_id: int,
+    barcode: str,
+    symbology: str,
+    active: bool,
+    is_primary: bool,
+) -> ItemBarcode:
+    obj = ItemBarcode(
+        item_id=int(item_id),
+        item_uom_id=int(item_uom_id),
+        barcode=str(barcode),
+        symbology=str(symbology),
+        active=bool(active),
+        is_primary=bool(is_primary),
+    )
+    db.add(obj)
+    return obj
+
+
+def update_item_barcode_fields(
+    obj: ItemBarcode,
+    *,
+    item_uom_id: int | None = None,
+    barcode: str | None = None,
+    symbology: str | None = None,
+    active: bool | None = None,
+    is_primary: bool | None = None,
+) -> None:
+    if item_uom_id is not None:
+        obj.item_uom_id = int(item_uom_id)
+    if barcode is not None:
+        obj.barcode = str(barcode)
+    if symbology is not None:
+        obj.symbology = str(symbology)
+    if active is not None:
+        obj.active = bool(active)
+    if is_primary is not None:
+        obj.is_primary = bool(is_primary)
+
+
+def clear_primary_flags_for_item(db: Session, *, item_id: int) -> None:
+    db.execute(
+        update(ItemBarcode)
+        .where(ItemBarcode.item_id == int(item_id))
+        .values(is_primary=False)
+    )
+
+
+def delete_item_barcode(db: Session, obj: ItemBarcode) -> None:
+    db.delete(obj)
+
+
+def refresh_item_barcode(db: Session, obj: ItemBarcode) -> None:
+    db.refresh(obj)
+
+
+def get_item_uom_by_id(db: Session, item_uom_id: int) -> ItemUOM | None:
+    if not item_uom_id or item_uom_id <= 0:
+        return None
+    return db.get(ItemUOM, int(item_uom_id))
+
+
+def list_barcode_row_sources_for_item(
+    db: Session,
+    *,
+    item_id: int,
+    active_only: bool,
+) -> list[tuple[ItemBarcode, ItemUOM, Item]]:
+    if not item_id or item_id <= 0:
+        return []
+
+    stmt = (
+        select(ItemBarcode, ItemUOM, Item)
+        .join(
+            ItemUOM,
+            (ItemUOM.id == ItemBarcode.item_uom_id)
+            & (ItemUOM.item_id == ItemBarcode.item_id),
+        )
+        .join(Item, Item.id == ItemBarcode.item_id)
+        .where(ItemBarcode.item_id == int(item_id))
+    )
+
+    if active_only:
+        stmt = stmt.where(ItemBarcode.active.is_(True))
+
+    stmt = stmt.order_by(
+        ItemUOM.ratio_to_base.asc(),
+        ItemUOM.id.asc(),
+        ItemBarcode.id.asc(),
+    )
+    return db.execute(stmt).all()
+
+
+def flush(db: Session) -> None:
+    db.flush()
+
+
+def commit(db: Session) -> None:
+    db.commit()
+
+
+def rollback(db: Session) -> None:
+    db.rollback()

--- a/app/pms/items/repos/item_uom_repo.py
+++ b/app/pms/items/repos/item_uom_repo.py
@@ -1,0 +1,268 @@
+# app/pms/items/repos/item_uom_repo.py
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.inbound_receipt import InboundReceiptLine
+from app.models.item import Item
+from app.models.item_barcode import ItemBarcode
+from app.models.item_uom import ItemUOM
+from app.models.purchase_order_line import PurchaseOrderLine
+
+
+def get_item_uom_by_id(db: Session, item_uom_id: int) -> ItemUOM | None:
+    if not item_uom_id or item_uom_id <= 0:
+        return None
+    return db.get(ItemUOM, int(item_uom_id))
+
+
+def list_item_uoms_by_item_id(db: Session, item_id: int) -> list[ItemUOM]:
+    if not item_id or item_id <= 0:
+        return []
+    stmt = (
+        select(ItemUOM)
+        .where(ItemUOM.item_id == int(item_id))
+        .order_by(ItemUOM.ratio_to_base.asc(), ItemUOM.id.asc())
+    )
+    return db.execute(stmt).scalars().all()
+
+
+def list_item_uoms_by_item_ids(db: Session, item_ids: Sequence[int]) -> list[ItemUOM]:
+    ids = sorted({int(x) for x in item_ids if int(x) > 0})
+    if not ids:
+        return []
+
+    stmt = (
+        select(ItemUOM)
+        .where(ItemUOM.item_id.in_(ids))
+        .order_by(ItemUOM.item_id.asc(), ItemUOM.ratio_to_base.asc(), ItemUOM.id.asc())
+    )
+    return db.execute(stmt).scalars().all()
+
+
+def get_base_item_uom(db: Session, item_id: int) -> ItemUOM | None:
+    if not item_id or item_id <= 0:
+        return None
+
+    stmt = (
+        select(ItemUOM)
+        .where(
+            ItemUOM.item_id == int(item_id),
+            ItemUOM.is_base.is_(True),
+        )
+        .limit(1)
+    )
+    return db.execute(stmt).scalars().first()
+
+
+def get_purchase_default_item_uom(db: Session, item_id: int) -> ItemUOM | None:
+    if not item_id or item_id <= 0:
+        return None
+
+    stmt = (
+        select(ItemUOM)
+        .where(
+            ItemUOM.item_id == int(item_id),
+            ItemUOM.is_purchase_default.is_(True),
+        )
+        .order_by(ItemUOM.is_base.desc(), ItemUOM.id.asc())
+        .limit(1)
+    )
+    return db.execute(stmt).scalars().first()
+
+
+def add_item_uom(db: Session, obj: ItemUOM) -> None:
+    db.add(obj)
+
+
+def create_item_uom(
+    db: Session,
+    *,
+    item_id: int,
+    uom: str,
+    ratio_to_base: int,
+    display_name: str | None = None,
+    net_weight_kg: float | None = None,
+    is_base: bool = False,
+    is_purchase_default: bool = False,
+    is_inbound_default: bool = False,
+    is_outbound_default: bool = False,
+) -> ItemUOM:
+    obj = ItemUOM(
+        item_id=int(item_id),
+        uom=str(uom),
+        ratio_to_base=int(ratio_to_base),
+        display_name=display_name,
+        net_weight_kg=net_weight_kg,
+        is_base=bool(is_base),
+        is_purchase_default=bool(is_purchase_default),
+        is_inbound_default=bool(is_inbound_default),
+        is_outbound_default=bool(is_outbound_default),
+    )
+    db.add(obj)
+    return obj
+
+
+def update_item_uom_fields(
+    obj: ItemUOM,
+    *,
+    uom: str | None = None,
+    ratio_to_base: int | None = None,
+    display_name: str | None = None,
+    net_weight_kg: float | None = None,
+    is_base: bool | None = None,
+    is_purchase_default: bool | None = None,
+    is_inbound_default: bool | None = None,
+    is_outbound_default: bool | None = None,
+) -> None:
+    if uom is not None:
+        obj.uom = str(uom)
+    if ratio_to_base is not None:
+        obj.ratio_to_base = int(ratio_to_base)
+
+    # 这些字段允许显式传 null
+    obj.display_name = display_name
+    obj.net_weight_kg = net_weight_kg
+
+    if is_base is not None:
+        obj.is_base = bool(is_base)
+    if is_purchase_default is not None:
+        obj.is_purchase_default = bool(is_purchase_default)
+    if is_inbound_default is not None:
+        obj.is_inbound_default = bool(is_inbound_default)
+    if is_outbound_default is not None:
+        obj.is_outbound_default = bool(is_outbound_default)
+
+
+def delete_item_uom(db: Session, obj: ItemUOM) -> None:
+    db.delete(obj)
+
+
+def refresh_item_uom(db: Session, obj: ItemUOM) -> None:
+    db.refresh(obj)
+
+
+def has_barcode_refs_for_item_uom(
+    db: Session,
+    *,
+    item_id: int,
+    item_uom_id: int,
+) -> bool:
+    stmt = (
+        select(ItemBarcode.id)
+        .where(
+            ItemBarcode.item_id == int(item_id),
+            ItemBarcode.item_uom_id == int(item_uom_id),
+        )
+        .limit(1)
+    )
+    return db.execute(stmt).scalar_one_or_none() is not None
+
+
+def has_po_line_refs_for_item_uom(db: Session, *, item_uom_id: int) -> bool:
+    stmt = (
+        select(PurchaseOrderLine.id)
+        .where(PurchaseOrderLine.purchase_uom_id_snapshot == int(item_uom_id))
+        .limit(1)
+    )
+    return db.execute(stmt).scalar_one_or_none() is not None
+
+
+def has_receipt_line_refs_for_item_uom(db: Session, *, item_uom_id: int) -> bool:
+    stmt = (
+        select(InboundReceiptLine.id)
+        .where(InboundReceiptLine.uom_id == int(item_uom_id))
+        .limit(1)
+    )
+    return db.execute(stmt).scalar_one_or_none() is not None
+
+
+def find_other_base_item_uom(
+    db: Session,
+    *,
+    item_id: int,
+    exclude_id: int,
+) -> ItemUOM | None:
+    stmt = (
+        select(ItemUOM)
+        .where(
+            ItemUOM.item_id == int(item_id),
+            ItemUOM.is_base.is_(True),
+            ItemUOM.id != int(exclude_id),
+        )
+        .limit(1)
+    )
+    return db.execute(stmt).scalars().first()
+
+
+def _barcode_rank(barcode: ItemBarcode) -> tuple[int, str, int]:
+    raw_ts = barcode.updated_at or barcode.created_at
+    ts = raw_ts.isoformat() if isinstance(raw_ts, datetime) else ""
+    return (
+        1 if bool(barcode.is_primary) else 0,
+        ts,
+        int(barcode.id),
+    )
+
+
+def _pick_barcode_by_uom(barcodes: list[ItemBarcode]) -> dict[int, ItemBarcode]:
+    out: dict[int, ItemBarcode] = {}
+
+    for barcode in barcodes:
+        current = out.get(int(barcode.item_uom_id))
+        if current is None or _barcode_rank(barcode) > _barcode_rank(current):
+            out[int(barcode.item_uom_id)] = barcode
+
+    return out
+
+
+def list_item_uom_row_sources_by_item_ids(
+    db: Session,
+    *,
+    item_ids: Sequence[int],
+    active_only: bool,
+) -> list[tuple[ItemUOM, Item, ItemBarcode | None]]:
+    ids = sorted({int(x) for x in item_ids if int(x) > 0})
+    if not ids:
+        return []
+
+    uom_stmt = (
+        select(ItemUOM, Item)
+        .join(Item, Item.id == ItemUOM.item_id)
+        .where(ItemUOM.item_id.in_(ids))
+        .order_by(
+            Item.sku.asc(),
+            Item.name.asc(),
+            ItemUOM.ratio_to_base.asc(),
+            ItemUOM.id.asc(),
+        )
+    )
+    uom_pairs = db.execute(uom_stmt).all()
+
+    barcode_stmt = select(ItemBarcode).where(ItemBarcode.item_id.in_(ids))
+    if active_only:
+        barcode_stmt = barcode_stmt.where(ItemBarcode.active.is_(True))
+
+    barcode_rows = db.execute(barcode_stmt).scalars().all()
+    barcode_by_uom = _pick_barcode_by_uom(list(barcode_rows))
+
+    return [
+        (uom, item, barcode_by_uom.get(int(uom.id)))
+        for uom, item in uom_pairs
+    ]
+
+
+def flush(db: Session) -> None:
+    db.flush()
+
+
+def commit(db: Session) -> None:
+    db.commit()
+
+
+def rollback(db: Session) -> None:
+    db.rollback()

--- a/app/pms/items/repos/item_write_repo.py
+++ b/app/pms/items/repos/item_write_repo.py
@@ -1,15 +1,94 @@
 # app/pms/items/repos/item_write_repo.py
 from __future__ import annotations
 
+from typing import Optional
+
+from sqlalchemy import String, cast, func, or_, select
 from sqlalchemy.orm import Session
 
 from app.models.item import Item
+from app.models.item_barcode import ItemBarcode
+
+
+def list_items(
+    db: Session,
+    *,
+    supplier_id: Optional[int] = None,
+    enabled: Optional[bool] = None,
+    q: Optional[str] = None,
+    limit: Optional[int] = None,
+) -> list[Item]:
+    stmt = select(Item)
+
+    if supplier_id is not None:
+        stmt = stmt.where(Item.supplier_id == supplier_id)
+
+    if enabled is not None:
+        stmt = stmt.where(Item.enabled == enabled)
+
+    q_raw = (q or "").strip()
+    if q_raw:
+        q_like = f"%{q_raw.lower()}%"
+
+        primary_barcode_expr = (
+            select(ItemBarcode.barcode)
+            .where(ItemBarcode.item_id == Item.id)
+            .where(ItemBarcode.is_primary.is_(True))
+            .where(ItemBarcode.active.is_(True))
+            .limit(1)
+            .scalar_subquery()
+        )
+
+        conds = [
+            func.lower(Item.sku).like(q_like),
+            func.lower(Item.name).like(q_like),
+            cast(Item.id, String).like(q_like),
+            func.lower(func.coalesce(primary_barcode_expr, "")).like(q_like),
+        ]
+
+        if q_raw.isdigit():
+            try:
+                conds.append(Item.id == int(q_raw))
+            except Exception:
+                pass
+
+        stmt = stmt.where(or_(*conds))
+
+    lim: Optional[int] = None
+    if limit is not None:
+        try:
+            x = int(limit)
+            if x > 0:
+                lim = x
+        except Exception:
+            lim = None
+    elif q_raw:
+        lim = 50
+
+    stmt = stmt.order_by(Item.id.asc())
+    if lim is not None:
+        stmt = stmt.limit(lim)
+
+    return db.execute(stmt).scalars().all()
+
+
+def get_item_by_id(db: Session, item_id: int) -> Item | None:
+    if not item_id or item_id <= 0:
+        return None
+    return db.get(Item, int(item_id))
 
 
 def get_item_by_id_for_update(db: Session, item_id: int) -> Item | None:
     if not item_id or item_id <= 0:
         return None
     return db.get(Item, int(item_id))
+
+
+def get_item_by_sku(db: Session, sku: str) -> Item | None:
+    s = (sku or "").strip()
+    if not s:
+        return None
+    return db.execute(select(Item).where(Item.sku == s)).scalar_one_or_none()
 
 
 def add_item(db: Session, item: Item) -> None:
@@ -22,3 +101,11 @@ def flush(db: Session) -> None:
 
 def refresh_item(db: Session, item: Item) -> None:
     db.refresh(item)
+
+
+def commit(db: Session) -> None:
+    db.commit()
+
+
+def rollback(db: Session) -> None:
+    db.rollback()

--- a/app/pms/items/routers/item_aggregate.py
+++ b/app/pms/items/routers/item_aggregate.py
@@ -1,0 +1,65 @@
+# app/pms/items/routers/item_aggregate.py
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.db.deps import get_db
+from app.pms.items.contracts.item_aggregate import ItemAggregateOut, ItemAggregatePayload
+from app.pms.items.services.item_owner_aggregate_service import ItemOwnerAggregateService
+
+router = APIRouter(prefix="/items", tags=["items-owner-aggregate"])
+
+
+def get_item_owner_aggregate_service(db: Session = Depends(get_db)) -> ItemOwnerAggregateService:
+    return ItemOwnerAggregateService(db)
+
+
+def _raise_from_value_error(e: ValueError) -> None:
+    detail = str(e)
+
+    if detail == "Item not found":
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail)
+
+    if (
+        detail == "SKU duplicate"
+        or "Barcode already exists" in detail
+        or "Current item_uom already bound to a barcode" in detail
+    ):
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=detail)
+
+    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
+
+
+@router.get("/{item_id}/aggregate", response_model=ItemAggregateOut)
+def get_item_aggregate(
+    item_id: int,
+    service: ItemOwnerAggregateService = Depends(get_item_owner_aggregate_service),
+):
+    try:
+        return service.get_aggregate(item_id=int(item_id))
+    except ValueError as e:
+        _raise_from_value_error(e)
+
+
+@router.post("/aggregate", response_model=ItemAggregateOut, status_code=status.HTTP_201_CREATED)
+def create_item_aggregate(
+    payload: ItemAggregatePayload,
+    service: ItemOwnerAggregateService = Depends(get_item_owner_aggregate_service),
+):
+    try:
+        return service.create_aggregate(payload=payload)
+    except ValueError as e:
+        _raise_from_value_error(e)
+
+
+@router.put("/{item_id}/aggregate", response_model=ItemAggregateOut)
+def replace_item_aggregate(
+    item_id: int,
+    payload: ItemAggregatePayload,
+    service: ItemOwnerAggregateService = Depends(get_item_owner_aggregate_service),
+):
+    try:
+        return service.replace_aggregate(item_id=int(item_id), payload=payload)
+    except ValueError as e:
+        _raise_from_value_error(e)

--- a/app/pms/items/routers/item_barcodes.py
+++ b/app/pms/items/routers/item_barcodes.py
@@ -6,13 +6,23 @@ from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 
 from app.db.deps import get_db
-from app.models.item import Item
-from app.models.item_barcode import ItemBarcode
-from app.models.item_uom import ItemUOM
+from app.pms.items.repos.item_barcode_repo import (
+    clear_primary_flags_for_item,
+    create_item_barcode,
+    delete_item_barcode,
+    get_item_barcode_by_code,
+    get_item_barcode_by_id,
+    get_item_uom_by_id,
+    has_barcode_bound_to_item_uom,
+    list_barcode_row_sources_for_item,
+    list_item_barcodes_by_item_id,
+    list_item_barcodes_by_item_ids,
+    refresh_item_barcode,
+    update_item_barcode_fields,
+)
 
 router = APIRouter(prefix="/item-barcodes", tags=["item-barcodes"])
 
@@ -22,8 +32,8 @@ def _normalize_symbology(v: str | None) -> str:
     return s or "CUSTOM"
 
 
-def _get_item_uom_or_404(db: Session, item_uom_id: int) -> ItemUOM:
-    obj = db.get(ItemUOM, int(item_uom_id))
+def _get_item_uom_or_404(db: Session, item_uom_id: int):
+    obj = get_item_uom_by_id(db, int(item_uom_id))
     if not obj:
         raise HTTPException(404, "ItemUom not found")
     return obj
@@ -36,15 +46,13 @@ def _ensure_item_uom_barcode_vacant(
     item_uom_id: int,
     exclude_barcode_id: int | None = None,
 ) -> None:
-    stmt = select(ItemBarcode.id).where(
-        ItemBarcode.item_id == int(item_id),
-        ItemBarcode.item_uom_id == int(item_uom_id),
+    exists = has_barcode_bound_to_item_uom(
+        db,
+        item_id=int(item_id),
+        item_uom_id=int(item_uom_id),
+        exclude_barcode_id=exclude_barcode_id,
     )
-    if exclude_barcode_id is not None:
-        stmt = stmt.where(ItemBarcode.id != int(exclude_barcode_id))
-
-    exists = db.execute(stmt.limit(1)).scalar_one_or_none()
-    if exists is not None:
+    if exists:
         raise HTTPException(409, "Current item_uom already bound to a barcode")
 
 
@@ -115,7 +123,7 @@ def create_barcode(
     if not code:
         raise HTTPException(400, "barcode is required")
 
-    exists = db.execute(select(ItemBarcode).where(ItemBarcode.barcode == code)).scalars().first()
+    exists = get_item_barcode_by_code(db, barcode=code)
     if exists:
         raise HTTPException(409, "Barcode already exists")
 
@@ -125,7 +133,8 @@ def create_barcode(
         item_uom_id=int(uom.id),
     )
 
-    obj = ItemBarcode(
+    obj = create_item_barcode(
+        db,
         item_id=int(uom.item_id),
         item_uom_id=int(uom.id),
         barcode=code,
@@ -133,9 +142,8 @@ def create_barcode(
         active=bool(body.active),
         is_primary=False,
     )
-    db.add(obj)
     db.commit()
-    db.refresh(obj)
+    refresh_item_barcode(db, obj)
     return obj
 
 
@@ -145,15 +153,11 @@ def list_barcodes_for_items(
     active_only: bool = Query(True, description="默认只返回 active=true"),
     db: Session = Depends(get_db),
 ):
-    ids = [int(x) for x in item_id if int(x) > 0]
-    if not ids:
-        return []
-
-    stmt = select(ItemBarcode).where(ItemBarcode.item_id.in_(ids))
-    if active_only:
-        stmt = stmt.where(ItemBarcode.active.is_(True))
-
-    rows = db.execute(stmt.order_by(ItemBarcode.item_id.asc(), ItemBarcode.id.asc())).scalars().all()
+    rows = list_item_barcodes_by_item_ids(
+        db,
+        item_ids=item_id,
+        active_only=bool(active_only),
+    )
     return list(rows)
 
 
@@ -171,27 +175,11 @@ def list_barcode_rows_for_item(
     if item_id <= 0:
         raise HTTPException(400, "invalid item_id")
 
-    stmt = (
-        select(ItemBarcode, ItemUOM, Item)
-        .join(
-            ItemUOM,
-            (ItemUOM.id == ItemBarcode.item_uom_id)
-            & (ItemUOM.item_id == ItemBarcode.item_id),
-        )
-        .join(Item, Item.id == ItemBarcode.item_id)
-        .where(ItemBarcode.item_id == item_id)
+    rows = list_barcode_row_sources_for_item(
+        db,
+        item_id=int(item_id),
+        active_only=bool(active_only),
     )
-
-    if active_only:
-        stmt = stmt.where(ItemBarcode.active.is_(True))
-
-    rows = db.execute(
-        stmt.order_by(
-            ItemUOM.ratio_to_base.asc(),
-            ItemUOM.id.asc(),
-            ItemBarcode.id.asc(),
-        )
-    ).all()
 
     return [
         ItemBarcodeCompositeRow(
@@ -220,29 +208,28 @@ def list_barcodes_for_item(item_id: int, db: Session = Depends(get_db)):
     if item_id <= 0:
         raise HTTPException(400, "invalid item_id")
 
-    rows = (
-        db.execute(
-            select(ItemBarcode).where(ItemBarcode.item_id == item_id).order_by(ItemBarcode.id.asc())
-        )
-        .scalars()
-        .all()
+    rows = list_item_barcodes_by_item_id(
+        db,
+        item_id=int(item_id),
+        active_only=None,
     )
     return list(rows)
 
 
 @router.post("/{id}/set-primary", response_model=ItemBarcodeOut)
 def set_primary(id: int, db: Session = Depends(get_db)):
-    bc = db.get(ItemBarcode, id)
+    bc = get_item_barcode_by_id(db, int(id))
     if not bc:
         raise HTTPException(404, "Barcode not found")
 
-    db.execute(
-        update(ItemBarcode).where(ItemBarcode.item_id == bc.item_id).values(is_primary=False)
+    clear_primary_flags_for_item(db, item_id=int(bc.item_id))
+    update_item_barcode_fields(
+        bc,
+        active=True,
+        is_primary=True,
     )
-    bc.active = True
-    bc.is_primary = True
     db.commit()
-    db.refresh(bc)
+    refresh_item_barcode(db, bc)
     return bc
 
 
@@ -254,10 +241,11 @@ def set_primary_compat(id: int, db: Session = Depends(get_db)):
 
 @router.patch("/{id}", response_model=ItemBarcodeOut)
 def update_barcode(id: int, body: ItemBarcodeUpdate, db: Session = Depends(get_db)):
-    bc = db.get(ItemBarcode, id)
+    bc = get_item_barcode_by_id(db, int(id))
     if not bc:
         raise HTTPException(404, "Barcode not found")
 
+    next_item_uom_id: int | None = None
     if body.item_uom_id is not None:
         target_uom = _get_item_uom_or_404(db, body.item_uom_id)
         if int(target_uom.item_id) != int(bc.item_id):
@@ -269,55 +257,56 @@ def update_barcode(id: int, body: ItemBarcodeUpdate, db: Session = Depends(get_d
             item_uom_id=int(target_uom.id),
             exclude_barcode_id=int(bc.id),
         )
-        bc.item_uom_id = int(target_uom.id)
+        next_item_uom_id = int(target_uom.id)
 
+    next_barcode: str | None = None
     if body.barcode is not None:
         code = body.barcode.strip()
         if not code:
             raise HTTPException(400, "barcode is required")
-        exists = (
-            db.execute(
-                select(ItemBarcode).where(
-                    ItemBarcode.barcode == code,
-                    ItemBarcode.id != bc.id,
-                )
-            )
-            .scalars()
-            .first()
+        exists = get_item_barcode_by_code(
+            db,
+            barcode=code,
+            exclude_id=int(bc.id),
         )
         if exists:
             raise HTTPException(409, "Barcode already exists")
-        bc.barcode = code
+        next_barcode = code
 
-    if body.symbology is not None:
-        bc.symbology = _normalize_symbology(body.symbology)
+    next_symbology = _normalize_symbology(body.symbology) if body.symbology is not None else None
 
     if body.active is not None:
         next_active = bool(body.active)
         if (body.is_primary is True) or (body.is_primary is None and bc.is_primary and not next_active):
             raise HTTPException(400, "primary barcode must be active")
-        bc.active = next_active
+    else:
+        next_active = None
 
     if body.is_primary is True:
-        db.execute(
-            update(ItemBarcode).where(ItemBarcode.item_id == bc.item_id).values(is_primary=False)
-        )
-        bc.active = True
-        bc.is_primary = True
-    elif body.is_primary is False:
-        bc.is_primary = False
+        clear_primary_flags_for_item(db, item_id=int(bc.item_id))
+        # 主条码必须 active
+        next_active = True
+
+    update_item_barcode_fields(
+        bc,
+        item_uom_id=next_item_uom_id,
+        barcode=next_barcode,
+        symbology=next_symbology,
+        active=next_active,
+        is_primary=body.is_primary,
+    )
 
     db.commit()
-    db.refresh(bc)
+    refresh_item_barcode(db, bc)
     return bc
 
 
 @router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_barcode(id: int, db: Session = Depends(get_db)):
-    bc = db.get(ItemBarcode, id)
+    bc = get_item_barcode_by_id(db, int(id))
     if not bc:
         raise HTTPException(404, "Barcode not found")
 
-    db.delete(bc)
+    delete_item_barcode(db, bc)
     db.commit()
     return None

--- a/app/pms/items/routers/item_uoms.py
+++ b/app/pms/items/routers/item_uoms.py
@@ -1,140 +1,192 @@
 # app/pms/items/routers/item_uoms.py
-from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
+from __future__ import annotations
 
-from app.db.session import get_session
-from app.models.inbound_receipt import InboundReceiptLine
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.db.deps import get_db
 from app.models.item_barcode import ItemBarcode
 from app.models.item_uom import ItemUOM
-from app.models.purchase_order_line import PurchaseOrderLine
 from app.pms.items.contracts.item_uom import (
+    ItemUomBarcodeRowOut,
     ItemUomCreate,
     ItemUomOut,
     ItemUomUpdate,
+)
+from app.pms.items.repos.item_uom_repo import (
+    create_item_uom,
+    delete_item_uom,
+    find_other_base_item_uom,
+    get_item_uom_by_id,
+    has_barcode_refs_for_item_uom,
+    has_po_line_refs_for_item_uom,
+    has_receipt_line_refs_for_item_uom,
+    list_item_uom_row_sources_by_item_ids,
+    list_item_uoms_by_item_id,
+    list_item_uoms_by_item_ids,
+    refresh_item_uom,
+    update_item_uom_fields,
 )
 
 router = APIRouter(prefix="/item-uoms", tags=["item-uoms"])
 
 
-async def _get_item_uom_or_404(session: AsyncSession, item_uom_id: int) -> ItemUOM:
-    obj = await session.get(ItemUOM, int(item_uom_id))
+def _get_item_uom_or_404(db: Session, item_uom_id: int) -> ItemUOM:
+    obj = get_item_uom_by_id(db, int(item_uom_id))
     if not obj:
         raise HTTPException(status_code=404, detail="ItemUom not found")
     return obj
 
 
-async def _has_barcode_refs(
-    session: AsyncSession,
+def _barcode_rank(barcode: ItemBarcode) -> tuple[int, str, int]:
+    raw_ts = barcode.updated_at or barcode.created_at
+    ts = raw_ts.isoformat() if isinstance(raw_ts, datetime) else ""
+    return (
+        1 if bool(barcode.is_primary) else 0,
+        ts,
+        int(barcode.id),
+    )
+
+
+def _build_item_uom_barcode_row(
     *,
-    item_id: int,
-    item_uom_id: int,
-) -> bool:
-    stmt = (
-        select(ItemBarcode.id)
-        .where(
-            ItemBarcode.item_id == int(item_id),
-            ItemBarcode.item_uom_id == int(item_uom_id),
-        )
-        .limit(1)
+    item,
+    uom: ItemUOM,
+    barcode: ItemBarcode | None,
+) -> ItemUomBarcodeRowOut:
+    row_updated_at = (
+        barcode.updated_at
+        if barcode is not None and barcode.updated_at is not None
+        else barcode.created_at
+        if barcode is not None and barcode.created_at is not None
+        else uom.updated_at
     )
-    return (await session.execute(stmt)).scalar_one_or_none() is not None
 
-
-async def _has_po_line_refs(session: AsyncSession, *, item_uom_id: int) -> bool:
-    stmt = (
-        select(PurchaseOrderLine.id)
-        .where(PurchaseOrderLine.purchase_uom_id_snapshot == int(item_uom_id))
-        .limit(1)
+    return ItemUomBarcodeRowOut(
+        sku=str(item.sku),
+        item_name=str(item.name),
+        item_id=int(item.id),
+        item_uom_id=int(uom.id),
+        uom=str(uom.uom),
+        display_name=str(uom.display_name).strip() if uom.display_name is not None else None,
+        ratio_to_base=int(uom.ratio_to_base),
+        net_weight_kg=float(uom.net_weight_kg) if uom.net_weight_kg is not None else None,
+        is_base=bool(uom.is_base),
+        is_purchase_default=bool(uom.is_purchase_default),
+        is_inbound_default=bool(uom.is_inbound_default),
+        is_outbound_default=bool(uom.is_outbound_default),
+        barcode_id=int(barcode.id) if barcode is not None else None,
+        barcode=str(barcode.barcode) if barcode is not None else None,
+        symbology=str(barcode.symbology) if barcode is not None else None,
+        is_primary=bool(barcode.is_primary) if barcode is not None else False,
+        active=bool(barcode.active) if barcode is not None else False,
+        updated_at=row_updated_at,
     )
-    return (await session.execute(stmt)).scalar_one_or_none() is not None
-
-
-async def _has_receipt_line_refs(session: AsyncSession, *, item_uom_id: int) -> bool:
-    stmt = (
-        select(InboundReceiptLine.id)
-        .where(InboundReceiptLine.uom_id == int(item_uom_id))
-        .limit(1)
-    )
-    return (await session.execute(stmt)).scalar_one_or_none() is not None
-
-
-async def _find_base_uom(
-    session: AsyncSession,
-    *,
-    item_id: int,
-    exclude_id: int,
-) -> ItemUOM | None:
-    stmt = (
-        select(ItemUOM)
-        .where(
-            ItemUOM.item_id == int(item_id),
-            ItemUOM.is_base.is_(True),
-            ItemUOM.id != int(exclude_id),
-        )
-        .limit(1)
-    )
-    return (await session.execute(stmt)).scalars().first()
 
 
 @router.post("", response_model=ItemUomOut)
-async def create_item_uom(
+def create_item_uom_route(
     payload: ItemUomCreate,
-    session: AsyncSession = Depends(get_session),
+    db: Session = Depends(get_db),
 ):
-    obj = ItemUOM(**payload.model_dump())
-    session.add(obj)
-    await session.commit()
-    await session.refresh(obj)
+    obj = create_item_uom(
+        db,
+        item_id=int(payload.item_id),
+        uom=str(payload.uom),
+        ratio_to_base=int(payload.ratio_to_base),
+        display_name=payload.display_name,
+        net_weight_kg=payload.net_weight_kg,
+        is_base=bool(payload.is_base),
+        is_purchase_default=bool(payload.is_purchase_default),
+        is_inbound_default=bool(payload.is_inbound_default),
+        is_outbound_default=bool(payload.is_outbound_default),
+    )
+    db.commit()
+    refresh_item_uom(db, obj)
     return obj
 
 
 @router.get("/item/{item_id}", response_model=list[ItemUomOut])
-async def list_item_uoms(
+def list_item_uoms(
     item_id: int,
-    session: AsyncSession = Depends(get_session),
+    db: Session = Depends(get_db),
 ):
-    q = await session.execute(select(ItemUOM).where(ItemUOM.item_id == item_id))
-    return q.scalars().all()
+    return list_item_uoms_by_item_id(db, int(item_id))
+
+
+@router.get("/item/{item_id}/rows", response_model=list[ItemUomBarcodeRowOut])
+def list_item_uom_rows_for_item(
+    item_id: int,
+    active_only: bool = Query(False, description="true 时仅挂 active=true 的条码；无条码包装仍返回"),
+    db: Session = Depends(get_db),
+):
+    if item_id <= 0:
+        raise HTTPException(status_code=400, detail="invalid item_id")
+
+    rows = list_item_uom_row_sources_by_item_ids(
+        db,
+        item_ids=[int(item_id)],
+        active_only=bool(active_only),
+    )
+    return [
+        _build_item_uom_barcode_row(item=item, uom=uom, barcode=barcode)
+        for uom, item, barcode in rows
+    ]
 
 
 @router.get("/by-items", response_model=list[ItemUomOut])
-async def list_item_uoms_for_items(
+def list_item_uoms_for_items(
     item_id: list[int] = Query(default=[]),
-    session: AsyncSession = Depends(get_session),
+    db: Session = Depends(get_db),
 ):
-    ids = [int(x) for x in item_id if int(x) > 0]
-    if not ids:
-        return []
+    return list_item_uoms_by_item_ids(db, item_id)
 
-    q = await session.execute(select(ItemUOM).where(ItemUOM.item_id.in_(ids)))
-    return q.scalars().all()
+
+@router.get("/rows/by-items", response_model=list[ItemUomBarcodeRowOut])
+def list_item_uom_rows_for_items(
+    item_id: list[int] = Query(default=[]),
+    active_only: bool = Query(False, description="true 时仅挂 active=true 的条码；无条码包装仍返回"),
+    db: Session = Depends(get_db),
+):
+    rows = list_item_uom_row_sources_by_item_ids(
+        db,
+        item_ids=item_id,
+        active_only=bool(active_only),
+    )
+    return [
+        _build_item_uom_barcode_row(item=item, uom=uom, barcode=barcode)
+        for uom, item, barcode in rows
+    ]
 
 
 @router.patch("/{id}", response_model=ItemUomOut)
-async def update_item_uom(
+def update_item_uom_route(
     id: int,
     payload: ItemUomUpdate,
-    session: AsyncSession = Depends(get_session),
+    db: Session = Depends(get_db),
 ):
-    obj = await session.get(ItemUOM, id)
+    obj = get_item_uom_by_id(db, int(id))
     if not obj:
         raise HTTPException(status_code=404, detail="ItemUom not found")
 
-    for k, v in payload.model_dump(exclude_unset=True).items():
-        setattr(obj, k, v)
+    update_item_uom_fields(
+        obj,
+        **payload.model_dump(exclude_unset=True),
+    )
 
-    await session.commit()
-    await session.refresh(obj)
+    db.commit()
+    refresh_item_uom(db, obj)
     return obj
 
 
 @router.delete("/{id}", status_code=status.HTTP_200_OK)
-async def delete_item_uom(
+def delete_item_uom_route(
     id: int,
-    session: AsyncSession = Depends(get_session),
+    db: Session = Depends(get_db),
 ):
-    obj = await _get_item_uom_or_404(session, id)
+    obj = _get_item_uom_or_404(db, int(id))
 
     if bool(obj.is_base):
         raise HTTPException(
@@ -142,8 +194,8 @@ async def delete_item_uom(
             detail="基础包装不能删除",
         )
 
-    if await _has_barcode_refs(
-        session,
+    if has_barcode_refs_for_item_uom(
+        db,
         item_id=int(obj.item_id),
         item_uom_id=int(obj.id),
     ):
@@ -152,13 +204,13 @@ async def delete_item_uom(
             detail="当前包装已绑定条码，不能删除；请先修改条码绑定",
         )
 
-    if await _has_po_line_refs(session, item_uom_id=int(obj.id)):
+    if has_po_line_refs_for_item_uom(db, item_uom_id=int(obj.id)):
         raise HTTPException(
             status_code=409,
             detail="当前包装已被采购单引用，不能删除",
         )
 
-    if await _has_receipt_line_refs(session, item_uom_id=int(obj.id)):
+    if has_receipt_line_refs_for_item_uom(db, item_uom_id=int(obj.id)):
         raise HTTPException(
             status_code=409,
             detail="当前包装已被收货记录引用，不能删除",
@@ -169,8 +221,8 @@ async def delete_item_uom(
     )
 
     if need_fallback_default:
-        base = await _find_base_uom(
-            session,
+        base = find_other_base_item_uom(
+            db,
             item_id=int(obj.item_id),
             exclude_id=int(obj.id),
         )
@@ -187,6 +239,6 @@ async def delete_item_uom(
         if obj.is_outbound_default:
             base.is_outbound_default = True
 
-    await session.delete(obj)
-    await session.commit()
+    delete_item_uom(db, obj)
+    db.commit()
     return {"ok": True}

--- a/app/pms/items/services/item_barcode_service.py
+++ b/app/pms/items/services/item_barcode_service.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 
 from typing import List
 
-from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.models.item_barcode import ItemBarcode
-from app.models.item_uom import ItemUOM
+from app.pms.items.repos.item_barcode_repo import (
+    create_item_barcode,
+    get_item_barcode_by_code,
+    load_primary_barcodes_map as repo_load_primary_barcodes_map,
+)
+from app.pms.items.repos.item_uom_repo import get_base_item_uom
 
 
 class ItemBarcodeService:
@@ -18,6 +21,10 @@ class ItemBarcodeService:
     - 输出层投影：primary_barcode（以及兼容 alias barcode）
     - 写入层：创建 item 时可选写入一条主条码；后续更新主条码必须走 /item-barcodes
     - 条码绑定终态：条码必须绑定到 item_uom_id；主条码默认绑定到 base item_uom
+
+    分层约束：
+    - repo 负责查询/创建/唯一性相关持久化动作
+    - service 只保留业务口径与错误语义，不直接写 select/ORM 细节
     """
 
     def __init__(self, db: Session) -> None:
@@ -29,46 +36,20 @@ class ItemBarcodeService:
         return s or "CUSTOM"
 
     def _require_base_item_uom_id(self, *, item_id: int) -> int:
-        row = self.db.execute(
-            select(ItemUOM.id)
-            .where(ItemUOM.item_id == int(item_id))
-            .where(ItemUOM.is_base.is_(True))
-            .limit(1)
-        ).scalar_one_or_none()
-        if row is None:
+        base = get_base_item_uom(self.db, int(item_id))
+        if base is None:
             raise ValueError(f"base item_uom missing for item_id={int(item_id)}")
-        return int(row)
+        return int(base.id)
 
     def load_primary_barcodes_map(self, *, item_ids: List[int]) -> dict[int, str]:
-        ids = sorted({int(x) for x in item_ids if x is not None})
-        if not ids:
-            return {}
-
-        rows = (
-            self.db.execute(
-                select(ItemBarcode.item_id, ItemBarcode.barcode)
-                .where(ItemBarcode.item_id.in_(ids))
-                .where(ItemBarcode.is_primary.is_(True))
-                .where(ItemBarcode.active.is_(True))
-            )
-            .all()
-        )
-        m: dict[int, str] = {}
-        for item_id, barcode in rows:
-            if item_id is None or barcode is None:
-                continue
-            m[int(item_id)] = str(barcode)
-        return m
+        return repo_load_primary_barcodes_map(self.db, item_ids=item_ids)
 
     def ensure_unique_or_raise(self, *, barcode: str) -> None:
         code = (barcode or "").strip()
         if not code:
             raise ValueError("barcode is required")
-        existing = (
-            self.db.execute(select(ItemBarcode).where(ItemBarcode.barcode == code))
-            .scalars()
-            .first()
-        )
+
+        existing = get_item_barcode_by_code(self.db, barcode=code)
         if existing is not None:
             raise ValueError("barcode duplicate: already bound to an item")
 
@@ -82,11 +63,12 @@ class ItemBarcodeService:
         code = (barcode or "").strip()
         if not code:
             return
-        self.ensure_unique_or_raise(barcode=code)
 
+        self.ensure_unique_or_raise(barcode=code)
         base_uom_id = self._require_base_item_uom_id(item_id=int(item_id))
 
-        b = ItemBarcode(
+        create_item_barcode(
+            self.db,
             item_id=int(item_id),
             item_uom_id=int(base_uom_id),
             barcode=code,
@@ -94,4 +76,3 @@ class ItemBarcodeService:
             active=True,
             is_primary=True,
         )
-        self.db.add(b)

--- a/app/pms/items/services/item_maintenance_service.py
+++ b/app/pms/items/services/item_maintenance_service.py
@@ -4,15 +4,47 @@ from __future__ import annotations
 import os
 from typing import Optional
 
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.models.item import Item
+from app.models.item_uom import ItemUOM
 from app.pms.items.services.item_barcode_service import ItemBarcodeService
 
 
 def _allow_create_item_by_id() -> bool:
     return os.getenv("WMS_ALLOW_CREATE_ITEM_BY_ID", "").strip() == "1"
+
+
+def _ensure_min_base_item_uom(db: Session, *, item_id: int) -> None:
+    """
+    maintenance 路径也补最小 base item_uom，避免：
+    - create_item_by_id 后条码写入失败
+    - 生成出一个不满足终态结构合同的 item
+    """
+    existing = db.execute(
+        select(ItemUOM.id)
+        .where(ItemUOM.item_id == int(item_id))
+        .where(ItemUOM.is_base.is_(True))
+        .limit(1)
+    ).scalar_one_or_none()
+    if existing is not None:
+        return
+
+    db.add(
+        ItemUOM(
+            item_id=int(item_id),
+            uom="PCS",
+            ratio_to_base=1,
+            display_name="PCS",
+            net_weight_kg=None,
+            is_base=True,
+            is_purchase_default=True,
+            is_inbound_default=True,
+            is_outbound_default=True,
+        )
+    )
 
 
 class ItemMaintenanceService:
@@ -31,6 +63,9 @@ class ItemMaintenanceService:
     Phase M-6：
     - 此通道不再接收/写入 items.weight_kg
     - 基础包装净重请改走 item_uoms（base uom）
+
+    Items page cutover：
+    - maintenance 创建 item 时也自动补最小 base item_uom（PCS × 1）
     """
 
     def __init__(self, db: Session) -> None:
@@ -103,6 +138,8 @@ class ItemMaintenanceService:
 
         self.db.add(obj)
         try:
+            self.db.flush()
+            _ensure_min_base_item_uom(self.db, item_id=int(obj.id))
             self.db.flush()
 
             code = (barcode or "").strip()

--- a/app/pms/items/services/item_owner_aggregate_service.py
+++ b/app/pms/items/services/item_owner_aggregate_service.py
@@ -1,0 +1,438 @@
+# app/pms/items/services/item_owner_aggregate_service.py
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models.item import Item
+from app.pms.items.contracts.item_aggregate import (
+    AggregateBarcodeInput,
+    AggregateItemInput,
+    AggregateUomInput,
+    ItemAggregateOut,
+    ItemAggregatePayload,
+)
+from app.pms.items.repos.item_barcode_repo import (
+    clear_primary_flags_for_item,
+    create_item_barcode,
+    delete_item_barcode,
+    get_item_barcode_by_code,
+    get_item_barcode_by_id,
+    has_barcode_bound_to_item_uom,
+    list_item_barcodes_by_item_id,
+    refresh_item_barcode,
+    update_item_barcode_fields,
+)
+from app.pms.items.repos.item_uom_repo import (
+    create_item_uom,
+    delete_item_uom,
+    has_barcode_refs_for_item_uom,
+    has_po_line_refs_for_item_uom,
+    has_receipt_line_refs_for_item_uom,
+    list_item_uoms_by_item_id,
+    refresh_item_uom,
+    update_item_uom_fields,
+)
+from app.pms.items.repos.item_write_repo import (
+    add_item,
+    commit as repo_commit,
+    flush as repo_flush,
+    get_item_by_id,
+    get_item_by_id_for_update,
+    refresh_item,
+    rollback as repo_rollback,
+)
+from app.pms.items.services.item_presenter import ItemPresenter
+from app.pms.items.services.item_sku import next_sku
+
+
+_ALLOWED_LOT_SOURCE_POLICIES = {"INTERNAL_ONLY", "SUPPLIER_ONLY"}
+_ALLOWED_EXPIRY_POLICIES = {"NONE", "REQUIRED"}
+_ALLOWED_SHELF_LIFE_UNITS = {"DAY", "WEEK", "MONTH", "YEAR"}
+
+
+def _norm_policy_str(v: Optional[str]) -> Optional[str]:
+    if v is None:
+        return None
+    s = str(v).strip().upper()
+    return s if s else None
+
+
+def _norm_text_or_none(v: Optional[str]) -> Optional[str]:
+    if v is None:
+        return None
+    s = str(v).strip()
+    return s or None
+
+
+def _norm_shelf_life_unit(v: Optional[str]) -> Optional[str]:
+    if v is None:
+        return None
+    s = str(v).strip().upper()
+    if not s:
+        return None
+    if s not in _ALLOWED_SHELF_LIFE_UNITS:
+        raise ValueError("invalid shelf_life_unit")
+    return s
+
+
+def _resolve_item_fields(item_in: AggregateItemInput) -> dict[str, object]:
+    name_val = _norm_text_or_none(item_in.name)
+    if not name_val:
+        raise ValueError("name is required")
+
+    spec_val = _norm_text_or_none(item_in.spec)
+    brand_val = _norm_text_or_none(item_in.brand)
+    category_val = _norm_text_or_none(item_in.category)
+
+    lot_policy = _norm_policy_str(item_in.lot_source_policy) or "SUPPLIER_ONLY"
+    if lot_policy not in _ALLOWED_LOT_SOURCE_POLICIES:
+        raise ValueError("invalid lot_source_policy")
+
+    exp_policy = _norm_policy_str(item_in.expiry_policy) or "NONE"
+    if exp_policy not in _ALLOWED_EXPIRY_POLICIES:
+        raise ValueError("invalid expiry_policy")
+
+    deriv_allowed = True if item_in.derivation_allowed is None else bool(item_in.derivation_allowed)
+    uom_gov = False if item_in.uom_governance_enabled is None else bool(item_in.uom_governance_enabled)
+
+    if item_in.shelf_life_value is not None and int(item_in.shelf_life_value) <= 0:
+        raise ValueError("shelf_life_value must be > 0")
+
+    sl_unit = _norm_shelf_life_unit(item_in.shelf_life_unit)
+
+    if exp_policy != "REQUIRED":
+        sl_value = None
+        sl_unit = None
+    else:
+        sl_value = int(item_in.shelf_life_value) if item_in.shelf_life_value is not None else None
+        if (sl_value is None) != (sl_unit is None):
+            raise ValueError("shelf_life_value and shelf_life_unit must be both set or both null")
+
+    return {
+        "name": name_val,
+        "spec": spec_val,
+        "brand": brand_val,
+        "category": category_val,
+        "enabled": bool(item_in.enabled),
+        "supplier_id": item_in.supplier_id,
+        "lot_source_policy": lot_policy,
+        "expiry_policy": exp_policy,
+        "derivation_allowed": deriv_allowed,
+        "uom_governance_enabled": uom_gov,
+        "shelf_life_value": sl_value,
+        "shelf_life_unit": sl_unit,
+    }
+
+
+class ItemOwnerAggregateService:
+    """
+    商品 owner 聚合写服务：
+
+    - 一次处理 item + item_uoms + item_barcodes
+    - 事务边界在 service
+    - 前端不再自己 orchestrate 多接口写入
+
+    终态语义：
+    - create / replace 都要求提交完整商品聚合
+    - POST /items/aggregate：完整创建
+    - PUT /items/{id}/aggregate：严格 full replace
+    """
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+        self._present = ItemPresenter(db)
+
+    def get_aggregate(self, *, item_id: int) -> ItemAggregateOut:
+        item = get_item_by_id(self.db, int(item_id))
+        if item is None:
+            raise ValueError("Item not found")
+
+        presented = self._present.present_item(item=item)
+        assert presented is not None
+
+        uoms = list_item_uoms_by_item_id(self.db, int(item_id))
+        barcodes = list_item_barcodes_by_item_id(self.db, item_id=int(item_id), active_only=None)
+        return ItemAggregateOut(item=presented, uoms=uoms, barcodes=barcodes)
+
+    def create_aggregate(self, *, payload: ItemAggregatePayload) -> ItemAggregateOut:
+        item_fields = _resolve_item_fields(payload.item)
+
+        sku_val = next_sku(self.db)
+        obj = Item(
+            sku=sku_val,
+            name=str(item_fields["name"]),
+            spec=item_fields["spec"],
+            enabled=bool(item_fields["enabled"]),
+            supplier_id=item_fields["supplier_id"],
+            brand=item_fields["brand"],
+            category=item_fields["category"],
+            lot_source_policy=str(item_fields["lot_source_policy"]),
+            expiry_policy=str(item_fields["expiry_policy"]),
+            derivation_allowed=bool(item_fields["derivation_allowed"]),
+            uom_governance_enabled=bool(item_fields["uom_governance_enabled"]),
+            shelf_life_value=item_fields["shelf_life_value"],
+            shelf_life_unit=item_fields["shelf_life_unit"],
+        )
+
+        add_item(self.db, obj)
+
+        try:
+            repo_flush(self.db)
+
+            uom_key_to_id, _keep_uom_ids = self._upsert_uoms(
+                item_id=int(obj.id),
+                payload_uoms=list(payload.uoms),
+                existing_uoms=[],
+            )
+
+            self._sync_barcodes(
+                item_id=int(obj.id),
+                payload_barcodes=list(payload.barcodes),
+                uom_key_to_id=uom_key_to_id,
+                existing_barcodes=[],
+            )
+
+            repo_commit(self.db)
+        except IntegrityError as e:
+            repo_rollback(self.db)
+            raw = str(getattr(e, "orig", e)).lower()
+            if "items_sku_key" in raw or ("unique" in raw and "sku" in raw):
+                raise ValueError("SKU duplicate") from e
+            raise ValueError(f"DB integrity error: {getattr(e, 'orig', e)}") from e
+        except ValueError:
+            repo_rollback(self.db)
+            raise
+
+        refresh_item(self.db, obj)
+        return self.get_aggregate(item_id=int(obj.id))
+
+    def replace_aggregate(
+        self,
+        *,
+        item_id: int,
+        payload: ItemAggregatePayload,
+    ) -> ItemAggregateOut:
+        obj = get_item_by_id_for_update(self.db, int(item_id))
+        if obj is None:
+            raise ValueError("Item not found")
+
+        item_fields = _resolve_item_fields(payload.item)
+
+        obj.name = str(item_fields["name"])
+        obj.spec = item_fields["spec"]
+        obj.enabled = bool(item_fields["enabled"])
+        obj.supplier_id = item_fields["supplier_id"]
+        obj.brand = item_fields["brand"]
+        obj.category = item_fields["category"]
+        obj.lot_source_policy = str(item_fields["lot_source_policy"])
+        obj.expiry_policy = str(item_fields["expiry_policy"])
+        obj.derivation_allowed = bool(item_fields["derivation_allowed"])
+        obj.uom_governance_enabled = bool(item_fields["uom_governance_enabled"])
+        obj.shelf_life_value = item_fields["shelf_life_value"]
+        obj.shelf_life_unit = item_fields["shelf_life_unit"]
+
+        existing_uoms = list_item_uoms_by_item_id(self.db, int(item_id))
+        existing_barcodes = list_item_barcodes_by_item_id(self.db, item_id=int(item_id), active_only=None)
+
+        try:
+            uom_key_to_id, keep_uom_ids = self._upsert_uoms(
+                item_id=int(item_id),
+                payload_uoms=list(payload.uoms),
+                existing_uoms=existing_uoms,
+            )
+
+            self._sync_barcodes(
+                item_id=int(item_id),
+                payload_barcodes=list(payload.barcodes),
+                uom_key_to_id=uom_key_to_id,
+                existing_barcodes=existing_barcodes,
+            )
+
+            self._cleanup_obsolete_uoms(
+                existing_uoms=existing_uoms,
+                keep_uom_ids=keep_uom_ids,
+            )
+
+            repo_commit(self.db)
+        except IntegrityError as e:
+            repo_rollback(self.db)
+            raise ValueError(f"DB integrity error: {getattr(e, 'orig', e)}") from e
+        except ValueError:
+            repo_rollback(self.db)
+            raise
+
+        refresh_item(self.db, obj)
+        return self.get_aggregate(item_id=int(item_id))
+
+    def _upsert_uoms(
+        self,
+        *,
+        item_id: int,
+        payload_uoms: list[AggregateUomInput],
+        existing_uoms: list,
+    ) -> tuple[dict[str, int], set[int]]:
+        existing_by_id = {int(x.id): x for x in existing_uoms}
+        keep_ids: set[int] = set()
+
+        # 先清默认位，避免 partial unique index 冲突
+        for u in existing_uoms:
+            u.is_base = False
+            u.is_purchase_default = False
+            u.is_inbound_default = False
+            u.is_outbound_default = False
+
+        repo_flush(self.db)
+
+        uom_key_to_id: dict[str, int] = {}
+
+        for row in payload_uoms:
+            if row.id is not None:
+                obj = existing_by_id.get(int(row.id))
+                if obj is None:
+                    raise ValueError(f"ItemUom not found: id={int(row.id)}")
+                keep_ids.add(int(obj.id))
+                update_item_uom_fields(
+                    obj,
+                    uom=str(row.uom),
+                    ratio_to_base=int(row.ratio_to_base),
+                    display_name=row.display_name,
+                    net_weight_kg=row.net_weight_kg,
+                    is_base=bool(row.is_base),
+                    is_purchase_default=bool(row.is_purchase_default),
+                    is_inbound_default=bool(row.is_inbound_default),
+                    is_outbound_default=bool(row.is_outbound_default),
+                )
+            else:
+                obj = create_item_uom(
+                    self.db,
+                    item_id=int(item_id),
+                    uom=str(row.uom),
+                    ratio_to_base=int(row.ratio_to_base),
+                    display_name=row.display_name,
+                    net_weight_kg=row.net_weight_kg,
+                    is_base=bool(row.is_base),
+                    is_purchase_default=bool(row.is_purchase_default),
+                    is_inbound_default=bool(row.is_inbound_default),
+                    is_outbound_default=bool(row.is_outbound_default),
+                )
+
+            repo_flush(self.db)
+            refresh_item_uom(self.db, obj)
+            keep_ids.add(int(obj.id))
+            uom_key_to_id[str(row.uom_key)] = int(obj.id)
+
+        return uom_key_to_id, keep_ids
+
+    def _sync_barcodes(
+        self,
+        *,
+        item_id: int,
+        payload_barcodes: list[AggregateBarcodeInput],
+        uom_key_to_id: dict[str, int],
+        existing_barcodes: list,
+    ) -> None:
+        existing_by_id = {int(x.id): x for x in existing_barcodes}
+
+        incoming_ids = {int(x.id) for x in payload_barcodes if x.id is not None}
+        for old in existing_barcodes:
+            if int(old.id) not in incoming_ids:
+                delete_item_barcode(self.db, old)
+
+        repo_flush(self.db)
+
+        has_primary = any(bool(x.is_primary) for x in payload_barcodes)
+        if has_primary:
+            clear_primary_flags_for_item(self.db, item_id=int(item_id))
+            repo_flush(self.db)
+
+        for row in payload_barcodes:
+            target_uom_id = uom_key_to_id.get(str(row.bind_uom_key))
+            if target_uom_id is None:
+                raise ValueError(f"barcode 绑定失败：uom_key 不存在 {row.bind_uom_key}")
+
+            if row.id is not None:
+                obj = existing_by_id.get(int(row.id))
+                if obj is None:
+                    obj = get_item_barcode_by_id(self.db, int(row.id))
+                if obj is None:
+                    raise ValueError(f"Barcode not found: id={int(row.id)}")
+
+                existing_same_code = get_item_barcode_by_code(
+                    self.db,
+                    barcode=str(row.barcode),
+                    exclude_id=int(obj.id),
+                )
+                if existing_same_code is not None:
+                    raise ValueError("Barcode already exists")
+
+                if target_uom_id != int(obj.item_uom_id):
+                    if has_barcode_bound_to_item_uom(
+                        self.db,
+                        item_id=int(item_id),
+                        item_uom_id=int(target_uom_id),
+                        exclude_barcode_id=int(obj.id),
+                    ):
+                        raise ValueError("Current item_uom already bound to a barcode")
+
+                update_item_barcode_fields(
+                    obj,
+                    item_uom_id=int(target_uom_id),
+                    barcode=str(row.barcode),
+                    symbology=str(row.symbology),
+                    active=bool(row.active),
+                    is_primary=bool(row.is_primary),
+                )
+            else:
+                existing_same_code = get_item_barcode_by_code(
+                    self.db,
+                    barcode=str(row.barcode),
+                )
+                if existing_same_code is not None:
+                    raise ValueError("Barcode already exists")
+
+                if has_barcode_bound_to_item_uom(
+                    self.db,
+                    item_id=int(item_id),
+                    item_uom_id=int(target_uom_id),
+                ):
+                    raise ValueError("Current item_uom already bound to a barcode")
+
+                obj = create_item_barcode(
+                    self.db,
+                    item_id=int(item_id),
+                    item_uom_id=int(target_uom_id),
+                    barcode=str(row.barcode),
+                    symbology=str(row.symbology),
+                    active=bool(row.active),
+                    is_primary=bool(row.is_primary),
+                )
+                repo_flush(self.db)
+                refresh_item_barcode(self.db, obj)
+
+    def _cleanup_obsolete_uoms(
+        self,
+        *,
+        existing_uoms: list,
+        keep_uom_ids: set[int],
+    ) -> None:
+        for old in existing_uoms:
+            if int(old.id) in keep_uom_ids:
+                continue
+
+            if has_barcode_refs_for_item_uom(
+                self.db,
+                item_id=int(old.item_id),
+                item_uom_id=int(old.id),
+            ):
+                raise ValueError("当前包装已绑定条码，不能删除；请先修改条码绑定")
+
+            if has_po_line_refs_for_item_uom(self.db, item_uom_id=int(old.id)):
+                raise ValueError("当前包装已被采购单引用，不能删除")
+
+            if has_receipt_line_refs_for_item_uom(self.db, item_uom_id=int(old.id)):
+                raise ValueError("当前包装已被收货记录引用，不能删除")
+
+            delete_item_uom(self.db, old)

--- a/app/pms/items/services/item_write_service.py
+++ b/app/pms/items/services/item_write_service.py
@@ -7,11 +7,14 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.models.item import Item
+from app.pms.items.repos.item_uom_repo import create_item_uom
 from app.pms.items.repos.item_write_repo import (
     add_item,
-    flush,
+    commit as repo_commit,
+    flush as repo_flush,
     get_item_by_id_for_update,
     refresh_item,
+    rollback as repo_rollback,
 )
 from app.pms.items.services.item_sku import next_sku
 
@@ -102,18 +105,21 @@ class ItemWriteService:
     """
     写入层（Write）：
 
-    - 负责 Item 的 create/update + 事务边界
+    - 负责 Item 本体（public.items）的 create/update + 事务边界
     - 负责字段归一、默认值、补丁语义
     - 不负责 HTTP 兼容字段
     - 不负责输出投影
+    - 不负责 item_uoms / item_barcodes 的聚合编排
     - 持久化动作交给 repos/item_write_repo.py
 
-    Phase M-5：
-    - items.uom 已物理移除；单位治理完全由 item_uoms 结构层承载
+    终态收口：
+    - items.uom / items.case_* / items.weight_kg 已移除
+    - 包装、单位、净重、条码属于商品聚合的其他真相源
+    - owner 聚合写接口应在更高一层 orchestrate item + item_uoms + item_barcodes
 
-    Phase M-6：
-    - items.weight_kg 不再作为写入真相源
-    - 基础包装净重请通过 item_uoms（base uom）维护
+    兼容保留：
+    - 主合同 `POST /items` 创建 item 时，仍自动补最小 base item_uom
+    - 这是当前 items 主合同与既有测试/调用链约定的一部分
     """
 
     def __init__(self, db: Session) -> None:
@@ -190,10 +196,26 @@ class ItemWriteService:
 
         add_item(self.db, obj)
         try:
-            flush(self.db)
-            self.db.commit()
+            repo_flush(self.db)
+
+            # 维持当前主合同语义：创建 item 时自动补最小 base item_uom
+            create_item_uom(
+                self.db,
+                item_id=int(obj.id),
+                uom="PCS",
+                ratio_to_base=1,
+                display_name="PCS",
+                net_weight_kg=None,
+                is_base=True,
+                is_purchase_default=True,
+                is_inbound_default=True,
+                is_outbound_default=True,
+            )
+
+            repo_flush(self.db)
+            repo_commit(self.db)
         except IntegrityError as e:
-            self.db.rollback()
+            repo_rollback(self.db)
             raw = str(getattr(e, "orig", e)).lower()
             if "items_sku_key" in raw or ("unique" in raw and "sku" in raw):
                 raise ValueError("SKU duplicate") from e
@@ -318,9 +340,9 @@ class ItemWriteService:
             return obj
 
         try:
-            self.db.commit()
+            repo_commit(self.db)
         except IntegrityError as e:
-            self.db.rollback()
+            repo_rollback(self.db)
             raise ValueError(f"DB integrity error: {getattr(e, 'orig', e)}") from e
 
         refresh_item(self.db, obj)

--- a/app/pms/suppliers/routers/supplier_contacts.py
+++ b/app/pms/suppliers/routers/supplier_contacts.py
@@ -28,7 +28,7 @@ from app.pms.suppliers.repos.supplier_contact_repo import (
 from app.pms.suppliers.repos.supplier_contact_repo import (
     save_contact as repo_save_contact,
 )
-from app.user.services.user_service import AuthorizationError, UserService
+from app.pms.suppliers.helpers.suppliers import check_perm
 
 router = APIRouter(tags=["supplier-contacts"])
 
@@ -51,14 +51,6 @@ class SupplierContactUpdateIn(BaseModel):
     role: Optional[str] = Field(None, max_length=32)
     is_primary: Optional[bool] = None
     active: Optional[bool] = None
-
-
-def _check_perm(db: Session, user) -> None:
-    svc = UserService(db)
-    try:
-        svc.check_permission(user, ["config.store.write"])
-    except AuthorizationError:
-        raise HTTPException(status_code=403, detail="Not authorized")
 
 
 def _to_out(c) -> SupplierContactOut:
@@ -94,7 +86,7 @@ def create_contact(
     db: Session = Depends(get_db),
     user=Depends(get_current_user),
 ):
-    _check_perm(db, user)
+    check_perm(db, user, ["page.pms.write"])
 
     supplier = repo_get_supplier(db, supplier_id)
     if not supplier:
@@ -137,7 +129,7 @@ def update_contact(
     db: Session = Depends(get_db),
     user=Depends(get_current_user),
 ):
-    _check_perm(db, user)
+    check_perm(db, user, ["page.pms.write"])
 
     contact = repo_get_contact(db, contact_id)
     if not contact:
@@ -186,7 +178,7 @@ def delete_contact(
     db: Session = Depends(get_db),
     user=Depends(get_current_user),
 ):
-    _check_perm(db, user)
+    check_perm(db, user, ["page.pms.write"])
 
     contact = repo_get_contact(db, contact_id)
     if not contact:

--- a/app/pms/suppliers/routers/suppliers_routes.py
+++ b/app/pms/suppliers/routers/suppliers_routes.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
 from pydantic import BaseModel
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.user.deps.auth import get_current_user
@@ -50,6 +51,39 @@ def _to_supplier_basic_out(supplier: Supplier) -> SupplierBasicOut:
     )
 
 
+def _normalize_name(value: str) -> str:
+    v = (value or "").strip()
+    if not v:
+        raise HTTPException(status_code=422, detail="name is required")
+    return v
+
+
+def _normalize_code(value: str) -> str:
+    v = (value or "").strip().upper()
+    if not v:
+        raise HTTPException(status_code=422, detail="code is required")
+    return v
+
+
+def _normalize_website(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    v = value.strip()
+    return v or None
+
+
+def _raise_supplier_integrity(db: Session, exc: IntegrityError) -> None:
+    db.rollback()
+    raw = str(getattr(exc, "orig", exc)).lower()
+
+    if "uq_suppliers_code" in raw or ("unique" in raw and "code" in raw):
+        raise HTTPException(status_code=409, detail="供应商编码已存在")
+    if "uq_suppliers_name" in raw or ("unique" in raw and "name" in raw):
+        raise HTTPException(status_code=409, detail="供应商名称已存在")
+
+    raise HTTPException(status_code=400, detail=f"DB integrity error: {getattr(exc, 'orig', exc)}")
+
+
 def register(router: APIRouter) -> None:
     @router.get("/suppliers", response_model=List[SupplierOut])
     def list_suppliers(
@@ -60,7 +94,7 @@ def register(router: APIRouter) -> None:
         db: Session = Depends(get_db),
         user=Depends(get_current_user),
     ):
-        check_perm(db, user, ["config.store.read"])
+        check_perm(db, user, ["page.pms.read"])
 
         suppliers = repo_list_suppliers(db, active=active, q=q)
         return [_to_supplier_out(s) for s in suppliers]
@@ -74,7 +108,7 @@ def register(router: APIRouter) -> None:
         db: Session = Depends(get_db),
         user=Depends(get_current_user),
     ):
-        check_perm(db, user, ["purchase.manage"])
+        check_perm(db, user, ["page.pms.read"])
 
         rows = repo_list_suppliers_basic(db, active=active, q=q)
         return [_to_supplier_basic_out(s) for s in rows]
@@ -85,24 +119,22 @@ def register(router: APIRouter) -> None:
         db: Session = Depends(get_db),
         user=Depends(get_current_user),
     ):
-        check_perm(db, user, ["config.store.write"])
+        check_perm(db, user, ["page.pms.write"])
 
-        name = payload.name.strip()
-        code = payload.code.strip()
-        if not name:
-            raise HTTPException(status_code=422, detail="name is required")
-        if not code:
-            raise HTTPException(status_code=422, detail="code is required")
+        name = _normalize_name(payload.name)
+        code = _normalize_code(payload.code)
+        website = _normalize_website(payload.website)
 
-        website = payload.website.strip() if payload.website and payload.website.strip() else None
-
-        supplier = repo_create_supplier(
-            db,
-            name=name,
-            code=code,
-            website=website,
-            active=bool(payload.active),
-        )
+        try:
+            supplier = repo_create_supplier(
+                db,
+                name=name,
+                code=code,
+                website=website,
+                active=bool(payload.active),
+            )
+        except IntegrityError as exc:
+            _raise_supplier_integrity(db, exc)
 
         return SupplierOut(
             id=supplier.id,
@@ -120,30 +152,27 @@ def register(router: APIRouter) -> None:
         db: Session = Depends(get_db),
         user=Depends(get_current_user),
     ):
-        check_perm(db, user, ["config.store.write"])
+        check_perm(db, user, ["page.pms.write"])
 
         supplier = repo_get_supplier_with_contacts(db, supplier_id)
         if not supplier:
             raise HTTPException(status_code=404, detail="Supplier not found")
 
         if payload.name is not None:
-            n = payload.name.strip()
-            if not n:
-                raise HTTPException(status_code=422, detail="name is required")
-            supplier.name = n
+            supplier.name = _normalize_name(payload.name)
 
         if payload.code is not None:
-            c = payload.code.strip()
-            if not c:
-                raise HTTPException(status_code=422, detail="code is required")
-            supplier.code = c
+            supplier.code = _normalize_code(payload.code)
 
         if payload.website is not None:
-            w = payload.website.strip()
-            supplier.website = w or None
+            supplier.website = _normalize_website(payload.website)
 
         if payload.active is not None:
             supplier.active = bool(payload.active)
 
-        supplier = repo_save_supplier(db, supplier)
+        try:
+            supplier = repo_save_supplier(db, supplier)
+        except IntegrityError as exc:
+            _raise_supplier_integrity(db, exc)
+
         return _to_supplier_out(supplier)

--- a/app/router_mount.py
+++ b/app/router_mount.py
@@ -22,6 +22,7 @@ def mount_routers(app: FastAPI, *, enable_dev_routes: bool) -> None:
     from app.wms.procurement.routers.purchase_orders_receive import po_receive_router as po_receive_router
     from app.wms.procurement.routers.inbound_receipts_routes import router as inbound_receipts_router
     from app.diagnostics.routers.intelligence import router as intelligence_router
+    from app.pms.items.routers.item_aggregate import router as item_aggregate_router
     from app.pms.items.routers.item_barcodes import router as item_barcodes_router
     from app.pms.items.routers.item_uoms import router as item_uoms_router
     from app.pms.items.routers.items import router as items_router
@@ -122,9 +123,11 @@ def mount_routers(app: FastAPI, *, enable_dev_routes: bool) -> None:
     # 商品相关：
     # - PMS public 读面先挂
     # - /items/barcode-probe 先于 /items/{id}
+    # - /items/aggregate 先于 /items/{id}
     # - /public/items 独立前缀，不与 owner /items 冲突
     app.include_router(pms_public_items_read_router)
     app.include_router(pms_public_barcode_probe_router)
+    app.include_router(item_aggregate_router)
     app.include_router(items_router)
     app.include_router(item_barcodes_router)
     app.include_router(item_uoms_router)

--- a/tests/api/test_item_owner_aggregate_api.py
+++ b/tests/api/test_item_owner_aggregate_api.py
@@ -1,0 +1,214 @@
+# tests/api/test_item_owner_aggregate_api.py
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import httpx
+import pytest
+
+
+async def _login_admin_headers(client: httpx.AsyncClient) -> Dict[str, str]:
+    r = await client.post("/users/login", json={"username": "admin", "password": "admin123"})
+    assert r.status_code == 200, r.text
+    token = r.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_payload() -> Dict[str, Any]:
+    return {
+        "item": {
+            "name": "UT-AGG-ITEM",
+            "spec": "500g",
+            "brand": "BRAND-A",
+            "category": "CATEGORY-A",
+            "enabled": True,
+            "supplier_id": 1,
+            "lot_source_policy": "SUPPLIER_ONLY",
+            "expiry_policy": "NONE",
+            "derivation_allowed": True,
+            "uom_governance_enabled": True,
+            "shelf_life_value": None,
+            "shelf_life_unit": None,
+        },
+        "uoms": [
+            {
+                "id": None,
+                "uom_key": "BASE",
+                "uom": "PCS",
+                "ratio_to_base": 1,
+                "display_name": "PCS",
+                "net_weight_kg": None,
+                "is_base": True,
+                "is_purchase_default": False,
+                "is_inbound_default": True,
+                "is_outbound_default": True,
+            },
+            {
+                "id": None,
+                "uom_key": "PURCHASE",
+                "uom": "BOX",
+                "ratio_to_base": 12,
+                "display_name": "箱",
+                "net_weight_kg": None,
+                "is_base": False,
+                "is_purchase_default": True,
+                "is_inbound_default": False,
+                "is_outbound_default": False,
+            },
+        ],
+        "barcodes": [
+            {
+                "id": None,
+                "barcode": "UT-AGG-ITEM-BC-BASE",
+                "symbology": "CUSTOM",
+                "active": True,
+                "is_primary": True,
+                "bind_uom_key": "BASE",
+            },
+            {
+                "id": None,
+                "barcode": "UT-AGG-ITEM-BC-BOX",
+                "symbology": "CUSTOM",
+                "active": True,
+                "is_primary": False,
+                "bind_uom_key": "PURCHASE",
+            },
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_item_aggregate(client: httpx.AsyncClient) -> None:
+    headers = await _login_admin_headers(client)
+
+    payload = _create_payload()
+
+    r = await client.post("/items/aggregate", json=payload, headers=headers)
+    assert r.status_code == 201, r.text
+
+    body = r.json()
+    assert isinstance(body, dict)
+
+    item = body["item"]
+    uoms = body["uoms"]
+    barcodes = body["barcodes"]
+
+    assert item["name"] == "UT-AGG-ITEM"
+    assert item["brand"] == "BRAND-A"
+    assert item["category"] == "CATEGORY-A"
+    assert item["supplier_id"] == 1
+    assert item["expiry_policy"] == "NONE"
+    assert item["lot_source_policy"] == "SUPPLIER_ONLY"
+
+    assert isinstance(uoms, list)
+    assert len(uoms) == 2
+
+    base = next(x for x in uoms if x["is_base"] is True)
+    purchase = next(x for x in uoms if x["is_purchase_default"] is True)
+
+    assert base["uom"] == "PCS"
+    assert base["ratio_to_base"] == 1
+    assert purchase["uom"] == "BOX"
+    assert purchase["ratio_to_base"] == 12
+
+    assert isinstance(barcodes, list)
+    assert len(barcodes) == 2
+    primary = next(x for x in barcodes if x["is_primary"] is True)
+    assert primary["barcode"] == "UT-AGG-ITEM-BC-BASE"
+    assert int(primary["item_uom_id"]) == int(base["id"])
+
+    item_id = int(item["id"])
+
+    r_get = await client.get(f"/items/{item_id}/aggregate", headers=headers)
+    assert r_get.status_code == 200, r_get.text
+    got = r_get.json()
+
+    assert got["item"]["id"] == item_id
+    assert len(got["uoms"]) == 2
+    assert len(got["barcodes"]) == 2
+
+
+
+@pytest.mark.asyncio
+async def test_replace_item_aggregate_can_drop_purchase_uom_and_purchase_barcode(
+    client: httpx.AsyncClient,
+) -> None:
+    headers = await _login_admin_headers(client)
+
+    create_payload = _create_payload()
+    r_create = await client.post("/items/aggregate", json=create_payload, headers=headers)
+    assert r_create.status_code == 201, r_create.text
+    created = r_create.json()
+
+    item_id = int(created["item"]["id"])
+    base_uom = next(x for x in created["uoms"] if x["is_base"] is True)
+    primary_barcode = next(x for x in created["barcodes"] if x["is_primary"] is True)
+
+    replace_payload = {
+        "item": {
+            "name": "UT-AGG-ITEM-V2",
+            "spec": "750g",
+            "brand": "BRAND-B",
+            "category": "CATEGORY-B",
+            "enabled": True,
+            "supplier_id": 1,
+            "lot_source_policy": "SUPPLIER_ONLY",
+            "expiry_policy": "NONE",
+            "derivation_allowed": False,
+            "uom_governance_enabled": True,
+            "shelf_life_value": None,
+            "shelf_life_unit": None,
+        },
+        "uoms": [
+            {
+                "id": int(base_uom["id"]),
+                "uom_key": "BASE",
+                "uom": "PCS",
+                "ratio_to_base": 1,
+                "display_name": "PCS",
+                "net_weight_kg": None,
+                "is_base": True,
+                "is_purchase_default": True,
+                "is_inbound_default": True,
+                "is_outbound_default": True,
+            }
+        ],
+        "barcodes": [
+            {
+                "id": int(primary_barcode["id"]),
+                "barcode": "UT-AGG-ITEM-BC-BASE-V2",
+                "symbology": "CUSTOM",
+                "active": True,
+                "is_primary": True,
+                "bind_uom_key": "BASE",
+            }
+        ],
+    }
+
+    r_put = await client.put(f"/items/{item_id}/aggregate", json=replace_payload, headers=headers)
+    assert r_put.status_code == 200, r_put.text
+
+    body = r_put.json()
+    assert body["item"]["name"] == "UT-AGG-ITEM-V2"
+    assert body["item"]["brand"] == "BRAND-B"
+    assert body["item"]["category"] == "CATEGORY-B"
+    assert body["item"]["derivation_allowed"] is False
+
+    assert len(body["uoms"]) == 1
+    only_uom = body["uoms"][0]
+    assert only_uom["is_base"] is True
+    assert only_uom["is_purchase_default"] is True
+
+    assert len(body["barcodes"]) == 1
+    only_barcode = body["barcodes"][0]
+    assert only_barcode["barcode"] == "UT-AGG-ITEM-BC-BASE-V2"
+    assert only_barcode["is_primary"] is True
+    assert int(only_barcode["item_uom_id"]) == int(only_uom["id"])
+
+    r_get = await client.get(f"/items/{item_id}/aggregate", headers=headers)
+    assert r_get.status_code == 200, r_get.text
+    got = r_get.json()
+
+    assert got["item"]["name"] == "UT-AGG-ITEM-V2"
+    assert len(got["uoms"]) == 1
+    assert len(got["barcodes"]) == 1

--- a/tests/api/test_items_main_contract_api.py
+++ b/tests/api/test_items_main_contract_api.py
@@ -6,6 +6,8 @@ from uuid import uuid4
 
 import httpx
 import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
 
 
 async def _login_admin_headers(client: httpx.AsyncClient) -> Dict[str, str]:
@@ -107,6 +109,62 @@ async def test_items_create_rejects_zero_shelf_life_value(client: httpx.AsyncCli
     }
     r = await client.post("/items", json=payload, headers=headers)
     assert r.status_code == 422, r.text
+
+
+@pytest.mark.asyncio
+async def test_items_create_auto_bootstraps_base_item_uom(
+    client: httpx.AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+
+    created = await _create_item(client, headers)
+    item_id = int(created["id"])
+
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  uom,
+                  ratio_to_base,
+                  display_name,
+                  is_base,
+                  is_purchase_default,
+                  is_inbound_default,
+                  is_outbound_default
+                FROM item_uoms
+                WHERE item_id = :item_id
+                  AND is_base = true
+                ORDER BY id ASC
+                LIMIT 1
+                """
+            ),
+            {"item_id": item_id},
+        )
+    ).mappings().first()
+
+    assert row is not None, {"msg": "new item should auto-create base item_uom", "item_id": item_id}
+    assert str(row["uom"]) == "PCS"
+    assert int(row["ratio_to_base"]) == 1
+    assert str(row["display_name"] or "").strip() == "PCS"
+    assert bool(row["is_base"]) is True
+    assert bool(row["is_purchase_default"]) is True
+    assert bool(row["is_inbound_default"]) is True
+    assert bool(row["is_outbound_default"]) is True
+
+    base_count = await session.execute(
+        text(
+            """
+            SELECT COUNT(*)
+            FROM item_uoms
+            WHERE item_id = :item_id
+              AND is_base = true
+            """
+        ),
+        {"item_id": item_id},
+    )
+    assert int(base_count.scalar_one()) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add item owner aggregate read/write path and related tests
- restore base item_uom bootstrap on item create
- align suppliers contract to allow updating code and normalize writes
- wire new routers and supporting repos/contracts

## Validation
- python3 -m compileall app/models/supplier.py app/pms/items/contracts/item_uom.py app/pms/items/contracts/item_aggregate.py app/pms/items/repos/item_write_repo.py app/pms/items/repos/item_barcode_repo.py app/pms/items/repos/item_uom_repo.py app/pms/items/routers/item_barcodes.py app/pms/items/routers/item_uoms.py app/pms/items/routers/item_aggregate.py app/pms/items/services/item_barcode_service.py app/pms/items/services/item_maintenance_service.py app/pms/items/services/item_write_service.py app/pms/items/services/item_owner_aggregate_service.py app/pms/suppliers/routers/supplier_contacts.py app/pms/suppliers/routers/suppliers_routes.py app/router_mount.py
- TESTS='tests/api/test_item_owner_aggregate_api.py tests/api/test_items_main_contract_api.py' make test