### PR TITLE
refactor(pms): add public suppliers and tighten item basic read

### DIFF
--- a/app/pms/public/items/contracts/item_basic.py
+++ b/app/pms/public/items/contracts/item_basic.py
@@ -24,7 +24,8 @@ class ItemBasic(_Base):
 
     说明：
     - 这是跨域 public read surface，不承载 owner 内部兼容输入语义
-    - 只暴露其他模块稳定需要的最小读取字段
+    - 只暴露 items 主表稳定需要的最小读取字段
+    - 不承载条码 / 单位 / 净重等跨子表事实
     """
 
     id: Annotated[int, Field(gt=0)]
@@ -38,15 +39,12 @@ class ItemBasic(_Base):
     brand: Annotated[str | None, Field(default=None, max_length=64)] = None
     category: Annotated[str | None, Field(default=None, max_length=64)] = None
 
-    primary_barcode: Annotated[str | None, Field(default=None, max_length=64)] = None
-
     @field_validator(
         "sku",
         "name",
         "spec",
         "brand",
         "category",
-        "primary_barcode",
         mode="before",
     )
     @classmethod

--- a/app/pms/public/items/services/item_read_service.py
+++ b/app/pms/public/items/services/item_read_service.py
@@ -8,11 +8,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from app.models.item import Item
-from app.models.item_barcode import ItemBarcode
 from app.pms.items.repos.item_repo import get_item_by_id as repo_get_item_by_id
 from app.pms.items.repos.item_repo import get_item_by_sku as repo_get_item_by_sku
 from app.pms.items.repos.item_repo import get_items as repo_get_items
-from app.pms.items.services.item_barcode_service import ItemBarcodeService
 from app.pms.public.items.contracts.item_basic import ItemBasic
 from app.pms.public.items.contracts.item_policy import ItemPolicy
 from app.pms.public.items.contracts.item_query import ItemReadQuery
@@ -36,8 +34,8 @@ class ItemReadService:
 
     说明：
     - 当前同时支持 sync Session 与 AsyncSession
-    - sync 路径复用 owner repo / barcode service
-    - async 路径在 public 层自行查询，避免把 owner 内部直接双栈化
+    - basic 只表达 items 主表级字段
+    - 条码 / 单位等跨子表事实不再混入 basic
     """
 
     def __init__(self, db: Session | AsyncSession) -> None:
@@ -108,9 +106,7 @@ class ItemReadService:
         obj = (await db.execute(stmt)).scalars().first()
         if obj is None:
             return None
-
-        barcode_map = await self._aload_primary_barcodes_map(item_ids=[int(obj.id)])
-        return self._build_item_basic(obj, barcode_map.get(int(obj.id)))
+        return self._build_item_basic(obj)
 
     async def aget_basics_by_item_ids(self, *, item_ids: Iterable[int]) -> dict[int, ItemBasic]:
         db = self._require_async_db()
@@ -123,8 +119,7 @@ class ItemReadService:
         if not rows:
             return {}
 
-        barcode_map = await self._aload_primary_barcodes_map(item_ids=ids)
-        basics = self._build_basics_from_items(rows, barcode_map)
+        basics = [self._build_item_basic(x) for x in rows]
         return {int(x.id): x for x in basics}
 
     async def aget_policy_by_id(self, *, item_id: int) -> ItemPolicy | None:
@@ -138,46 +133,10 @@ class ItemReadService:
     def _map_items_to_basic(self, items: list[Item]) -> List[ItemBasic]:
         if not items:
             return []
-
-        db = self._require_sync_db()
-        barcode_map = ItemBarcodeService(db).load_primary_barcodes_map(
-            item_ids=[int(x.id) for x in items if getattr(x, "id", None) is not None]
-        )
-        return self._build_basics_from_items(items, barcode_map)
+        return [self._build_item_basic(x) for x in items]
 
     def _map_item_to_basic(self, item: Item) -> ItemBasic:
-        db = self._require_sync_db()
-        barcode_map = ItemBarcodeService(db).load_primary_barcodes_map(item_ids=[int(item.id)])
-        return self._build_item_basic(item, barcode_map.get(int(item.id)))
-
-    async def _aload_primary_barcodes_map(self, *, item_ids: Iterable[int]) -> dict[int, str]:
-        db = self._require_async_db()
-        ids = sorted({int(x) for x in item_ids if x is not None})
-        if not ids:
-            return {}
-
-        rows = (
-            await db.execute(
-                select(ItemBarcode.item_id, ItemBarcode.barcode)
-                .where(ItemBarcode.item_id.in_(ids))
-                .where(ItemBarcode.is_primary.is_(True))
-                .where(ItemBarcode.active.is_(True))
-            )
-        ).all()
-
-        result: dict[int, str] = {}
-        for item_id, barcode in rows:
-            if item_id is None or barcode is None:
-                continue
-            result[int(item_id)] = str(barcode)
-        return result
-
-    def _build_basics_from_items(
-        self,
-        items: list[Item],
-        barcode_map: dict[int, str],
-    ) -> List[ItemBasic]:
-        return [self._build_item_basic(x, barcode_map.get(int(x.id))) for x in items]
+        return self._build_item_basic(item)
 
     def _map_item_to_policy(self, item: Item) -> ItemPolicy:
         expiry_policy = _enum_value(getattr(item, "expiry_policy", None))
@@ -211,7 +170,7 @@ class ItemReadService:
             uom_governance_enabled=bool(getattr(item, "uom_governance_enabled")),
         )
 
-    def _build_item_basic(self, item: Item, primary_barcode: str | None) -> ItemBasic:
+    def _build_item_basic(self, item: Item) -> ItemBasic:
         return ItemBasic(
             id=int(item.id),
             sku=str(item.sku),
@@ -229,5 +188,4 @@ class ItemReadService:
                 if getattr(item, "category", None) is not None
                 else None
             ),
-            primary_barcode=(primary_barcode.strip() if isinstance(primary_barcode, str) else None),
         )

--- a/app/pms/public/suppliers/__init__.py
+++ b/app/pms/public/suppliers/__init__.py
@@ -1,0 +1,1 @@
+# app/pms/public/suppliers/__init__.py

--- a/app/pms/public/suppliers/contracts/__init__.py
+++ b/app/pms/public/suppliers/contracts/__init__.py
@@ -1,0 +1,1 @@
+# app/pms/public/suppliers/contracts/__init__.py

--- a/app/pms/public/suppliers/contracts/supplier_basic.py
+++ b/app/pms/public/suppliers/contracts/supplier_basic.py
@@ -1,0 +1,28 @@
+# app/pms/public/suppliers/contracts/supplier_basic.py
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class SupplierBasic(BaseModel):
+    """
+    PMS 对外最小供应商读模型。
+
+    说明：
+    - 这是跨域 public read surface
+    - 只暴露其他模块稳定需要的最小读取字段
+    - 不承载 owner contacts / 写入语义
+    """
+
+    model_config = ConfigDict(
+        from_attributes=True,
+        extra="ignore",
+        populate_by_name=True,
+    )
+
+    id: int
+    name: str
+    code: Optional[str] = None
+    active: bool

--- a/app/pms/public/suppliers/routers/__init__.py
+++ b/app/pms/public/suppliers/routers/__init__.py
@@ -1,0 +1,1 @@
+# app/pms/public/suppliers/routers/__init__.py

--- a/app/pms/public/suppliers/routers/suppliers_read.py
+++ b/app/pms/public/suppliers/routers/suppliers_read.py
@@ -1,0 +1,32 @@
+# app/pms/public/suppliers/routers/suppliers_read.py
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.orm import Session
+
+from app.db.deps import get_db
+from app.pms.public.suppliers.contracts.supplier_basic import SupplierBasic
+from app.pms.public.suppliers.services.supplier_read_service import SupplierReadService
+
+router = APIRouter(prefix="/public/suppliers", tags=["pms-public-suppliers"])
+
+
+def get_supplier_read_service(db: Session = Depends(get_db)) -> SupplierReadService:
+    return SupplierReadService(db)
+
+
+@router.get("", response_model=list[SupplierBasic], status_code=status.HTTP_200_OK)
+def list_public_suppliers(
+    active: Optional[bool] = Query(
+        True,
+        description="默认仅返回合作中供应商（用于跨模块下拉）",
+    ),
+    q: Optional[str] = Query(
+        None,
+        description="名称/编码 模糊搜索",
+    ),
+    service: SupplierReadService = Depends(get_supplier_read_service),
+) -> list[SupplierBasic]:
+    return service.list_basic(active=active, q=q)

--- a/app/pms/public/suppliers/services/__init__.py
+++ b/app/pms/public/suppliers/services/__init__.py
@@ -1,0 +1,1 @@
+# app/pms/public/suppliers/services/__init__.py

--- a/app/pms/public/suppliers/services/supplier_read_service.py
+++ b/app/pms/public/suppliers/services/supplier_read_service.py
@@ -1,0 +1,44 @@
+# app/pms/public/suppliers/services/supplier_read_service.py
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.supplier import Supplier
+from app.pms.public.suppliers.contracts.supplier_basic import SupplierBasic
+from app.pms.suppliers.repos.supplier_repo import (
+    list_suppliers_basic as repo_list_suppliers_basic,
+)
+
+
+class SupplierReadService:
+    """
+    PMS public supplier read service。
+
+    定位：
+    - 供其他模块读取 PMS 供应商最小事实
+    - 不承载 contacts 聚合
+    - 不承载写入语义
+    """
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def list_basic(
+        self,
+        *,
+        active: Optional[bool] = True,
+        q: Optional[str] = None,
+    ) -> list[SupplierBasic]:
+        rows = repo_list_suppliers_basic(self.db, active=active, q=q)
+        return [self._to_basic(x) for x in rows]
+
+    @staticmethod
+    def _to_basic(supplier: Supplier) -> SupplierBasic:
+        return SupplierBasic(
+            id=int(supplier.id),
+            name=str(supplier.name),
+            code=supplier.code,
+            active=bool(supplier.active),
+        )

--- a/app/pms/suppliers/routers/suppliers_routes.py
+++ b/app/pms/suppliers/routers/suppliers_routes.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
-from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -17,18 +16,8 @@ from app.pms.suppliers.repos.supplier_repo import (
     create_supplier as repo_create_supplier,
     get_supplier_with_contacts as repo_get_supplier_with_contacts,
     list_suppliers as repo_list_suppliers,
-    list_suppliers_basic as repo_list_suppliers_basic,
     save_supplier as repo_save_supplier,
 )
-
-
-class SupplierBasicOut(BaseModel):
-    """采购/收货用：供应商基础信息（不带 contacts）"""
-
-    id: int
-    name: str
-    code: Optional[str] = None
-    active: bool
 
 
 def _to_supplier_out(supplier: Supplier) -> SupplierOut:
@@ -39,15 +28,6 @@ def _to_supplier_out(supplier: Supplier) -> SupplierOut:
         website=supplier.website,
         active=bool(supplier.active),
         contacts=contacts_out(list(supplier.contacts or [])),
-    )
-
-
-def _to_supplier_basic_out(supplier: Supplier) -> SupplierBasicOut:
-    return SupplierBasicOut(
-        id=supplier.id,
-        name=supplier.name,
-        code=supplier.code,
-        active=bool(supplier.active),
     )
 
 
@@ -88,7 +68,7 @@ def register(router: APIRouter) -> None:
     @router.get("/suppliers", response_model=List[SupplierOut])
     def list_suppliers(
         active: Optional[bool] = Query(
-            None, description="active=true 仅返回合作中供应商（用于下拉）"
+            None, description="active=true 仅返回合作中供应商（owner 页面使用）"
         ),
         q: Optional[str] = Query(None, description="名称/编码/联系人/电话/邮箱/微信 模糊搜索"),
         db: Session = Depends(get_db),
@@ -98,20 +78,6 @@ def register(router: APIRouter) -> None:
 
         suppliers = repo_list_suppliers(db, active=active, q=q)
         return [_to_supplier_out(s) for s in suppliers]
-
-    @router.get("/suppliers/basic", response_model=List[SupplierBasicOut])
-    def list_suppliers_basic(
-        active: Optional[bool] = Query(
-            True, description="默认仅返回合作中供应商（用于下拉）"
-        ),
-        q: Optional[str] = Query(None, description="名称/编码 模糊搜索"),
-        db: Session = Depends(get_db),
-        user=Depends(get_current_user),
-    ):
-        check_perm(db, user, ["page.pms.read"])
-
-        rows = repo_list_suppliers_basic(db, active=active, q=q)
-        return [_to_supplier_basic_out(s) for s in rows]
 
     @router.post("/suppliers", response_model=SupplierOut, status_code=status.HTTP_201_CREATED)
     def create_supplier(

--- a/app/router_mount.py
+++ b/app/router_mount.py
@@ -28,6 +28,9 @@ def mount_routers(app: FastAPI, *, enable_dev_routes: bool) -> None:
     from app.pms.items.routers.items import router as items_router
     from app.pms.public.items.routers.barcode_probe import router as pms_public_barcode_probe_router
     from app.pms.public.items.routers.items_read import router as pms_public_items_read_router
+    from app.pms.public.suppliers.routers.suppliers_read import (
+        router as pms_public_suppliers_read_router,
+    )
     from app.wms.analysis.routers.ledger_reconcile_v2 import router as ledger_reconcile_v2_router
     from app.wms.ledger.routers.ledger_timeline import router as ledger_timeline_router
     from app.diagnostics.routers.lifecycle import router as lifecycle_router
@@ -120,13 +123,14 @@ def mount_routers(app: FastAPI, *, enable_dev_routes: bool) -> None:
 
     app.include_router(warehouses_router)
 
-    # 商品相关：
-    # - PMS public 读面先挂
+    # PMS 相关：
+    # - public 读面先挂
     # - /items/barcode-probe 先于 /items/{id}
     # - /items/aggregate 先于 /items/{id}
-    # - /public/items 独立前缀，不与 owner /items 冲突
+    # - /public/items、/public/suppliers 独立前缀，不与 owner 冲突
     app.include_router(pms_public_items_read_router)
     app.include_router(pms_public_barcode_probe_router)
+    app.include_router(pms_public_suppliers_read_router)
     app.include_router(item_aggregate_router)
     app.include_router(items_router)
     app.include_router(item_barcodes_router)

--- a/tests/api/test_pms_public_suppliers_api.py
+++ b/tests/api/test_pms_public_suppliers_api.py
@@ -1,0 +1,58 @@
+# tests/api/test_pms_public_suppliers_api.py
+from __future__ import annotations
+
+from urllib.parse import quote
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_public_suppliers_returns_basic_rows_without_contacts(
+    client: httpx.AsyncClient,
+) -> None:
+    r = await client.get("/public/suppliers")
+    assert r.status_code == 200, r.text
+
+    data = r.json()
+    assert isinstance(data, list)
+    assert data, "base_seed 应至少存在一个供应商"
+
+    row = data[0]
+    assert {"id", "name", "code", "active"} <= set(row.keys())
+    assert "contacts" not in row
+
+
+async def test_public_suppliers_supports_active_and_q(
+    client: httpx.AsyncClient,
+) -> None:
+    r = await client.get("/public/suppliers?active=true")
+    assert r.status_code == 200, r.text
+
+    rows = r.json()
+    assert isinstance(rows, list)
+    assert rows, "active=true 应至少返回一个合作中供应商"
+
+    for row in rows:
+        assert row["active"] is True
+
+    sample = rows[0]
+    source = str(sample.get("code") or sample.get("name") or "").strip()
+    assert source
+
+    q = source[:2] if len(source) >= 2 else source[:1]
+    assert q
+
+    rq = await client.get(f"/public/suppliers?active=true&q={quote(q)}")
+    assert rq.status_code == 200, rq.text
+
+    filtered = rq.json()
+    assert isinstance(filtered, list)
+    assert filtered
+
+    q_lower = q.lower()
+    for row in filtered:
+        name = str(row.get("name") or "").lower()
+        code = str(row.get("code") or "").lower()
+        assert q_lower in name or q_lower in code

--- a/tests/services/test_pms_public_item_read_service.py
+++ b/tests/services/test_pms_public_item_read_service.py
@@ -52,7 +52,7 @@ async def test_item_read_service_aget_policy_by_id_returns_policy(
     assert got.uom_governance_enabled is bool(row["uom_governance_enabled"])
 
 
-async def test_item_read_service_aget_basics_by_item_ids_returns_basic_and_primary_barcode(
+async def test_item_read_service_aget_basics_by_item_ids_returns_items_table_fields_only(
     session: AsyncSession,
 ) -> None:
     rows = (
@@ -67,16 +67,7 @@ async def test_item_read_service_aget_basics_by_item_ids_returns_basic_and_prima
                   i.enabled,
                   i.supplier_id,
                   i.brand,
-                  i.category,
-                  (
-                    SELECT ib.barcode
-                    FROM item_barcodes ib
-                    WHERE ib.item_id = i.id
-                      AND ib.is_primary = true
-                      AND ib.active = true
-                    ORDER BY ib.id
-                    LIMIT 1
-                  ) AS primary_barcode
+                  i.category
                 FROM items i
                 ORDER BY i.id
                 LIMIT 5
@@ -109,8 +100,4 @@ async def test_item_read_service_aget_basics_by_item_ids_returns_basic_and_prima
         assert basic.category == (
             str(row["category"]).strip() if row["category"] is not None else None
         )
-        assert basic.primary_barcode == (
-            str(row["primary_barcode"]).strip()
-            if row["primary_barcode"] is not None
-            else None
-        )
+        assert not hasattr(basic, "primary_barcode")


### PR DESCRIPTION
## Summary
- add PMS public suppliers read surface under /public/suppliers
- remove owner-side /suppliers/basic transitional read entry
- tighten PMS public item basic contract to item-table-level fields only
- wire router_mount to the new public supplier router
- add backend tests for public suppliers api and updated public item basic read service

## Testing
- make test TESTS=tests/api/test_pms_public_suppliers_api.py
- make test TESTS=tests/services/test_pms_public_item_read_service.py