### PR TITLE
refactor(pms): downshift models and tighten public reads

### DIFF
--- a/app/db/base.py
+++ b/app/db/base.py
@@ -19,24 +19,19 @@ class Base(DeclarativeBase):
 
 _INITIALIZED: bool = False  # 防重复初始化
 
-# Phase 5：这些 legacy 模型对应的表在当前 DB/主线迁移中不存在，
-# 若被导入会污染 Base.metadata，触发 alembic-check 误报 add_table。
-# ✅ 规则：主线 metadata 禁止加载它们（不允许双真相 / 不复活旧表）。
 _DEFAULT_EXCLUDE: Set[str] = {
     "app.models.batch",
 }
 
-# Phase M-5：表名级别的 legacy 黑名单（防止未来模块改名/移动导致 ex 失效）
-# 一旦被导入，必须从 Base.metadata 移除，避免 alembic-check 噪音。
 _LEGACY_TABLE_NAMES: Set[str] = {
     "stocks",
     "batches",
-    "snapshots",  # 若未来有人误复活 v1 快照表
+    "snapshots",
 }
 
 
-def _iter_model_modules_recursive(pkg_name: str = "app.models") -> Iterator[str]:
-    """递归发现 app.models.* 下的所有模块（排除以下划线开头的内部模块）"""
+def _iter_model_modules_recursive(pkg_name: str) -> Iterator[str]:
+    """递归发现给定 package 下的所有模块（排除以下划线开头的内部模块）"""
     try:
         pkg = importlib.import_module(pkg_name)
     except ModuleNotFoundError:
@@ -85,26 +80,30 @@ def init_models(
     """
     集中导入模型 + 固化关系映射：
       1) 先显式导入关键模型（保证字符串关系目标类已注册）
-      2) 再递归导入 app.models.* 补齐遗漏
+      2) 再递归导入模型包补齐遗漏
       3) 最后统一 configure_mappers()
 
-    Phase 5 约束（硬）：
-    - 主线 metadata 禁止加载 legacy 的 batch（对应表不存在），避免 alembic-check 误报。
+    当前阶段：
+    - 通用模型继续位于 app.models
+    - PMS items 域拥有的 ORM 模型已下沉到 app.pms.items.models
+    - 主线 metadata 禁止加载 legacy 的 batch
     """
     global _INITIALIZED
     if _INITIALIZED and not force:
         log.debug("init_models() called again; already initialized, skipping.")
         return
 
-    # 合并 exclude：调用方 exclude + 默认排除（Phase 5 legacy）
     ex: Set[str] = set(exclude or [])
     ex |= set(_DEFAULT_EXCLUDE)
 
     loaded: List[str] = []
 
-    # ✅ 显式加载链：只放“主线真相表”的模型（避免把 legacy 表带进 metadata）
     explicit_chain = [
-        "app.models.item",
+        "app.pms.suppliers.models.supplier",
+        "app.pms.suppliers.models.supplier_contact",
+        "app.pms.items.models.item",
+        "app.pms.items.models.item_uom",
+        "app.pms.items.models.item_barcode",
         "app.models.lot",
         "app.models.stock_lot",
         "app.models.stock_ledger",
@@ -122,12 +121,12 @@ def init_models(
         if _safe_import(mod):
             loaded.append(mod)
 
-    # ✅ 递归补齐：仍然允许导入其它模型，但要尊重 ex（避免 legacy 被扫进来）
-    for mod in _iter_model_modules_recursive("app.models"):
-        if mod in ex or mod in loaded:
-            continue
-        if _safe_import(mod):
-            loaded.append(mod)
+    for pkg_name in ("app.models", "app.pms.items.models", "app.pms.suppliers.models"):
+        for mod in _iter_model_modules_recursive(pkg_name):
+            if mod in ex or mod in loaded:
+                continue
+            if _safe_import(mod):
+                loaded.append(mod)
 
     if extra_modules:
         for mod in extra_modules:

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -20,8 +20,8 @@ MODEL_SPECS = [
     # ------------------------------------------------------------------
     # 主数据（必须最早加载，供其它模型 relationship 引用）
     # ------------------------------------------------------------------
-    ("app.models.supplier", "Supplier"),
-    ("app.models.supplier_contact", "SupplierContact"),
+    ("app.pms.suppliers.models.supplier", "Supplier"),
+    ("app.pms.suppliers.models.supplier_contact", "SupplierContact"),
     # ⚠️ 关键顺序：先加载 WarehouseShippingProvider
     # 再加载 ShippingProvider / Warehouse
     ("app.models.warehouse_shipping_provider", "WarehouseShippingProvider"),
@@ -33,9 +33,9 @@ MODEL_SPECS = [
     # ------------------------------------------------------------------
     ("app.models.warehouse", "Warehouse"),
     # ✅ 旧“库位维度”已从主线移除（库存主链路仅使用 warehouse_id）
-    ("app.models.item", "Item"),
+    ("app.pms.items.models.item", "Item"),
     # ✅ Phase M-2：多包装/多单位结构化
-    ("app.models.item_uom", "ItemUOM"),
+    ("app.pms.items.models.item_uom", "ItemUOM"),
     ("app.models.item_test_set", "ItemTestSet"),
     ("app.models.item_test_set_item", "ItemTestSetItem"),
     ("app.models.lot", "Lot"),

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.db.base import Base
 
 if TYPE_CHECKING:
-    from .item import Item
+    from app.pms.items.models.item import Item
     from .order_item import OrderItem
     from .order_logistics import OrderLogistics
     from .store import Store

--- a/app/models/order_item.py
+++ b/app/models/order_item.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.db.base import Base
 
 if TYPE_CHECKING:
-    from .item import Item
+    from app.pms.items.models.item import Item
     from .order import Order
 
 

--- a/app/models/stock_snapshot.py
+++ b/app/models/stock_snapshot.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.db.base import Base
 
 if TYPE_CHECKING:
-    from .item import Item
+    from app.pms.items.models.item import Item
 
 
 class StockSnapshot(Base):

--- a/app/pms/items/models/__init__.py
+++ b/app/pms/items/models/__init__.py
@@ -1,0 +1,12 @@
+# app/pms/items/models/__init__.py
+from app.pms.items.models.item import ExpiryPolicy, Item, LotSourcePolicy
+from app.pms.items.models.item_barcode import ItemBarcode
+from app.pms.items.models.item_uom import ItemUOM
+
+__all__ = [
+    "Item",
+    "LotSourcePolicy",
+    "ExpiryPolicy",
+    "ItemUOM",
+    "ItemBarcode",
+]

--- a/app/pms/items/models/item.py
+++ b/app/pms/items/models/item.py
@@ -1,4 +1,4 @@
-# app/models/item.py
+# app/pms/items/models/item.py
 from __future__ import annotations
 
 import enum
@@ -11,10 +11,10 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.db.base import Base
 
 if TYPE_CHECKING:
-    from .item_uom import ItemUOM
-    from .order import Order
-    from .order_item import OrderItem
-    from .supplier import Supplier
+    from app.models.order import Order
+    from app.models.order_item import OrderItem
+    from app.pms.suppliers.models.supplier import Supplier
+    from app.pms.items.models.item_uom import ItemUOM
 
 
 class LotSourcePolicy(str, enum.Enum):

--- a/app/pms/items/models/item_barcode.py
+++ b/app/pms/items/models/item_barcode.py
@@ -1,4 +1,4 @@
-# app/models/item_barcode.py
+# app/pms/items/models/item_barcode.py
 from __future__ import annotations
 
 from datetime import datetime
@@ -94,14 +94,12 @@ class ItemBarcode(Base):
             ["item_uoms.id", "item_uoms.item_id"],
             name="fk_item_barcodes_item_uom_pair",
         ),
-        # 一个 item 只能有一个主条码（部分索引）
         Index(
             "uq_item_barcodes_primary",
             "item_id",
             unique=True,
             postgresql_where=text("is_primary = true"),
         ),
-        # 提示 Alembic 在 autogenerate 时跳过这个表（我们用手写迁移来保证结构）
         {"info": {"skip_autogen": True}},
     )
 

--- a/app/pms/items/models/item_uom.py
+++ b/app/pms/items/models/item_uom.py
@@ -1,4 +1,4 @@
-# app/models/item_uom.py
+# app/pms/items/models/item_uom.py
 from __future__ import annotations
 
 from datetime import datetime
@@ -22,7 +22,7 @@ from sqlalchemy.sql import func
 from app.db.base import Base
 
 if TYPE_CHECKING:
-    from .item import Item
+    from app.pms.items.models.item import Item
 
 
 class ItemUOM(Base):
@@ -118,7 +118,6 @@ class ItemUOM(Base):
             unique=True,
             postgresql_where=text("is_base = true"),
         ),
-        # Phase M-5: one default per item（partial unique）
         Index(
             "uq_item_uoms_one_purchase_default_per_item",
             "item_id",

--- a/app/pms/items/repos/item_aggregate_read_repo.py
+++ b/app/pms/items/repos/item_aggregate_read_repo.py
@@ -1,0 +1,45 @@
+# app/pms/items/repos/item_aggregate_read_repo.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy.orm import Session
+
+from app.pms.items.models.item import Item
+from app.pms.items.models.item_barcode import ItemBarcode
+from app.pms.items.models.item_uom import ItemUOM
+from app.pms.items.repos.item_barcode_repo import list_item_barcodes_by_item_id
+from app.pms.items.repos.item_uom_repo import list_item_uoms_by_item_id
+
+
+@dataclass(slots=True)
+class ItemAggregateRecord:
+    item: Item
+    uoms: list[ItemUOM]
+    barcodes: list[ItemBarcode]
+
+
+def get_item_aggregate_record(
+    db: Session,
+    *,
+    item_id: int,
+    active_only: bool | None = None,
+) -> ItemAggregateRecord | None:
+    if not item_id or int(item_id) <= 0:
+        return None
+
+    item = db.get(Item, int(item_id))
+    if item is None:
+        return None
+
+    uoms = list_item_uoms_by_item_id(db, int(item_id))
+    barcodes = list_item_barcodes_by_item_id(
+        db,
+        item_id=int(item_id),
+        active_only=active_only,
+    )
+    return ItemAggregateRecord(
+        item=item,
+        uoms=uoms,
+        barcodes=barcodes,
+    )

--- a/app/pms/items/repos/item_barcode_repo.py
+++ b/app/pms/items/repos/item_barcode_repo.py
@@ -6,9 +6,9 @@ from typing import Sequence
 from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 
-from app.models.item import Item
-from app.models.item_barcode import ItemBarcode
-from app.models.item_uom import ItemUOM
+from app.pms.items.models.item import Item
+from app.pms.items.models.item_barcode import ItemBarcode
+from app.pms.items.models.item_uom import ItemUOM
 
 
 def get_item_barcode_by_id(db: Session, barcode_id: int) -> ItemBarcode | None:

--- a/app/pms/items/repos/item_repo.py
+++ b/app/pms/items/repos/item_repo.py
@@ -6,8 +6,8 @@ from typing import List, Optional
 from sqlalchemy import String, cast, func, or_, select
 from sqlalchemy.orm import Session
 
-from app.models.item import Item
-from app.models.item_barcode import ItemBarcode
+from app.pms.items.models.item import Item
+from app.pms.items.models.item_barcode import ItemBarcode
 
 
 def get_items(

--- a/app/pms/items/repos/item_uom_repo.py
+++ b/app/pms/items/repos/item_uom_repo.py
@@ -8,9 +8,9 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.models.inbound_receipt import InboundReceiptLine
-from app.models.item import Item
-from app.models.item_barcode import ItemBarcode
-from app.models.item_uom import ItemUOM
+from app.pms.items.models.item import Item
+from app.pms.items.models.item_barcode import ItemBarcode
+from app.pms.items.models.item_uom import ItemUOM
 from app.models.purchase_order_line import PurchaseOrderLine
 
 

--- a/app/pms/items/repos/item_write_repo.py
+++ b/app/pms/items/repos/item_write_repo.py
@@ -6,8 +6,8 @@ from typing import Optional
 from sqlalchemy import String, cast, func, or_, select
 from sqlalchemy.orm import Session
 
-from app.models.item import Item
-from app.models.item_barcode import ItemBarcode
+from app.pms.items.models.item import Item
+from app.pms.items.models.item_barcode import ItemBarcode
 
 
 def list_items(

--- a/app/pms/items/routers/item_uoms.py
+++ b/app/pms/items/routers/item_uoms.py
@@ -7,8 +7,8 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 from app.db.deps import get_db
-from app.models.item_barcode import ItemBarcode
-from app.models.item_uom import ItemUOM
+from app.pms.items.models.item_barcode import ItemBarcode
+from app.pms.items.models.item_uom import ItemUOM
 from app.pms.items.contracts.item_uom import (
     ItemUomBarcodeRowOut,
     ItemUomCreate,

--- a/app/pms/items/services/item_maintenance_service.py
+++ b/app/pms/items/services/item_maintenance_service.py
@@ -8,8 +8,8 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.models.item import Item
-from app.models.item_uom import ItemUOM
+from app.pms.items.models.item import Item
+from app.pms.items.models.item_uom import ItemUOM
 from app.pms.items.services.item_barcode_service import ItemBarcodeService
 
 

--- a/app/pms/items/services/item_owner_aggregate_service.py
+++ b/app/pms/items/services/item_owner_aggregate_service.py
@@ -6,7 +6,7 @@ from typing import Optional
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.models.item import Item
+from app.pms.items.models.item import Item
 from app.pms.items.contracts.item_aggregate import (
     AggregateBarcodeInput,
     AggregateItemInput,
@@ -14,6 +14,7 @@ from app.pms.items.contracts.item_aggregate import (
     ItemAggregateOut,
     ItemAggregatePayload,
 )
+from app.pms.items.repos.item_aggregate_read_repo import get_item_aggregate_record
 from app.pms.items.repos.item_barcode_repo import (
     clear_primary_flags_for_item,
     create_item_barcode,
@@ -39,7 +40,6 @@ from app.pms.items.repos.item_write_repo import (
     add_item,
     commit as repo_commit,
     flush as repo_flush,
-    get_item_by_id,
     get_item_by_id_for_update,
     refresh_item,
     rollback as repo_rollback,
@@ -146,16 +146,22 @@ class ItemOwnerAggregateService:
         self._present = ItemPresenter(db)
 
     def get_aggregate(self, *, item_id: int) -> ItemAggregateOut:
-        item = get_item_by_id(self.db, int(item_id))
-        if item is None:
+        record = get_item_aggregate_record(
+            self.db,
+            item_id=int(item_id),
+            active_only=None,
+        )
+        if record is None:
             raise ValueError("Item not found")
 
-        presented = self._present.present_item(item=item)
+        presented = self._present.present_item(item=record.item)
         assert presented is not None
 
-        uoms = list_item_uoms_by_item_id(self.db, int(item_id))
-        barcodes = list_item_barcodes_by_item_id(self.db, item_id=int(item_id), active_only=None)
-        return ItemAggregateOut(item=presented, uoms=uoms, barcodes=barcodes)
+        return ItemAggregateOut(
+            item=presented,
+            uoms=record.uoms,
+            barcodes=record.barcodes,
+        )
 
     def create_aggregate(self, *, payload: ItemAggregatePayload) -> ItemAggregateOut:
         item_fields = _resolve_item_fields(payload.item)

--- a/app/pms/items/services/item_presenter.py
+++ b/app/pms/items/services/item_presenter.py
@@ -5,7 +5,7 @@ from typing import List
 
 from sqlalchemy.orm import Session
 
-from app.models.item import Item
+from app.pms.items.models.item import Item
 from app.pms.items.services.item_barcode_service import ItemBarcodeService
 from app.pms.items.services.item_rules import decorate_rules
 from app.pms.items.services.item_test_set_service import ItemTestSetService

--- a/app/pms/items/services/item_query_service.py
+++ b/app/pms/items/services/item_query_service.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 
 from sqlalchemy.orm import Session
 
-from app.models.item import Item
+from app.pms.items.models.item import Item
 from app.pms.items.repos.item_repo import get_item_by_id as repo_get_item_by_id
 from app.pms.items.repos.item_repo import get_item_by_sku as repo_get_item_by_sku
 from app.pms.items.repos.item_repo import get_items as repo_get_items

--- a/app/pms/items/services/item_rules.py
+++ b/app/pms/items/services/item_rules.py
@@ -1,7 +1,7 @@
 # app/pms/items/services/item_rules.py
 from __future__ import annotations
 
-from app.models.item import Item
+from app.pms.items.models.item import Item
 
 NOEXP_BATCH_CODE = "NOEXP"
 

--- a/app/pms/items/services/item_service.py
+++ b/app/pms/items/services/item_service.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 
 from sqlalchemy.orm import Session
 
-from app.models.item import Item
+from app.pms.items.models.item import Item
 from app.pms.items.services.item_maintenance_service import ItemMaintenanceService
 from app.pms.items.services.item_presenter import ItemPresenter
 from app.pms.items.services.item_query_service import ItemQueryService

--- a/app/pms/items/services/item_test_set_service.py
+++ b/app/pms/items/services/item_test_set_service.py
@@ -6,7 +6,7 @@ from typing import Any, List
 
 from sqlalchemy import text
 
-from app.models.item import Item
+from app.pms.items.models.item import Item
 
 
 class ItemTestSetService:

--- a/app/pms/items/services/item_write_service.py
+++ b/app/pms/items/services/item_write_service.py
@@ -6,7 +6,7 @@ from typing import Optional
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.models.item import Item
+from app.pms.items.models.item import Item
 from app.pms.items.repos.item_uom_repo import create_item_uom
 from app.pms.items.repos.item_write_repo import (
     add_item,

--- a/app/pms/public/items/contracts/item_aggregate.py
+++ b/app/pms/public/items/contracts/item_aggregate.py
@@ -1,0 +1,67 @@
+# app/pms/public/items/contracts/item_aggregate.py
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.pms.items.contracts.item import ExpiryPolicy, LotSourcePolicy, ShelfLifeUnit
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(
+        from_attributes=True,
+        extra="ignore",
+        populate_by_name=True,
+    )
+
+
+class PublicAggregateItem(_Base):
+    id: int
+    sku: str
+    name: str
+    spec: str | None = None
+    enabled: bool
+
+    supplier_id: int | None = None
+    brand: str | None = None
+    category: str | None = None
+
+    lot_source_policy: LotSourcePolicy
+    expiry_policy: ExpiryPolicy
+    derivation_allowed: bool
+    uom_governance_enabled: bool
+
+    shelf_life_value: int | None = Field(default=None, gt=0)
+    shelf_life_unit: ShelfLifeUnit | None = None
+
+
+class PublicAggregateUom(_Base):
+    id: int
+    item_id: int
+
+    uom: str
+    ratio_to_base: int
+
+    display_name: str | None = None
+    net_weight_kg: float | None = Field(default=None, ge=0)
+
+    is_base: bool
+    is_purchase_default: bool
+    is_inbound_default: bool
+    is_outbound_default: bool
+
+
+class PublicAggregateBarcode(_Base):
+    id: int
+    item_id: int
+    item_uom_id: int
+
+    barcode: str
+    symbology: str
+    active: bool
+    is_primary: bool
+
+
+class PublicItemAggregateOut(_Base):
+    item: PublicAggregateItem
+    uoms: list[PublicAggregateUom]
+    barcodes: list[PublicAggregateBarcode]

--- a/app/pms/public/items/routers/item_aggregate_read.py
+++ b/app/pms/public/items/routers/item_aggregate_read.py
@@ -1,0 +1,26 @@
+# app/pms/public/items/routers/item_aggregate_read.py
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.db.deps import get_db
+from app.pms.public.items.contracts.item_aggregate import PublicItemAggregateOut
+from app.pms.public.items.services.item_aggregate_read_service import ItemAggregateReadService
+
+router = APIRouter(prefix="/public/items", tags=["pms-public-items"])
+
+
+def get_item_aggregate_read_service(db: Session = Depends(get_db)) -> ItemAggregateReadService:
+    return ItemAggregateReadService(db)
+
+
+@router.get("/{item_id}/aggregate", response_model=PublicItemAggregateOut, status_code=status.HTTP_200_OK)
+def get_public_item_aggregate_by_id(
+    item_id: int,
+    service: ItemAggregateReadService = Depends(get_item_aggregate_read_service),
+) -> PublicItemAggregateOut:
+    obj = service.get_aggregate_by_id(item_id=int(item_id))
+    if obj is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Item not found")
+    return obj

--- a/app/pms/public/items/services/barcode_probe_service.py
+++ b/app/pms/public/items/services/barcode_probe_service.py
@@ -5,8 +5,8 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
-from app.models.item_barcode import ItemBarcode
-from app.models.item_uom import ItemUOM
+from app.pms.items.models.item_barcode import ItemBarcode
+from app.pms.items.models.item_uom import ItemUOM
 from app.pms.public.items.contracts.barcode_probe import (
     BarcodeProbeError,
     BarcodeProbeOut,

--- a/app/pms/public/items/services/item_aggregate_read_service.py
+++ b/app/pms/public/items/services/item_aggregate_read_service.py
@@ -1,0 +1,127 @@
+# app/pms/public/items/services/item_aggregate_read_service.py
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.pms.items.repos.item_aggregate_read_repo import get_item_aggregate_record
+from app.pms.public.items.contracts.item_aggregate import (
+    PublicAggregateBarcode,
+    PublicAggregateItem,
+    PublicAggregateUom,
+    PublicItemAggregateOut,
+)
+
+
+def _enum_value(v: object) -> str | None:
+    if v is None:
+        return None
+    value = getattr(v, "value", v)
+    return str(value) if value is not None else None
+
+
+class ItemAggregateReadService:
+    """
+    PMS public aggregate read service。
+
+    定位：
+    - 对外提供商品完整读面（item + uoms + barcodes）
+    - 不承载 owner presenter 语义
+    - 不复用 owner aggregate contract
+    """
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def get_aggregate_by_id(self, *, item_id: int) -> PublicItemAggregateOut | None:
+        record = get_item_aggregate_record(
+            self.db,
+            item_id=int(item_id),
+            active_only=None,
+        )
+        if record is None:
+            return None
+
+        item = record.item
+
+        lot_source_policy = _enum_value(getattr(item, "lot_source_policy", None))
+        expiry_policy = _enum_value(getattr(item, "expiry_policy", None))
+        shelf_life_unit = _enum_value(getattr(item, "shelf_life_unit", None))
+
+        if lot_source_policy not in {"INTERNAL_ONLY", "SUPPLIER_ONLY"}:
+            raise RuntimeError(
+                f"unexpected lot_source_policy for item_id={int(item.id)}: {lot_source_policy!r}"
+            )
+        if expiry_policy not in {"NONE", "REQUIRED"}:
+            raise RuntimeError(
+                f"unexpected expiry_policy for item_id={int(item.id)}: {expiry_policy!r}"
+            )
+        if shelf_life_unit is not None and shelf_life_unit not in {"DAY", "WEEK", "MONTH", "YEAR"}:
+            raise RuntimeError(
+                f"unexpected shelf_life_unit for item_id={int(item.id)}: {shelf_life_unit!r}"
+            )
+
+        return PublicItemAggregateOut(
+            item=PublicAggregateItem(
+                id=int(item.id),
+                sku=str(item.sku),
+                name=str(item.name),
+                spec=str(item.spec).strip() if getattr(item, "spec", None) is not None else None,
+                enabled=bool(item.enabled),
+                supplier_id=(
+                    int(item.supplier_id)
+                    if getattr(item, "supplier_id", None) is not None
+                    else None
+                ),
+                brand=str(item.brand).strip() if getattr(item, "brand", None) is not None else None,
+                category=(
+                    str(item.category).strip()
+                    if getattr(item, "category", None) is not None
+                    else None
+                ),
+                lot_source_policy=lot_source_policy,
+                expiry_policy=expiry_policy,
+                derivation_allowed=bool(getattr(item, "derivation_allowed")),
+                uom_governance_enabled=bool(getattr(item, "uom_governance_enabled")),
+                shelf_life_value=(
+                    int(item.shelf_life_value)
+                    if getattr(item, "shelf_life_value", None) is not None
+                    else None
+                ),
+                shelf_life_unit=shelf_life_unit,
+            ),
+            uoms=[
+                PublicAggregateUom(
+                    id=int(u.id),
+                    item_id=int(u.item_id),
+                    uom=str(u.uom),
+                    ratio_to_base=int(u.ratio_to_base),
+                    display_name=(
+                        str(u.display_name).strip()
+                        if getattr(u, "display_name", None) is not None
+                        else None
+                    ),
+                    net_weight_kg=(
+                        float(u.net_weight_kg)
+                        if getattr(u, "net_weight_kg", None) is not None
+                        else None
+                    ),
+                    is_base=bool(u.is_base),
+                    is_purchase_default=bool(u.is_purchase_default),
+                    is_inbound_default=bool(u.is_inbound_default),
+                    is_outbound_default=bool(u.is_outbound_default),
+                )
+                for u in record.uoms
+            ],
+            barcodes=[
+                PublicAggregateBarcode(
+                    id=int(b.id),
+                    item_id=int(b.item_id),
+                    item_uom_id=int(b.item_uom_id),
+                    barcode=str(b.barcode),
+                    symbology=str(b.symbology),
+                    active=bool(b.active),
+                    is_primary=bool(b.is_primary),
+                )
+                for b in record.barcodes
+            ],
+        )

--- a/app/pms/public/items/services/item_read_service.py
+++ b/app/pms/public/items/services/item_read_service.py
@@ -1,13 +1,15 @@
 # app/pms/public/items/services/item_read_service.py
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Iterable, List
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
-from app.models.item import Item
+from app.pms.items.models.item import Item
+from app.pms.items.models.item_barcode import ItemBarcode
 from app.pms.items.repos.item_repo import get_item_by_id as repo_get_item_by_id
 from app.pms.items.repos.item_repo import get_item_by_sku as repo_get_item_by_sku
 from app.pms.items.repos.item_repo import get_items as repo_get_items
@@ -21,6 +23,23 @@ def _enum_value(v: object) -> str | None:
         return None
     value = getattr(v, "value", v)
     return str(value) if value is not None else None
+
+
+def _strip_or_none(v: object) -> str | None:
+    if v is None:
+        return None
+    s = str(v).strip()
+    return s or None
+
+
+@dataclass(slots=True)
+class ItemReportMeta:
+    item_id: int
+    sku: str
+    name: str
+    brand: str | None
+    category: str | None
+    barcode: str | None
 
 
 class ItemReadService:
@@ -129,6 +148,118 @@ class ItemReadService:
         if obj is None:
             return None
         return self._map_item_to_policy(obj)
+
+    async def asearch_report_item_ids_by_keyword(
+        self,
+        *,
+        keyword: str,
+        limit: int | None = None,
+    ) -> list[int]:
+        """
+        面向跨域报表/台账的最小异步搜索能力：
+        - 匹配 item.name
+        - 匹配 item.sku
+        - 匹配 active barcode
+        返回 item_id 列表，不暴露 ORM。
+        """
+        db = self._require_async_db()
+        kw = str(keyword or "").strip()
+        if not kw:
+            return []
+
+        like_kw = f"%{kw}%"
+        barcode_exists = (
+            select(ItemBarcode.id)
+            .where(
+                ItemBarcode.item_id == Item.id,
+                ItemBarcode.active.is_(True),
+                ItemBarcode.barcode.ilike(like_kw),
+            )
+            .limit(1)
+            .exists()
+        )
+
+        stmt = (
+            select(Item.id)
+            .where(
+                or_(
+                    Item.name.ilike(like_kw),
+                    Item.sku.ilike(like_kw),
+                    barcode_exists,
+                )
+            )
+            .order_by(Item.id.asc())
+        )
+
+        if limit is not None and int(limit) > 0:
+            stmt = stmt.limit(int(limit))
+
+        rows = (await db.execute(stmt)).scalars().all()
+        return [int(x) for x in rows]
+
+    async def aget_report_meta_by_item_ids(
+        self,
+        *,
+        item_ids: Iterable[int],
+    ) -> dict[int, ItemReportMeta]:
+        """
+        面向跨域报表/台账的最小批量元信息读面：
+        - sku
+        - name
+        - brand
+        - category
+        - 主条码（优先 is_primary，其次最小 id 的 active barcode）
+        """
+        db = self._require_async_db()
+        ids = sorted({int(x) for x in item_ids if x is not None and int(x) > 0})
+        if not ids:
+            return {}
+
+        item_stmt = select(Item).where(Item.id.in_(ids)).order_by(Item.id.asc())
+        items = (await db.execute(item_stmt)).scalars().all()
+        if not items:
+            return {}
+
+        barcode_stmt = (
+            select(
+                ItemBarcode.item_id,
+                ItemBarcode.barcode,
+                ItemBarcode.is_primary,
+                ItemBarcode.id,
+            )
+            .where(
+                ItemBarcode.item_id.in_(ids),
+                ItemBarcode.active.is_(True),
+            )
+            .order_by(
+                ItemBarcode.item_id.asc(),
+                ItemBarcode.is_primary.desc(),
+                ItemBarcode.id.asc(),
+            )
+        )
+        barcode_rows = (await db.execute(barcode_stmt)).all()
+
+        primary_barcode_map: dict[int, str] = {}
+        for item_id, barcode, _is_primary, _barcode_id in barcode_rows:
+            iid = int(item_id)
+            if iid in primary_barcode_map:
+                continue
+            b = _strip_or_none(barcode)
+            if b is not None:
+                primary_barcode_map[iid] = b
+
+        out: dict[int, ItemReportMeta] = {}
+        for item in items:
+            iid = int(item.id)
+            out[iid] = ItemReportMeta(
+                item_id=iid,
+                sku=str(item.sku),
+                name=str(item.name),
+                brand=_strip_or_none(getattr(item, "brand", None)),
+                category=_strip_or_none(getattr(item, "category", None)),
+                barcode=primary_barcode_map.get(iid),
+            )
+        return out
 
     def _map_items_to_basic(self, items: list[Item]) -> List[ItemBasic]:
         if not items:

--- a/app/pms/public/suppliers/services/supplier_read_service.py
+++ b/app/pms/public/suppliers/services/supplier_read_service.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from sqlalchemy.orm import Session
 
-from app.models.supplier import Supplier
+from app.pms.suppliers.models.supplier import Supplier
 from app.pms.public.suppliers.contracts.supplier_basic import SupplierBasic
 from app.pms.suppliers.repos.supplier_repo import (
     list_suppliers_basic as repo_list_suppliers_basic,

--- a/app/pms/suppliers/helpers/suppliers.py
+++ b/app/pms/suppliers/helpers/suppliers.py
@@ -6,7 +6,7 @@ from typing import List
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
-from app.models.supplier_contact import SupplierContact
+from app.pms.suppliers.models.supplier_contact import SupplierContact
 from app.user.services.user_service import AuthorizationError, UserService
 from app.pms.suppliers.contracts.suppliers import SupplierContactOut
 

--- a/app/pms/suppliers/models/__init__.py
+++ b/app/pms/suppliers/models/__init__.py
@@ -1,0 +1,8 @@
+# app/pms/suppliers/models/__init__.py
+from app.pms.suppliers.models.supplier import Supplier
+from app.pms.suppliers.models.supplier_contact import SupplierContact
+
+__all__ = [
+    "Supplier",
+    "SupplierContact",
+]

--- a/app/pms/suppliers/models/supplier.py
+++ b/app/pms/suppliers/models/supplier.py
@@ -1,4 +1,4 @@
-# app/models/supplier.py
+# app/pms/suppliers/models/supplier.py
 from __future__ import annotations
 
 from datetime import datetime
@@ -18,7 +18,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship, validates
 from app.db.base import Base
 
 if TYPE_CHECKING:
-    from app.models.supplier_contact import SupplierContact
+    from app.pms.suppliers.models.supplier_contact import SupplierContact
 
 
 class Supplier(Base):
@@ -26,11 +26,9 @@ class Supplier(Base):
     __table_args__ = (
         UniqueConstraint("name", name="uq_suppliers_name"),
         UniqueConstraint("code", name="uq_suppliers_code"),
-        # code：允许修改，但必须规范化且不可为空白
         CheckConstraint("btrim(code) <> ''", name="ck_suppliers_code_nonblank"),
         CheckConstraint("code = btrim(code)", name="ck_suppliers_code_trimmed"),
         CheckConstraint("code = upper(code)", name="ck_suppliers_code_upper"),
-        # name：展示字段，不允许空白，且统一 trim
         CheckConstraint("btrim(name) <> ''", name="ck_suppliers_name_nonblank"),
         CheckConstraint("name = btrim(name)", name="ck_suppliers_name_trimmed"),
         {"info": {"skip_autogen": True}},
@@ -61,12 +59,6 @@ class Supplier(Base):
 
     @validates("code")
     def _validate_code(self, _key: str, value: str) -> str:
-        """
-        供应商编码：
-        - 统一 trim + upper
-        - 禁止空白
-        - 允许更新；唯一性由 DB UNIQUE 约束保证
-        """
         if value is None:
             raise ValueError("supplier.code 不能为空")
 

--- a/app/pms/suppliers/models/supplier_contact.py
+++ b/app/pms/suppliers/models/supplier_contact.py
@@ -1,4 +1,4 @@
-# app/models/supplier_contact.py
+# app/pms/suppliers/models/supplier_contact.py
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/pms/suppliers/repos/supplier_contact_repo.py
+++ b/app/pms/suppliers/repos/supplier_contact_repo.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 from sqlalchemy.orm import Session
 
-from app.models.supplier import Supplier
-from app.models.supplier_contact import SupplierContact
+from app.pms.suppliers.models.supplier import Supplier
+from app.pms.suppliers.models.supplier_contact import SupplierContact
 
 
 def get_supplier(db: Session, supplier_id: int) -> Supplier | None:

--- a/app/pms/suppliers/repos/supplier_repo.py
+++ b/app/pms/suppliers/repos/supplier_repo.py
@@ -6,8 +6,8 @@ from typing import List, Optional
 from sqlalchemy import exists, or_
 from sqlalchemy.orm import Session, selectinload
 
-from app.models.supplier import Supplier
-from app.models.supplier_contact import SupplierContact
+from app.pms.suppliers.models.supplier import Supplier
+from app.pms.suppliers.models.supplier_contact import SupplierContact
 
 
 def list_suppliers(

--- a/app/pms/suppliers/routers/suppliers_routes.py
+++ b/app/pms/suppliers/routers/suppliers_routes.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 
 from app.user.deps.auth import get_current_user
 from app.db.deps import get_db
-from app.models.supplier import Supplier
+from app.pms.suppliers.models.supplier import Supplier
 from app.pms.suppliers.contracts.suppliers import SupplierCreateIn, SupplierOut, SupplierUpdateIn
 from app.pms.suppliers.helpers.suppliers import check_perm, contacts_out
 from app.pms.suppliers.repos.supplier_repo import (

--- a/app/router_mount.py
+++ b/app/router_mount.py
@@ -27,6 +27,9 @@ def mount_routers(app: FastAPI, *, enable_dev_routes: bool) -> None:
     from app.pms.items.routers.item_uoms import router as item_uoms_router
     from app.pms.items.routers.items import router as items_router
     from app.pms.public.items.routers.barcode_probe import router as pms_public_barcode_probe_router
+    from app.pms.public.items.routers.item_aggregate_read import (
+        router as pms_public_item_aggregate_read_router,
+    )
     from app.pms.public.items.routers.items_read import router as pms_public_items_read_router
     from app.pms.public.suppliers.routers.suppliers_read import (
         router as pms_public_suppliers_read_router,
@@ -128,6 +131,7 @@ def mount_routers(app: FastAPI, *, enable_dev_routes: bool) -> None:
     # - /items/barcode-probe 先于 /items/{id}
     # - /items/aggregate 先于 /items/{id}
     # - /public/items、/public/suppliers 独立前缀，不与 owner 冲突
+    app.include_router(pms_public_item_aggregate_read_router)
     app.include_router(pms_public_items_read_router)
     app.include_router(pms_public_barcode_probe_router)
     app.include_router(pms_public_suppliers_read_router)

--- a/app/wms/ledger/helpers/stock_ledger.py
+++ b/app/wms/ledger/helpers/stock_ledger.py
@@ -11,11 +11,19 @@ from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.wms.shared.services.lot_code_contract import normalize_optional_lot_code
-from app.models.item import Item
 from app.models.lot import Lot
 from app.models.stock_ledger import StockLedger
 from app.wms.ledger.contracts.stock_ledger import LedgerQuery
+from app.wms.shared.services.lot_code_contract import normalize_optional_lot_code
+
+# 仅用于 ledger 关键词过滤的轻量只读表映射：
+# 先去掉对 PMS Item ORM 的直接依赖，不改 helper 的调用签名。
+ITEMS_TABLE = sa.table(
+    "items",
+    sa.column("id"),
+    sa.column("name"),
+    sa.column("sku"),
+)
 
 
 def normalize_time_range(q: LedgerQuery) -> Tuple[datetime, datetime]:
@@ -75,7 +83,6 @@ def _to_str_or_none(v) -> str | None:
     """
     if v is None:
         return None
-    # Enum: 优先取 value（ReasonCanon / SubReason）
     vv = getattr(v, "value", None)
     if isinstance(vv, str):
         x = vv.strip()
@@ -83,7 +90,6 @@ def _to_str_or_none(v) -> str | None:
     if isinstance(v, str):
         x = v.strip()
         return x or None
-    # 其他类型尽量转字符串（保险）
     x = str(v).strip()
     return x or None
 
@@ -108,18 +114,12 @@ def build_common_filters(q: LedgerQuery, time_from: datetime, time_to: datetime)
     if q.warehouse_id is not None:
         conditions.append(StockLedger.warehouse_id == q.warehouse_id)
 
-    # Phase 4A-2a: lot 维度过滤（精确）
     if getattr(q, "lot_id", None) is not None:
         conditions.append(StockLedger.lot_id == getattr(q, "lot_id"))
 
-    # ✅ lot-only：batch_code 仅作为展示码（lots.lot_code）过滤
-    # - 不传 batch_code：不加过滤
-    # - 传 "" / "None"：归一为 None -> lots.lot_code IS NULL（无批次标签槽位）
-    # - 传 "B2026..."：lots.lot_code = 'B2026...'
     fields_set = getattr(q, "model_fields_set", set())
     if "batch_code" in fields_set:
         norm_bc = normalize_optional_lot_code(getattr(q, "batch_code", None))
-        # 通过 EXISTS 约束到 lots.lot_code（支持 NULL 语义）
         if norm_bc is None:
             conditions.append(
                 sa.exists(
@@ -146,19 +146,14 @@ def build_common_filters(q: LedgerQuery, time_from: datetime, time_to: datetime)
     if q.reason:
         conditions.append(StockLedger.reason == q.reason)
 
-    # ✅ 新增：reason_canon（Enum/str 都支持）
     rc = _to_str_or_none(getattr(q, "reason_canon", None))
     if rc:
         conditions.append(StockLedger.reason_canon == rc)
 
-    # ✅ 新增：sub_reason（Enum/str 都支持）
     sr = _to_str_or_none(getattr(q, "sub_reason", None))
     if sr:
         conditions.append(StockLedger.sub_reason == sr)
 
-    # ✅ ref 等价匹配（解决 ref 口径漂移：UT-OUT-2 vs UT:UT:UT-OUT-2）
-    # - 用户输入不含 ":" 时：匹配 ref==x OR ref LIKE "%:x"
-    # - 用户输入含 ":" 时：既匹配原值，也匹配其最后一段（以及 "%:最后一段"）
     if q.ref:
         x = str(q.ref).strip()
         if x:
@@ -184,23 +179,18 @@ def infer_movement_type(reason: str | None) -> str | None:
         return None
     r = reason.upper()
 
-    # 入库类
     if r in {"RECEIPT", "INBOUND", "INBOUND_RECEIPT"}:
         return "INBOUND"
 
-    # 出库 / 发货类
     if r in {"SHIP", "SHIPMENT", "OUTBOUND_SHIP", "OUTBOUND_COMMIT"}:
         return "OUTBOUND"
 
-    # 盘点类
     if r in {"COUNT", "STOCK_COUNT", "INVENTORY_COUNT"}:
         return "COUNT"
 
-    # 调整类
     if r in {"ADJUSTMENT", "ADJUST", "MANUAL_ADJUST"}:
         return "ADJUST"
 
-    # 退货 / 逆向
     if r in {"RETURN", "RMA", "INBOUND_RETURN"}:
         return "RETURN"
 
@@ -214,18 +204,21 @@ def build_base_ids_stmt(q: LedgerQuery, time_from: datetime, time_to: datetime):
     - 支持按 item_id / warehouse_id / lot_id / batch_code(展示码) / reason / reason_canon / sub_reason / ref / trace_id / 时间过滤；
     - 支持按 item_keyword 模糊匹配 items.name / items.sku；
     - 不再依赖 stock_id / batch_id，完全对齐当前 StockLedger 模型。
+
+    当前阶段：
+    - 先去掉对 PMS Item ORM 的直接依赖
+    - 仍保持查询语义和 helper 签名不变
     """
     stmt = select(StockLedger.id).select_from(StockLedger)
     conditions = build_common_filters(q, time_from, time_to)
 
-    # item_keyword 模糊搜索：name/sku
     if q.item_keyword:
         kw = f"%{q.item_keyword.strip()}%"
-        stmt = stmt.join(Item, Item.id == StockLedger.item_id)
+        stmt = stmt.join(ITEMS_TABLE, ITEMS_TABLE.c.id == StockLedger.item_id)
         conditions.append(
             sa.or_(
-                Item.name.ilike(kw),
-                Item.sku.ilike(kw),
+                ITEMS_TABLE.c.name.ilike(kw),
+                ITEMS_TABLE.c.sku.ilike(kw),
             )
         )
 

--- a/app/wms/ledger/routers/stock_ledger_routes_summary.py
+++ b/app/wms/ledger/routers/stock_ledger_routes_summary.py
@@ -8,14 +8,17 @@ from fastapi import APIRouter, Depends
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.wms.shared.services.lot_code_contract import normalize_optional_lot_code
 from app.db.session import get_session
-from app.models.item import Item
 from app.models.item_test_set import ItemTestSet
 from app.models.item_test_set_item import ItemTestSetItem
 from app.models.stock_ledger import StockLedger
 from app.wms.ledger.contracts.stock_ledger import LedgerQuery, LedgerReasonStat, LedgerSummary
-from app.wms.ledger.helpers.stock_ledger import build_common_filters, normalize_time_range
+from app.wms.ledger.helpers.stock_ledger import (
+    ITEMS_TABLE,
+    build_common_filters,
+    normalize_time_range,
+)
+from app.wms.shared.services.lot_code_contract import normalize_optional_lot_code
 
 
 def register(router: APIRouter) -> None:
@@ -57,11 +60,11 @@ def register(router: APIRouter) -> None:
 
         if payload.item_keyword:
             kw = f"%{payload.item_keyword.strip()}%"
-            stmt = stmt.join(Item, Item.id == StockLedger.item_id)
+            stmt = stmt.join(ITEMS_TABLE, ITEMS_TABLE.c.id == StockLedger.item_id)
             conditions.append(
                 sa.or_(
-                    Item.name.ilike(kw),
-                    Item.sku.ilike(kw),
+                    ITEMS_TABLE.c.name.ilike(kw),
+                    ITEMS_TABLE.c.sku.ilike(kw),
                 )
             )
 

--- a/app/wms/procurement/routers/purchase_reports_routes_items.py
+++ b/app/wms/procurement/routers/purchase_reports_routes_items.py
@@ -3,22 +3,75 @@ from __future__ import annotations
 
 from datetime import date
 from decimal import Decimal
-from typing import List, Optional, Literal
+from typing import List, Literal, Optional
 
 from fastapi import APIRouter, Depends, Query
-from sqlalchemy import and_, distinct, func, select, or_
+from sqlalchemy import and_, distinct, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.wms.procurement.helpers.purchase_reports import apply_common_filters, time_mode_query
 from app.db.session import get_session
 from app.models.inbound_receipt import InboundReceipt, InboundReceiptLine
-from app.models.item import Item
-from app.models.item_barcode import ItemBarcode
 from app.models.item_test_set import ItemTestSet
 from app.models.item_test_set_item import ItemTestSetItem
 from app.models.purchase_order import PurchaseOrder
 from app.models.purchase_order_line import PurchaseOrderLine
+from app.pms.public.items.services.item_read_service import ItemReadService
 from app.wms.procurement.contracts.purchase_report import ItemPurchaseReportItem
+from app.wms.procurement.helpers.purchase_reports import apply_common_filters, time_mode_query
+
+
+async def _resolve_report_item_ids(
+    session: AsyncSession,
+    *,
+    item_id: Optional[int],
+    item_keyword: Optional[str],
+) -> Optional[list[int]]:
+    """
+    返回：
+    - [item_id]：显式 item_id 过滤
+    - [ids...]：按 PMS public item 搜索出的 item_id 集合
+    - None：不加 item 过滤
+    """
+    if item_id is not None:
+        return [int(item_id)]
+
+    kw = str(item_keyword or "").strip()
+    if not kw:
+        return None
+
+    svc = ItemReadService(session)
+    return await svc.asearch_report_item_ids_by_keyword(keyword=kw)
+
+
+def _build_report_item(
+    *,
+    item_id_val: int,
+    supplier_name: str | None,
+    order_count: int,
+    total_units: int,
+    total_amount: Decimal | None,
+    avg_unit_price: Decimal | None,
+    meta,
+) -> ItemPurchaseReportItem:
+    item_sku = meta.sku if meta is not None else ""
+    item_name = meta.name if meta is not None else f"ITEM-{int(item_id_val)}"
+    barcode = meta.barcode if meta is not None else None
+    brand = meta.brand if meta is not None else None
+    category = meta.category if meta is not None else None
+
+    return ItemPurchaseReportItem(
+        item_id=int(item_id_val),
+        item_sku=item_sku,
+        item_name=item_name,
+        barcode=barcode,
+        brand=brand,
+        category=category,
+        supplier_name=supplier_name,
+        order_count=int(order_count or 0),
+        total_units=int(total_units or 0),
+        total_amount=total_amount,
+        avg_unit_price=avg_unit_price,
+    )
 
 
 def register(router: APIRouter) -> None:
@@ -40,44 +93,34 @@ def register(router: APIRouter) -> None:
             select(ItemTestSet.id).where(ItemTestSet.code == "DEFAULT").limit(1).scalar_subquery()
         )
 
-        main_barcode_expr = (
-            select(ItemBarcode.barcode)
-            .where(ItemBarcode.item_id == Item.id, ItemBarcode.active.is_(True))
-            .order_by(ItemBarcode.is_primary.desc(), ItemBarcode.id.asc())
-            .limit(1)
-            .scalar_subquery()
+        report_item_ids = await _resolve_report_item_ids(
+            session,
+            item_id=item_id,
+            item_keyword=item_keyword,
         )
+        if report_item_ids is not None and not report_item_ids:
+            return []
+
+        item_read_svc = ItemReadService(session)
 
         if mode == "fact":
-            supplier_name_expr = func.coalesce(InboundReceipt.supplier_name, "").label(
-                "supplier_name"
-            )
+            supplier_name_expr = func.coalesce(InboundReceipt.supplier_name, "").label("supplier_name")
 
             stmt = (
                 select(
                     InboundReceiptLine.item_id.label("item_id"),
-                    Item.sku.label("item_sku"),
-                    Item.name.label("item_name"),
-                    main_barcode_expr.label("barcode"),
-                    Item.brand.label("brand"),
-                    Item.category.label("category"),
                     supplier_name_expr,
                     func.count(distinct(InboundReceipt.source_id)).label("order_count"),
-                    func.coalesce(func.sum(InboundReceiptLine.qty_base), 0).label(
-                        "total_units"
-                    ),
-                    func.coalesce(func.sum(InboundReceiptLine.line_amount), 0).label(
-                        "total_amount"
-                    ),
+                    func.coalesce(func.sum(InboundReceiptLine.qty_base), 0).label("total_units"),
+                    func.coalesce(func.sum(InboundReceiptLine.line_amount), 0).label("total_amount"),
                 )
                 .select_from(InboundReceipt)
                 .join(InboundReceiptLine, InboundReceiptLine.receipt_id == InboundReceipt.id)
                 .join(PurchaseOrder, PurchaseOrder.id == InboundReceipt.source_id)
-                .join(Item, Item.id == InboundReceiptLine.item_id)
                 .outerjoin(
                     ItemTestSetItem,
                     and_(
-                        ItemTestSetItem.item_id == Item.id,
+                        ItemTestSetItem.item_id == InboundReceiptLine.item_id,
                         ItemTestSetItem.set_id == default_set_id_sq,
                     ),
                 )
@@ -96,45 +139,27 @@ def register(router: APIRouter) -> None:
                 time_mode=time_mode,
             )
 
-            if item_id is not None:
-                stmt = stmt.where(InboundReceiptLine.item_id == int(item_id))
-            elif item_keyword and str(item_keyword).strip():
-                kw = f"%{str(item_keyword).strip()}%"
-                stmt = stmt.where(
-                    or_(
-                        Item.name.ilike(kw),
-                        Item.sku.ilike(kw),
-                        main_barcode_expr.ilike(kw),
-                    )
-                )
+            if report_item_ids is not None:
+                stmt = stmt.where(InboundReceiptLine.item_id.in_(report_item_ids))
 
             stmt = stmt.group_by(
                 InboundReceiptLine.item_id,
-                Item.sku,
-                Item.name,
-                Item.brand,
-                Item.category,
                 supplier_name_expr,
-                main_barcode_expr,
             ).order_by(InboundReceiptLine.item_id.asc())
 
-            rows = (await session.execute(stmt)).all()
+            rows = (await session.execute(stmt)).mappings().all()
+            if not rows:
+                return []
+
+            meta_map = await item_read_svc.aget_report_meta_by_item_ids(
+                item_ids=[int(r["item_id"]) for r in rows]
+            )
 
             items: List[ItemPurchaseReportItem] = []
-            for (
-                item_id_val,
-                item_sku,
-                item_name,
-                barcode,
-                brand,
-                category,
-                supplier_name,
-                order_count,
-                total_units,
-                total_amount,
-            ) in rows:
-                total_units_int = int(total_units or 0)
-                total_amount_dec = Decimal(str(total_amount or 0))
+            for row in rows:
+                item_id_val = int(row["item_id"])
+                total_units_int = int(row["total_units"] or 0)
+                total_amount_dec = Decimal(str(row["total_amount"] or 0))
                 avg_unit_price = (
                     (total_amount_dec / total_units_int).quantize(Decimal("0.0001"))
                     if total_units_int > 0
@@ -142,62 +167,55 @@ def register(router: APIRouter) -> None:
                 )
 
                 items.append(
-                    ItemPurchaseReportItem(
-                        item_id=int(item_id_val),
-                        item_sku=item_sku,
-                        item_name=item_name,
-                        barcode=barcode,
-                        brand=brand,
-                        category=category,
-                        supplier_name=supplier_name,
-                        order_count=int(order_count or 0),
+                    _build_report_item(
+                        item_id_val=item_id_val,
+                        supplier_name=row["supplier_name"],
+                        order_count=int(row["order_count"] or 0),
                         total_units=total_units_int,
                         total_amount=total_amount_dec,
                         avg_unit_price=avg_unit_price,
+                        meta=meta_map.get(item_id_val),
                     )
                 )
             return items
 
-        # PLAN 模式（全部基于 base）
-        supplier_name_expr = func.coalesce(
-            PurchaseOrder.supplier_name, ""
-        ).label("supplier_name")
+        # PLAN 模式：本次仅收跨域 item/barcode ORM 直连；
+        # 不顺手改既有 plan 过滤语义。
+        supplier_name_expr = func.coalesce(PurchaseOrder.supplier_name, "").label("supplier_name")
 
         stmt = (
             select(
                 PurchaseOrderLine.item_id.label("item_id"),
-                Item.sku.label("item_sku"),
-                Item.name.label("item_name"),
                 supplier_name_expr,
                 func.count(distinct(PurchaseOrder.id)).label("order_count"),
-                func.coalesce(func.sum(PurchaseOrderLine.qty_ordered_base), 0).label(
-                    "total_units"
-                ),
+                func.coalesce(func.sum(PurchaseOrderLine.qty_ordered_base), 0).label("total_units"),
             )
             .select_from(PurchaseOrder)
             .join(PurchaseOrderLine, PurchaseOrderLine.po_id == PurchaseOrder.id)
-            .join(Item, Item.id == PurchaseOrderLine.item_id)
         )
 
         stmt = stmt.group_by(
             PurchaseOrderLine.item_id,
-            Item.sku,
-            Item.name,
             supplier_name_expr,
         )
 
-        rows = (await session.execute(stmt)).all()
+        rows = (await session.execute(stmt)).mappings().all()
+        if not rows:
+            return []
+
+        meta_map = await item_read_svc.aget_report_meta_by_item_ids(
+            item_ids=[int(r["item_id"]) for r in rows]
+        )
 
         return [
-            ItemPurchaseReportItem(
-                item_id=int(r[0]),
-                item_sku=r[1],
-                item_name=r[2],
-                supplier_name=r[3],
-                order_count=int(r[4] or 0),
-                total_units=int(r[5] or 0),
+            _build_report_item(
+                item_id_val=int(r["item_id"]),
+                supplier_name=r["supplier_name"],
+                order_count=int(r["order_count"] or 0),
+                total_units=int(r["total_units"] or 0),
                 total_amount=None,
                 avg_unit_price=None,
+                meta=meta_map.get(int(r["item_id"])),
             )
             for r in rows
         ]

--- a/app/wms/procurement/services/purchase_order_create.py
+++ b/app/wms/procurement/services/purchase_order_create.py
@@ -5,12 +5,11 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Any, Dict, List, Optional, Tuple
 
-from sqlalchemy import select, text
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.purchase_order import PurchaseOrder
 from app.models.purchase_order_line import PurchaseOrderLine
-from app.models.supplier import Supplier
 from app.pms.public.items.contracts.item_basic import ItemBasic
 from app.pms.public.items.services.item_read_service import ItemReadService
 
@@ -22,18 +21,45 @@ async def _load_items_map(session: AsyncSession, item_ids: List[int]) -> Dict[in
     return await svc.aget_basics_by_item_ids(item_ids=item_ids)
 
 
-async def _require_supplier_for_po(session: AsyncSession, supplier_id: Optional[int]) -> Supplier:
+async def _require_supplier_snapshot_for_po(
+    session: AsyncSession,
+    supplier_id: Optional[int],
+) -> Tuple[int, str]:
+    """
+    当前阶段先去掉 WMS procurement 对 PMS Supplier ORM 的直接依赖。
+
+    返回：
+    - supplier_id
+    - supplier_name（用于 PO 快照）
+
+    说明：
+    - 这里只解决“跨域直接摸 Supplier ORM”问题
+    - 还没有把 supplier 校验完全提升为 PMS public/service 异步读面
+    """
     if supplier_id is None:
         raise ValueError("supplier_id 不能为空：采购单必须绑定供应商")
+
     sid = int(supplier_id)
     if sid <= 0:
         raise ValueError("supplier_id 非法：采购单必须绑定供应商")
 
-    supplier = ((await session.execute(select(Supplier).where(Supplier.id == sid))).scalars().first())
-    if supplier is None:
+    row = await session.execute(
+        text(
+            """
+            SELECT id, name
+            FROM suppliers
+            WHERE id = :supplier_id
+            LIMIT 1
+            """
+        ),
+        {"supplier_id": sid},
+    )
+    r = row.mappings().first()
+    if r is None:
         raise ValueError(f"supplier_id 不存在：未找到供应商（supplier_id={sid})")
 
-    return supplier
+    supplier_name = str(r.get("name") or "").strip()
+    return int(r["id"]), supplier_name
 
 
 def _trim_or_none(v: Any) -> Optional[str]:
@@ -177,9 +203,7 @@ async def create_po_v2(
     if not lines:
         raise ValueError("create_po_v2 需要至少一行行项目（lines 不可为空）")
 
-    supplier_obj = await _require_supplier_for_po(session, supplier_id)
-    po_supplier_id = int(getattr(supplier_obj, "id"))
-    po_supplier_name = str(getattr(supplier_obj, "name") or "").strip()
+    po_supplier_id, po_supplier_name = await _require_supplier_snapshot_for_po(session, supplier_id)
 
     raw_item_ids = [int(raw["item_id"]) for raw in lines]
     items_map = await _load_items_map(session, raw_item_ids)

--- a/tests/fixtures/po_batch_semantics_fixtures.py
+++ b/tests/fixtures/po_batch_semantics_fixtures.py
@@ -7,8 +7,8 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.item import Item
-from app.models.item_uom import ItemUOM
+from app.pms.items.models.item import Item
+from app.pms.items.models.item_uom import ItemUOM
 from app.models.purchase_order import PurchaseOrder
 from app.models.purchase_order_line import PurchaseOrderLine
 


### PR DESCRIPTION
## Summary
- move PMS-owned ORM models into app/pms/items/models and app/pms/suppliers/models
- add PMS public item aggregate read surface
- remove remaining WMS cross-domain supplier/item ORM direct usage on key paths
- tighten model registration and imports after model downshift

## Testing
- make test TESTS="tests/services/test_pms_public_item_read_service.py tests/api/test_item_owner_aggregate_api.py tests/api/test_pms_public_suppliers_api.py"