### PR TITLE
feat(wms): harden required lot expiry and canonical date flow

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -72,7 +72,7 @@ def build_scoped_metadata(scope: str) -> MetaData:
     md = MetaData()
     if scope == "all":
         for t in Base.metadata.tables.values():
-            t.tometadata(md)
+            t.to_metadata(md)
         return md
 
     wanted: set[str] = set()
@@ -83,12 +83,12 @@ def build_scoped_metadata(scope: str) -> MetaData:
     else:
         # 未知 scope 时退回全量，宁可多查，不搞黑盒
         for t in Base.metadata.tables.values():
-            t.tometadata(md)
+            t.to_metadata(md)
         return md
 
     for name, tbl in Base.metadata.tables.items():
         if name in wanted:
-            tbl.tometadata(md)
+            tbl.to_metadata(md)
 
     return md
 

--- a/alembic/versions/0e7c789ec00b_drop_lots_lot_code_key_column.py
+++ b/alembic/versions/0e7c789ec00b_drop_lots_lot_code_key_column.py
@@ -1,0 +1,47 @@
+"""drop lots lot_code_key column
+
+Revision ID: 0e7c789ec00b
+Revises: d13519e5d5ac
+Create Date: 2026-04-11 17:13:52.315969
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0e7c789ec00b"
+down_revision: Union[str, Sequence[str], None] = "d13519e5d5ac"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.drop_index("ix_lots_wh_item_lot_code_key", table_name="lots")
+    op.drop_column("lots", "lot_code_key")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.add_column("lots", sa.Column("lot_code_key", sa.Text(), nullable=True))
+
+    op.execute(
+        sa.text(
+            """
+            UPDATE lots
+               SET lot_code_key = upper(btrim(lot_code))
+             WHERE lot_code IS NOT NULL
+            """
+        )
+    )
+
+    op.create_index(
+        "ix_lots_wh_item_lot_code_key",
+        "lots",
+        ["warehouse_id", "item_id", "lot_code_key"],
+        unique=False,
+        postgresql_where=sa.text("lot_code IS NOT NULL"),
+    )

--- a/alembic/versions/24ddc21b01e6_backfill_lots_production_date_from_.py
+++ b/alembic/versions/24ddc21b01e6_backfill_lots_production_date_from_.py
@@ -1,0 +1,126 @@
+"""backfill lots production_date from ledger and receipt
+
+Revision ID: 24ddc21b01e6
+Revises: f054e01c63b1
+Create Date: 2026-04-11 15:10:00.676420
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "24ddc21b01e6"
+down_revision: Union[str, Sequence[str], None] = "f054e01c63b1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.execute(
+        sa.text(
+            """
+            WITH ledger_one AS (
+                SELECT
+                    g.lot_id,
+                    MIN(g.production_date) AS pd,
+                    COUNT(DISTINCT g.production_date) AS distinct_pd
+                FROM stock_ledger AS g
+                WHERE g.reason_canon = 'RECEIPT'
+                  AND g.production_date IS NOT NULL
+                GROUP BY g.lot_id
+            ),
+            receipt_one AS (
+                SELECT
+                    rl.lot_id,
+                    MIN(rl.production_date) AS pd,
+                    COUNT(DISTINCT rl.production_date) AS distinct_pd
+                FROM inbound_receipt_lines AS rl
+                WHERE rl.production_date IS NOT NULL
+                GROUP BY rl.lot_id
+            ),
+            resolved AS (
+                SELECT
+                    l.id AS lot_id,
+                    CASE
+                        WHEN lo.distinct_pd = 1 AND COALESCE(ro.distinct_pd, 0) = 0 THEN lo.pd
+                        WHEN ro.distinct_pd = 1 AND COALESCE(lo.distinct_pd, 0) = 0 THEN ro.pd
+                        WHEN lo.distinct_pd = 1 AND ro.distinct_pd = 1 AND lo.pd = ro.pd THEN lo.pd
+                        ELSE NULL
+                    END AS candidate_pd
+                FROM lots AS l
+                LEFT JOIN ledger_one AS lo
+                  ON lo.lot_id = l.id
+                LEFT JOIN receipt_one AS ro
+                  ON ro.lot_id = l.id
+                WHERE l.item_expiry_policy_snapshot = 'REQUIRED'::expiry_policy
+                  AND l.production_date IS NULL
+            )
+            UPDATE lots AS l
+               SET production_date = r.candidate_pd
+              FROM resolved AS r
+             WHERE l.id = r.lot_id
+               AND r.candidate_pd IS NOT NULL
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Best-effort rollback for this backfill step only:
+    only revert rows whose current production_date still matches the same
+    uniquely-derived candidate from ledger / receipt sources.
+    """
+    op.execute(
+        sa.text(
+            """
+            WITH ledger_one AS (
+                SELECT
+                    g.lot_id,
+                    MIN(g.production_date) AS pd,
+                    COUNT(DISTINCT g.production_date) AS distinct_pd
+                FROM stock_ledger AS g
+                WHERE g.reason_canon = 'RECEIPT'
+                  AND g.production_date IS NOT NULL
+                GROUP BY g.lot_id
+            ),
+            receipt_one AS (
+                SELECT
+                    rl.lot_id,
+                    MIN(rl.production_date) AS pd,
+                    COUNT(DISTINCT rl.production_date) AS distinct_pd
+                FROM inbound_receipt_lines AS rl
+                WHERE rl.production_date IS NOT NULL
+                GROUP BY rl.lot_id
+            ),
+            resolved AS (
+                SELECT
+                    l.id AS lot_id,
+                    CASE
+                        WHEN lo.distinct_pd = 1 AND COALESCE(ro.distinct_pd, 0) = 0 THEN lo.pd
+                        WHEN ro.distinct_pd = 1 AND COALESCE(lo.distinct_pd, 0) = 0 THEN ro.pd
+                        WHEN lo.distinct_pd = 1 AND ro.distinct_pd = 1 AND lo.pd = ro.pd THEN lo.pd
+                        ELSE NULL
+                    END AS candidate_pd
+                FROM lots AS l
+                LEFT JOIN ledger_one AS lo
+                  ON lo.lot_id = l.id
+                LEFT JOIN receipt_one AS ro
+                  ON ro.lot_id = l.id
+                WHERE l.item_expiry_policy_snapshot = 'REQUIRED'::expiry_policy
+                  AND l.production_date IS NOT NULL
+            )
+            UPDATE lots AS l
+               SET production_date = NULL
+              FROM resolved AS r
+             WHERE l.id = r.lot_id
+               AND r.candidate_pd IS NOT NULL
+               AND l.production_date = r.candidate_pd
+            """
+        )
+    )

--- a/alembic/versions/3bd2a92976ba_wms_lot_backfill_expiry_date_from_.py
+++ b/alembic/versions/3bd2a92976ba_wms_lot_backfill_expiry_date_from_.py
@@ -1,0 +1,205 @@
+"""wms_lot_backfill_expiry_date_from_receipt_and_ledger
+
+Revision ID: 3bd2a92976ba
+Revises: 6176a3ab53ba
+Create Date: 2026-04-11 19:52:50.909587
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "3bd2a92976ba"
+down_revision: Union[str, Sequence[str], None] = "6176a3ab53ba"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    conn = op.get_bind()
+
+    # 1) receipt line 内部：同一 lot 不能出现多个不同 expiry_date
+    line_conflicts = conn.execute(
+        sa.text(
+            """
+            WITH target_lots AS (
+                SELECT id
+                FROM lots
+                WHERE item_expiry_policy_snapshot = 'REQUIRED'
+                  AND lot_code_source = 'SUPPLIER'
+            ),
+            conflicts AS (
+                SELECT rl.lot_id
+                FROM inbound_receipt_lines rl
+                JOIN target_lots tl
+                  ON tl.id = rl.lot_id
+                WHERE rl.expiry_date IS NOT NULL
+                GROUP BY rl.lot_id
+                HAVING COUNT(DISTINCT rl.expiry_date) > 1
+            )
+            SELECT COUNT(*) FROM conflicts
+            """
+        )
+    ).scalar_one()
+    if int(line_conflicts or 0) > 0:
+        raise RuntimeError(
+            "wms_lot_backfill_expiry_date_from_receipt_and_ledger: "
+            f"found {int(line_conflicts)} lots with conflicting expiry_date in inbound_receipt_lines"
+        )
+
+    # 2) ledger 内部：同一 lot 的 RECEIPT 事件不能出现多个不同 expiry_date
+    ledger_conflicts = conn.execute(
+        sa.text(
+            """
+            WITH target_lots AS (
+                SELECT id
+                FROM lots
+                WHERE item_expiry_policy_snapshot = 'REQUIRED'
+                  AND lot_code_source = 'SUPPLIER'
+            ),
+            conflicts AS (
+                SELECT sl.lot_id
+                FROM stock_ledger sl
+                JOIN target_lots tl
+                  ON tl.id = sl.lot_id
+                WHERE sl.reason_canon = 'RECEIPT'
+                  AND sl.expiry_date IS NOT NULL
+                GROUP BY sl.lot_id
+                HAVING COUNT(DISTINCT sl.expiry_date) > 1
+            )
+            SELECT COUNT(*) FROM conflicts
+            """
+        )
+    ).scalar_one()
+    if int(ledger_conflicts or 0) > 0:
+        raise RuntimeError(
+            "wms_lot_backfill_expiry_date_from_receipt_and_ledger: "
+            f"found {int(ledger_conflicts)} lots with conflicting expiry_date in stock_ledger(RECEIPT)"
+        )
+
+    # 3) line 与 ledger 若同时有值，不能互相打架
+    cross_conflicts = conn.execute(
+        sa.text(
+            """
+            WITH target_lots AS (
+                SELECT id
+                FROM lots
+                WHERE item_expiry_policy_snapshot = 'REQUIRED'
+                  AND lot_code_source = 'SUPPLIER'
+            ),
+            line_src AS (
+                SELECT
+                    rl.lot_id,
+                    MIN(rl.expiry_date) AS expiry_date
+                FROM inbound_receipt_lines rl
+                JOIN target_lots tl
+                  ON tl.id = rl.lot_id
+                WHERE rl.expiry_date IS NOT NULL
+                GROUP BY rl.lot_id
+            ),
+            ledger_src AS (
+                SELECT
+                    sl.lot_id,
+                    MIN(sl.expiry_date) AS expiry_date
+                FROM stock_ledger sl
+                JOIN target_lots tl
+                  ON tl.id = sl.lot_id
+                WHERE sl.reason_canon = 'RECEIPT'
+                  AND sl.expiry_date IS NOT NULL
+                GROUP BY sl.lot_id
+            ),
+            conflicts AS (
+                SELECT l.lot_id
+                FROM line_src l
+                JOIN ledger_src g
+                  ON g.lot_id = l.lot_id
+                WHERE l.expiry_date <> g.expiry_date
+            )
+            SELECT COUNT(*) FROM conflicts
+            """
+        )
+    ).scalar_one()
+    if int(cross_conflicts or 0) > 0:
+        raise RuntimeError(
+            "wms_lot_backfill_expiry_date_from_receipt_and_ledger: "
+            f"found {int(cross_conflicts)} lots with line/ledger expiry_date mismatch"
+        )
+
+    # 4) 优先用 receipt line 回填
+    conn.execute(
+        sa.text(
+            """
+            WITH line_src AS (
+                SELECT
+                    rl.lot_id,
+                    MIN(rl.expiry_date) AS expiry_date
+                FROM inbound_receipt_lines rl
+                JOIN lots l
+                  ON l.id = rl.lot_id
+                WHERE l.item_expiry_policy_snapshot = 'REQUIRED'
+                  AND l.lot_code_source = 'SUPPLIER'
+                  AND rl.expiry_date IS NOT NULL
+                GROUP BY rl.lot_id
+            )
+            UPDATE lots l
+               SET expiry_date = src.expiry_date
+              FROM line_src src
+             WHERE l.id = src.lot_id
+               AND l.item_expiry_policy_snapshot = 'REQUIRED'
+               AND l.lot_code_source = 'SUPPLIER'
+               AND l.expiry_date IS NULL
+               AND (l.production_date IS NULL OR src.expiry_date >= l.production_date)
+            """
+        )
+    )
+
+    # 5) 再用 RECEIPT ledger 兜底
+    conn.execute(
+        sa.text(
+            """
+            WITH ledger_src AS (
+                SELECT
+                    sl.lot_id,
+                    MIN(sl.expiry_date) AS expiry_date
+                FROM stock_ledger sl
+                JOIN lots l
+                  ON l.id = sl.lot_id
+                WHERE l.item_expiry_policy_snapshot = 'REQUIRED'
+                  AND l.lot_code_source = 'SUPPLIER'
+                  AND sl.reason_canon = 'RECEIPT'
+                  AND sl.expiry_date IS NOT NULL
+                GROUP BY sl.lot_id
+            )
+            UPDATE lots l
+               SET expiry_date = src.expiry_date
+              FROM ledger_src src
+             WHERE l.id = src.lot_id
+               AND l.item_expiry_policy_snapshot = 'REQUIRED'
+               AND l.lot_code_source = 'SUPPLIER'
+               AND l.expiry_date IS NULL
+               AND (l.production_date IS NULL OR src.expiry_date >= l.production_date)
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    conn = op.get_bind()
+
+    # best-effort rollback：
+    # 仅清空 REQUIRED + SUPPLIER lots 上这一轮回填得到的 canonical expiry_date
+    conn.execute(
+        sa.text(
+            """
+            UPDATE lots
+               SET expiry_date = NULL
+             WHERE item_expiry_policy_snapshot = 'REQUIRED'
+               AND lot_code_source = 'SUPPLIER'
+            """
+        )
+    )

--- a/alembic/versions/6176a3ab53ba_wms_lot_add_expiry_date.py
+++ b/alembic/versions/6176a3ab53ba_wms_lot_add_expiry_date.py
@@ -1,0 +1,49 @@
+"""wms_lot_add_expiry_date
+
+Revision ID: 6176a3ab53ba
+Revises: 0e7c789ec00b
+Create Date: 2026-04-11 19:48:05.177282
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "6176a3ab53ba"
+down_revision: Union[str, Sequence[str], None] = "0e7c789ec00b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+
+    op.add_column(
+        "lots",
+        sa.Column("expiry_date", sa.Date(), nullable=True),
+    )
+
+    op.create_check_constraint(
+        "ck_lots_production_le_expiry",
+        "lots",
+        sa.text(
+            "(production_date IS NULL) OR "
+            "(expiry_date IS NULL) OR "
+            "(production_date <= expiry_date)"
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+
+    op.drop_constraint(
+        "ck_lots_production_le_expiry",
+        "lots",
+        type_="check",
+    )
+
+    op.drop_column("lots", "expiry_date")

--- a/alembic/versions/763cb99a6e13_delete_none_supplier_lots_test_data.py
+++ b/alembic/versions/763cb99a6e13_delete_none_supplier_lots_test_data.py
@@ -1,0 +1,107 @@
+"""delete none supplier lots test data
+
+Revision ID: 763cb99a6e13
+Revises: 846b07d478c8
+Create Date: 2026-04-11 15:23:56.410027
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "763cb99a6e13"
+down_revision: Union[str, Sequence[str], None] = "846b07d478c8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    测试数据清理：
+    - 删除所有 NONE 商品下的 SUPPLIER lots
+    - 以及这些 lot 挂载的 stock_ledger / stocks_lot / stock_snapshots / inbound_receipt_lines
+    - 不做 merge / repoint
+    """
+    bind = op.get_bind()
+
+    bind.execute(
+        sa.text(
+            """
+            WITH doomed AS (
+                SELECT id AS lot_id
+                FROM lots
+                WHERE item_expiry_policy_snapshot = 'NONE'::expiry_policy
+                  AND lot_code_source = 'SUPPLIER'
+            )
+            DELETE FROM stock_ledger
+            WHERE lot_id IN (SELECT lot_id FROM doomed)
+            """
+        )
+    )
+
+    bind.execute(
+        sa.text(
+            """
+            WITH doomed AS (
+                SELECT id AS lot_id
+                FROM lots
+                WHERE item_expiry_policy_snapshot = 'NONE'::expiry_policy
+                  AND lot_code_source = 'SUPPLIER'
+            )
+            DELETE FROM stocks_lot
+            WHERE lot_id IN (SELECT lot_id FROM doomed)
+            """
+        )
+    )
+
+    bind.execute(
+        sa.text(
+            """
+            WITH doomed AS (
+                SELECT id AS lot_id
+                FROM lots
+                WHERE item_expiry_policy_snapshot = 'NONE'::expiry_policy
+                  AND lot_code_source = 'SUPPLIER'
+            )
+            DELETE FROM stock_snapshots
+            WHERE lot_id IN (SELECT lot_id FROM doomed)
+            """
+        )
+    )
+
+    bind.execute(
+        sa.text(
+            """
+            WITH doomed AS (
+                SELECT id AS lot_id
+                FROM lots
+                WHERE item_expiry_policy_snapshot = 'NONE'::expiry_policy
+                  AND lot_code_source = 'SUPPLIER'
+            )
+            DELETE FROM inbound_receipt_lines
+            WHERE lot_id IN (SELECT lot_id FROM doomed)
+            """
+        )
+    )
+
+    bind.execute(
+        sa.text(
+            """
+            DELETE FROM lots
+            WHERE item_expiry_policy_snapshot = 'NONE'::expiry_policy
+              AND lot_code_source = 'SUPPLIER'
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    测试数据删除不可逆。
+    """
+    raise NotImplementedError("irreversible test-data cleanup migration")

--- a/alembic/versions/846b07d478c8_delete_duplicate_required_lots_test_data.py
+++ b/alembic/versions/846b07d478c8_delete_duplicate_required_lots_test_data.py
@@ -1,0 +1,149 @@
+"""delete duplicate required lots test data
+
+Revision ID: 846b07d478c8
+Revises: 24ddc21b01e6
+Create Date: 2026-04-11 15:20:22.543878
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "846b07d478c8"
+down_revision: Union[str, Sequence[str], None] = "24ddc21b01e6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    测试数据清理策略：
+    - 对 REQUIRED 商品下，同 (warehouse_id, item_id, production_date) 的重复 lots，
+      保留最小 id 作为 canonical_lot_id
+    - 直接删除其它 duplicate lots 及其挂载的测试数据
+    - 不做 merge / repoint
+    """
+    bind = op.get_bind()
+
+    # 先删引用表，后删 lots
+    bind.execute(
+        sa.text(
+            """
+            WITH dup AS (
+                SELECT
+                    id AS old_lot_id,
+                    MIN(id) OVER (PARTITION BY warehouse_id, item_id, production_date) AS canonical_lot_id
+                FROM lots
+                WHERE item_expiry_policy_snapshot = 'REQUIRED'::expiry_policy
+                  AND production_date IS NOT NULL
+            ),
+            doomed AS (
+                SELECT old_lot_id
+                FROM dup
+                WHERE old_lot_id <> canonical_lot_id
+            )
+            DELETE FROM stock_ledger
+            WHERE lot_id IN (SELECT old_lot_id FROM doomed)
+            """
+        )
+    )
+
+    bind.execute(
+        sa.text(
+            """
+            WITH dup AS (
+                SELECT
+                    id AS old_lot_id,
+                    MIN(id) OVER (PARTITION BY warehouse_id, item_id, production_date) AS canonical_lot_id
+                FROM lots
+                WHERE item_expiry_policy_snapshot = 'REQUIRED'::expiry_policy
+                  AND production_date IS NOT NULL
+            ),
+            doomed AS (
+                SELECT old_lot_id
+                FROM dup
+                WHERE old_lot_id <> canonical_lot_id
+            )
+            DELETE FROM stocks_lot
+            WHERE lot_id IN (SELECT old_lot_id FROM doomed)
+            """
+        )
+    )
+
+    bind.execute(
+        sa.text(
+            """
+            WITH dup AS (
+                SELECT
+                    id AS old_lot_id,
+                    MIN(id) OVER (PARTITION BY warehouse_id, item_id, production_date) AS canonical_lot_id
+                FROM lots
+                WHERE item_expiry_policy_snapshot = 'REQUIRED'::expiry_policy
+                  AND production_date IS NOT NULL
+            ),
+            doomed AS (
+                SELECT old_lot_id
+                FROM dup
+                WHERE old_lot_id <> canonical_lot_id
+            )
+            DELETE FROM stock_snapshots
+            WHERE lot_id IN (SELECT old_lot_id FROM doomed)
+            """
+        )
+    )
+
+    bind.execute(
+        sa.text(
+            """
+            WITH dup AS (
+                SELECT
+                    id AS old_lot_id,
+                    MIN(id) OVER (PARTITION BY warehouse_id, item_id, production_date) AS canonical_lot_id
+                FROM lots
+                WHERE item_expiry_policy_snapshot = 'REQUIRED'::expiry_policy
+                  AND production_date IS NOT NULL
+            ),
+            doomed AS (
+                SELECT old_lot_id
+                FROM dup
+                WHERE old_lot_id <> canonical_lot_id
+            )
+            DELETE FROM inbound_receipt_lines
+            WHERE lot_id IN (SELECT old_lot_id FROM doomed)
+            """
+        )
+    )
+
+    bind.execute(
+        sa.text(
+            """
+            WITH dup AS (
+                SELECT
+                    id AS old_lot_id,
+                    MIN(id) OVER (PARTITION BY warehouse_id, item_id, production_date) AS canonical_lot_id
+                FROM lots
+                WHERE item_expiry_policy_snapshot = 'REQUIRED'::expiry_policy
+                  AND production_date IS NOT NULL
+            ),
+            doomed AS (
+                SELECT old_lot_id
+                FROM dup
+                WHERE old_lot_id <> canonical_lot_id
+            )
+            DELETE FROM lots
+            WHERE id IN (SELECT old_lot_id FROM doomed)
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    这是测试数据清理迁移，删除不可逆。
+    """
+    raise NotImplementedError("irreversible test-data cleanup migration")

--- a/alembic/versions/d13519e5d5ac_switch_lots_required_identity_unique_to_.py
+++ b/alembic/versions/d13519e5d5ac_switch_lots_required_identity_unique_to_.py
@@ -1,0 +1,87 @@
+"""switch lots required identity unique to production_date
+
+Revision ID: d13519e5d5ac
+Revises: 763cb99a6e13
+Create Date: 2026-04-11 16:22:05.964900
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d13519e5d5ac"
+down_revision: Union[str, Sequence[str], None] = "763cb99a6e13"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.drop_index("uq_lots_wh_item_lot_code_key", table_name="lots")
+    op.drop_index("ix_lots_wh_item_production_date", table_name="lots")
+
+    op.create_check_constraint(
+        "ck_lots_production_date_by_expiry_policy",
+        "lots",
+        "("
+        "(item_expiry_policy_snapshot = 'REQUIRED' AND production_date IS NOT NULL) OR "
+        "(item_expiry_policy_snapshot <> 'REQUIRED' AND production_date IS NULL)"
+        ")",
+    )
+
+    op.create_check_constraint(
+        "ck_lots_required_supplier_source",
+        "lots",
+        "("
+        "item_expiry_policy_snapshot <> 'REQUIRED' OR "
+        "lot_code_source = 'SUPPLIER'"
+        ")",
+    )
+
+    op.create_index(
+        "uq_lots_required_single_wh_item_prod",
+        "lots",
+        ["warehouse_id", "item_id", "production_date"],
+        unique=True,
+        postgresql_where=sa.text(
+            "lot_code_source = 'SUPPLIER' "
+            "AND item_expiry_policy_snapshot = 'REQUIRED' "
+            "AND production_date IS NOT NULL"
+        ),
+    )
+
+    op.create_index(
+        "ix_lots_wh_item_lot_code_key",
+        "lots",
+        ["warehouse_id", "item_id", "lot_code_key"],
+        unique=False,
+        postgresql_where=sa.text("lot_code IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("ix_lots_wh_item_lot_code_key", table_name="lots")
+    op.drop_index("uq_lots_required_single_wh_item_prod", table_name="lots")
+
+    op.drop_constraint("ck_lots_required_supplier_source", "lots", type_="check")
+    op.drop_constraint("ck_lots_production_date_by_expiry_policy", "lots", type_="check")
+
+    op.create_index(
+        "ix_lots_wh_item_production_date",
+        "lots",
+        ["warehouse_id", "item_id", "production_date"],
+        unique=False,
+        postgresql_where=sa.text("production_date IS NOT NULL"),
+    )
+
+    op.create_index(
+        "uq_lots_wh_item_lot_code_key",
+        "lots",
+        ["warehouse_id", "item_id", "lot_code_key"],
+        unique=True,
+        postgresql_where=sa.text("lot_code IS NOT NULL"),
+    )

--- a/alembic/versions/e2e22af73937_wms_lot_require_expiry_for_required_.py
+++ b/alembic/versions/e2e22af73937_wms_lot_require_expiry_for_required_.py
@@ -1,0 +1,158 @@
+"""wms_lot_require_expiry_for_required_supplier_lot
+
+Revision ID: e2e22af73937
+Revises: 3bd2a92976ba
+Create Date: 2026-04-11 21:58:55.883692
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "e2e22af73937"
+down_revision: Union[str, Sequence[str], None] = "3bd2a92976ba"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+CONSTRAINT_NAME = "ck_lots_required_supplier_expiry_not_null"
+TABLE_NAME = "lots"
+
+
+def _get_existing_check_def(conn) -> str | None:
+    row = conn.execute(
+        sa.text(
+            """
+            SELECT pg_get_constraintdef(c.oid) AS definition
+              FROM pg_constraint c
+              JOIN pg_class t
+                ON t.oid = c.conrelid
+             WHERE c.conname = :constraint_name
+               AND c.contype = 'c'
+               AND t.relname = :table_name
+             ORDER BY c.oid
+             LIMIT 1
+            """
+        ),
+        {
+            "constraint_name": CONSTRAINT_NAME,
+            "table_name": TABLE_NAME,
+        },
+    ).mappings().first()
+    if row is None:
+        return None
+    got = row["definition"]
+    return str(got) if got is not None else None
+
+
+def _normalize_sql(sql: str) -> str:
+    return " ".join(str(sql or "").replace("\n", " ").split()).strip().upper()
+
+
+def _constraint_def_looks_expected(definition: str) -> bool:
+    norm = _normalize_sql(definition)
+    required_fragments = (
+        "CHECK",
+        "ITEM_EXPIRY_POLICY_SNAPSHOT",
+        "LOT_CODE_SOURCE",
+        "EXPIRY_DATE IS NOT NULL",
+        "'REQUIRED'",
+        "'SUPPLIER'",
+    )
+    return all(fragment in norm for fragment in required_fragments)
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    conn = op.get_bind()
+
+    # 先做一次保守回填：
+    # 仅当同一 lot_id 在 stock_ledger 中存在唯一非空 expiry_date 时，
+    # 才允许把 lots.expiry_date 从 NULL 补成该值。
+    # 只补空，不覆盖已有非空值。
+    conn.execute(
+        sa.text(
+            """
+            WITH ledger_unique_expiry AS (
+                SELECT
+                    sl.lot_id AS lot_id,
+                    MIN(sl.expiry_date) AS expiry_date
+                FROM stock_ledger sl
+                WHERE sl.lot_id IS NOT NULL
+                  AND sl.expiry_date IS NOT NULL
+                GROUP BY sl.lot_id
+                HAVING COUNT(DISTINCT sl.expiry_date) = 1
+            )
+            UPDATE lots l
+               SET expiry_date = src.expiry_date
+              FROM ledger_unique_expiry src
+             WHERE l.id = src.lot_id
+               AND l.item_expiry_policy_snapshot = 'REQUIRED'
+               AND l.lot_code_source = 'SUPPLIER'
+               AND l.expiry_date IS NULL
+            """
+        )
+    )
+
+    null_count = conn.execute(
+        sa.text(
+            """
+            SELECT COUNT(*)
+            FROM lots
+            WHERE item_expiry_policy_snapshot = 'REQUIRED'
+              AND lot_code_source = 'SUPPLIER'
+              AND expiry_date IS NULL
+            """
+        )
+    ).scalar_one()
+
+    if int(null_count or 0) > 0:
+        raise RuntimeError(
+            "wms_lot_require_expiry_for_required_supplier_lot: "
+            f"found {int(null_count)} REQUIRED+SUPPLIER lots with NULL expiry_date"
+        )
+
+    existing_def = _get_existing_check_def(conn)
+    if existing_def is None:
+        op.create_check_constraint(
+            CONSTRAINT_NAME,
+            TABLE_NAME,
+            sa.text(
+                "("
+                "item_expiry_policy_snapshot <> 'REQUIRED' "
+                "OR lot_code_source <> 'SUPPLIER' "
+                "OR expiry_date IS NOT NULL"
+                ")"
+            ),
+        )
+        return
+
+    if not _constraint_def_looks_expected(existing_def):
+        raise RuntimeError(
+            f"{CONSTRAINT_NAME}: constraint already exists on {TABLE_NAME}, "
+            f"but definition is unexpected: {existing_def}"
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    conn = op.get_bind()
+
+    existing_def = _get_existing_check_def(conn)
+    if existing_def is None:
+        return
+
+    if not _constraint_def_looks_expected(existing_def):
+        raise RuntimeError(
+            f"{CONSTRAINT_NAME}: constraint already exists on {TABLE_NAME}, "
+            f"but definition is unexpected: {existing_def}"
+        )
+
+    op.drop_constraint(
+        CONSTRAINT_NAME,
+        TABLE_NAME,
+        type_="check",
+    )

--- a/alembic/versions/f054e01c63b1_add_lots_production_date_for_lot_.py
+++ b/alembic/versions/f054e01c63b1_add_lots_production_date_for_lot_.py
@@ -1,0 +1,40 @@
+"""add lots production_date for lot identity redesign
+
+Revision ID: f054e01c63b1
+Revises: cc39721e46a8
+Create Date: 2026-04-11 15:01:13.479087
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f054e01c63b1"
+down_revision: Union[str, Sequence[str], None] = "cc39721e46a8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "lots",
+        sa.Column("production_date", sa.Date(), nullable=True),
+    )
+
+    op.create_index(
+        "ix_lots_wh_item_production_date",
+        "lots",
+        ["warehouse_id", "item_id", "production_date"],
+        unique=False,
+        postgresql_where=sa.text("production_date IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("ix_lots_wh_item_production_date", table_name="lots")
+    op.drop_column("lots", "production_date")

--- a/app/diagnostics/routers/metrics.py
+++ b/app/diagnostics/routers/metrics.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Path, Query
@@ -24,10 +24,11 @@ from app.tms.alerts.service import load_alerts
 from app.tms.quote.metrics.failures import load_shipping_quote_failures
 
 router = APIRouter(prefix="/metrics", tags=["metrics"])
+UTC = timezone.utc
 
 
 def _today_utc_date() -> date:
-    return datetime.utcnow().date()
+    return datetime.now(UTC).date()
 
 
 # ---------------------------------------------------------

--- a/app/diagnostics/services/inventory_insights_service.py
+++ b/app/diagnostics/services/inventory_insights_service.py
@@ -17,7 +17,7 @@ class InventoryInsightsService:
     Phase M-2 / Phase 3（lot-only）：
     - stock_rows 统计 stocks_lot
     - ledger vs stock 一致性：使用 lot_id 维度对齐
-    - 过期风险：从 stock_ledger(RECEIPT) 读取 expiry_date（lot 不承载日期真相）
+    - 过期风险：从 lots.expiry_date 读取 canonical 到期日期
 
     ✅ 运维口径（封板）：
     - 默认只统计 PROD（排除 DEFAULT Test Set 商品）
@@ -164,16 +164,18 @@ class InventoryInsightsService:
         )
         active_events_30d = int((await session.execute(active_sql)).scalar() or 0)
 
-        # 5) 过期风险：从 stock_ledger(RECEIPT) 读取 expiry_date（PROD-only）
+        # 5) 过期风险：从 lots.expiry_date 读取 canonical 到期日期（只统计仍有库存 lot）
         ageing_sql = text(
             default_set_cte
             + """
-            SELECT l.expiry_date
-            FROM stock_ledger l
+            SELECT DISTINCT l.expiry_date
+            FROM stocks_lot s
+            JOIN lots l
+              ON l.id = s.lot_id
             LEFT JOIN item_test_set_items its
-              ON its.item_id = l.item_id
+              ON its.item_id = s.item_id
              AND its.set_id  = (SELECT set_id FROM default_set)
-            WHERE l.reason_canon = 'RECEIPT'
+            WHERE s.qty > 0
               AND l.expiry_date IS NOT NULL
               AND its.id IS NULL
         """
@@ -215,7 +217,7 @@ class InventoryInsightsService:
         wh = (await session.execute(wh_sql)).mappings().first() or {}
         warehouse_efficiency = round((wh.get("outbound_events") or 0) / (wh.get("total_events") or 1), 4)
 
-        # ⚠️ 输出 key 维持历史命名（避免前端立刻炸），但语义已为 lot-only
+        # 输出 key 维持历史命名，避免前端立刻炸；但 expiry 口径已切为 lot canonical
         return {
             "inventory_health_score": inventory_health_score,
             "inventory_accuracy_score": inventory_accuracy_score,

--- a/app/pms/items/models/item_barcode.py
+++ b/app/pms/items/models/item_barcode.py
@@ -1,7 +1,7 @@
 # app/pms/items/models/item_barcode.py
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import (
     BigInteger,
@@ -17,6 +17,10 @@ from sqlalchemy import (
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
 
 
 class ItemBarcode(Base):
@@ -85,7 +89,7 @@ class ItemBarcode(Base):
         DateTime(timezone=True),
         nullable=False,
         server_default=text("now()"),
-        onupdate=datetime.utcnow,
+        onupdate=_utcnow,
     )
 
     __table_args__ = (

--- a/app/tms/alerts/service.py
+++ b/app/tms/alerts/service.py
@@ -1,7 +1,7 @@
 # app/tms/alerts/service.py
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import Dict, List, Optional, Tuple
 
 from sqlalchemy import text
@@ -9,9 +9,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.analytics.contracts.metrics_alerts import AlertItem, AlertsResponse
 
+UTC = timezone.utc
+
 
 def _today_utc_date() -> date:
-    return datetime.utcnow().date()
+    return datetime.now(UTC).date()
 
 
 def _severity_for_threshold(count: int, threshold: int, *, crit_factor: float = 3.0) -> str:

--- a/app/wms/inbound/repos/inbound_stock_write_repo.py
+++ b/app/wms/inbound/repos/inbound_stock_write_repo.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -20,6 +20,8 @@ async def apply_inbound_stock(
     ref_line: int,
     occurred_at: datetime | None,
     batch_code: str | None,
+    production_date: date | None,
+    expiry_date: date | None,
     trace_id: str,
     source_type: str,
     source_biz_type: str | None,
@@ -29,6 +31,10 @@ async def apply_inbound_stock(
     """
     第一阶段 repo 仍临时包裹既有 StockService.adjust_lot。
     这样 atomic service 不直接依赖旧 service 细节。
+
+    当前中心任务：
+    - receipt line 的 production_date / expiry_date 必须继续向下传，
+      让 lot snapshot 与 RECEIPT ledger snapshot 使用同一决策输入
     """
     stock_svc = StockService()
 
@@ -50,8 +56,8 @@ async def apply_inbound_stock(
             "source_ref": source_ref,
             "remark": remark,
         },
-        production_date=None,
-        expiry_date=None,
+        production_date=production_date,
+        expiry_date=expiry_date,
         trace_id=trace_id,
         shadow_write_stocks=False,
     )

--- a/app/wms/inbound/repos/lot_resolve_repo.py
+++ b/app/wms/inbound/repos/lot_resolve_repo.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import date
+
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.pms.public.items.contracts.item_policy import ItemPolicy
@@ -8,11 +10,12 @@ from app.wms.stock.services.lot_service import resolve_or_create_lot
 
 def infer_lot_code_source_from_policy(item_policy: ItemPolicy) -> str:
     """
-    原子入库第一阶段最小规则：
-    - 商品 lot_source_policy = SUPPLIER_ONLY 时，用 SUPPLIER
-    - 其他默认 INTERNAL
+    当前中心任务收口：
+
+    - REQUIRED 商品：走 SUPPLIER lot 路径，由 production_date 决定 lot 身份
+    - 其他商品：统一走 INTERNAL singleton
     """
-    if item_policy.lot_source_policy == "SUPPLIER_ONLY":
+    if str(item_policy.expiry_policy or "").upper() == "REQUIRED":
         return "SUPPLIER"
     return "INTERNAL"
 
@@ -23,6 +26,8 @@ async def resolve_inbound_lot(
     warehouse_id: int,
     item_policy: ItemPolicy,
     lot_code: str | None,
+    production_date: date | None,
+    expiry_date: date | None,
 ) -> int:
     lot_code_source = infer_lot_code_source_from_policy(item_policy)
 
@@ -31,6 +36,8 @@ async def resolve_inbound_lot(
 
     if lot_code_source != "SUPPLIER":
         lot_code = None
+        production_date = None
+        expiry_date = None
 
     return await resolve_or_create_lot(
         db=session,
@@ -38,6 +45,8 @@ async def resolve_inbound_lot(
         item_policy=item_policy,
         lot_code_source=lot_code_source,
         lot_code=lot_code,
+        production_date=production_date,
+        expiry_date=expiry_date,
         source_receipt_id=source_receipt_id,
         source_line_no=source_line_no,
     )

--- a/app/wms/inbound/services/inbound_atomic_service.py
+++ b/app/wms/inbound/services/inbound_atomic_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Sequence
 from uuid import uuid4
 
@@ -32,8 +32,8 @@ class ResolvedInboundLine:
     qty: int
     ref_line: int | None = None
     lot_code: str | None = None
-    production_date: datetime | None = None
-    expiry_date: datetime | None = None
+    production_date: date | None = None
+    expiry_date: date | None = None
 
 
 async def _resolve_lines(
@@ -61,16 +61,8 @@ async def _resolve_lines(
                 qty=int(line.qty),
                 ref_line=int(line.ref_line) if line.ref_line is not None else None,
                 lot_code=line.lot_code,
-                production_date=(
-                    datetime.combine(line.production_date, datetime.min.time(), tzinfo=UTC)
-                    if line.production_date is not None
-                    else None
-                ),
-                expiry_date=(
-                    datetime.combine(line.expiry_date, datetime.min.time(), tzinfo=UTC)
-                    if line.expiry_date is not None
-                    else None
-                ),
+                production_date=line.production_date,
+                expiry_date=line.expiry_date,
             )
         )
 
@@ -108,6 +100,8 @@ async def _apply_inbound_lines(
             warehouse_id=int(warehouse_id),
             item_policy=item_policy,
             lot_code=line.lot_code,
+            production_date=line.production_date,
+            expiry_date=line.expiry_date,
         )
 
         ref = source_ref or trace_id
@@ -123,6 +117,8 @@ async def _apply_inbound_lines(
             ref_line=ref_line,
             occurred_at=datetime.now(UTC),
             batch_code=line.lot_code,
+            production_date=line.production_date,
+            expiry_date=line.expiry_date,
             trace_id=trace_id,
             source_type=source_type,
             source_biz_type=source_biz_type,

--- a/app/wms/outbound/services/outbound_commit_service.py
+++ b/app/wms/outbound/services/outbound_commit_service.py
@@ -112,13 +112,13 @@ async def _load_existing_order_id(session: AsyncSession, *, order_ref: str) -> i
     return 0
 
 
-def _norm_lot_code_key(v: str | None) -> str | None:
+def _norm_lot_code(v: str | None) -> str | None:
     if v is None:
         return None
     s = str(v).strip()
     if not s:
         return None
-    return s.upper()
+    return s
 
 
 def _requires_batch_from_expiry_policy(v: object) -> bool:
@@ -132,11 +132,11 @@ async def _resolve_lot_id_by_lot_code(
     item_id: int,
     lot_code: str,
 ) -> Optional[int]:
-    k = _norm_lot_code_key(lot_code)
-    if not k:
+    code = _norm_lot_code(lot_code)
+    if not code:
         return None
 
-    row = (
+    rows = (
         await session.execute(
             sa.text(
                 """
@@ -145,14 +145,21 @@ async def _resolve_lot_id_by_lot_code(
                  WHERE warehouse_id = :w
                    AND item_id      = :i
                    AND lot_code_source = 'SUPPLIER'
-                   AND lot_code_key = :k
-                 LIMIT 1
+                   AND lot_code = :code
+                 ORDER BY id ASC
+                 LIMIT 2
                 """
             ),
-            {"w": int(warehouse_id), "i": int(item_id), "k": str(k)},
+            {"w": int(warehouse_id), "i": int(item_id), "code": str(code)},
         )
-    ).first()
-    return int(row[0]) if row else None
+    ).all()
+
+    if not rows:
+        return None
+    if len(rows) > 1:
+        raise ValueError("supplier_lot_code_ambiguous")
+
+    return int(rows[0][0])
 
 
 class OutboundService:
@@ -294,7 +301,6 @@ class OutboundService:
 
             try:
                 if requires_batch and (batch_code is not None) and (lot_id is not None):
-                    # lot-only：adjust_lot 可能抛 ValueError(insufficient stock...)
                     res = await self.stock_svc.adjust_lot(
                         session=session,
                         item_id=item_id,
@@ -371,7 +377,19 @@ class OutboundService:
 
             except ValueError as e:
                 msg = str(e)
-                if "insufficient stock" in msg.lower():
+                if msg == "supplier_lot_code_ambiguous":
+                    results.append(
+                        {
+                            "item_id": item_id,
+                            "batch_code": batch_code,
+                            "warehouse_id": wh_id,
+                            "qty": need,
+                            "status": "REJECTED",
+                            "error_code": "supplier_lot_code_ambiguous",
+                            "error": msg,
+                        }
+                    )
+                elif "insufficient stock" in msg.lower():
                     results.append(
                         {
                             "item_id": item_id,

--- a/app/wms/outbound/services/pick_service.py
+++ b/app/wms/outbound/services/pick_service.py
@@ -8,8 +8,14 @@ from sqlalchemy import text as SA
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.enums import MovementType
-from app.wms.stock.services.lots import normalize_lot_code
 from app.wms.stock.services.stock_service import StockService
+
+
+def _norm_lot_code(v: str | None) -> str | None:
+    if v is None:
+        return None
+    s = str(v).strip()
+    return s or None
 
 
 class PickService:
@@ -19,6 +25,11 @@ class PickService:
     - record_pick：按 (warehouse,item,batch_code?) 扣减库存并写台账
     - SUPPLIER（batch_code 非空）：必须能解析到既有 lot_id（不允许 outflow 时隐式创建 lot）
     - NONE（batch_code 为空）：由 StockService 走 INTERNAL 单例 lot（合同闸门裁决）
+
+    当前中心任务收口：
+    - REQUIRED lot 身份已经切到 production_date
+    - batch_code / lot_code 不再是结构身份，只能作为辅助解析输入
+    - 若同一个 lot_code 命中多个 SUPPLIER lots，必须显式报歧义
     """
 
     def __init__(self, stock_svc: Optional[StockService] = None) -> None:
@@ -32,9 +43,11 @@ class PickService:
         item_id: int,
         lot_code: str,
     ) -> Optional[int]:
-        _code_raw, code_key = normalize_lot_code(lot_code)
+        lot_norm = _norm_lot_code(lot_code)
+        if lot_norm is None:
+            return None
 
-        row = (
+        rows = (
             await session.execute(
                 SA(
                     """
@@ -43,18 +56,21 @@ class PickService:
                      WHERE warehouse_id = :w
                        AND item_id      = :i
                        AND lot_code_source = 'SUPPLIER'
-                       AND lot_code_key = :k
-                     LIMIT 1
+                       AND lot_code = :code
+                     ORDER BY id ASC
+                     LIMIT 2
                     """
                 ),
-                {"w": int(warehouse_id), "i": int(item_id), "k": str(code_key)},
+                {"w": int(warehouse_id), "i": int(item_id), "code": str(lot_norm)},
             )
-        ).first()
+        ).all()
 
-        if not row:
+        if not rows:
             return None
+        if len(rows) > 1:
+            raise ValueError("supplier_lot_code_ambiguous")
 
-        return int(row[0])
+        return int(rows[0][0])
 
     async def record_pick(
         self,
@@ -78,15 +94,14 @@ class PickService:
             * REQUIRED 商品：非空（由路由/contract 校验保证）
             * NONE 商品：必须为 None（由路由/contract 校验保证）
 
-        任务3 第二刀（StockService API 拆分）：
-        - SUPPLIER（batch_code 非空）路径改为走 StockService.adjust_lot（lot-only 执行入口）
-          前提：这里已显式解析 lot_id，且解析不到直接拒绝（不允许 outflow 隐式创建 lot）。
-        - NONE（batch_code 为空）路径继续走 StockService.adjust，让合同闸门裁决 INTERNAL 单例 lot。
+        当前阶段：
+        - SUPPLIER（batch_code 非空）路径走 StockService.adjust_lot
+        - NONE（batch_code 为空）路径继续走 StockService.adjust
         """
         if int(qty) <= 0:
             raise ValueError("pick_qty_must_be_positive")
 
-        bc_norm = (str(batch_code).strip() if batch_code is not None else None) or None
+        bc_norm = _norm_lot_code(batch_code)
 
         # SUPPLIER：必须解析到既有 lot_id，否则拒绝
         if bc_norm is not None:
@@ -97,7 +112,6 @@ class PickService:
                 lot_code=str(bc_norm),
             )
             if resolved_lot_id is None:
-                # 终态语义：出库扣减必须落到既有 lot_id；找不到就是业务数据缺失
                 raise ValueError("lot_not_found")
 
             res = await self.stock_svc.adjust_lot(
@@ -110,14 +124,13 @@ class PickService:
                 ref=str(ref),
                 ref_line=int(start_ref_line),
                 occurred_at=occurred_at,
-                batch_code=bc_norm,  # 展示码（lots.lot_code）
+                batch_code=bc_norm,
                 production_date=None,
                 expiry_date=None,
                 trace_id=trace_id,
                 shadow_write_stocks=False,
             )
         else:
-            # NONE：交给 StockService.adjust 走合同闸门 -> INTERNAL 单例 lot
             res = await self.stock_svc.adjust(
                 session=session,
                 item_id=int(item_id),

--- a/app/wms/outbound/services/pick_task_commit_ship_apply_stock.py
+++ b/app/wms/outbound/services/pick_task_commit_ship_apply_stock.py
@@ -16,13 +16,13 @@ from app.wms.outbound.services.pick_task_commit_ship_apply_stock_details import 
 from app.wms.outbound.services.pick_task_commit_ship_apply_stock_queries import load_on_hand_qty
 
 
-def _norm_lot_code_key(v: str | None) -> str | None:
+def _norm_lot_code(v: str | None) -> str | None:
     if v is None:
         return None
     s = str(v).strip()
     if not s:
         return None
-    return s.upper()
+    return s
 
 
 async def _resolve_supplier_lot_id(
@@ -33,17 +33,17 @@ async def _resolve_supplier_lot_id(
     lot_code: str,
 ) -> Optional[int]:
     """
-    批次受控商品（展示码非空）：lot_code 视为 lots.lot_code（SUPPLIER）。
+    批次受控商品（展示码非空）：lot_code 仅作为 lots.lot_code 的辅助解析输入。
 
-    终态：
-    - SUPPLIER 批次按 lot_code_key 唯一（防漂移）
-    - 找不到 lot_id 属于业务数据缺失（应提示“lot_not_found”类问题）
+    当前阶段：
+    - lot_code 不再是结构身份
+    - 若命中多个 SUPPLIER lots，则显式报歧义
     """
-    k = _norm_lot_code_key(lot_code)
-    if not k:
+    code = _norm_lot_code(lot_code)
+    if not code:
         return None
 
-    row = (
+    rows = (
         await session.execute(
             SA(
                 """
@@ -52,16 +52,20 @@ async def _resolve_supplier_lot_id(
                  WHERE warehouse_id = :w
                    AND item_id      = :i
                    AND lot_code_source = 'SUPPLIER'
-                   AND lot_code_key = :k
-                 LIMIT 1
+                   AND lot_code = :code
+                 ORDER BY id ASC
+                 LIMIT 2
                 """
             ),
-            {"w": int(warehouse_id), "i": int(item_id), "k": str(k)},
+            {"w": int(warehouse_id), "i": int(item_id), "code": str(code)},
         )
-    ).first()
-    if not row:
+    ).all()
+
+    if not rows:
         return None
-    return int(row[0])
+    if len(rows) > 1:
+        raise ValueError("supplier_lot_code_ambiguous")
+    return int(rows[0][0])
 
 
 async def _pick_one_lot_for_none_code(
@@ -162,7 +166,6 @@ async def apply_stock_deductions_impl(
 
         need_total = int(total_picked)
 
-        # 只读校验（用于可行动错误提示；不参与扣减原子性裁决）
         on_hand = await load_on_hand_qty(
             session,
             warehouse_id=int(warehouse_id),
@@ -198,9 +201,7 @@ async def apply_stock_deductions_impl(
             )
 
         try:
-            # --- lot_id 解析 + 扣减 ---
             if bc_norm:
-                # 批次受控：lot_code -> SUPPLIER lot_id（按 lot_code_key 唯一）
                 lot_id = await _resolve_supplier_lot_id(
                     session,
                     warehouse_id=int(warehouse_id),
@@ -223,7 +224,7 @@ async def apply_stock_deductions_impl(
                             {
                                 "type": "validation",
                                 "path": "stock_adjust",
-                                "reason": "failed to resolve lot_id from batch_code",
+                                "reason": "failed to resolve lot_id from lot_code",
                             }
                         ],
                         next_actions=[
@@ -259,8 +260,6 @@ async def apply_stock_deductions_impl(
                 ref_line += 1
                 continue
 
-            # 非批次商品：batch_code=None（展示码为空）
-            # INTERNAL 单例 lot：仍按“从可扣减库存中找一个 lot”执行（更稳健）
             remain = int(need_total)
             while remain > 0:
                 pick = await _pick_one_lot_for_none_code(
@@ -269,7 +268,6 @@ async def apply_stock_deductions_impl(
                     item_id=int(item_id),
                 )
                 if pick is None:
-                    # 理论上不会发生（前面 on_hand 已校验够），但为防“总量够但没有可扣 lot”的脏数据情况
                     raise_problem(
                         status_code=409,
                         error_code="insufficient_stock",
@@ -327,10 +325,47 @@ async def apply_stock_deductions_impl(
                 remain -= int(take)
 
         except HTTPException:
-            # ✅ Problem 化异常原样透传（库存不足/批次不合法/其它业务拒绝）
             raise
+        except ValueError as e:
+            if str(e) == "supplier_lot_code_ambiguous":
+                raise_problem(
+                    status_code=422,
+                    error_code="supplier_lot_code_ambiguous",
+                    message="同一展示批次码命中多个库存槽位，禁止提交出库。",
+                    context={
+                        "task_id": int(task_id),
+                        "warehouse_id": int(warehouse_id),
+                        "ref": str(order_ref),
+                        "item_id": int(item_id),
+                        "batch_code": bc_norm,
+                    },
+                    details=[
+                        {
+                            "type": "validation",
+                            "path": "stock_adjust",
+                            "reason": "lot_code matched multiple supplier lots",
+                        }
+                    ],
+                    next_actions=[
+                        {"action": "rescan_stock", "label": "刷新库存"},
+                        {"action": "edit_batch", "label": "更正批次"},
+                    ],
+                )
+
+            raise_problem(
+                status_code=500,
+                error_code="pick_apply_failed",
+                message="拣货扣减失败：系统异常。",
+                context={
+                    "task_id": int(task_id),
+                    "warehouse_id": int(warehouse_id),
+                    "ref": str(order_ref),
+                    "item_id": int(item_id),
+                    "batch_code": bc_norm,
+                },
+                details=[{"type": "state", "path": "apply_stock_deductions", "reason": str(e)}],
+            )
         except Exception as e:
-            # ✅ 未知异常统一收敛为 500 Problem
             raise_problem(
                 status_code=500,
                 error_code="pick_apply_failed",

--- a/app/wms/outbound/services/return_task_service_impl.py
+++ b/app/wms/outbound/services/return_task_service_impl.py
@@ -11,8 +11,8 @@ from sqlalchemy.orm import selectinload
 from app.models.enums import MovementType
 from app.models.return_task import ReturnTask, ReturnTaskLine
 from app.wms.ledger.models.stock_ledger import StockLedger
-from app.wms.stock.services.stock_service import StockService
 from app.wms.reconciliation.services.three_books_enforcer import enforce_three_books
+from app.wms.stock.services.stock_service import StockService
 
 UTC = timezone.utc
 
@@ -31,48 +31,57 @@ def _norm_bc(v: Any) -> Optional[str]:
     return s2
 
 
-def _norm_lot_code_key(v: str | None) -> str | None:
+def _norm_lot_code(v: str | None) -> str | None:
     if v is None:
         return None
     s = str(v).strip()
     if not s:
         return None
-    return s.upper()
+    return s
 
 
-async def _resolve_lot_id_by_lot_code(
+async def _load_supplier_lot_snapshot_by_lot_code(
     session: AsyncSession,
     *,
     warehouse_id: int,
     item_id: int,
     lot_code: str | None,
-) -> Optional[int]:
+) -> Optional[dict[str, Any]]:
     if lot_code is None:
         return None
-    k = _norm_lot_code_key(lot_code)
-    if not k:
+
+    code = _norm_lot_code(lot_code)
+    if not code:
         return None
-    row = (
+
+    rows = (
         await session.execute(
             text(
                 """
-                SELECT id
+                SELECT id, production_date, expiry_date
                   FROM lots
                  WHERE warehouse_id = :w
                    AND item_id      = :i
                    AND lot_code_source = 'SUPPLIER'
-                   AND lot_code_key = :k
+                   AND lot_code = :code
                  LIMIT 2
                 """
             ),
-            {"w": int(warehouse_id), "i": int(item_id), "k": str(k)},
+            {"w": int(warehouse_id), "i": int(item_id), "code": str(code)},
         )
-    ).fetchall()
-    if not row:
+    ).mappings().all()
+
+    if not rows:
         return None
-    if len(row) > 1:
+    if len(rows) > 1:
         return None
-    return int(row[0][0])
+
+    row = rows[0]
+    return {
+        "id": int(row["id"]),
+        "production_date": row.get("production_date"),
+        "expiry_date": row.get("expiry_date"),
+    }
 
 
 class ReturnTaskServiceImpl:
@@ -289,30 +298,51 @@ class ReturnTaskServiceImpl:
             bc = _norm_bc(ln.batch_code)
 
             resolved_lot_id: Optional[int] = None
+
             if bc is not None:
-                resolved_lot_id = await _resolve_lot_id_by_lot_code(
+                lot_snapshot = await _load_supplier_lot_snapshot_by_lot_code(
                     session,
                     warehouse_id=int(task.warehouse_id),
                     item_id=int(ln.item_id),
                     lot_code=str(bc),
                 )
-                if resolved_lot_id is None:
+                if lot_snapshot is None:
                     raise ValueError("lot_not_found_for_batch_code")
 
-            # ✅ 任务3 收口：不再把 lot_id 传给 adjust（合同入口禁止混用）
-            res = await self.stock_svc.adjust(
-                session=session,
-                item_id=int(ln.item_id),
-                delta=+picked,
-                reason=MovementType.RETURN,
-                ref=str(task.order_id),
-                ref_line=ref_line,
-                occurred_at=ts,
-                batch_code=bc,
-                warehouse_id=int(task.warehouse_id),
-                trace_id=trace_id,
-                meta={"sub_reason": "RETURN_RECEIPT"},
-            )
+                resolved_lot_id = int(lot_snapshot["id"])
+
+                # 已经解析到真实 lot_id 后，直接走 lot-only 原语入口，
+                # 不再让 RETURN 正增量再次走 batch_code -> 日期裁决。
+                res = await self.stock_svc.adjust_lot(
+                    session=session,
+                    item_id=int(ln.item_id),
+                    warehouse_id=int(task.warehouse_id),
+                    lot_id=int(resolved_lot_id),
+                    delta=+picked,
+                    reason=MovementType.RETURN,
+                    ref=str(task.order_id),
+                    ref_line=ref_line,
+                    occurred_at=ts,
+                    batch_code=None,
+                    production_date=lot_snapshot.get("production_date"),
+                    expiry_date=lot_snapshot.get("expiry_date"),
+                    trace_id=trace_id,
+                    meta={"sub_reason": "RETURN_RECEIPT"},
+                )
+            else:
+                res = await self.stock_svc.adjust(
+                    session=session,
+                    item_id=int(ln.item_id),
+                    delta=+picked,
+                    reason=MovementType.RETURN,
+                    ref=str(task.order_id),
+                    ref_line=ref_line,
+                    occurred_at=ts,
+                    batch_code=None,
+                    warehouse_id=int(task.warehouse_id),
+                    trace_id=trace_id,
+                    meta={"sub_reason": "RETURN_RECEIPT"},
+                )
 
             applied_lot_id = int(res.get("lot_id") or (resolved_lot_id or 0) or 0)
 

--- a/app/wms/procurement/services/inbound_atomic_adapter.py
+++ b/app/wms/procurement/services/inbound_atomic_adapter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any
 
 from app.wms.inbound.contracts.inbound_atomic import InboundAtomicCreateIn
@@ -17,6 +17,8 @@ async def apply_receipt_line_via_atomic_inbound(
     item_id: int,
     qty_base: int,
     lot_code: str | None,
+    production_date: date | None,
+    expiry_date: date | None,
 ) -> dict[str, Any]:
     """
     procurement -> atomic inbound adapter（第一阶段）：
@@ -25,6 +27,7 @@ async def apply_receipt_line_via_atomic_inbound(
     - source_type 固定为 upstream
     - source_biz_type 固定为 purchase_receipt_confirm
     - source_ref 使用 receipt.ref，保持 ledger 关联稳定
+    - production_date / expiry_date 由 receipt line 作为唯一决策输入传入
     """
     _ = occurred_at
 
@@ -40,6 +43,8 @@ async def apply_receipt_line_via_atomic_inbound(
                     "qty": int(qty_base),
                     "ref_line": int(ref_line),
                     "lot_code": lot_code,
+                    "production_date": production_date,
+                    "expiry_date": expiry_date,
                 }
             ],
         }

--- a/app/wms/procurement/services/inbound_receipt_confirm.py
+++ b/app/wms/procurement/services/inbound_receipt_confirm.py
@@ -18,6 +18,7 @@ from app.wms.procurement.repos.inbound_receipt_confirm_repo import (
 )
 from app.wms.procurement.services.inbound_receipt_explain import explain_receipt
 from app.wms.procurement.services.inbound_atomic_adapter import apply_receipt_line_via_atomic_inbound
+from app.wms.shared.services.expiry_resolver import normalize_batch_dates_for_item
 
 UTC = timezone.utc
 _PSEUDO_LOT_CODE_TOKENS = {"NOEXP", "NONE"}
@@ -78,6 +79,37 @@ async def confirm_receipt(
                 message=f"商品不存在：item_id={item_id}",
             )
 
+        raw_production_date = getattr(rl, "production_date", None)
+        raw_expiry_date = getattr(rl, "expiry_date", None)
+
+        resolved_production_date, resolved_expiry_date, _resolution_mode = await normalize_batch_dates_for_item(
+            session,
+            item_id=item_id,
+            production_date=raw_production_date,
+            expiry_date=raw_expiry_date,
+        )
+
+        item_expiry_policy = str(getattr(item, "expiry_policy", "NONE") or "NONE").upper()
+        if item_expiry_policy == "REQUIRED":
+            if resolved_production_date is None:
+                raise_problem(
+                    status_code=422,
+                    error_code="RECEIPT_LINE_DATE_UNRESOLVED",
+                    message="批次受控商品必须提供 production_date，或提供可结合保质期反推出 production_date 的 expiry_date。",
+                    details=[{"line_no": int(getattr(rl, "line_no", idx)), "item_id": int(item_id)}],
+                )
+            if resolved_expiry_date is None:
+                raise_problem(
+                    status_code=422,
+                    error_code="RECEIPT_LINE_DATE_UNRESOLVED",
+                    message="未提供到期日期，且商品未配置可用于推算的保质期，无法形成 canonical expiry_date。",
+                    details=[{"line_no": int(getattr(rl, "line_no", idx)), "item_id": int(item_id)}],
+                )
+
+        # 把 line 上的日期更新成 canonical，避免确认后仍残留原始输入语义
+        rl.production_date = resolved_production_date
+        rl.expiry_date = resolved_expiry_date
+
         res = await apply_receipt_line_via_atomic_inbound(
             session,
             warehouse_id=warehouse_id,
@@ -87,6 +119,8 @@ async def confirm_receipt(
             item_id=item_id,
             qty_base=qty_delta,
             lot_code=getattr(rl, "lot_code_input", None),
+            production_date=resolved_production_date,
+            expiry_date=resolved_expiry_date,
         )
 
         row = res.get("row")

--- a/app/wms/procurement/services/inbound_service.py
+++ b/app/wms/procurement/services/inbound_service.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.enums import MovementType
 from app.wms.stock.services.stock_service import StockService
-from app.wms.shared.services.expiry_resolver import resolve_batch_dates_for_item
+from app.wms.shared.services.expiry_resolver import normalize_batch_dates_for_item
 
 UTC = timezone.utc
 
@@ -65,12 +65,13 @@ class InboundService:
         sub_reason: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
-        任务3 第四刀修正：
+        入库服务（owner 入口）：
 
         - REQUIRED/NONE 的批次裁决仍由 StockService.adjust(合同闸门)负责；
         - 但对 expiry_policy=NONE 的商品，入口层必须把 batch_code 投影为 None，
-          否则会触发合同的 batch_forbidden（这符合终态合同：NONE 商品 batch_code 必须为 null）。
-        - 日期规则仅对 REQUIRED 强制。
+          否则会触发合同的 batch_forbidden（这符合终态合同：NONE 商品 batch_code 必须为 null）；
+        - 对 REQUIRED 商品，入口层必须先把用户输入归一为 resolved_production_date /
+          resolved_expiry_date，再交给 lot / ledger 写入口。
         """
         if qty <= 0:
             raise ValueError("Receive quantity must be positive.")
@@ -87,29 +88,27 @@ class InboundService:
         # 轻量归一：空串/空格 -> None
         code = (str(batch_code).strip() if batch_code is not None else None) or None
 
-        # ✅ 关键：NONE 商品必须把 batch_code 投影为 None（不允许传入任何值）
+        # NONE 商品必须把 batch_code 投影为 None（不允许传入任何值）
         if not requires_batch:
             code = None
-
-        # 日期规则（仅 REQUIRED 强制）
-        if requires_batch:
+            resolved_production_date = None
+            resolved_expiry_date = None
+        else:
             if production_date is None and expiry_date is None:
                 raise ValueError("该商品需要有效期管理：必须提供生产日期或到期日期（至少其一）")
 
-            prod, exp = await resolve_batch_dates_for_item(
+            resolved_production_date, resolved_expiry_date, _resolution_mode = await normalize_batch_dates_for_item(
                 session,
                 item_id=iid,
                 production_date=production_date,
                 expiry_date=expiry_date,
             )
-            production_date, expiry_date = prod, exp
 
-            if expiry_date is None:
-                raise ValueError("未提供到期日期，且商品未配置保质期参数，无法推算到期日期")
-        else:
-            # NONE：不写日期事实
-            production_date = None
-            expiry_date = None
+            if resolved_production_date is None:
+                raise ValueError("批次受控商品必须提供 production_date，或提供可结合保质期反推出 production_date 的 expiry_date。")
+
+            if resolved_expiry_date is None:
+                raise ValueError("未提供到期日期，且商品未配置可用于推算的保质期，无法形成 canonical expiry_date。")
 
         meta = {"sub_reason": sub_reason} if (sub_reason and str(sub_reason).strip()) else None
 
@@ -124,8 +123,8 @@ class InboundService:
             occurred_at=occurred_at or datetime.now(UTC),
             meta=meta,
             batch_code=code,
-            production_date=production_date,
-            expiry_date=expiry_date,
+            production_date=resolved_production_date,
+            expiry_date=resolved_expiry_date,
             trace_id=trace_id,
         )
 

--- a/app/wms/procurement/services/purchase_order_receive_workbench_canon.py
+++ b/app/wms/procurement/services/purchase_order_receive_workbench_canon.py
@@ -8,7 +8,6 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.wms.stock.models.lot import Lot
-from app.wms.ledger.models.stock_ledger import StockLedger
 from app.wms.procurement.contracts.purchase_order_receive_workbench import WorkbenchBatchRowOut
 
 
@@ -20,13 +19,17 @@ async def fill_canonical_lot_dates(
     batches_map: Dict[int, List[WorkbenchBatchRowOut]],
 ) -> None:
     """
-    将 WorkbenchBatchRowOut.production_date/expiry_date 回填为 canonical
-    （来自 lots + stock_ledger(reason_canon='RECEIPT')）。
+    将 WorkbenchBatchRowOut.production_date / expiry_date 回填为 canonical。
 
     合同：
-    - lot_code=None => prod/exp 必须为 None
-    - lot_code!=None => 先按 (warehouse_id, item_id, lot_code) 定位 lots，
-      再从 stock_ledger 的 RECEIPT 时间事实回填 production_date/expiry_date
+    - lot_code=None => production_date / expiry_date 必须为 None
+    - lot_code!=None => 按 (warehouse_id, item_id, lot_code) 定位 lots，
+      从 lots.production_date / lots.expiry_date 读取 canonical snapshot
+
+    说明：
+    - 当前 workbench 仍以 (item_id, lot_code) 做批次聚合展示；
+      因此这里继续按该维度聚合 lots，并保持与现有展示合同一致。
+    - 这一步的目标，是让 workbench 的日期展示完全跟随 lot canonical snapshot。
     """
     need_pairs: set[tuple[int, str]] = set()
     for po_line_id, xs in batches_map.items():
@@ -45,19 +48,10 @@ async def fill_canonical_lot_dates(
             select(
                 Lot.item_id,
                 Lot.lot_code,
-                sa.func.max(StockLedger.production_date).label("production_date"),
-                sa.func.max(StockLedger.expiry_date).label("expiry_date"),
+                sa.func.max(Lot.production_date).label("production_date"),
+                sa.func.max(Lot.expiry_date).label("expiry_date"),
             )
             .select_from(Lot)
-            .join(
-                StockLedger,
-                sa.and_(
-                    StockLedger.lot_id == Lot.id,
-                    StockLedger.warehouse_id == Lot.warehouse_id,
-                    StockLedger.item_id == Lot.item_id,
-                    StockLedger.reason_canon == "RECEIPT",
-                ),
-            )
             .where(Lot.warehouse_id == int(warehouse_id))
             .where(sa.tuple_(Lot.item_id, Lot.lot_code).in_(list(need_pairs)))
             .group_by(Lot.item_id, Lot.lot_code)
@@ -76,6 +70,10 @@ async def fill_canonical_lot_dates(
                 b.production_date = None
                 b.expiry_date = None
                 continue
-            production_date, expiry_date = canon_map.get((int(item_id), str(lot_code)), (None, None))
+
+            production_date, expiry_date = canon_map.get(
+                (int(item_id), str(lot_code)),
+                (None, None),
+            )
             b.production_date = production_date
             b.expiry_date = expiry_date

--- a/app/wms/procurement/services/receive_po_line.py
+++ b/app/wms/procurement/services/receive_po_line.py
@@ -23,6 +23,7 @@ from app.wms.procurement.repos.receipt_draft_repo import (
     sum_confirmed_received_base,
     sum_draft_received_base,
 )
+from app.wms.shared.services.expiry_resolver import normalize_batch_dates_for_item
 
 _PSEUDO_LOT_CODE_TOKENS = {"NOEXP", "NONE"}
 
@@ -69,6 +70,15 @@ async def receive_po_line(
     - 输入：uom_id + qty（qty 是输入数量，按该 uom）
     - 事实：qty_base = qty * ratio_to_base（ratio 来自 item_uoms）
     - 禁止：units_per_case / 历史字段 fallback
+
+    日期语义：
+    - DRAFT line 现在直接写入 canonical 日期对
+    - REQUIRED 商品：允许 production-only / both / expiry-only 三种输入，但落库前必须先归一
+    - NONE 商品：统一不写日期
+
+    校验顺序：
+    - 先判标签层（lot_source_policy / lot_code）
+    - 再判日期层（expiry_policy / canonical dates）
     """
     _ = occurred_at
     _ = barcode
@@ -97,7 +107,7 @@ async def receive_po_line(
                 break
 
     if target is None:
-        raise ValueError(f"在采购单 {po_id} 中未找到匹配的行")
+        raise ValueError("在采购单 %s 中未找到匹配的行" % po_id)
 
     draft = await get_latest_po_draft_receipt(session, po_id=int(po.id))
     if draft is None:
@@ -126,27 +136,54 @@ async def receive_po_line(
 
     next_line_no = await next_receipt_line_no(session, receipt_id=int(draft.id))
 
+    lot_code = _normalize_lot_code(lot_code)
+    if _is_pseudo_lot_code(lot_code):
+        raise HTTPException(status_code=400, detail="lot_code 禁止伪码（NOEXP/NONE）")
+
+    # 先判标签层
+    lot_source_policy = await load_item_lot_source_policy(session, item_id=item_id_val)
+    if lot_source_policy == "SUPPLIER_ONLY" and lot_code is None:
+        raise HTTPException(status_code=400, detail="供应商 lot_code 必填（lot_source_policy=SUPPLIER_ONLY）")
+
+    # 再判日期层
     expiry_policy = await load_item_expiry_policy(session, item_id=item_id_val)
     if expiry_policy == "NONE":
         production_date = None
         expiry_date = None
+    else:
+        if production_date is None and expiry_date is None:
+            raise HTTPException(status_code=400, detail="该商品需要有效期管理：必须提供生产日期或到期日期（至少其一）")
+
+        try:
+            production_date, expiry_date, _resolution_mode = await normalize_batch_dates_for_item(
+                session,
+                item_id=item_id_val,
+                production_date=production_date,
+                expiry_date=expiry_date,
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+
+        if production_date is None:
+            raise HTTPException(
+                status_code=400,
+                detail="批次受控商品必须提供 production_date，或提供可结合保质期反推出 production_date 的 expiry_date。",
+            )
+        if expiry_date is None:
+            raise HTTPException(
+                status_code=400,
+                detail="未提供到期日期，且商品未配置可用于推算的保质期，无法形成 canonical expiry_date。",
+            )
 
     try:
         _validate_dates_light(production_date=production_date, expiry_date=expiry_date)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
-    lot_code = _normalize_lot_code(lot_code)
-    if _is_pseudo_lot_code(lot_code):
-        raise HTTPException(status_code=400, detail="lot_code 禁止伪码（NOEXP/NONE）")
-
-    lot_source_policy = await load_item_lot_source_policy(session, item_id=item_id_val)
-    if lot_source_policy == "SUPPLIER_ONLY" and lot_code is None:
-        raise HTTPException(status_code=400, detail="供应商 lot_code 必填（lot_source_policy=SUPPLIER_ONLY）")
-
     # ✅ Route B：draft 不生成 lot_id；confirm 时填
     # ✅ 终态字段：
     # - lot_code_input 作为输入标签/展示码写入 lot_code_input
+    # - production_date / expiry_date 在 DRAFT 行上即保存 canonical 日期对
     # - receipt_status_snapshot NOT NULL（DRAFT/CONFIRMED）
     rl = InboundReceiptLine(
         receipt_id=int(draft.id),

--- a/app/wms/reconciliation/services/count_handler.py
+++ b/app/wms/reconciliation/services/count_handler.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.enums import MovementType
 from app.wms.stock.services.stock_service import StockService
 from app.wms.reconciliation.services.three_books_enforcer import enforce_three_books
-from app.wms.shared.services.expiry_resolver import resolve_batch_dates_for_item
+from app.wms.shared.services.expiry_resolver import normalize_batch_dates_for_item
 
 
 async def _ensure_supplier_lot_id(
@@ -22,13 +22,10 @@ async def _ensure_supplier_lot_id(
     expiry_date: date | None,
 ) -> int:
     """
-    Phase 2：Lot upsert 收口到 app/services/stock/lots.py（ensure_lot_full）
-    - Count 仍要求 batch_code（盘点维度必须落到确定 SUPPLIER lot 槽位）
+    Count 仍要求 batch_code，但对 REQUIRED 商品，lot 身份已经切到 production_date。
+    因此这里必须把 production_date / expiry_date 继续传给 ensure_lot_full。
     """
     from app.wms.stock.services.lots import ensure_lot_full
-
-    _ = production_date
-    _ = expiry_date
 
     code = str(lot_code).strip()
     if not code:
@@ -39,8 +36,8 @@ async def _ensure_supplier_lot_id(
         item_id=int(item_id),
         warehouse_id=int(warehouse_id),
         lot_code=str(code),
-        production_date=None,
-        expiry_date=None,
+        production_date=production_date,
+        expiry_date=expiry_date,
     )
 
 
@@ -107,8 +104,6 @@ async def _refresh_snapshot_for_item(
         {"d": snapshot_date, "w": int(warehouse_id), "i": int(item_id)},
     )
 
-    # Lot-world: snapshot grain is (snapshot_date, warehouse_id, item_id, lot_id).
-    # Do NOT write batch_code into stock_snapshots (column no longer exists).
     await session.execute(
         sa.text(
             """
@@ -164,13 +159,24 @@ async def handle_count(
 
     bcode = str(batch_code).strip()
 
+    resolved_production_date = production_date
+    resolved_expiry_date = expiry_date
+
+    if production_date is not None or expiry_date is not None:
+        resolved_production_date, resolved_expiry_date, _resolution_mode = await normalize_batch_dates_for_item(
+            session,
+            item_id=item_id,
+            production_date=production_date,
+            expiry_date=expiry_date,
+        )
+
     lot_id = await _ensure_supplier_lot_id(
         session,
         warehouse_id=int(warehouse_id),
         item_id=int(item_id),
         lot_code=bcode,
-        production_date=production_date,
-        expiry_date=expiry_date,
+        production_date=resolved_production_date,
+        expiry_date=resolved_expiry_date,
     )
 
     current = await _lock_current_qty_by_lot(
@@ -188,18 +194,23 @@ async def handle_count(
         if production_date is None and expiry_date is None:
             raise ValueError("盘盈为入库行为，必须提供 production_date 或 expiry_date。")
 
-        production_date, expiry_date = await resolve_batch_dates_for_item(
+        resolved_production_date, resolved_expiry_date, _resolution_mode = await normalize_batch_dates_for_item(
             session,
             item_id=item_id,
             production_date=production_date,
             expiry_date=expiry_date,
         )
 
+        if resolved_production_date is None:
+            raise ValueError("批次受控商品必须提供 production_date，或提供可结合保质期反推出 production_date 的 expiry_date。")
+
+        if resolved_expiry_date is None:
+            raise ValueError("未提供到期日期，且商品未配置可用于推算的保质期，无法形成 canonical expiry_date。")
+
     meta = {"sub_reason": "COUNT_ADJUST" if delta != 0 else "COUNT_CONFIRM"}
     if delta == 0:
         meta["allow_zero_delta_ledger"] = True
 
-    # ✅ 任务3 终态：Count 已持有 authoritative lot_id，必须走 adjust_lot（lot-only 原语入口）
     stock_svc = StockService()
     await stock_svc.adjust_lot(
         session=session,
@@ -213,8 +224,8 @@ async def handle_count(
         occurred_at=None,
         meta=meta,
         batch_code=bcode,
-        production_date=production_date,
-        expiry_date=expiry_date,
+        production_date=resolved_production_date,
+        expiry_date=resolved_expiry_date,
         trace_id=trace_id,
         shadow_write_stocks=False,
     )
@@ -253,6 +264,6 @@ async def handle_count(
         "delta": int(delta),
         "before": int(before),
         "after": int(after),
-        "production_date": production_date,
-        "expiry_date": expiry_date,
+        "production_date": resolved_production_date,
+        "expiry_date": resolved_expiry_date,
     }

--- a/app/wms/reconciliation/services/receive_handler.py
+++ b/app/wms/reconciliation/services/receive_handler.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.enums import MovementType
 from app.wms.stock.services.stock_adjust.db_items import item_requires_batch
 from app.wms.stock.services.stock_service import StockService
-from app.wms.shared.services.expiry_resolver import resolve_batch_dates_for_item
+from app.wms.shared.services.expiry_resolver import normalize_batch_dates_for_item
 
 
 async def handle_receive(
@@ -24,12 +24,13 @@ async def handle_receive(
     trace_id: str | None = None,
 ) -> dict:
     """
-    任务3 第四刀修正：
+    入库入口（receive）：
 
     - REQUIRED/NONE 的 batch_code 裁决仍由 StockService.adjust(合同闸门)负责；
     - 但对 requires_batch=False（expiry_policy=NONE），入口层必须把 batch_code 投影为 None，
-      否则会触发合同 batch_forbidden。
-    - 日期规则：仅 REQUIRED 强制。
+      否则会触发合同 batch_forbidden；
+    - 对 requires_batch=True，入口层必须先把用户输入日期归一成 resolved_production_date /
+      resolved_expiry_date，再交给下游 lot / ledger 写入口。
     """
     if qty <= 0:
         raise ValueError("Receive quantity must be positive.")
@@ -40,19 +41,29 @@ async def handle_receive(
 
     bc_norm = (str(batch_code).strip() if batch_code is not None else None) or None
 
-    # ✅ NONE 商品必须把 batch_code 投影为 None
+    # NONE 商品必须把 batch_code 投影为 None
     if not requires_batch:
         bc_norm = None
+        resolved_production_date = None
+        resolved_expiry_date = None
+    else:
+        if production_date is None and expiry_date is None:
+            raise ValueError("入库操作必须提供 production_date 或 expiry_date（至少其一）。")
 
-    if requires_batch and (production_date is None and expiry_date is None):
-        raise ValueError("入库操作必须提供 production_date 或 expiry_date（至少其一）。")
+        resolved_production_date, resolved_expiry_date, _resolution_mode = await normalize_batch_dates_for_item(
+            session,
+            item_id=item_id,
+            production_date=production_date,
+            expiry_date=expiry_date,
+        )
 
-    production_date, expiry_date = await resolve_batch_dates_for_item(
-        session,
-        item_id=item_id,
-        production_date=production_date,
-        expiry_date=expiry_date,
-    )
+        # 当前 REQUIRED lot 身份仍依赖 production_date
+        if resolved_production_date is None:
+            raise ValueError("批次受控商品必须提供 production_date，或提供可结合保质期反推出 production_date 的 expiry_date。")
+
+        # lot canonical 现在要求 expiry_date 一并形成
+        if resolved_expiry_date is None:
+            raise ValueError("未提供到期日期，且商品未配置可用于推算的保质期，无法形成 canonical expiry_date。")
 
     res = await StockService().adjust(
         session=session,
@@ -62,8 +73,8 @@ async def handle_receive(
         reason=MovementType.INBOUND,
         ref=ref,
         batch_code=bc_norm,
-        production_date=production_date if requires_batch else None,
-        expiry_date=expiry_date if requires_batch else None,
+        production_date=resolved_production_date if requires_batch else None,
+        expiry_date=resolved_expiry_date if requires_batch else None,
         trace_id=trace_id,
     )
 

--- a/app/wms/reconciliation/services/three_books_consistency.py
+++ b/app/wms/reconciliation/services/three_books_consistency.py
@@ -23,15 +23,6 @@ def _norm_bc(v: Any) -> str | None:
     return s2
 
 
-def _norm_lot_code_key(v: str | None) -> str | None:
-    if v is None:
-        return None
-    s = str(v).strip()
-    if not s:
-        return None
-    return s.upper()
-
-
 async def _resolve_lot_id_by_lot_code(
     session: AsyncSession,
     *,
@@ -42,18 +33,19 @@ async def _resolve_lot_id_by_lot_code(
     """
     兼容入口：用展示码 lot_code（旧名 batch_code）解析 lot_id。
 
-    终态：
-    - SUPPLIER 批次以 lot_code_key 唯一（防漂移）
-    - lot_code 为 NULL 时表示 INTERNAL，不参与此解析（应由上游显式给 lot_id）
+    当前阶段：
+    - REQUIRED lot 身份已切到 production_date
+    - lot_code 只作为展示 / 输入 / 追溯属性
+    - 若同一展示码命中多个 SUPPLIER lots，则返回 None，让上游显式报错
     """
     if lot_code is None:
         return None
 
-    k = _norm_lot_code_key(lot_code)
-    if not k:
+    code = _norm_bc(lot_code)
+    if not code:
         return None
 
-    row = (
+    rows = (
         await session.execute(
             text(
                 """
@@ -62,20 +54,20 @@ async def _resolve_lot_id_by_lot_code(
                  WHERE warehouse_id = :w
                    AND item_id      = :i
                    AND lot_code_source = 'SUPPLIER'
-                   AND lot_code_key = :k
+                   AND lot_code = :code
+                 ORDER BY id ASC
                  LIMIT 2
                 """
             ),
-            {"w": int(warehouse_id), "i": int(item_id), "k": str(k)},
+            {"w": int(warehouse_id), "i": int(item_id), "code": str(code)},
         )
     ).fetchall()
 
-    if not row:
+    if not rows:
         return None
-    if len(row) > 1:
-        # uq_lots_wh_item_lot_code_key 应保证唯一，但这里仍做防御
+    if len(rows) > 1:
         return None
-    return int(row[0][0])
+    return int(rows[0][0])
 
 
 async def verify_commit_three_books(
@@ -116,7 +108,6 @@ async def verify_commit_three_books(
 
         lot_id = e.get("lot_id")
         if lot_id is None:
-            # 兼容：尝试用 batch_code(展示码) 唯一解析 lot_id（仅 SUPPLIER）
             bc = _norm_bc(e.get("batch_code"))
             lot_id = await _resolve_lot_id_by_lot_code(
                 session,

--- a/app/wms/shared/services/expiry_analytics_allocator.py
+++ b/app/wms/shared/services/expiry_analytics_allocator.py
@@ -21,7 +21,7 @@ class Allocation(TypedDict):
     语义：
     - stock_id   : lot_id
     - batch_code : lots.lot_code（展示用）
-    - expiry_date: 从 ledger 的 RECEIPT 时间事实推导出的最早 expiry
+    - expiry_date: lots.expiry_date（canonical）
     """
 
     stock_id: int
@@ -35,7 +35,7 @@ class ExpiryAnalyticsAllocator:
     """
     只读建议器（分析域）：
     - 只读 lot-world：stocks_lot + lots
-    - 时间事实（expiry_date）来自 stock_ledger（reason_canon='RECEIPT'）
+    - 到期日期来自 lots.expiry_date（canonical snapshot）
     - 用于“临期风险 / 老化分析 / FEFO 贴合度”类指标，不参与执行域扣减
     """
 
@@ -90,18 +90,10 @@ class ExpiryAnalyticsAllocator:
                 s.lot_id AS stock_id,
                 l.lot_code AS batch_code,
                 GREATEST(COALESCE(s.qty, 0), 0) AS avail,
-                led.expiry_date AS expiry_date
+                l.expiry_date AS expiry_date
             FROM   stocks_lot s
             LEFT   JOIN lots l
               ON  l.id = s.lot_id
-            LEFT JOIN LATERAL (
-                SELECT MIN(sl.expiry_date) AS expiry_date
-                  FROM stock_ledger sl
-                 WHERE sl.warehouse_id = s.warehouse_id
-                   AND sl.item_id      = s.item_id
-                   AND sl.lot_id       = s.lot_id
-                   AND sl.reason_canon = 'RECEIPT'
-            ) led ON TRUE
             WHERE  s.item_id = :item_id
               AND  GREATEST(COALESCE(s.qty, 0), 0) > 0
         """
@@ -111,7 +103,7 @@ class ExpiryAnalyticsAllocator:
             params["warehouse_id"] = int(warehouse_id)
 
         if not allow_expired:
-            sql += " AND (led.expiry_date IS NULL OR led.expiry_date > CURRENT_DATE)"
+            sql += " AND (l.expiry_date IS NULL OR l.expiry_date > CURRENT_DATE)"
 
         res: Result = await session.execute(text(sql), params)
         return [dict(r._mapping) for r in res]

--- a/app/wms/shared/services/expiry_resolver.py
+++ b/app/wms/shared/services/expiry_resolver.py
@@ -1,75 +1,178 @@
 from __future__ import annotations
 
-from datetime import date
-from typing import Optional, Tuple
+from datetime import date, datetime
+from enum import Enum
+from typing import Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.pms.public.items.services.item_read_service import ItemReadService
-from app.wms.shared.services.expiry_rules import ShelfLife, ShelfLifeUnit, resolve_expiry_date
+from app.wms.shared.services.expiry_rules import (
+    ShelfLife,
+    ShelfLifeUnit,
+    resolve_expiry_date,
+    resolve_production_date,
+    validate_expiry_consistency,
+)
 
 
-async def resolve_batch_dates_for_item(
+class BatchDateResolutionMode(str, Enum):
+    FROM_PRODUCTION_AND_SHELF_LIFE = "FROM_PRODUCTION_AND_SHELF_LIFE"
+    FROM_BOTH_EXPLICIT = "FROM_BOTH_EXPLICIT"
+    FROM_EXPIRY_AND_SHELF_LIFE_REVERSE = "FROM_EXPIRY_AND_SHELF_LIFE_REVERSE"
+
+
+def _coerce_date_like(v: object, *, field_name: str) -> Optional[date]:
+    if v is None:
+        return None
+
+    if isinstance(v, datetime):
+        return v.date()
+
+    if isinstance(v, date):
+        return v
+
+    s = str(v).strip()
+    if not s:
+        return None
+
+    try:
+        return date.fromisoformat(s)
+    except ValueError:
+        pass
+
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00")).date()
+    except ValueError as e:
+        raise ValueError(f"{field_name} must be a valid ISO date/datetime string") from e
+
+
+def _build_shelf_life(*, value: object, unit_str: object) -> Optional[ShelfLife]:
+    if value is None or unit_str is None:
+        return None
+
+    try:
+        v = int(value)
+    except (TypeError, ValueError):
+        return None
+
+    if v <= 0:
+        return None
+
+    try:
+        unit = ShelfLifeUnit(str(unit_str))
+    except ValueError:
+        # 保底按 DAY 处理脏数据，避免直接 500
+        unit = ShelfLifeUnit.DAY
+
+    shelf_life = ShelfLife(value=v, unit=unit)
+    return shelf_life if shelf_life.is_effective() else None
+
+
+async def normalize_batch_dates_for_item(
     session: AsyncSession,
     *,
     item_id: int,
-    production_date: Optional[date],
-    expiry_date: Optional[date],
-) -> Tuple[Optional[date], Optional[date]]:
+    production_date: Optional[date | datetime | str],
+    expiry_date: Optional[date | datetime | str],
+) -> tuple[Optional[date], Optional[date], Optional[BatchDateResolutionMode]]:
     """
-    统一“批次日期解析”逻辑：
+    统一“批次日期归一”逻辑：
 
     输入：
-    - item_id          : 商品 ID（用于读取保质期配置）
-    - production_date  : 生产日期（可空）
-    - expiry_date      : 到期日期（可空）
+    - item_id          : 商品 ID（用于读取 expiry_policy / shelf_life / derivation_allowed）
+    - production_date  : 生产日期（可空；支持 date / datetime / ISO string）
+    - expiry_date      : 到期日期（可空；支持 date / datetime / ISO string）
+
+    输出：
+    - resolved_production_date
+    - resolved_expiry_date
+    - resolution_mode（成功归一时给出；若无法归一则为 None）
 
     规则：
-    1) 如果显式给了 expiry_date → 直接使用（不动）
-    2) 若未给 expiry_date 且有 production_date：
-         - 从 PMS public policy 读取 expiry_policy / shelf_life
-         - 若 expiry_policy=REQUIRED 且存在有效保质期 → 通过 expiry_rules 计算 expiry_date
-    3) 若两者皆无或无保质期配置 → 如实返回（可能都是 None）
+    1) expiry_policy=NONE：
+       - 统一归一为 (None, None, None)
+    2) 两者都给：
+       - 直接保留
+       - 若 production_date > expiry_date，则报错
+       - 若存在有效 shelf_life，可做轻量一致性校验（当前先不硬拦）
+    3) 只给 production_date：
+       - 若 derivation_allowed + shelf_life 有效，则正推 expiry_date
+       - 否则返回 (production_date, None, None)
+    4) 只给 expiry_date：
+       - 若 derivation_allowed + shelf_life 有效，则反推 production_date
+       - 否则返回 (None, expiry_date, None)
+    5) 两者都空：
+       - 返回 (None, None, None)
 
     注意：
-    - 不做硬校验；是否允许 None 由调用方根据场景决定（入库/盘盈可以强制）
-    - 只读，不会修改数据库
+    - 这里不做“结果必须非空”的硬校验；是否允许 unresolved，交给调用方场景判断
+    - 当前 lot identity 仍依赖 production_date，因此 REQUIRED 路径若最终 resolved_production_date 仍为空，
+      应由调用方或后续 lot 解析层报错
     """
-    # 显式给了到期日：尊重调用方
-    if expiry_date is not None:
-        return production_date, expiry_date
+    production_date = _coerce_date_like(production_date, field_name="production_date")
+    expiry_date = _coerce_date_like(expiry_date, field_name="expiry_date")
 
-    # 没有生产日期就没法推算
-    if production_date is None:
-        return None, None
+    # 两者都空：直接返回
+    if production_date is None and expiry_date is None:
+        return None, None, None
 
     svc = ItemReadService(session)
     policy = await svc.aget_policy_by_id(item_id=int(item_id))
     if policy is None:
-        # 未找到 item，直接返回原值，后续由调用方决定是否抛错
-        return production_date, None
+        # 未找到 item：保守返回原值，不在共享层擅自抛错
+        if production_date is not None and expiry_date is not None:
+            if production_date > expiry_date:
+                raise ValueError("production_date cannot be later than expiry_date")
+            return production_date, expiry_date, BatchDateResolutionMode.FROM_BOTH_EXPLICIT
+        return production_date, expiry_date, None
 
-    if policy.expiry_policy == "NONE":
-        # 明确无效期策略：不推算
-        return production_date, None
-
-    value = policy.shelf_life_value
-    unit_str = policy.shelf_life_unit
-    if value is None or value <= 0 or unit_str is None:
-        # 没配置完整保质期，无法推断
-        return production_date, None
-
-    # 解析单位字符串；异常时保底按 DAY 处理，避免脏数据引发 500
-    try:
-        unit = ShelfLifeUnit(unit_str or "DAY")
-    except ValueError:
-        unit = ShelfLifeUnit.DAY
-
-    shelf_life = ShelfLife(value=int(value), unit=unit)
-
-    computed = resolve_expiry_date(
-        production_date=production_date,
-        expiry_date=None,
-        shelf_life=shelf_life,
+    expiry_policy = str(getattr(policy, "expiry_policy", "NONE") or "NONE").upper()
+    derivation_allowed = bool(getattr(policy, "derivation_allowed", True))
+    shelf_life = _build_shelf_life(
+        value=getattr(policy, "shelf_life_value", None),
+        unit_str=getattr(policy, "shelf_life_unit", None),
     )
-    return production_date, computed
+
+    # NONE 商品：统一不承载日期
+    if expiry_policy == "NONE":
+        return None, None, None
+
+    # 两者都给：保留显式值
+    if production_date is not None and expiry_date is not None:
+        if production_date > expiry_date:
+            raise ValueError("production_date cannot be later than expiry_date")
+
+        # 当前先做轻量一致性检查；不在共享层硬拦
+        _ = validate_expiry_consistency(
+            production_date=production_date,
+            expiry_date=expiry_date,
+            shelf_life=shelf_life,
+        )
+        return production_date, expiry_date, BatchDateResolutionMode.FROM_BOTH_EXPLICIT
+
+    # 只给生产日期：正推 expiry_date
+    if production_date is not None and expiry_date is None:
+        if derivation_allowed and shelf_life is not None:
+            resolved_expiry = resolve_expiry_date(
+                production_date=production_date,
+                expiry_date=None,
+                shelf_life=shelf_life,
+            )
+            return production_date, resolved_expiry, BatchDateResolutionMode.FROM_PRODUCTION_AND_SHELF_LIFE
+
+        return production_date, None, None
+
+    # 只给到期日期：反推 production_date
+    if production_date is None and expiry_date is not None:
+        if derivation_allowed and shelf_life is not None:
+            resolved_production = resolve_production_date(
+                production_date=None,
+                expiry_date=expiry_date,
+                shelf_life=shelf_life,
+            )
+            return resolved_production, expiry_date, BatchDateResolutionMode.FROM_EXPIRY_AND_SHELF_LIFE_REVERSE
+
+        return None, expiry_date, None
+
+    return production_date, expiry_date, None

--- a/app/wms/shared/services/expiry_rules.py
+++ b/app/wms/shared/services/expiry_rules.py
@@ -36,12 +36,13 @@ class ShelfLife:
 
 def add_months(d: date, months: int) -> date:
     """
-    按“自然月”增加月份，而不是简单 30 * N 天。
+    按“自然月”增减月份，而不是简单 30 * N 天。
 
     规则：
     - 2025-01-15 + 1 月 -> 2025-02-15
     - 2025-01-31 + 1 月 -> 2025-02-28（取该月最后一天）
     - 2025-01-31 + 2 月 -> 2025-03-31
+    - 2025-03-31 - 1 月 -> 2025-02-28
     """
     if months == 0:
         return d
@@ -85,6 +86,35 @@ def compute_expiry_from_shelf_life(
     return add_months(production_date, shelf_life.value)
 
 
+def compute_production_from_shelf_life(
+    expiry_date: date,
+    shelf_life: ShelfLife,
+) -> date:
+    """
+    根据“到期日 + 保质期”反推生产日期。
+
+    语义约定：
+    - 与 compute_expiry_from_shelf_life 对称
+    - DAY  ：production = expiry_date - value 天
+    - MONTH：production = expiry_date - value 个月（自然月逆推）
+
+    注意：
+    - 这里按当前工程语义把 expiry_date 视为“最后一个合规日（含当天）”，
+      因此反推时不做额外 ±1 天处理，保持和正推规则镜像。
+    """
+    if expiry_date is None:
+        raise ValueError("expiry_date is required to compute production_date")
+
+    if not shelf_life.is_effective():
+        raise ValueError("shelf_life must be a positive value")
+
+    if shelf_life.unit == ShelfLifeUnit.DAY:
+        return expiry_date - timedelta(days=shelf_life.value)
+
+    # 默认按月逆推
+    return add_months(expiry_date, -shelf_life.value)
+
+
 def resolve_expiry_date(
     *,
     production_date: Optional[date],
@@ -108,6 +138,29 @@ def resolve_expiry_date(
 
     if production_date is not None and shelf_life is not None and shelf_life.is_effective():
         return compute_expiry_from_shelf_life(production_date, shelf_life)
+
+    return None
+
+
+def resolve_production_date(
+    *,
+    production_date: Optional[date],
+    expiry_date: Optional[date],
+    shelf_life: Optional[ShelfLife],
+) -> Optional[date]:
+    """
+    统一“生产日期”解析规则：
+
+    优先级：
+    1) 如果显式给了 production_date → 直接使用
+    2) 否则，如果给了 expiry_date + 有效 shelf_life → 通过保质期反推
+    3) 否则 → 返回 None
+    """
+    if production_date is not None:
+        return production_date
+
+    if expiry_date is not None and shelf_life is not None and shelf_life.is_effective():
+        return compute_production_from_shelf_life(expiry_date, shelf_life)
 
     return None
 

--- a/app/wms/stock/models/lot.py
+++ b/app/wms/stock/models/lot.py
@@ -1,19 +1,19 @@
 # app/models/lot.py
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Optional
 
 from sqlalchemy import (
     Boolean,
     CheckConstraint,
+    Date,
     DateTime,
     Enum,
     ForeignKey,
     Index,
     Integer,
     String,
-    Text,
     text,
 )
 from sqlalchemy.orm import Mapped, mapped_column
@@ -27,13 +27,15 @@ class Lot(Base):
 
     结构关键点：
       - lot_id（Lot.id）是库存身份锚点，独立于 lot_code
-      - lot_code == batch_code（展示/来源码），业务需防“输入漂移”
+      - lot_code 为展示/来源码，不再决定 lot 身份
       - lots 冻结 item 侧关键主数据（policy），防主数据漂移污染历史解释链
 
-    Phase M-5（结构治理：unit_governance 二阶段）：
-      - 单位真相源 = item_uoms（结构层）
-      - 冻结点 = PO/Receipt lines 的 *_ratio_to_base_snapshot + qty_base
-      - lots 的单位快照列已物理移除（通过 Alembic migration）
+    Phase lot identity redesign：
+      - REQUIRED 商品：lot 身份 = (warehouse_id, item_id, production_date)
+      - NONE 商品：lot 身份 = INTERNAL singleton (warehouse_id, item_id)
+      - lot_code 只保留为展示 / 输入 / 追溯属性
+      - lots.production_date / lots.expiry_date 形成 canonical snapshot
+      - stock_ledger.production_date / stock_ledger.expiry_date 继续保留为 RECEIPT event snapshot
     """
 
     __tablename__ = "lots"
@@ -57,9 +59,11 @@ class Lot(Base):
     # 展示/输入批次码（SUPPLIER lot 可填；INTERNAL lot 必须为 NULL）
     lot_code: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
 
-    # 防批次漂移：lot_code 的归一化 key（至少 upper + trim）
-    # DB migration: lot_code_key = upper(btrim(lot_code))
-    lot_code_key: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    # REQUIRED 商品 lot 身份快照
+    production_date: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
+
+    # lot canonical 到期日期快照
+    expiry_date: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
 
     source_receipt_id: Mapped[Optional[int]] = mapped_column(
         Integer,
@@ -114,14 +118,48 @@ class Lot(Base):
             ")",
             name="ck_lots_sl_params_by_policy_snap",
         ),
-        # SUPPLIER lot：按归一化 key 唯一，防 lot_code 输入漂移（trim/upper）
+        CheckConstraint(
+            "("
+            "(item_expiry_policy_snapshot = 'REQUIRED' AND production_date IS NOT NULL) OR "
+            "(item_expiry_policy_snapshot <> 'REQUIRED' AND production_date IS NULL)"
+            ")",
+            name="ck_lots_production_date_by_expiry_policy",
+        ),
+        CheckConstraint(
+            "("
+            "production_date IS NULL OR "
+            "expiry_date IS NULL OR "
+            "production_date <= expiry_date"
+            ")",
+            name="ck_lots_production_le_expiry",
+        ),
+        CheckConstraint(
+            "("
+            "item_expiry_policy_snapshot <> 'REQUIRED' OR "
+            "lot_code_source <> 'SUPPLIER' OR "
+            "expiry_date IS NOT NULL"
+            ")",
+            name="ck_lots_required_supplier_expiry_not_null",
+        ),
+        CheckConstraint(
+            "("
+            "item_expiry_policy_snapshot <> 'REQUIRED' OR "
+            "lot_code_source = 'SUPPLIER'"
+            ")",
+            name="ck_lots_required_supplier_source",
+        ),
+        # REQUIRED lot：按 (warehouse_id,item_id,production_date) 唯一
         Index(
-            "uq_lots_wh_item_lot_code_key",
+            "uq_lots_required_single_wh_item_prod",
             "warehouse_id",
             "item_id",
-            "lot_code_key",
+            "production_date",
             unique=True,
-            postgresql_where=text("lot_code IS NOT NULL"),
+            postgresql_where=text(
+                "lot_code_source = 'SUPPLIER' "
+                "AND item_expiry_policy_snapshot = 'REQUIRED' "
+                "AND production_date IS NOT NULL"
+            ),
         ),
         # INTERNAL lot：每 (warehouse,item) 单例（lot_code 必须为 NULL）
         Index(

--- a/app/wms/stock/repos/inventory_read_repo.py
+++ b/app/wms/stock/repos/inventory_read_repo.py
@@ -45,9 +45,9 @@ def _build_inventory_where(
 
     if near_expiry is True:
         cond.append(
-            "rd.expiry_date IS NOT NULL "
-            "AND rd.expiry_date >= CURRENT_DATE "
-            "AND rd.expiry_date <= CURRENT_DATE + 30"
+            "l.expiry_date IS NOT NULL "
+            "AND l.expiry_date >= CURRENT_DATE "
+            "AND l.expiry_date <= CURRENT_DATE + 30"
         )
 
     return " AND ".join(cond), params
@@ -76,18 +76,7 @@ async def query_inventory_rows(
 
     count_sql = text(
         f"""
-        WITH receipt_dates AS (
-            SELECT
-                warehouse_id,
-                item_id,
-                lot_id,
-                MAX(production_date) AS production_date,
-                MAX(expiry_date) AS expiry_date
-            FROM stock_ledger
-            WHERE reason_canon = 'RECEIPT'
-            GROUP BY warehouse_id, item_id, lot_id
-        ),
-        base AS (
+        WITH base AS (
             SELECT
                 s.item_id,
                 i.name AS item_name,
@@ -97,9 +86,9 @@ async def query_inventory_rows(
                 i.category AS category,
                 s.warehouse_id,
                 l.lot_code AS lot_code,
+                l.production_date AS production_date,
+                l.expiry_date AS expiry_date,
                 s.qty,
-                rd.production_date,
-                rd.expiry_date,
                 (
                     SELECT ib.barcode
                     FROM item_barcodes AS ib
@@ -113,10 +102,6 @@ async def query_inventory_rows(
               ON i.id = s.item_id
             LEFT JOIN lots AS l
               ON l.id = s.lot_id
-            LEFT JOIN receipt_dates AS rd
-              ON rd.warehouse_id = s.warehouse_id
-             AND rd.item_id = s.item_id
-             AND rd.lot_id = s.lot_id
             WHERE {where_sql}
         )
         SELECT COUNT(*)::int AS total
@@ -128,17 +113,6 @@ async def query_inventory_rows(
 
     list_sql = text(
         f"""
-        WITH receipt_dates AS (
-            SELECT
-                warehouse_id,
-                item_id,
-                lot_id,
-                MAX(production_date) AS production_date,
-                MAX(expiry_date) AS expiry_date
-            FROM stock_ledger
-            WHERE reason_canon = 'RECEIPT'
-            GROUP BY warehouse_id, item_id, lot_id
-        )
         SELECT
             s.item_id,
             i.name AS item_name,
@@ -148,9 +122,9 @@ async def query_inventory_rows(
             i.category AS category,
             s.warehouse_id,
             l.lot_code AS lot_code,
+            l.production_date AS production_date,
+            l.expiry_date AS expiry_date,
             s.qty,
-            rd.production_date,
-            rd.expiry_date,
             (
                 SELECT ib.barcode
                 FROM item_barcodes AS ib
@@ -164,10 +138,6 @@ async def query_inventory_rows(
           ON i.id = s.item_id
         LEFT JOIN lots AS l
           ON l.id = s.lot_id
-        LEFT JOIN receipt_dates AS rd
-          ON rd.warehouse_id = s.warehouse_id
-         AND rd.item_id = s.item_id
-         AND rd.lot_id = s.lot_id
         WHERE {where_sql}
         ORDER BY i.name ASC, s.item_id ASC, s.warehouse_id ASC, l.lot_code NULLS FIRST
         OFFSET :offset
@@ -201,26 +171,15 @@ async def query_inventory_detail_rows(
 
     sql = text(
         f"""
-        WITH receipt_dates AS (
-            SELECT
-                warehouse_id,
-                item_id,
-                lot_id,
-                MAX(production_date) AS production_date,
-                MAX(expiry_date) AS expiry_date
-            FROM stock_ledger
-            WHERE reason_canon = 'RECEIPT'
-            GROUP BY warehouse_id, item_id, lot_id
-        )
         SELECT
             s.item_id,
             i.name AS item_name,
             s.warehouse_id,
             w.name AS warehouse_name,
             l.lot_code AS lot_code,
-            s.qty,
-            rd.production_date,
-            rd.expiry_date
+            l.production_date AS production_date,
+            l.expiry_date AS expiry_date,
+            s.qty
         FROM stocks_lot AS s
         JOIN items AS i
           ON i.id = s.item_id
@@ -228,10 +187,6 @@ async def query_inventory_detail_rows(
           ON w.id = s.warehouse_id
         LEFT JOIN lots AS l
           ON l.id = s.lot_id
-        LEFT JOIN receipt_dates AS rd
-          ON rd.warehouse_id = s.warehouse_id
-         AND rd.item_id = s.item_id
-         AND rd.lot_id = s.lot_id
         WHERE {" AND ".join(cond)}
         ORDER BY s.warehouse_id ASC, l.lot_code NULLS FIRST
         """

--- a/app/wms/stock/services/inventory_read_service.py
+++ b/app/wms/stock/services/inventory_read_service.py
@@ -63,6 +63,7 @@ class InventoryReadService:
                     category=r.get("category"),
                     warehouse_id=int(r["warehouse_id"]),
                     lot_code=r.get("lot_code"),
+                    production_date=r.get("production_date"),
                     qty=int(r["qty"] or 0),
                     expiry_date=expiry_date,
                     near_expiry=near_expiry,

--- a/app/wms/stock/services/lot_resolver.py
+++ b/app/wms/stock/services/lot_resolver.py
@@ -1,7 +1,7 @@
 # app/wms/stock/services/lot_resolver.py
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Optional
 
 from sqlalchemy import text as SA
@@ -10,21 +10,25 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.wms.stock.services.lots import ensure_internal_lot_singleton, ensure_lot_full
 
 
-def _norm_lot_code_key(v: str | None) -> str | None:
+def _norm_lot_code(v: str | None) -> str | None:
     if v is None:
         return None
     s = str(v).strip()
     if not s:
         return None
-    return s.upper()
+    return s
 
 
 class LotResolver:
     """
     只负责“lot 决议 + lot 创建/复用”的纯服务：
-    - supplier lot: ensure_lot_full（partial unique index 的 ON CONFLICT 必须带 WHERE）
+    - supplier lot: ensure_lot_full
     - internal lot: ensure_internal_lot_singleton（(warehouse,item) 单例）
     - 可用量估算：仅用于错误提示/诊断（不参与扣减决策）
+
+    当前阶段：
+    - REQUIRED lot 身份已切到 (warehouse_id, item_id, production_date)
+    - batch_code / lot_code 只作为展示码 / 辅助解析输入
     """
 
     async def requires_batch(self, session: AsyncSession, *, item_id: int) -> bool:
@@ -34,7 +38,6 @@ class LotResolver:
         )
         v = row.scalar_one_or_none()
         if v is None:
-            # unknown item 必须先拦住，不能被 NONE/REQUIRED 合同判断遮蔽
             raise ValueError("item_not_found")
         return str(v or "").upper() == "REQUIRED"
 
@@ -46,6 +49,8 @@ class LotResolver:
         item_id: int,
         lot_code: str,
         occurred_at: Optional[datetime],
+        production_date: Optional[date] = None,
+        expiry_date: Optional[date] = None,
     ) -> int:
         _ = occurred_at
         return await ensure_lot_full(
@@ -53,8 +58,8 @@ class LotResolver:
             item_id=int(item_id),
             warehouse_id=int(warehouse_id),
             lot_code=str(lot_code),
-            production_date=None,
-            expiry_date=None,
+            production_date=production_date,
+            expiry_date=expiry_date,
         )
 
     async def ensure_internal_lot_id(
@@ -87,8 +92,12 @@ class LotResolver:
     ) -> int:
         """
         只用于错误提示/诊断的“可用量”估算：
-        - batch_code 非空：按 lot_code_key（防漂移）聚合 SUPPLIER lot 的余额
         - batch_code 为空：聚合该 item 在该仓的总余额
+        - batch_code 非空：按展示码 lots.lot_code 聚合 SUPPLIER lot 的余额
+
+        注意：
+        - lot_code 不再是结构身份
+        - 这里按 lot_code 聚合只是为了提示用户，不参与扣减裁决
         """
         if batch_code is None:
             row = (
@@ -105,7 +114,7 @@ class LotResolver:
                 )
             ).first()
         else:
-            k = _norm_lot_code_key(batch_code) or ""
+            code = _norm_lot_code(batch_code) or ""
             row = (
                 await session.execute(
                     SA(
@@ -116,10 +125,10 @@ class LotResolver:
                          WHERE s.warehouse_id = :w
                            AND s.item_id      = :i
                            AND lo.lot_code_source = 'SUPPLIER'
-                           AND lo.lot_code_key = :k
+                           AND lo.lot_code = :code
                         """
                     ),
-                    {"w": int(warehouse_id), "i": int(item_id), "k": str(k)},
+                    {"w": int(warehouse_id), "i": int(item_id), "code": str(code)},
                 )
             ).first()
 

--- a/app/wms/stock/services/lot_service.py
+++ b/app/wms/stock/services/lot_service.py
@@ -1,6 +1,7 @@
 # app/wms/stock/services/lot_service.py
 from __future__ import annotations
 
+from datetime import date
 from typing import Optional
 
 from fastapi import HTTPException
@@ -35,17 +36,18 @@ async def resolve_or_create_lot(
     item_policy: ItemPolicy,
     lot_code_source: str,
     lot_code: Optional[str],
+    production_date: Optional[date],
+    expiry_date: Optional[date],
     source_receipt_id: Optional[int],
     source_line_no: Optional[int],
 ) -> int:
     """
     兼容层 lot 创建/解析（Phase M-5）：
 
-    终态收口：
-    - SUPPLIER lot 统一走 ensure_lot_full（写 lot_code_key 防漂移）
-    - INTERNAL lot 统一走 ensure_internal_lot_singleton（按 wh+item 单例）
-    - 本模块不再直接 new Lot()/flush，避免第二入口造成漂移与约束冲突
-    - 跨域输入不再接收 Item ORM，而是接收 PMS public ItemPolicy
+    当前中心任务收口：
+    - REQUIRED 商品：production_date 是 lot 身份决策输入
+    - SUPPLIER lot 仍保留 lot_code 作为展示/追溯属性
+    - INTERNAL lot 继续走 singleton（warehouse,item）
     """
     lot_code_source_u = str(lot_code_source or "").upper().strip()
     if lot_code_source_u not in ("SUPPLIER", "INTERNAL"):
@@ -69,17 +71,24 @@ async def resolve_or_create_lot(
         if not lot_code or not str(lot_code).strip():
             raise HTTPException(status_code=422, detail="supplier_lot_code_required")
 
-        # ensure supplier lot by key (drift-proof)
-        lot_id = await ensure_lot_full(
-            db,
-            item_id=int(item_policy.item_id),
-            warehouse_id=int(warehouse_id),
-            lot_code=str(lot_code),
-            production_date=None,
-            expiry_date=None,
-        )
+        if str(snapshot["item_expiry_policy_snapshot"]).upper() == "REQUIRED" and production_date is None:
+            raise HTTPException(status_code=422, detail="production_date_required_for_required_lot")
 
-        # read back to verify snapshot compatibility (historical freeze)
+        try:
+            lot_id = await ensure_lot_full(
+                db,
+                item_id=int(item_policy.item_id),
+                warehouse_id=int(warehouse_id),
+                lot_code=str(lot_code),
+                production_date=production_date,
+                expiry_date=expiry_date,
+            )
+        except ValueError as e:
+            detail = str(e)
+            if detail == "supplier_lot_legacy_key_conflict":
+                raise HTTPException(status_code=409, detail=detail) from e
+            raise HTTPException(status_code=422, detail=detail) from e
+
         stmt = select(Lot).where(Lot.id == int(lot_id))
         existing = (await db.execute(stmt)).scalars().first()
         if existing is None:
@@ -89,7 +98,6 @@ async def resolve_or_create_lot(
             raise HTTPException(status_code=409, detail="lot_snapshot_conflict")
         return int(existing.id)
 
-    # INTERNAL: singleton per (warehouse,item); provenance optional but paired
     try:
         lot_id2 = await ensure_internal_lot_singleton(
             db,
@@ -100,5 +108,4 @@ async def resolve_or_create_lot(
         )
         return int(lot_id2)
     except ValueError as e:
-        # internal provenance pair violated
         raise HTTPException(status_code=422, detail=str(e)) from e

--- a/app/wms/stock/services/lots.py
+++ b/app/wms/stock/services/lots.py
@@ -1,6 +1,9 @@
 # app/wms/stock/services/lots.py
 from __future__ import annotations
 
+from calendar import monthrange
+from datetime import date, datetime, timedelta
+from decimal import Decimal, InvalidOperation
 from typing import Optional
 
 from sqlalchemy import text
@@ -9,19 +12,18 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 def normalize_lot_code(code: str | None) -> tuple[str, str]:
     """
-    Normalize supplier lot_code to prevent drift.
+    Normalize supplier lot_code for display / tracing.
 
     Returns:
-        (code_raw, code_key)
+        (code_raw, code_lookup)
 
-    Rules:
-        - code_raw: stripped original input (kept for display)
-        - code_key: upper(trim(code_raw)) used for uniqueness / lookups
+    兼容保留 tuple 形态，避免外部调用方解包时报错；
+    当前 code_lookup 与 code_raw 相同，不再存在 lot_code_key。
     """
     s = (str(code) if code is not None else "").strip()
     if not s:
         raise ValueError("lot_code empty")
-    return s, s.upper()
+    return s, s
 
 
 def _pair_or_null(a: Optional[int], b: Optional[int]) -> tuple[Optional[int], Optional[int]]:
@@ -36,6 +38,229 @@ def _pair_or_null(a: Optional[int], b: Optional[int]) -> tuple[Optional[int], Op
     raise ValueError("internal_source_receipt_line_pair_required")
 
 
+def _normalize_date_value(v: object) -> date | None:
+    if v is None:
+        return None
+    if isinstance(v, datetime):
+        return v.date()
+    if isinstance(v, date):
+        return v
+
+    s = str(v).strip()
+    if not s:
+        return None
+
+    try:
+        return date.fromisoformat(s)
+    except ValueError:
+        pass
+
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00")).date()
+    except ValueError:
+        return None
+
+
+def _normalize_positive_int(v: object) -> int | None:
+    if v is None or isinstance(v, bool):
+        return None
+    if isinstance(v, int):
+        return int(v) if int(v) > 0 else None
+
+    s = str(v).strip()
+    if not s:
+        return None
+
+    try:
+        n = int(s)
+    except ValueError:
+        try:
+            n = int(Decimal(s))
+        except (InvalidOperation, ValueError):
+            return None
+
+    return n if n > 0 else None
+
+
+def _normalize_shelf_life_unit(v: object) -> str | None:
+    s = str(v or "").strip().upper()
+    if not s:
+        return None
+
+    mapping = {
+        "DAY": "DAY",
+        "DAYS": "DAY",
+        "D": "DAY",
+        "天": "DAY",
+        "日": "DAY",
+        "WEEK": "WEEK",
+        "WEEKS": "WEEK",
+        "W": "WEEK",
+        "周": "WEEK",
+        "MONTH": "MONTH",
+        "MONTHS": "MONTH",
+        "M": "MONTH",
+        "月": "MONTH",
+        "YEAR": "YEAR",
+        "YEARS": "YEAR",
+        "Y": "YEAR",
+        "年": "YEAR",
+    }
+    return mapping.get(s)
+
+
+def _add_months(base: date, months: int) -> date:
+    month_index = (base.month - 1) + months
+    year = base.year + (month_index // 12)
+    month = (month_index % 12) + 1
+    day = min(base.day, monthrange(year, month)[1])
+    return date(year, month, day)
+
+
+def _add_years(base: date, years: int) -> date:
+    year = base.year + years
+    day = min(base.day, monthrange(year, base.month)[1])
+    return date(year, base.month, day)
+
+
+def _shift_date_by_shelf_life(
+    base: date,
+    *,
+    shelf_life_value: int | None,
+    shelf_life_unit: str | None,
+    direction: int,
+) -> date | None:
+    if shelf_life_value is None or shelf_life_unit is None:
+        return None
+
+    step = shelf_life_value if direction >= 0 else -shelf_life_value
+    if shelf_life_unit == "DAY":
+        return base + timedelta(days=step)
+    if shelf_life_unit == "WEEK":
+        return base + timedelta(weeks=step)
+    if shelf_life_unit == "MONTH":
+        return _add_months(base, step)
+    if shelf_life_unit == "YEAR":
+        return _add_years(base, step)
+    return None
+
+
+async def _load_item_expiry_context(
+    session: AsyncSession,
+    *,
+    item_id: int,
+) -> tuple[str, int | None, str | None]:
+    row = await session.execute(
+        text(
+            """
+            SELECT
+                expiry_policy,
+                shelf_life_value,
+                shelf_life_unit
+              FROM items
+             WHERE id = :i
+             LIMIT 1
+            """
+        ),
+        {"i": int(item_id)},
+    )
+    got = row.mappings().first()
+    if got is None:
+        raise ValueError("item_not_found")
+
+    expiry_policy = str(got["expiry_policy"] or "").strip().upper()
+    shelf_life_value = _normalize_positive_int(got["shelf_life_value"])
+    shelf_life_unit = _normalize_shelf_life_unit(got["shelf_life_unit"])
+    return expiry_policy, shelf_life_value, shelf_life_unit
+
+
+async def _load_item_expiry_policy(
+    session: AsyncSession,
+    *,
+    item_id: int,
+) -> str:
+    expiry_policy, _, _ = await _load_item_expiry_context(session, item_id=item_id)
+    return expiry_policy
+
+
+async def _get_supplier_lot_by_production_date(
+    session: AsyncSession,
+    *,
+    item_id: int,
+    warehouse_id: int,
+    production_date: date,
+) -> int | None:
+    row = await session.execute(
+        text(
+            """
+            SELECT id
+              FROM lots
+             WHERE warehouse_id = :w
+               AND item_id      = :i
+               AND lot_code_source = 'SUPPLIER'
+               AND production_date = :pd
+             ORDER BY id ASC
+             LIMIT 1
+            """
+        ),
+        {"w": int(warehouse_id), "i": int(item_id), "pd": production_date},
+    )
+    got = row.scalar_one_or_none()
+    return int(got) if got is not None else None
+
+
+async def _get_supplier_lot_ids_by_lot_code(
+    session: AsyncSession,
+    *,
+    item_id: int,
+    warehouse_id: int,
+    lot_code: str,
+) -> list[int]:
+    rows = await session.execute(
+        text(
+            """
+            SELECT id
+              FROM lots
+             WHERE warehouse_id = :w
+               AND item_id      = :i
+               AND lot_code_source = 'SUPPLIER'
+               AND lot_code = :code
+             ORDER BY id ASC
+             LIMIT 2
+            """
+        ),
+        {"w": int(warehouse_id), "i": int(item_id), "code": str(lot_code)},
+    )
+    return [int(r[0]) for r in rows.fetchall()]
+
+
+async def _patch_lot_expiry_if_null(
+    session: AsyncSession,
+    *,
+    lot_id: int,
+    expiry_date: date | None,
+) -> None:
+    """
+    单向补丁：
+    - 只允许 NULL -> 值
+    - 不允许覆盖已有非空 expiry_date
+    """
+    if expiry_date is None:
+        return
+
+    await session.execute(
+        text(
+            """
+            UPDATE lots
+               SET expiry_date = :ed
+             WHERE id = :lot_id
+               AND expiry_date IS NULL
+            """
+        ),
+        {"lot_id": int(lot_id), "ed": expiry_date},
+    )
+
+
 async def ensure_internal_lot_singleton(
     session: AsyncSession,
     *,
@@ -47,11 +272,11 @@ async def ensure_internal_lot_singleton(
     """
     INTERNAL lot singleton (warehouse_id, item_id):
     - lot_code_source='INTERNAL'
-    - lot_code IS NULL (enforced by ck_lots_lot_code_by_source)
+    - lot_code IS NULL
     - UNIQUE (warehouse_id,item_id) WHERE INTERNAL & lot_code IS NULL
 
     source_receipt_id/source_line_no are optional provenance fields:
-    - both NULL, or both NOT NULL (enforced by ck_lots_internal_source_receipt_line_pair)
+    - both NULL, or both NOT NULL
     """
     rid, rln = _pair_or_null(source_receipt_id, source_line_no)
 
@@ -82,15 +307,12 @@ async def ensure_internal_lot_singleton(
                 item_id,
                 lot_code_source,
                 lot_code,
-                lot_code_key,
                 source_receipt_id,
                 source_line_no,
-                -- required snapshots (NOT NULL)
                 item_lot_source_policy_snapshot,
                 item_expiry_policy_snapshot,
                 item_derivation_allowed_snapshot,
                 item_uom_governance_enabled_snapshot,
-                -- optional snapshots (nullable)
                 item_shelf_life_value_snapshot,
                 item_shelf_life_unit_snapshot
             )
@@ -98,7 +320,6 @@ async def ensure_internal_lot_singleton(
                 :w,
                 :i,
                 'INTERNAL',
-                NULL,
                 NULL,
                 :rid,
                 :rln,
@@ -153,86 +374,148 @@ async def ensure_lot_full(
     """
     SUPPLIER lot 唯一入口。
 
-    注意：supplier 唯一性是 partial unique index：
-      uq_lots_wh_item_lot_code_key (warehouse_id,item_id,lot_code_key) WHERE lot_code IS NOT NULL
-    因此 ON CONFLICT 必须携带相同 WHERE 子句，否则 PG 会报 InvalidColumnReference。
+    当前主链语义：
+    - REQUIRED 商品：lot 身份 = (warehouse_id, item_id, production_date)
+    - lot_code 只保留为展示 / 输入 / 追溯属性
+    - NONE 商品不再创建新的 SUPPLIER lot；只允许回查历史遗留（若仍存在且唯一）
     """
-    _ = production_date
-    _ = expiry_date
+    code_raw, _code_lookup = normalize_lot_code(lot_code)
+    pd = _normalize_date_value(production_date)
+    ed = _normalize_date_value(expiry_date)
+    expiry_policy, shelf_life_value, shelf_life_unit = await _load_item_expiry_context(
+        session,
+        item_id=int(item_id),
+    )
 
-    code_raw, code_key = normalize_lot_code(lot_code)
-
-    row = await session.execute(
-        text(
-            """
-            INSERT INTO lots(
-                warehouse_id,
-                item_id,
-                lot_code_source,
-                lot_code,
-                lot_code_key,
-                source_receipt_id,
-                source_line_no,
-                -- required snapshots (NOT NULL)
-                item_lot_source_policy_snapshot,
-                item_expiry_policy_snapshot,
-                item_derivation_allowed_snapshot,
-                item_uom_governance_enabled_snapshot,
-                -- optional snapshots (nullable)
-                item_shelf_life_value_snapshot,
-                item_shelf_life_unit_snapshot
+    if expiry_policy == "REQUIRED":
+        if ed is None and pd is not None:
+            ed = _shift_date_by_shelf_life(
+                pd,
+                shelf_life_value=shelf_life_value,
+                shelf_life_unit=shelf_life_unit,
+                direction=1,
             )
-            SELECT
-                :w,
-                :i,
-                'SUPPLIER',
-                :code_raw,
-                :code_key,
-                NULL,
-                NULL,
-                it.lot_source_policy,
-                it.expiry_policy,
-                it.derivation_allowed,
-                it.uom_governance_enabled,
-                it.shelf_life_value,
-                it.shelf_life_unit
-              FROM items it
-             WHERE it.id = :i
-            ON CONFLICT (warehouse_id, item_id, lot_code_key)
-            WHERE lot_code IS NOT NULL
-            DO NOTHING
-            RETURNING id
-            """
-        ),
-        {
-            "w": int(warehouse_id),
-            "i": int(item_id),
-            "code_raw": code_raw,
-            "code_key": code_key,
-        },
-    )
-    got = row.scalar_one_or_none()
-    if got is not None:
-        return int(got)
+        if pd is None and ed is not None:
+            pd = _shift_date_by_shelf_life(
+                ed,
+                shelf_life_value=shelf_life_value,
+                shelf_life_unit=shelf_life_unit,
+                direction=-1,
+            )
 
-    row2 = await session.execute(
-        text(
-            """
-            SELECT id
-              FROM lots
-             WHERE warehouse_id = :w
-               AND item_id      = :i
-               AND lot_code_source = 'SUPPLIER'
-               AND lot_code_key = :code_key
-             LIMIT 1
-            """
-        ),
-        {"w": int(warehouse_id), "i": int(item_id), "code_key": code_key},
+    if ed is not None and pd is not None and ed < pd:
+        raise ValueError("expiry_date_cannot_be_earlier_than_production_date")
+
+    if expiry_policy == "REQUIRED":
+        if pd is None:
+            legacy_ids = await _get_supplier_lot_ids_by_lot_code(
+                session,
+                item_id=int(item_id),
+                warehouse_id=int(warehouse_id),
+                lot_code=code_raw,
+            )
+            if len(legacy_ids) == 1:
+                lot_id = int(legacy_ids[0])
+                await _patch_lot_expiry_if_null(session, lot_id=lot_id, expiry_date=ed)
+                return lot_id
+            if len(legacy_ids) > 1:
+                raise ValueError("supplier_lot_code_ambiguous")
+            raise ValueError("production_date_required_for_required_lot")
+
+        existing_by_pd = await _get_supplier_lot_by_production_date(
+            session,
+            item_id=int(item_id),
+            warehouse_id=int(warehouse_id),
+            production_date=pd,
+        )
+        if existing_by_pd is not None:
+            lot_id = int(existing_by_pd)
+            await _patch_lot_expiry_if_null(session, lot_id=lot_id, expiry_date=ed)
+            return lot_id
+
+        if ed is None:
+            raise ValueError("expiry_date_required_for_required_lot")
+
+        row = await session.execute(
+            text(
+                """
+                INSERT INTO lots(
+                    warehouse_id,
+                    item_id,
+                    lot_code_source,
+                    lot_code,
+                    production_date,
+                    expiry_date,
+                    source_receipt_id,
+                    source_line_no,
+                    item_lot_source_policy_snapshot,
+                    item_expiry_policy_snapshot,
+                    item_derivation_allowed_snapshot,
+                    item_uom_governance_enabled_snapshot,
+                    item_shelf_life_value_snapshot,
+                    item_shelf_life_unit_snapshot
+                )
+                SELECT
+                    :w,
+                    :i,
+                    'SUPPLIER',
+                    :code_raw,
+                    :pd,
+                    :ed,
+                    NULL,
+                    NULL,
+                    it.lot_source_policy,
+                    it.expiry_policy,
+                    it.derivation_allowed,
+                    it.uom_governance_enabled,
+                    it.shelf_life_value,
+                    it.shelf_life_unit
+                  FROM items it
+                 WHERE it.id = :i
+                ON CONFLICT (warehouse_id, item_id, production_date)
+                WHERE lot_code_source = 'SUPPLIER'
+                  AND item_expiry_policy_snapshot = 'REQUIRED'
+                  AND production_date IS NOT NULL
+                DO NOTHING
+                RETURNING id
+                """
+            ),
+            {
+                "w": int(warehouse_id),
+                "i": int(item_id),
+                "code_raw": code_raw,
+                "pd": pd,
+                "ed": ed,
+            },
+        )
+        got = row.scalar_one_or_none()
+        if got is not None:
+            return int(got)
+
+        existing_by_pd_2 = await _get_supplier_lot_by_production_date(
+            session,
+            item_id=int(item_id),
+            warehouse_id=int(warehouse_id),
+            production_date=pd,
+        )
+        if existing_by_pd_2 is not None:
+            lot_id = int(existing_by_pd_2)
+            await _patch_lot_expiry_if_null(session, lot_id=lot_id, expiry_date=ed)
+            return lot_id
+
+        raise RuntimeError("ensure_lot_full failed to materialize lot row by production_date")
+
+    legacy_ids = await _get_supplier_lot_ids_by_lot_code(
+        session,
+        item_id=int(item_id),
+        warehouse_id=int(warehouse_id),
+        lot_code=code_raw,
     )
-    got2 = row2.scalar_one_or_none()
-    if got2 is None:
-        raise RuntimeError("ensure_lot_full failed to materialize lot row")
-    return int(got2)
+    if len(legacy_ids) == 1:
+        return int(legacy_ids[0])
+    if len(legacy_ids) > 1:
+        raise ValueError("supplier_lot_code_ambiguous")
+    raise ValueError("supplier_lot_not_allowed_for_nonrequired_item")
 
 
 async def ensure_batch_full(

--- a/app/wms/stock/services/stock_adjust/date_rules.py
+++ b/app/wms/stock/services/stock_adjust/date_rules.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.wms.shared.services.expiry_resolver import resolve_batch_dates_for_item
+from app.wms.shared.services.expiry_resolver import normalize_batch_dates_for_item
 
 
 async def resolve_and_validate_dates_for_inbound(
@@ -18,26 +18,37 @@ async def resolve_and_validate_dates_for_inbound(
     production_date: Optional[date],
     expiry_date: Optional[date],
 ) -> tuple[Optional[date], Optional[date]]:
+    """
+    入库侧日期裁决：
+
+    - 有 batch_code 的路径，统一走 normalize_batch_dates_for_item
+    - 不再私自用 date.today() 补 production_date
+    - 对 delta>0（入库正增量），若最终仍无法形成 canonical production/expiry，则明确报错
+    """
     pd = production_date
     ed = expiry_date
 
-    if delta > 0 and batch_code_norm is not None:
-        if pd is None and ed is None:
-            pd = pd or date.today()
-
-        pd, ed = await resolve_batch_dates_for_item(
-            session=session,
-            item_id=item_id,
-            production_date=pd,
-            expiry_date=ed,
-        )
-
-        if ed is not None and pd is not None:
-            if ed < pd:
-                raise ValueError(f"expiry_date({ed}) < production_date({pd})")
-
     if batch_code_norm is None:
-        pd = None
-        ed = None
+        return None, None
+
+    pd, ed, _resolution_mode = await normalize_batch_dates_for_item(
+        session=session,
+        item_id=item_id,
+        production_date=pd,
+        expiry_date=ed,
+    )
+
+    if delta > 0:
+        if pd is None:
+            raise ValueError(
+                "批次受控商品必须提供 production_date，或提供可结合保质期反推出 production_date 的 expiry_date。"
+            )
+        if ed is None:
+            raise ValueError(
+                "未提供到期日期，且商品未配置可用于推算的保质期，无法形成 canonical expiry_date。"
+            )
+
+    if ed is not None and pd is not None and ed < pd:
+        raise ValueError(f"expiry_date({ed}) < production_date({pd})")
 
     return pd, ed

--- a/app/wms/stock/services/stock_contract_resolver.py
+++ b/app/wms/stock/services/stock_contract_resolver.py
@@ -1,7 +1,7 @@
 # app/wms/stock/services/stock_contract_resolver.py
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Optional, Tuple
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -20,6 +20,8 @@ async def resolve_lot_for_stock_adjust(
     lot_id: Optional[int],
     ref: str,
     occurred_at: Optional[datetime],
+    production_date: Optional[date],
+    expiry_date: Optional[date],
 ) -> Tuple[int, Optional[str]]:
     """
     任务3（StockService API 拆分）第一刀：抽离“合同裁决 + lot_id 解析”。
@@ -30,6 +32,9 @@ async def resolve_lot_for_stock_adjust(
         2) validate_lot_code_contract（REQUIRED/NONE 合同裁决）
         3) ensure_*_lot_id（lot identity 解析 / 创建入口）
     - 不负责写库存（不得调用 adjust_lot_impl），以保持“执行器单入口”铁律。
+
+    当前阶段：
+    - REQUIRED 商品：若需要创建 / 解析 SUPPLIER lot，必须携带 production_date
     """
     requires_batch = await lot_resolver.requires_batch(session, item_id=int(item_id))
     bc_norm = validate_lot_code_contract(requires_batch=requires_batch, lot_code=batch_code)
@@ -49,6 +54,8 @@ async def resolve_lot_for_stock_adjust(
             item_id=int(item_id),
             lot_code=bc_norm,
             occurred_at=occurred_at,
+            production_date=production_date,
+            expiry_date=expiry_date,
         )
 
     return int(resolved_lot_id), bc_norm

--- a/app/wms/stock/services/stock_service.py
+++ b/app/wms/stock/services/stock_service.py
@@ -32,18 +32,37 @@ class StockService:
 
     def _classify_adjust_value_error(self, msg: str) -> str:
         m = (msg or "").strip()
+        ml = m.lower()
 
-        if "insufficient stock" in m.lower():
+        if "insufficient stock" in ml:
             return "insufficient_stock"
-        if "item_not_found" in m.lower():
+        if "item_not_found" in ml:
             return "item_not_found"
-        if "lot_not_found" in m.lower():
+        if "lot_not_found" in ml:
             return "lot_not_found"
-        if "lot_mismatch" in m.lower():
+        if "lot_mismatch" in ml:
             return "lot_mismatch"
+        if "supplier_lot_code_ambiguous" in ml:
+            return "supplier_lot_code_ambiguous"
 
-        if ("batch_code" in m.lower()) or ("批次" in m):
-            if ("必须" in m) or ("required" in m.lower()):
+        if "production_date_required_for_required_lot" in ml:
+            return "production_date_required_for_required_lot"
+        if "expiry_date_required_for_required_lot" in ml:
+            return "expiry_date_required_for_required_lot"
+
+        if ("production_date" in ml and "必须" in m) or ("生产日期" in m and "必须" in m):
+            return "production_date_required_for_required_lot"
+
+        if (
+            ("expiry_date" in ml and "必须" in m)
+            or ("到期日期" in m and "必须" in m)
+            or ("未提供到期日期" in m)
+            or ("canonical expiry_date" in ml)
+        ):
+            return "expiry_date_required_for_required_lot"
+
+        if ("batch_code" in ml) or ("批次" in m):
+            if ("必须" in m) or ("required" in ml):
                 return "batch_required"
             return "stock_adjust_reject"
 
@@ -127,6 +146,42 @@ class StockService:
             )
             return
 
+        if kind == "production_date_required_for_required_lot":
+            raise_problem(
+                status_code=422,
+                error_code="production_date_required_for_required_lot",
+                message="批次受控商品必须提供 production_date，或提供可结合保质期反推出 production_date 的 expiry_date。",
+                context=ctx,
+                details=[
+                    {
+                        "type": "date",
+                        "path": "stock_adjust",
+                        "item_id": int(item_id),
+                        "batch_code": bc_norm2,
+                        "reason": msg,
+                    }
+                ],
+            )
+            return
+
+        if kind == "expiry_date_required_for_required_lot":
+            raise_problem(
+                status_code=422,
+                error_code="expiry_date_required_for_required_lot",
+                message="批次受控商品必须提供 expiry_date，或提供可结合保质期正推出 expiry_date 的 production_date。",
+                context=ctx,
+                details=[
+                    {
+                        "type": "date",
+                        "path": "stock_adjust",
+                        "item_id": int(item_id),
+                        "batch_code": bc_norm2,
+                        "reason": msg,
+                    }
+                ],
+            )
+            return
+
         if kind == "batch_required":
             raise_problem(
                 status_code=422,
@@ -183,6 +238,25 @@ class StockService:
             )
             return
 
+        if kind == "supplier_lot_code_ambiguous":
+            raise_problem(
+                status_code=422,
+                error_code="supplier_lot_code_ambiguous",
+                message="同一展示批次码命中多个库存槽位，写入被拒绝。",
+                context=ctx,
+                details=[
+                    {
+                        "type": "lot",
+                        "path": "stock_adjust",
+                        "warehouse_id": int(warehouse_id),
+                        "item_id": int(item_id),
+                        "batch_code": bc_norm2,
+                        "reason": "supplier_lot_code_ambiguous",
+                    }
+                ],
+            )
+            return
+
         raise_problem(
             status_code=422,
             error_code="stock_adjust_reject",
@@ -223,6 +297,8 @@ class StockService:
                 lot_id=None,
                 ref=str(ref),
                 occurred_at=occurred_at,
+                production_date=production_date,
+                expiry_date=expiry_date,
             )
 
             return await adjust_lot_impl(

--- a/app/wms/stock/services/stock_ship_service.py
+++ b/app/wms/stock/services/stock_ship_service.py
@@ -1,18 +1,19 @@
 # app/wms/stock/services/stock_ship_service.py
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable, Dict, Optional
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.wms.shared.services.lot_code_contract import fetch_item_expiry_policy_map
 from app.core.problem import raise_problem
 from app.models.enums import MovementType
 from app.wms.outbound.services.invariant_guard_outbound import enforce_outbound_invariant_guard
+from app.wms.shared.services.lot_code_contract import fetch_item_expiry_policy_map
 
 AdjustLotFn = Callable[..., Awaitable[Dict[str, Any]]]
+UTC = timezone.utc
 
 
 def _shortage_detail(
@@ -68,7 +69,7 @@ async def ship_commit_direct_lot_impl(
     - REQUIRED 商品：必须显式批次（但本函数 lines 不含 batch_code），因此直接拒绝。
     - NONE 商品：batch_code 必须为 null，统一扣 INTERNAL 槽位（lots.lot_code IS NULL）。
     """
-    ts = occurred_at or datetime.utcnow()
+    ts = occurred_at or datetime.now(UTC)
 
     need_by_item: Dict[int, int] = {}
     for line in lines or []:

--- a/tests/alembic/test_migration_contract.py
+++ b/tests/alembic/test_migration_contract.py
@@ -21,10 +21,13 @@ async def _get_index_defs(session: AsyncSession, *, table: str) -> list[str]:
     return [str(r[0]) for r in rows.fetchall()]
 
 
-def _has_supplier_unique_by_key(idx_defs: list[str]) -> bool:
+def _has_required_unique_by_production_date(idx_defs: list[str]) -> bool:
     """
     Expect:
-      UNIQUE (warehouse_id, item_id, lot_code_key) WHERE lot_code IS NOT NULL
+      UNIQUE (warehouse_id, item_id, production_date)
+      WHERE lot_code_source='SUPPLIER'
+        AND item_expiry_policy_snapshot='REQUIRED'
+        AND production_date IS NOT NULL
     """
     for d in idx_defs:
         dd = d.lower()
@@ -32,8 +35,15 @@ def _has_supplier_unique_by_key(idx_defs: list[str]) -> bool:
             continue
         if " on public.lots " not in dd:
             continue
-        if "(warehouse_id, item_id, lot_code_key)" in dd and "where (lot_code is not null)" in dd:
-            return True
+        if "(warehouse_id, item_id, production_date)" not in dd:
+            continue
+        if "item_expiry_policy_snapshot" not in dd or "required" not in dd:
+            continue
+        if "production_date is not null" not in dd:
+            continue
+        if "lot_code_source" not in dd or "supplier" not in dd:
+            continue
+        return True
     return False
 
 
@@ -49,6 +59,22 @@ def _has_internal_singleton_unique(idx_defs: list[str]) -> bool:
         if " on public.lots " not in dd:
             continue
         if "(warehouse_id, item_id)" in dd and "where" in dd and "lot_code is null" in dd and "internal" in dd:
+            return True
+    return False
+
+
+def _has_legacy_unique_by_key(idx_defs: list[str]) -> bool:
+    """
+    Legacy (should be retired):
+      UNIQUE (warehouse_id, item_id, lot_code_key) WHERE lot_code IS NOT NULL
+    """
+    for d in idx_defs:
+        dd = d.lower()
+        if "unique index" not in dd:
+            continue
+        if " on public.lots " not in dd:
+            continue
+        if "(warehouse_id, item_id, lot_code_key)" in dd and "where (lot_code is not null)" in dd:
             return True
     return False
 
@@ -75,9 +101,15 @@ async def test_alembic_single_head_and_stocks_lot_contract(session: AsyncSession
 
     # 3) lots indexes contracts
     idx_defs = await _get_index_defs(session, table="lots")
-    assert _has_supplier_unique_by_key(idx_defs), (
-        "missing supplier-lot uniqueness: UNIQUE (warehouse_id,item_id,lot_code_key) WHERE lot_code IS NOT NULL"
+    assert _has_required_unique_by_production_date(idx_defs), (
+        "missing required-lot uniqueness: "
+        "UNIQUE (warehouse_id,item_id,production_date) "
+        "WHERE lot_code_source='SUPPLIER' AND item_expiry_policy_snapshot='REQUIRED' AND production_date IS NOT NULL"
     )
     assert _has_internal_singleton_unique(idx_defs), (
-        "missing internal-lot uniqueness: UNIQUE (warehouse_id,item_id) WHERE lot_code_source='INTERNAL' AND lot_code IS NULL"
+        "missing internal-lot uniqueness: UNIQUE (warehouse_id,item_id) "
+        "WHERE lot_code_source='INTERNAL' AND lot_code IS NULL"
+    )
+    assert not _has_legacy_unique_by_key(idx_defs), (
+        "legacy supplier-lot uniqueness by lot_code_key must be retired"
     )

--- a/tests/api/test_debug_trace_api.py
+++ b/tests/api/test_debug_trace_api.py
@@ -1,5 +1,6 @@
-# tests/api/test_debug_trace_api.py
 from __future__ import annotations
+
+from datetime import date, timedelta
 
 import pytest
 from sqlalchemy import text
@@ -41,6 +42,7 @@ async def _seed_trace_case(session: AsyncSession) -> str:
         id=int(item_id),
         sku=f"UT-SKU-{item_id}",
         name=f"UT-Item-{item_id}",
+        expiry_required=True,
     )
 
     store_id = await ensure_store(
@@ -131,13 +133,15 @@ async def _seed_trace_case(session: AsyncSession) -> str:
 
     # ensure SUPPLIER lot（展示码 lot_code='B-TRACE-1'）
     lot_code = "B-TRACE-1"
+    prod = date.today()
+    exp = prod + timedelta(days=365)
     lot_id = await ensure_lot_full(
         session,
         item_id=int(item_id),
         warehouse_id=int(wh_id),
         lot_code=str(lot_code),
-        production_date=None,
-        expiry_date=None,
+        production_date=prod,
+        expiry_date=exp,
     )
 
     # stock_ledger：SHIPMENT（lot_id 维度；不写 batch_code）

--- a/tests/api/test_debug_trace_by_warehouse.py
+++ b/tests/api/test_debug_trace_by_warehouse.py
@@ -1,4 +1,3 @@
-# tests/api/test_debug_trace_by_warehouse.py
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
@@ -33,9 +32,18 @@ async def test_debug_trace_filter_by_warehouse(client, session: AsyncSession):
     await ensure_wh_loc_item(session, wh=wh1, loc=wh1, item=item_id)
     await ensure_wh_loc_item(session, wh=wh2, loc=wh2, item=item_id)
 
-    # 终态合同：本测试要用 batch_code，所以必须把该 item 设为 REQUIRED
+    # 终态合同：本测试要用 batch_code，所以必须把该 item 设为 REQUIRED + SUPPLIER_ONLY
     await session.execute(
-        text("UPDATE items SET expiry_policy='REQUIRED'::expiry_policy WHERE id=:i"),
+        text(
+            """
+            UPDATE items
+               SET expiry_policy = 'REQUIRED'::expiry_policy,
+                   lot_source_policy = 'SUPPLIER_ONLY'::lot_source_policy,
+                   derivation_allowed = TRUE,
+                   uom_governance_enabled = TRUE
+             WHERE id = :i
+            """
+        ),
         {"i": int(item_id)},
     )
     await session.commit()
@@ -43,14 +51,19 @@ async def test_debug_trace_filter_by_warehouse(client, session: AsyncSession):
     stock_svc = StockService()
     now = datetime.now(UTC)
 
+    prod1 = now.date()
+    exp1 = prod1 + timedelta(days=30)
+    prod2 = (now + timedelta(days=1)).date()
+    exp2 = prod2 + timedelta(days=30)
+
     # ✅ 显式种 WH1 批次槽位库存
     lot1 = await ensure_lot_full(
         session,
         item_id=int(item_id),
         warehouse_id=int(wh1),
         lot_code=str(batch1),
-        production_date=None,
-        expiry_date=None,
+        production_date=prod1,
+        expiry_date=exp1,
     )
     await stock_svc.adjust_lot(
         session=session,
@@ -63,8 +76,8 @@ async def test_debug_trace_filter_by_warehouse(client, session: AsyncSession):
         ref_line=1,
         occurred_at=now,
         batch_code=str(batch1),
-        production_date=None,
-        expiry_date=None,
+        production_date=prod1,
+        expiry_date=exp1,
         trace_id=trace_id,
     )
 
@@ -74,8 +87,8 @@ async def test_debug_trace_filter_by_warehouse(client, session: AsyncSession):
         item_id=int(item_id),
         warehouse_id=int(wh2),
         lot_code=str(batch2),
-        production_date=None,
-        expiry_date=None,
+        production_date=prod2,
+        expiry_date=exp2,
     )
     await stock_svc.adjust_lot(
         session=session,
@@ -88,8 +101,8 @@ async def test_debug_trace_filter_by_warehouse(client, session: AsyncSession):
         ref_line=1,
         occurred_at=now,
         batch_code=str(batch2),
-        production_date=None,
-        expiry_date=None,
+        production_date=prod2,
+        expiry_date=exp2,
         trace_id=trace_id,
     )
 

--- a/tests/api/test_pick_tasks_api.py
+++ b/tests/api/test_pick_tasks_api.py
@@ -40,13 +40,16 @@ async def _ensure_supplier_lot(session: AsyncSession, *, wh_id: int, item_id: in
     """
     Lot-World 终态：SUPPLIER lot 必须走 ensure_lot_full（lot_code_key + partial unique index）。
     """
+    prod = date.today()
+    exp = prod + timedelta(days=365)
+
     return await ensure_lot_full(
         session,
         item_id=int(item_id),
         warehouse_id=int(wh_id),
         lot_code=str(lot_code),
-        production_date=None,
-        expiry_date=None,
+        production_date=prod,
+        expiry_date=exp,
     )
 
 

--- a/tests/api/test_pick_tasks_from_order_contract.py
+++ b/tests/api/test_pick_tasks_from_order_contract.py
@@ -38,18 +38,20 @@ async def _item_requires_batch(session: AsyncSession, item_id: int) -> bool:
 
 async def _ensure_supplier_lot(session: AsyncSession, *, wh_id: int, item_id: int, lot_code: str) -> int:
     """
-    Lot-World 终态：
-    - SUPPLIER lot identity = (warehouse_id,item_id,lot_code_key)
-    - partial unique index: UNIQUE(warehouse_id,item_id,lot_code_key) WHERE lot_code IS NOT NULL
-    因此测试侧必须走统一入口 ensure_lot_full（避免散装 ON CONFLICT 写错）。
+    当前终态：
+    - REQUIRED lot 身份 = (warehouse_id, item_id, production_date)
+    - lot_code 只保留为展示/输入/追溯属性
+    因此测试侧必须走统一入口 ensure_lot_full，并在 REQUIRED 商品下显式给 production_date + expiry_date。
     """
+    production_date = date.today() if await _item_requires_batch(session, int(item_id)) else None
+    expiry_date = (production_date + timedelta(days=365)) if production_date is not None else None
     return await ensure_lot_full(
         session,
         item_id=int(item_id),
         warehouse_id=int(wh_id),
         lot_code=str(lot_code),
-        production_date=None,
-        expiry_date=None,
+        production_date=production_date,
+        expiry_date=expiry_date,
     )
 
 

--- a/tests/api/test_pick_tasks_print_job_contract.py
+++ b/tests/api/test_pick_tasks_print_job_contract.py
@@ -40,13 +40,15 @@ async def _ensure_supplier_lot(session: AsyncSession, *, wh_id: int, item_id: in
     """
     Lot-World 终态：SUPPLIER lot 必须走 ensure_lot_full（lot_code_key + partial unique index）。
     """
+    prod = date.today()
+    exp = prod + timedelta(days=365)
     return await ensure_lot_full(
         session,
         item_id=int(item_id),
         warehouse_id=int(wh_id),
         lot_code=str(lot_code),
-        production_date=None,
-        expiry_date=None,
+        production_date=prod,
+        expiry_date=exp,
     )
 
 

--- a/tests/api/test_scan_count_v2.py
+++ b/tests/api/test_scan_count_v2.py
@@ -1,4 +1,3 @@
-# tests/api/test_scan_count_v2.py
 from __future__ import annotations
 
 import pytest
@@ -20,6 +19,7 @@ async def test_scan_count_v2_adjusts_stock(client):
     # ✅ 用基线更稳的 item_id，避免依赖隐式 seed
     item_id = 1
     batch_code = "BATCH-COUNT-V2"
+    production_date = "2030-01-01"
     expiry_date = "2030-12-31"
 
     recv_payload = {
@@ -28,6 +28,7 @@ async def test_scan_count_v2_adjusts_stock(client):
         "qty": 5,
         "warehouse_id": warehouse_id,
         "batch_code": batch_code,
+        "production_date": production_date,
         "expiry_date": expiry_date,
         "ctx": {"device_id": "scan-count-v2-test"},
     }
@@ -43,6 +44,7 @@ async def test_scan_count_v2_adjusts_stock(client):
         "qty": 2,
         "warehouse_id": warehouse_id,
         "batch_code": batch_code,
+        "production_date": production_date,
         "expiry_date": expiry_date,
         "ctx": {"device_id": "scan-count-v2-test"},
     }

--- a/tests/api/test_scan_pick_v2.py
+++ b/tests/api/test_scan_pick_v2.py
@@ -1,4 +1,3 @@
-# tests/api/test_scan_pick_v2.py
 from __future__ import annotations
 
 import pytest
@@ -21,6 +20,7 @@ async def test_scan_pick_v2_decreases_stock(client):
     warehouse_id = 1
     item_id = 3001
     batch_code = "BATCH-PICK-V2"
+    production_date = "2030-01-01"
     expiry_date = "2030-12-31"
 
     # 1) 先收货 10 件
@@ -30,6 +30,7 @@ async def test_scan_pick_v2_decreases_stock(client):
         "qty": 10,
         "warehouse_id": warehouse_id,
         "batch_code": batch_code,
+        "production_date": production_date,
         "expiry_date": expiry_date,
         "ctx": {"device_id": "scan-pick-v2-test"},
     }
@@ -46,6 +47,8 @@ async def test_scan_pick_v2_decreases_stock(client):
         "qty": 4,
         "warehouse_id": warehouse_id,
         "batch_code": batch_code,
+        "production_date": production_date,
+        "expiry_date": expiry_date,
         "ctx": {"device_id": "scan-pick-v2-test"},
     }
     r2 = await client.post("/scan", json=pick_payload)

--- a/tests/api/test_stock_inventory_read_api.py
+++ b/tests/api/test_stock_inventory_read_api.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from tests.helpers.inventory import seed_batch_slot
+from tests.helpers.inventory import ensure_wh_loc_item, seed_batch_slot
 
 
 async def _login_admin_headers(client: AsyncClient) -> dict[str, str]:
@@ -94,6 +95,15 @@ async def test_stock_inventory_detail_returns_totals_and_slices(
     item_id = 910001
     warehouse_id = 1
     lot_code = "UT-STOCK-DETAIL-001"
+
+    # 先确保基础行存在；否则直接 UPDATE items 可能打空
+    await ensure_wh_loc_item(session, wh=warehouse_id, loc=warehouse_id, item=item_id)
+
+    # 当前主链：新建 SUPPLIER lot 前，测试商品必须显式走 REQUIRED
+    await session.execute(
+        text("UPDATE items SET expiry_policy='REQUIRED'::expiry_policy WHERE id=:i"),
+        {"i": int(item_id)},
+    )
 
     await seed_batch_slot(
         session,

--- a/tests/api/test_v2_full_chain.py
+++ b/tests/api/test_v2_full_chain.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from uuid import uuid4
 
 import pytest
@@ -66,17 +66,17 @@ async def _ensure_store_route_to_wh1(session: AsyncSession, *, plat: str, shop_i
 
 async def _ensure_supplier_lot(session: AsyncSession, *, wh_id: int, item_id: int, lot_code: str) -> int:
     """
-    Lot-World 终态：
-    - SUPPLIER lot identity = (warehouse_id,item_id,lot_code_key)
-    - partial unique index: UNIQUE(warehouse_id,item_id,lot_code_key) WHERE lot_code IS NOT NULL
-    因此测试侧必须走统一入口 ensure_lot_full（避免散装 ON CONFLICT 写错）。
+    当前终态：
+    - REQUIRED lot 身份 = (warehouse_id, item_id, production_date)
+    - lot_code 只保留为展示/输入/追溯属性
+    因此测试侧必须走统一入口 ensure_lot_full，并在 REQUIRED 商品下显式给 production_date。
     """
     return await ensure_lot_full(
         session,
         item_id=int(item_id),
         warehouse_id=int(wh_id),
         lot_code=str(lot_code),
-        production_date=None,
+        production_date=date.today(),
         expiry_date=None,
     )
 

--- a/tests/ci/test_db_invariants.py
+++ b/tests/ci/test_db_invariants.py
@@ -1,6 +1,6 @@
 # tests/ci/test_db_invariants.py
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy import text
@@ -41,15 +41,26 @@ async def _seed_wh_item_lot_stock(
         {"wh_id": int(wh_id)},
     )
 
-    await ensure_item(session, id=int(item_id), sku=f"SKU-{int(item_id)}", name=f"Item-{int(item_id)}")
+    # 本测试要验证 SUPPLIER lot 与 ledger/stocks_lot 的维度一致性，
+    # 因此商品策略必须显式站到 REQUIRED 上。
+    await ensure_item(
+        session,
+        id=int(item_id),
+        sku=f"SKU-{int(item_id)}",
+        name=f"Item-{int(item_id)}",
+        expiry_required=True,
+    )
+
+    prod = date(2030, 1, 1)
+    exp = prod + timedelta(days=365)
 
     lot_id = await ensure_lot_full(
         session,
         item_id=int(item_id),
         warehouse_id=int(wh_id),
         lot_code=str(lot_code),
-        production_date=None,
-        expiry_date=None,
+        production_date=prod,
+        expiry_date=exp,
     )
 
     # 用唯一写入器写一条 COUNT（delta=1 -> after=1），同时确保 stocks_lot 槽位存在且与 ledger 一致
@@ -65,8 +76,8 @@ async def _seed_wh_item_lot_stock(
         occurred_at=datetime.now(timezone.utc),
         meta=None,
         batch_code=str(lot_code),
-        production_date=None,
-        expiry_date=None,
+        production_date=prod,
+        expiry_date=exp,
         trace_id=None,
         utc_now=lambda: datetime.now(timezone.utc),
         shadow_write_stocks=False,

--- a/tests/ci/test_outbound_metrics_view.py
+++ b/tests/ci/test_outbound_metrics_view.py
@@ -1,15 +1,26 @@
-from datetime import datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.wms.stock.services.lots import ensure_internal_lot_singleton
+from app.wms.stock.services.lots import ensure_internal_lot_singleton, ensure_lot_full
 from app.wms.stock.services.stock_adjust import adjust_lot_impl
 
 pytestmark = pytest.mark.asyncio
 
 UTC = timezone.utc
+
+
+async def _item_requires_batch(session: AsyncSession, *, item_id: int) -> bool:
+    row = await session.execute(
+        text("SELECT expiry_policy::text FROM items WHERE id=:i LIMIT 1"),
+        {"i": int(item_id)},
+    )
+    val = row.scalar_one_or_none()
+    if val is None:
+        raise RuntimeError(f"item_not_found: {item_id}")
+    return str(val).strip().upper() == "REQUIRED"
 
 
 async def _pick_one_lot_id_for_item(session: AsyncSession, *, warehouse_id: int, item_id: int) -> int:
@@ -18,7 +29,9 @@ async def _pick_one_lot_id_for_item(session: AsyncSession, *, warehouse_id: int,
     从 stocks_lot 中挑一个现存槽位的 lot_id（qty 可以为 0）。
 
     Phase M-5 收口后 baseline 不再隐式种 stocks_lot 槽位，因此：
-    - 若不存在槽位：显式 seed 一个 INTERNAL lot 槽位（delta=+1），再返回 lot_id。
+    - 若不存在槽位：
+      - REQUIRED 商品：显式 seed 一个 SUPPLIER lot 槽位（带 production/expiry）
+      - NONE 商品：显式 seed 一个 INTERNAL lot 槽位（delta=+1）
     """
     row = (
         await session.execute(
@@ -38,33 +51,66 @@ async def _pick_one_lot_id_for_item(session: AsyncSession, *, warehouse_id: int,
     if row is not None:
         return int(row[0])
 
-    # 显式 seed：创建 INTERNAL singleton lot + 写入一笔 delta=+1（确保 stocks_lot slot 被 materialize）
-    lot_id = await ensure_internal_lot_singleton(
-        session,
-        item_id=int(item_id),
-        warehouse_id=int(warehouse_id),
-        source_receipt_id=None,
-        source_line_no=None,
-    )
+    requires_batch = await _item_requires_batch(session, item_id=int(item_id))
 
-    await adjust_lot_impl(
-        session=session,
-        item_id=int(item_id),
-        warehouse_id=int(warehouse_id),
-        lot_id=int(lot_id),
-        delta=1,
-        reason="UT_METRICS_SEED",
-        ref="ut:metrics:seed",
-        ref_line=1,
-        occurred_at=datetime.now(UTC),
-        meta=None,
-        batch_code=None,
-        production_date=None,
-        expiry_date=None,
-        trace_id=None,
-        utc_now=lambda: datetime.now(UTC),
-        shadow_write_stocks=False,
-    )
+    if requires_batch:
+        lot_code = f"UT-METRICS-SEED-{int(warehouse_id)}-{int(item_id)}"
+        prod = date(2030, 1, 1)
+        exp = prod + timedelta(days=365)
+        lot_id = await ensure_lot_full(
+            session,
+            item_id=int(item_id),
+            warehouse_id=int(warehouse_id),
+            lot_code=lot_code,
+            production_date=prod,
+            expiry_date=exp,
+        )
+        await adjust_lot_impl(
+            session=session,
+            item_id=int(item_id),
+            warehouse_id=int(warehouse_id),
+            lot_id=int(lot_id),
+            delta=1,
+            reason="UT_METRICS_SEED",
+            ref="ut:metrics:seed",
+            ref_line=1,
+            occurred_at=datetime.now(UTC),
+            meta=None,
+            batch_code=lot_code,
+            production_date=prod,
+            expiry_date=exp,
+            trace_id=None,
+            utc_now=lambda: datetime.now(UTC),
+            shadow_write_stocks=False,
+        )
+    else:
+        # 显式 seed：创建 INTERNAL singleton lot + 写入一笔 delta=+1（确保 stocks_lot slot 被 materialize）
+        lot_id = await ensure_internal_lot_singleton(
+            session,
+            item_id=int(item_id),
+            warehouse_id=int(warehouse_id),
+            source_receipt_id=None,
+            source_line_no=None,
+        )
+
+        await adjust_lot_impl(
+            session=session,
+            item_id=int(item_id),
+            warehouse_id=int(warehouse_id),
+            lot_id=int(lot_id),
+            delta=1,
+            reason="UT_METRICS_SEED",
+            ref="ut:metrics:seed",
+            ref_line=1,
+            occurred_at=datetime.now(UTC),
+            meta=None,
+            batch_code=None,
+            production_date=None,
+            expiry_date=None,
+            trace_id=None,
+            utc_now=lambda: datetime.now(UTC),
+            shadow_write_stocks=False,
+        )
 
     row2 = (
         await session.execute(
@@ -99,7 +145,7 @@ async def test_metrics_view_basic(session: AsyncSession) -> None:
     item_id = 1
     wh_id = 1
 
-    # 终态：需要一个真实 lot_id（若 baseline 无 slot，则显式 seed）
+    # 终态：需要一个真实 lot_id（若 baseline 无 slot，则按当前 item policy 显式 seed）
     lot_id = await _pick_one_lot_id_for_item(session, warehouse_id=wh_id, item_id=item_id)
 
     # 2) 清理同 ref 残留（先清再写，保证幂等复跑）

--- a/tests/helpers/inventory.py
+++ b/tests/helpers/inventory.py
@@ -1,6 +1,7 @@
 # tests/helpers/inventory.py
 from __future__ import annotations
 
+import hashlib
 from datetime import date, datetime, timedelta, timezone
 from typing import Iterable, List, Optional, Tuple
 
@@ -65,6 +66,26 @@ def _as_lot_id(v: object) -> int:
     tests 侧用这个函数统一兼容，避免类型漂移导致的 AttributeError。
     """
     return int(getattr(v, "id", v))
+
+
+def _stable_required_dates_from_code(code_raw: str, *, days: int) -> tuple[date, date]:
+    """
+    REQUIRED lot helper：按 lot_code 稳定生成日期，避免不同批次都撞到同一天 production_date。
+
+    规则：
+    - 同一 code -> 同一 production_date
+    - 不同 code -> 大概率不同 production_date
+    - expiry_date = production_date + days
+    """
+    code = str(code_raw).strip()
+    if not code:
+        raise ValueError("code empty")
+
+    digest = hashlib.sha1(code.encode("utf-8")).hexdigest()
+    offset_days = int(digest[:8], 16) % 73000  # ~200 years range, collision risk much lower than using today
+    production_date = date(2000, 1, 1) + timedelta(days=offset_days)
+    expiry_date = production_date + timedelta(days=int(days))
+    return production_date, expiry_date
 
 
 async def ensure_wh_loc_item(
@@ -132,8 +153,8 @@ async def seed_batch_slot(
       （等价于旧实现的 ON CONFLICT DO UPDATE SET qty）
 
     关键：日期合同必须认真对待
-    - 若 item.expiry_policy == 'REQUIRED' 且发生入库（delta>0），必须提供 expiry_date（production_date 可为空）
-    - 若 item.expiry_policy == 'NONE'，日期一律传 None（避免伪造日期事实）
+    - seed_batch_slot 的语义就是“造一个 SUPPLIER batch slot”，因此商品必须走 REQUIRED
+    - REQUIRED 且发生入库（delta>0）时，必须提供 production/expiry 事实
     """
     wh = _wh_from_loc(loc)
     code_raw = str(code).strip()
@@ -145,14 +166,21 @@ async def seed_batch_slot(
         SA("INSERT INTO warehouses (id, name) VALUES (:w, 'WH') ON CONFLICT (id) DO NOTHING"),
         {"w": int(wh)},
     )
-    await ensure_item(session, id=int(item), sku=f"SKU-{item}", name=f"ITEM-{item}")
+
+    # 当前 helper 语义就是“造 batch slot”，因此显式把商品设为 REQUIRED。
+    # 不能用 ensure_item 默认值（expiry_required=False），否则会把上游已设好的 REQUIRED 冲回 NONE。
+    await ensure_item(
+        session,
+        id=int(item),
+        sku=f"SKU-{item}",
+        name=f"ITEM-{item}",
+        expiry_required=True,
+    )
 
     expiry_policy = await _load_item_expiry_policy(session, item_id=int(item))
 
-    # 先确保 lot（满足 ensure_lot_full 的强制入参）
     if expiry_policy == "REQUIRED":
-        expiry_date: Optional[date] = date.today() + timedelta(days=int(days))
-        production_date: Optional[date] = None
+        production_date, expiry_date = _stable_required_dates_from_code(code_raw, days=int(days))
     else:
         expiry_date = None
         production_date = None
@@ -173,12 +201,9 @@ async def seed_batch_slot(
     if delta == 0:
         return
 
-    # 入库合同：REQUIRED 且 delta>0 必须提供 expiry_date
     if expiry_policy == "REQUIRED" and int(delta) > 0 and expiry_date is None:
-        expiry_date = date.today() + timedelta(days=int(days))
+        production_date, expiry_date = _stable_required_dates_from_code(code_raw, days=int(days))
 
-    # 用 ref 携带 target，保证“重复 seed 同 qty”幂等，
-    # 但“不同 qty 的 overwrite”不会被 idem 吃掉（等价于旧 DO UPDATE）。
     ref = f"ut:seed_batch_slot:set:{int(wh)}:{int(item)}:{code_raw}:{int(target)}"
 
     await adjust_lot_impl(

--- a/tests/quick/test_outbound_commit_v2.py
+++ b/tests/quick/test_outbound_commit_v2.py
@@ -1,3 +1,5 @@
+from datetime import date, timedelta, datetime, timezone
+
 import pytest
 from fastapi import HTTPException
 from sqlalchemy import text
@@ -23,8 +25,15 @@ async def _requires_batch(session: AsyncSession, item_id: int) -> bool:
 
 
 async def _slot_code(session: AsyncSession, item_id: int) -> str | None:
-    # 批次受控 => 用 NEAR；非批次 => 强护栏口径用 NULL 槽位（lot_id IS NULL）
+    # 批次受控 => 用 NEAR；非批次 => 用无展示码内部槽位
     return "NEAR" if await _requires_batch(session, item_id) else None
+
+
+def _required_dates_for_code(code: str) -> tuple[date, date]:
+    # quick 测试里固定给一组稳定日期即可
+    prod = date(2030, 1, 1)
+    exp = prod + timedelta(days=365)
+    return prod, exp
 
 
 async def _ensure_order_ref_exists(session: AsyncSession, *, order_ref: str) -> None:
@@ -52,6 +61,7 @@ async def _ensure_order_ref_exists(session: AsyncSession, *, order_ref: str) -> 
             "sid": str(shop_id),
             "store_id": int(store_id),
             "ext": str(ext_order_no),
+            "created_at": datetime.now(timezone.utc),
         },
     )
     await session.commit()
@@ -66,7 +76,6 @@ async def _qty(session: AsyncSession, item_id: int, wh: int, code: str | None) -
                   FROM stocks_lot
                  WHERE item_id=:i
                    AND warehouse_id=:w
-                   /* lot_id NOT NULL in DB: filter by lots.lot_code */
                  LIMIT 1
                 """
             ),
@@ -114,6 +123,7 @@ async def _ensure_stock_seed(session: AsyncSession, *, item_id: int, wh: int, co
             batch_code=None,
         )
     else:
+        prod, exp = _required_dates_for_code(str(code))
         await svc.adjust(
             session=session,
             item_id=int(item_id),
@@ -124,8 +134,8 @@ async def _ensure_stock_seed(session: AsyncSession, *, item_id: int, wh: int, co
             ref_line=1,
             occurred_at=None,
             batch_code=str(code),
-            production_date=None,  # allow auto fallback
-            expiry_date=None,
+            production_date=prod,
+            expiry_date=exp,
         )
     await session.commit()
 
@@ -141,8 +151,8 @@ async def test_outbound_idem_and_insufficient(session: AsyncSession):
       - 另一单 Q-OUT-2 请求超量，抛 409(outbound_commit_reject)，details.results 至少一条 INSUFFICIENT。
 
     槽位口径（与后端 requires_batch 派生一致）：
-      - 批次受控：batch_code='NEAR'（承载 lot_code 展示码）
-      - 非批次受控：batch_code=NULL（NULL 槽位：lot_id IS NULL）
+      - 批次受控：batch_code='NEAR'
+      - 非批次受控：batch_code=NULL（内部槽位）
     """
     item_id, wh = 3003, 1
     code = await _slot_code(session, item_id)

--- a/tests/quick/test_outbound_core_v2.py
+++ b/tests/quick/test_outbound_core_v2.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 from fastapi import HTTPException
@@ -82,6 +82,8 @@ async def _ensure_stock_seed(session: AsyncSession, *, item_id: int, wh: int, co
             batch_code=None,
         )
     else:
+        prod = date.today()
+        exp = prod + timedelta(days=365)
         await svc.adjust(
             session=session,
             item_id=int(item_id),
@@ -92,7 +94,8 @@ async def _ensure_stock_seed(session: AsyncSession, *, item_id: int, wh: int, co
             ref_line=1,
             occurred_at=datetime.now(UTC),
             batch_code=str(code),
-            production_date=date.today(),
+            production_date=prod,
+            expiry_date=exp,
         )
     await session.commit()
 

--- a/tests/quick/test_outbound_pg.py
+++ b/tests/quick/test_outbound_pg.py
@@ -1,5 +1,5 @@
 # tests/quick/test_outbound_pg.py — v2: warehouse + batch_code 口径
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 from fastapi import HTTPException
@@ -125,6 +125,8 @@ async def _ensure_stock_seed(session: AsyncSession, *, item_id: int, wh: int, co
             batch_code=None,
         )
     else:
+        prod = date.today()
+        exp = prod + timedelta(days=365)
         await svc.adjust(
             session=session,
             item_id=int(item_id),
@@ -135,7 +137,8 @@ async def _ensure_stock_seed(session: AsyncSession, *, item_id: int, wh: int, co
             ref_line=1,
             occurred_at=now,
             batch_code=str(code),
-            production_date=date.today(),
+            production_date=prod,
+            expiry_date=exp,
         )
     await session.commit()
 
@@ -201,6 +204,8 @@ async def test_outbound_insufficient_stock(session: AsyncSession):
     cur = await _qty(session, item_id, wh, code)
     if cur != 0:
         svc = StockService()
+        zero_prod = date.today() if code is not None else None
+        zero_exp = (zero_prod + timedelta(days=365)) if zero_prod is not None else None
         await svc.adjust(
             session=session,
             item_id=int(item_id),
@@ -211,8 +216,8 @@ async def test_outbound_insufficient_stock(session: AsyncSession):
             ref_line=1,
             occurred_at=datetime.now(UTC),
             batch_code=code,
-            production_date=date.today() if code is not None else None,
-            expiry_date=None,
+            production_date=zero_prod,
+            expiry_date=zero_exp,
         )
         await session.commit()
 

--- a/tests/services/order_lifecycle_v2/seeders.py
+++ b/tests/services/order_lifecycle_v2/seeders.py
@@ -1,5 +1,6 @@
-# tests/services/order_lifecycle_v2/seeders.py
 from __future__ import annotations
+
+from datetime import date, timedelta
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -141,8 +142,14 @@ async def seed_full_lifecycle_case(session: AsyncSession) -> str:
         {"w": int(wh_id)},
     )
 
-    # items（Phase M：items policy NOT NULL，必须最小合法插入）
-    await ensure_item(session, id=int(item_id), sku=f"UT-SKU-{item_id}", name=f"UT-Item-{item_id}")
+    # items（本场景显式走 SUPPLIER lot，因此商品必须站到 REQUIRED）
+    await ensure_item(
+        session,
+        id=int(item_id),
+        sku=f"UT-SKU-{item_id}",
+        name=f"UT-Item-{item_id}",
+        expiry_required=True,
+    )
 
     # orders + order_fulfillment（Phase5+）
     await _upsert_order_and_fulfillment(
@@ -193,13 +200,15 @@ async def seed_full_lifecycle_case(session: AsyncSession) -> str:
 
     # ensure SUPPLIER lot (lot_code 展示码)
     lot_code = "B-LIFE-1"
+    prod = date(2030, 1, 1)
+    exp = prod + timedelta(days=365)
     lot_id = await ensure_lot_full(
         session,
         item_id=int(item_id),
         warehouse_id=int(wh_id),
         lot_code=str(lot_code),
-        production_date=None,
-        expiry_date=None,
+        production_date=prod,
+        expiry_date=exp,
     )
 
     # stock_ledger：SHIPMENT / RETURN_IN（lot_id 维度；不写 batch_code）
@@ -218,7 +227,9 @@ async def seed_full_lifecycle_case(session: AsyncSession) -> str:
                 delta,
                 occurred_at,
                 created_at,
-                after_qty
+                after_qty,
+                production_date,
+                expiry_date
             )
             VALUES
             (
@@ -233,7 +244,9 @@ async def seed_full_lifecycle_case(session: AsyncSession) -> str:
                 -2,
                 now() + INTERVAL '5 min',
                 now() + INTERVAL '5 min',
-                0
+                0,
+                NULL,
+                NULL
             ),
             (
                 :trace_id,
@@ -247,11 +260,21 @@ async def seed_full_lifecycle_case(session: AsyncSession) -> str:
                 1,
                 now() + INTERVAL '20 min',
                 now() + INTERVAL '20 min',
-                1
+                1,
+                :prod,
+                :exp
             )
             """
         ),
-        {"trace_id": trace_id, "wh_id": wh_id, "item_id": item_id, "lot_id": int(lot_id), "ref": order_ref},
+        {
+            "trace_id": trace_id,
+            "wh_id": wh_id,
+            "item_id": item_id,
+            "lot_id": int(lot_id),
+            "ref": order_ref,
+            "prod": prod,
+            "exp": exp,
+        },
     )
 
     await session.commit()

--- a/tests/services/pick/test_pick_blueprint_commit_idempotency_contract.py
+++ b/tests/services/pick/test_pick_blueprint_commit_idempotency_contract.py
@@ -1,7 +1,7 @@
 # tests/services/pick/test_pick_blueprint_commit_idempotency_contract.py
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -51,6 +51,7 @@ async def test_blueprint_commit_is_only_judgment_point_and_idempotency_conflict(
 
     # ✅ 为 commit 造库存（否则会 409 insufficient_stock）
     now = datetime.now(timezone.utc)
+    exp = now.date() + timedelta(days=365)
     stock = StockService()
     await stock.adjust(
         session=db_session_like_pg,
@@ -63,7 +64,7 @@ async def test_blueprint_commit_is_only_judgment_point_and_idempotency_conflict(
         occurred_at=now,
         batch_code=bc_norm,
         production_date=now.date(),
-        expiry_date=None,
+        expiry_date=exp,
         trace_id="T-UT-SEED",
         meta={"sub_reason": "UT_BLUEPRINT_SEED"},
     )

--- a/tests/services/pick/test_pick_blueprint_db_evidence_contract.py
+++ b/tests/services/pick/test_pick_blueprint_db_evidence_contract.py
@@ -1,7 +1,7 @@
 # tests/services/pick/test_pick_blueprint_db_evidence_contract.py
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy import text
@@ -82,6 +82,7 @@ async def test_blueprint_commit_writes_db_evidence_and_is_idempotent(
 
     # ✅ 为 commit 造库存（否则会 409 insufficient_stock）
     now = datetime.now(timezone.utc)
+    exp = now.date() + timedelta(days=365)
     stock = StockService()
     await stock.adjust(
         session=db_session_like_pg,
@@ -94,7 +95,7 @@ async def test_blueprint_commit_writes_db_evidence_and_is_idempotent(
         occurred_at=now,
         batch_code=bc_norm,
         production_date=now.date(),
-        expiry_date=None,
+        expiry_date=exp,
         trace_id="T-UT-SEED",
         meta={"sub_reason": "UT_BLUEPRINT_SEED"},
     )

--- a/tests/services/test_inbound_atomic_integration.py
+++ b/tests/services/test_inbound_atomic_integration.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import date, timedelta
+
 from sqlalchemy import text
 
 from app.wms.inbound.contracts.inbound_atomic import InboundAtomicCreateIn
@@ -48,8 +50,11 @@ async def test_inbound_atomic_direct_single_line_happy_path(session):
         id=item_id,
         sku=f"SKU-{item_id}",
         name=f"ITEM-{item_id}",
-        expiry_required=False,
+        expiry_required=True,
     )
+
+    prod = date.today()
+    exp = prod + timedelta(days=30)
 
     payload = InboundAtomicCreateIn.model_validate(
         {
@@ -62,6 +67,8 @@ async def test_inbound_atomic_direct_single_line_happy_path(session):
                     "item_id": item_id,
                     "qty": qty,
                     "lot_code": lot_code,
+                    "production_date": prod.isoformat(),
+                    "expiry_date": exp.isoformat(),
                 }
             ],
         }

--- a/tests/services/test_inbound_atomic_service.py
+++ b/tests/services/test_inbound_atomic_service.py
@@ -63,10 +63,14 @@ async def test_create_inbound_atomic_happy_path_with_repo_mocks(monkeypatch):
         warehouse_id: int,
         item_policy,
         lot_code: str | None,
+        production_date,
+        expiry_date,
     ):
         assert warehouse_id == 1
         assert item_policy.item_id == 101
         assert lot_code == "LOT-001"
+        assert production_date is None
+        assert expiry_date is None
         return 9001
 
     async def fake_apply_inbound_stock(
@@ -80,6 +84,8 @@ async def test_create_inbound_atomic_happy_path_with_repo_mocks(monkeypatch):
         ref_line: int,
         occurred_at,
         batch_code: str | None,
+        production_date,
+        expiry_date,
         trace_id: str,
         source_type: str,
         source_biz_type: str | None,
@@ -92,6 +98,8 @@ async def test_create_inbound_atomic_happy_path_with_repo_mocks(monkeypatch):
         assert qty == 2
         assert ref_line == 1
         assert batch_code == "LOT-001"
+        assert production_date is None
+        assert expiry_date is None
         assert source_type == "direct"
         assert source_biz_type == "manual_adjust"
         assert source_ref is None

--- a/tests/services/test_inbound_service.py
+++ b/tests/services/test_inbound_service.py
@@ -2,6 +2,7 @@
 from datetime import date, datetime, timedelta, timezone
 
 import pytest
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 # 测试辅助：按项目实际路径导入
@@ -28,26 +29,33 @@ async def test_inbound_creates_batch_and_increases_stock(session: AsyncSession):
       * 再用 StockService.adjust_lot 入库（写 stocks_lot + ledger(lot_id)）
       * 最终用 qty_by_code（lot-world 口径）断言 qty=6
 
-    Phase M-3：
-    - items.case_ratio/case_uom 已删除；lots 不再承载 item_case_*_snapshot / item_uom_snapshot 等历史残影列
-    - lots 也不再承载 production_date/expiry_date/expiry_source（日期事实在 receipt/ledger 侧表达）
+    当前终态：
+    - REQUIRED lot 身份 = (warehouse_id, item_id, production_date)
+    - 非 REQUIRED 商品不再允许新建 SUPPLIER lot
     """
     wh, loc, item, code = 1, 1, 5001, "INB-DEMO-BATCH"
 
     await ensure_wh_loc_item(session, wh=wh, loc=loc, item=item)
+
+    # 当前主链：要创建新的 SUPPLIER lot，测试商品必须显式走 REQUIRED
+    await session.execute(
+        text("UPDATE items SET expiry_policy='REQUIRED'::expiry_policy WHERE id=:i"),
+        {"i": int(item)},
+    )
     await session.commit()
 
     ref = f"IN-{int(datetime.now(UTC).timestamp())}"
-    exp = date.today() + timedelta(days=365)
+    prod = date.today()
+    exp = prod + timedelta(days=365)
 
-    # ✅ 终态：supplier lot 必须走 ensure_lot_full（lot_code_key + partial unique index）
+    # 当前终态：supplier lot 必须走 ensure_lot_full，且 REQUIRED 商品必须给 production_date + expiry_date
     lot_id = await ensure_lot_full(
         session,
         item_id=int(item),
         warehouse_id=int(wh),
         lot_code=str(code),
-        production_date=None,
-        expiry_date=None,
+        production_date=prod,
+        expiry_date=exp,
     )
 
     await session.commit()
@@ -62,6 +70,7 @@ async def test_inbound_creates_batch_and_increases_stock(session: AsyncSession):
             ref=ref,
             occurred_at=datetime.now(UTC),
             batch_code=code,
+            production_date=prod,
             expiry_date=exp,
         )
 

--- a/tests/services/test_internal_outbound_service.py
+++ b/tests/services/test_internal_outbound_service.py
@@ -1,6 +1,6 @@
 # tests/services/test_internal_outbound_service.py
 import pytest
-from datetime import date
+from datetime import date, timedelta
 
 from sqlalchemy import text
 
@@ -20,21 +20,15 @@ async def test_internal_outbound_end_to_end():
       3) 添加一行 item_id=1, qty=4，指定同一 lot_code（batch_code 展示码）
       4) 确认内部出库（扣 stocks_lot）
       5) 验证：stocks_lot 减少 / ledger 写入 INTERNAL_OUT 记录
-
-    Phase M-3：
-      - items.case_ratio/case_uom 已删除；lots 不再承载 item_case_*_snapshot / item_uom_snapshot 等历史残影列
-      - lots 也不再承载 production_date/expiry_date/expiry_source（日期事实在 receipt/ledger 侧表达）
     """
 
     warehouse_id = 1
     item_id = 1
     qty_seed = 10
     qty_outbound = 4
-    batch_code = "INT-SEED-TEST-001"  # 作为 SUPPLIER lot_code 使用
+    batch_code = "INT-SEED-TEST-001"
 
-    code_key = str(batch_code).strip().upper()
-
-    # STEP 0 — 清理现场：删除旧的 seed 测试台账 + lot-world 库存
+    # STEP 0 — 清理现场
     async with async_session_maker() as session:
         await session.execute(text("DELETE FROM stock_ledger WHERE ref = 'INT-SEED-TEST-001'"))
 
@@ -50,11 +44,11 @@ async def test_internal_outbound_end_to_end():
                         WHERE warehouse_id = :w
                           AND item_id      = :i
                           AND lot_code_source = 'SUPPLIER'
-                          AND lot_code_key = :k
+                          AND lot_code = :code
                    )
                 """
             ),
-            {"w": int(warehouse_id), "i": int(item_id), "k": str(code_key)},
+            {"w": int(warehouse_id), "i": int(item_id), "code": str(batch_code)},
         )
 
         await session.execute(
@@ -64,20 +58,19 @@ async def test_internal_outbound_end_to_end():
                  WHERE warehouse_id = :w
                    AND item_id      = :i
                    AND lot_code_source = 'SUPPLIER'
-                   AND lot_code_key = :k
+                   AND lot_code = :code
                 """
             ),
-            {"w": int(warehouse_id), "i": int(item_id), "k": str(code_key)},
+            {"w": int(warehouse_id), "i": int(item_id), "code": str(batch_code)},
         )
 
         await session.commit()
 
-    # STEP 1 — 种子库存 +10（特定 lot_code）
+    # STEP 1 — 种子库存 +10
     async with async_session_maker() as session:
         await ensure_warehouse(session, id=int(warehouse_id), name="WH-1")
         await ensure_item(session, id=int(item_id), sku=f"SKU-{item_id}", name=f"ITEM-{item_id}")
 
-        # 本测试走显式批次（SUPPLIER lot_code），因此必须把 item 设为 REQUIRED（终态合同）
         await session.execute(
             text("UPDATE items SET expiry_policy='REQUIRED'::expiry_policy WHERE id=:i"),
             {"i": int(item_id)},
@@ -85,14 +78,16 @@ async def test_internal_outbound_end_to_end():
 
         await session.commit()
 
-        # ✅ 终态：supplier lot 必须走 ensure_lot_full（lot_code_key + partial unique index）
+        prod = date.today()
+        exp = prod + timedelta(days=365)
+
         lot_id = await ensure_lot_full(
             session,
             item_id=int(item_id),
             warehouse_id=int(warehouse_id),
             lot_code=str(batch_code),
-            production_date=None,
-            expiry_date=None,
+            production_date=prod,
+            expiry_date=exp,
         )
 
         stock_svc = StockService()
@@ -106,8 +101,8 @@ async def test_internal_outbound_end_to_end():
             ref="INT-SEED-TEST-001",
             ref_line=1,
             batch_code=batch_code,
-            production_date=date.today(),
-            expiry_date=None,
+            production_date=prod,
+            expiry_date=exp,
             trace_id="INT-SEED-TRACE",
         )
         await session.commit()
@@ -129,7 +124,7 @@ async def test_internal_outbound_end_to_end():
         assert doc.status == "DRAFT"
         assert doc.recipient_name == "张三"
 
-    # STEP 3 — 添加一行 qty=4，显式指定和种子相同的 lot_code（batch_code 展示码）
+    # STEP 3 — 添加一行 qty=4
     async with async_session_maker() as session:
         svc = InternalOutboundService()
         await svc.upsert_line(
@@ -174,14 +169,14 @@ async def test_internal_outbound_end_to_end():
                      WHERE sl.warehouse_id = :w
                        AND sl.item_id      = :i
                        AND l.lot_code_source = 'SUPPLIER'
-                       AND l.lot_code_key = :k
+                       AND l.lot_code = :code
                     """
                 ),
-                {"w": int(warehouse_id), "i": int(item_id), "k": str(code_key)},
+                {"w": int(warehouse_id), "i": int(item_id), "code": str(batch_code)},
             )
         ).scalar()
 
-        assert int(stock or 0) == qty_seed - qty_outbound  # 10 - 4 = 6
+        assert int(stock or 0) == qty_seed - qty_outbound
 
         ledger_rows = (
             await session.execute(

--- a/tests/services/test_order_rma_and_reconcile.py
+++ b/tests/services/test_order_rma_and_reconcile.py
@@ -1,7 +1,7 @@
 # tests/services/test_order_rma_and_reconcile.py
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import Optional, Tuple
 
 import pytest
@@ -64,11 +64,10 @@ async def _pick_base_uom_and_ratio(session: AsyncSession, *, item_id: int) -> Tu
 
 async def _ensure_supplier_lot(session: AsyncSession, *, warehouse_id: int, item_id: int, code: str) -> int:
     """
-    SUPPLIER lot（终态合同）：
-    - identity = (warehouse_id, item_id, lot_code_key)
-    - unique index = UNIQUE(warehouse_id,item_id,lot_code_key) WHERE lot_code IS NOT NULL
-    - lot_code 为展示码；lot_code_key 为 normalize(key) 防漂移（trim+upper）
-    - 必填快照从 items 取值。
+    SUPPLIER lot（当前终态合同）：
+    - REQUIRED lot 身份 = (warehouse_id, item_id, production_date)
+    - lot_code 只保留为展示/输入/追溯属性
+    - 必填快照从 items 取值
 
     ✅ 终态收口：禁止 tests 直接 INSERT INTO lots
     -> 统一走 app/services/stock/lots.py: ensure_lot_full
@@ -76,13 +75,17 @@ async def _ensure_supplier_lot(session: AsyncSession, *, warehouse_id: int, item
     code_raw = str(code).strip()
     assert code_raw, {"msg": "empty lot_code", "warehouse_id": warehouse_id, "item_id": item_id}
 
+    required = await _item_batch_mode_is_required(session, item_id=int(item_id))
+    production_date = date.today() if required else None
+    expiry_date = (production_date + timedelta(days=30)) if production_date is not None else None
+
     lot_id = await ensure_lot_full(
         session,
         item_id=int(item_id),
         warehouse_id=int(warehouse_id),
         lot_code=str(code_raw),
-        production_date=None,
-        expiry_date=None,
+        production_date=production_date,
+        expiry_date=expiry_date,
     )
     return int(lot_id)
 
@@ -278,7 +281,7 @@ async def test_rma_cannot_exceed_shipped(session: AsyncSession) -> None:
     if required:
         bc: Optional[str] = "RMA-BATCH-1"
         pd = date.today()
-        ed = None
+        ed = pd + timedelta(days=30)
     else:
         bc = None
         pd = None
@@ -414,7 +417,7 @@ async def test_rma_receipt_updates_counters_and_status(session: AsyncSession) ->
     if required:
         bc: Optional[str] = "RMA-BATCH-2"
         pd = date.today()
-        ed = None
+        ed = pd + timedelta(days=30)
     else:
         bc = None
         pd = None

--- a/tests/services/test_order_service.py
+++ b/tests/services/test_order_service.py
@@ -158,7 +158,7 @@ async def test_pick_task_commit_writes_shipment_reason(session: AsyncSession):
     - stocks_lot.lot_id NOT NULL（不存在 NULL 槽位）
     - 非批次商品用 INTERNAL lot（lots.lot_code 可能为 NULL）承载
     """
-    wh, item = 1, 3003
+    wh, item = 1, 93003  # 用 fresh NONE item，避免命中 baseline 中可能已被提升为 REQUIRED 的旧 id
 
     await ensure_wh_loc_item(session, wh=wh, loc=1, item=item)
 

--- a/tests/services/test_outbound_idempotency.py
+++ b/tests/services/test_outbound_idempotency.py
@@ -4,7 +4,7 @@
 """
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 import sqlalchemy as sa
@@ -53,6 +53,8 @@ async def _seed_stock(
 
     svc = StockService()
     ts = datetime.now(UTC)
+    prod = date.today()
+    exp = prod + timedelta(days=365)
 
     await svc.adjust(
         session=session,
@@ -64,8 +66,8 @@ async def _seed_stock(
         occurred_at=ts,
         warehouse_id=warehouse_id,
         batch_code=batch_code,
-        production_date=date.today(),
-        expiry_date=None,
+        production_date=prod,
+        expiry_date=exp,
     )
     await session.commit()
 

--- a/tests/services/test_outbound_ledger_consistency.py
+++ b/tests/services/test_outbound_ledger_consistency.py
@@ -26,20 +26,27 @@ async def _seed_minimal_order_for_outbound(
     - platform = 'PDD'
     - shop_id = 'UT-SHOP'
     - actual_warehouse_id = 1（写入 order_fulfillment）
-    - item_id = 1
+    - item_id 使用 fresh NONE item，避免命中 baseline 漂移
     - ext_order_no = 'LEDGER-OUT-1'
     - ref = ORD:{platform}:{shop_id}:{ext_order_no}
     """
     platform = "PDD"
     shop_id = "UT-SHOP"
     wh_id = 1
-    item_id = 1
+    item_id = 91001  # fresh NONE item，避免 baseline item 可能已被提升为 REQUIRED
     ext_order_no = "LEDGER-OUT-1"
     order_ref = f"ORD:{platform}:{shop_id}:{ext_order_no}"
     trace_id = "TRACE-LEDGER-OUT-1"
 
     # Phase M：items 有 NOT NULL policy 护栏，必须走合法插入（helper 统一兜底）
-    await ensure_item(session, id=int(item_id), sku="SKU-0001", name="UT-ITEM-1")
+    # 这里明确保持 NONE 语义，供 INTERNAL lot 场景使用。
+    await ensure_item(
+        session,
+        id=int(item_id),
+        sku=f"SKU-{item_id}",
+        name="UT-ITEM-OUTBOUND-LEDGER-NONE",
+        expiry_required=False,
+    )
 
     store_id = await ensure_store(
         session,
@@ -128,6 +135,7 @@ async def _seed_minimal_order_for_outbound(
 async def _seed_positive_internal_stock(session: AsyncSession, *, warehouse_id: int, item_id: int, qty: int) -> None:
     """
     baseline 不再提供隐式 stocks_lot qty>0，因此显式 seed 一笔 INTERNAL 库存。
+    该 helper 只用于 NONE 商品。
     """
     await session.execute(
         text("INSERT INTO warehouses (id, name) VALUES (:w, 'WH-UT') ON CONFLICT (id) DO NOTHING"),
@@ -223,6 +231,7 @@ async def _pick_one_lot_slot_for_item(session: AsyncSession, *, warehouse_id: in
 async def test_outbound_commit_writes_consistent_ledger(session: AsyncSession) -> None:
     """
     验证：出库 commit 之后，台账中的 OUTBOUND_SHIP 记录在维度上与 lot-world 槽位一致。
+    本用例明确站在 NONE 商品 + INTERNAL lot 语义上。
     """
     order_ref, wh_id, item_id, trace_id = await _seed_minimal_order_for_outbound(session)
 

--- a/tests/services/test_outbound_service_adjust_path.py
+++ b/tests/services/test_outbound_service_adjust_path.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 import pytest
 from sqlalchemy import text
@@ -71,13 +71,13 @@ async def _ensure_seed_stock_slot(
         {"i": it},
     )
 
-    # ✅ 终态：supplier lot 必须走 ensure_lot_full（内部会写 lot_code_key，并匹配 partial unique index）
+    # ✅ 当前终态：REQUIRED lot 身份已经切到 production_date
     lot_id = await ensure_lot_full(
         session,
         item_id=it,
         warehouse_id=wh,
         lot_code=code_raw,
-        production_date=None,
+        production_date=date.today(),
         expiry_date=None,
     )
 

--- a/tests/services/test_pick_commit_idempotent_shape.py
+++ b/tests/services/test_pick_commit_idempotent_shape.py
@@ -1,7 +1,7 @@
 # tests/services/test_pick_commit_idempotent_shape.py
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -74,6 +74,7 @@ async def test_pick_commit_idempotent_shape(client, session: AsyncSession):
 
     # ✅ commit 需要真实库存，否则会 409 insufficient_stock
     now = datetime.now(UTC)
+    exp = now.date() + timedelta(days=365)
     stock = StockService()
     await stock.adjust(
         session=session,
@@ -86,7 +87,7 @@ async def test_pick_commit_idempotent_shape(client, session: AsyncSession):
         occurred_at=now,
         batch_code=batch_code,
         production_date=now.date(),
-        expiry_date=None,
+        expiry_date=exp,
         trace_id="T-UT-SEED",
         meta={"sub_reason": "UT_PICK_SHAPE_SEED"},
     )

--- a/tests/test_phase3_three_books_receive_commit.py
+++ b/tests/test_phase3_three_books_receive_commit.py
@@ -18,7 +18,7 @@ from app.wms.reconciliation.services.three_books_consistency import verify_recei
 async def _pick_test_item(session: AsyncSession) -> tuple[int, bool]:
     """
     尽量挑一个不需要有效期管理的商品（避免被业务校验噪音卡住）。
-    若找不到，则退回任意一个 item（expiry_policy=REQUIRED 也行，测试会显式填 expiry_date）。
+    若找不到，则退回任意一个 item（expiry_policy=REQUIRED 也行，测试会显式填写 production_date / expiry_date）。
     """
     row = (
         await session.execute(
@@ -107,24 +107,56 @@ async def _ensure_base_uom(session: AsyncSession, *, item_id: int) -> Tuple[int,
     return int(row2[0]), int(row2[1])
 
 
-async def _ensure_supplier_lot(session: AsyncSession, *, warehouse_id: int, item_id: int, lot_code: str) -> int:
+async def _is_required_item(session: AsyncSession, *, item_id: int) -> bool:
+    row = await session.execute(
+        text("SELECT expiry_policy::text FROM items WHERE id=:i LIMIT 1"),
+        {"i": int(item_id)},
+    )
+    policy = row.scalar_one_or_none()
+    if policy is None:
+        raise RuntimeError(f"item_not_found: {item_id}")
+    return str(policy).strip().upper() == "REQUIRED"
+
+
+async def _ensure_supplier_lot(
+    session: AsyncSession,
+    *,
+    warehouse_id: int,
+    item_id: int,
+    lot_code: str,
+    production_date: Optional[date],
+    expiry_date: Optional[date],
+) -> int:
     """
     确保 SUPPLIER lot 存在，返回 lot_id。
 
     ✅ 终态收口：禁止 tests 直接 INSERT INTO lots
     -> 统一走 app/services/stock/lots.py: ensure_lot_full
+
+    语义收口：
+    - REQUIRED 商品：lot 身份已切到 (warehouse_id, item_id, production_date)
+    - 因此在 REQUIRED 路径下，这里必须显式传入 production_date
     """
     code = str(lot_code).strip()
     if not code:
         raise ValueError("lot_code required for supplier lot")
+
+    if await _is_required_item(session, item_id=int(item_id)) and production_date is None:
+        raise AssertionError(
+            {
+                "msg": "REQUIRED supplier lot must carry production_date in test helper",
+                "item_id": int(item_id),
+                "lot_code": code,
+            }
+        )
 
     lot_id = await ensure_lot_full(
         session,
         item_id=int(item_id),
         warehouse_id=int(warehouse_id),
         lot_code=str(code),
-        production_date=None,
-        expiry_date=None,
+        production_date=production_date,
+        expiry_date=expiry_date,
     )
     return int(lot_id)
 
@@ -220,7 +252,14 @@ async def _insert_confirmed_receipt_with_line(
     qty_base = int(qty_input) * int(ratio)
 
     if batch_code is not None:
-        lot_id = await _ensure_supplier_lot(session, warehouse_id=int(warehouse_id), item_id=int(item_id), lot_code=str(batch_code))
+        lot_id = await _ensure_supplier_lot(
+            session,
+            warehouse_id=int(warehouse_id),
+            item_id=int(item_id),
+            lot_code=str(batch_code),
+            production_date=production_date,
+            expiry_date=expiry_date,
+        )
         lot_code_input = str(batch_code)
     else:
         lot_id = await _ensure_internal_lot_for_receipt(session, warehouse_id=int(warehouse_id), item_id=int(item_id), receipt_id=int(receipt_id))

--- a/tests/unit/test_fefo_query_v2.py
+++ b/tests/unit/test_fefo_query_v2.py
@@ -20,8 +20,8 @@ async def test_expiry_analytics_query_returns_sorted_not_enforcing(session: Asyn
     Expiry analytics 查询 smoke（lot-world）：
 
     终态事实：
-    - lots 只承载 identity（lot_code）
-    - 时间事实（production_date/expiry_date）在 stock_ledger（reason_canon='RECEIPT'）
+    - lots 承载 lot canonical snapshot（production_date / expiry_date）
+    - RECEIPT stock_ledger 保留事件快照（production_date / expiry_date）
     - 余额事实在 stocks_lot
 
     测试：
@@ -44,7 +44,7 @@ async def test_expiry_analytics_query_returns_sorted_not_enforcing(session: Asyn
     exp_near = prod + timedelta(days=1)
     exp_far = prod + timedelta(days=10)
 
-    # 用正路写入：reason_canon='RECEIPT' 的台账行允许携带 production/expiry
+    # 用正路写入：RECEIPT 路径写 lot canonical snapshot + RECEIPT ledger snapshot
     # ref 必须不同，避免 ledger 唯一键冲突
     await svc.adjust(
         session=session,

--- a/tests/unit/test_ledger_writer_idem_v2.py
+++ b/tests/unit/test_ledger_writer_idem_v2.py
@@ -1,5 +1,4 @@
-# tests/unit/test_ledger_writer_idem_v2.py
-from datetime import datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy import text
@@ -18,7 +17,10 @@ async def test_write_ledger_idempotent(session: AsyncSession):
     await session.execute(
         text("INSERT INTO warehouses (id, name) VALUES (1, 'WH-1') ON CONFLICT (id) DO NOTHING")
     )
-    await ensure_item(session, id=3003, sku="SKU-3003", name="ITEM-3003", expiry_required=False)
+    await ensure_item(session, id=3003, sku="SKU-3003", name="ITEM-3003", expiry_required=True)
+
+    prod = date.today()
+    exp = prod + timedelta(days=365)
 
     # 终态：lot 创建必须走 ensure_lot_full（禁止 tests 直接 INSERT INTO lots）
     lot_id = await ensure_lot_full(
@@ -26,8 +28,8 @@ async def test_write_ledger_idempotent(session: AsyncSession):
         item_id=3003,
         warehouse_id=1,
         lot_code="IDEM",
-        production_date=None,
-        expiry_date=None,
+        production_date=prod,
+        expiry_date=exp,
     )
 
     # 终态：本测试只验证 ledger writer 的幂等（不需要散装写 stocks_lot）

--- a/tests/unit/test_stock_service_v2.py
+++ b/tests/unit/test_stock_service_v2.py
@@ -1,5 +1,5 @@
 # tests/unit/test_stock_service_v2.py
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 from fastapi import HTTPException
@@ -30,6 +30,13 @@ async def _slot_code(session: AsyncSession, item_id: int) -> str | None:
     return "NEAR" if await _requires_batch(session, item_id) else None
 
 
+def _required_lot_dates(requires_batch: bool) -> tuple[date | None, date | None]:
+    if not requires_batch:
+        return None, None
+    prod = date.today()
+    return prod, prod + timedelta(days=365)
+
+
 async def _ensure_supplier_lot(
     session: AsyncSession,
     *,
@@ -38,11 +45,17 @@ async def _ensure_supplier_lot(
     code: str,
 ) -> int:
     """
-    终态：SUPPLIER lot 创建必须走 ensure_lot_full（防漂移 + partial unique index 对齐）。
+    终态：SUPPLIER lot 创建必须走 ensure_lot_full。
+
+    当前 REQUIRED lot 身份已经切到 (warehouse_id, item_id, production_date)，
+    因此测试种子在 REQUIRED 商品下也必须显式给 production_date + expiry_date。
     """
     lot_code = str(code).strip()
     if not lot_code:
         raise ValueError("lot_code required")
+
+    requires_batch = await _requires_batch(session, int(item_id))
+    pd, ed = _required_lot_dates(requires_batch)
 
     return int(
         await ensure_lot_full(
@@ -50,8 +63,8 @@ async def _ensure_supplier_lot(
             item_id=int(item_id),
             warehouse_id=int(wh),
             lot_code=str(lot_code),
-            production_date=None,
-            expiry_date=None,
+            production_date=pd,
+            expiry_date=ed,
         )
     )
 
@@ -138,6 +151,7 @@ async def _ensure_stock_seed(session: AsyncSession, *, item_id: int, wh: int, co
         )
     else:
         lot_id = await _ensure_supplier_lot(session, wh=int(wh), item_id=int(item_id), code=str(code))
+        prod, exp = _required_lot_dates(True)
         await svc.adjust_lot(
             session=session,
             item_id=int(item_id),
@@ -149,7 +163,8 @@ async def _ensure_stock_seed(session: AsyncSession, *, item_id: int, wh: int, co
             ref_line=1,
             occurred_at=now,
             batch_code=str(code),
-            production_date=date.today(),
+            production_date=prod,
+            expiry_date=exp,
         )
 
     await session.commit()
@@ -162,6 +177,7 @@ async def test_adjust_inbound_auto_resolves_dates(session: AsyncSession):
     item_id = 3001
     wh = 1
     code = "B1"
+    prod, exp = _required_lot_dates(True)
 
     lot_id = await _ensure_supplier_lot(session, wh=wh, item_id=item_id, code=code)
     before = await _qty(session, item_id=item_id, wh=wh, code=code)
@@ -177,17 +193,17 @@ async def test_adjust_inbound_auto_resolves_dates(session: AsyncSession):
         ref_line=1,
         occurred_at=datetime.now(UTC),
         batch_code=code,
+        production_date=prod,
+        expiry_date=exp,
     )
 
     after = await _qty(session, item_id=item_id, wh=wh, code=code)
     assert after == before + 1
 
-    prod = res.get("production_date")
-    exp = res.get("expiry_date")
-
-    assert isinstance(prod, date)
-    if exp is not None:
-        assert exp >= prod
+    res_prod = res.get("production_date")
+    res_exp = res.get("expiry_date")
+    assert res_prod == prod
+    assert res_exp == exp
 
 
 @pytest.mark.asyncio
@@ -220,6 +236,7 @@ async def test_adjust_idempotent(session: AsyncSession):
     wh = 1
     code = "NEAR"
     now = datetime.now(UTC)
+    prod, exp = _required_lot_dates(True)
 
     lot_id = await _ensure_supplier_lot(session, wh=wh, item_id=item_id, code=code)
 
@@ -234,7 +251,8 @@ async def test_adjust_idempotent(session: AsyncSession):
         ref_line=1,
         occurred_at=now,
         batch_code=code,
-        production_date=date.today(),
+        production_date=prod,
+        expiry_date=exp,
     )
 
     res = await svc.adjust_lot(
@@ -248,7 +266,8 @@ async def test_adjust_idempotent(session: AsyncSession):
         ref_line=1,
         occurred_at=now,
         batch_code=code,
-        production_date=date.today(),
+        production_date=prod,
+        expiry_date=exp,
     )
     assert res.get("applied") is False and res.get("idempotent") is True
 
@@ -327,14 +346,17 @@ async def _insert_supplier_lot(session: AsyncSession, *, warehouse_id: int, item
     终态收口后不允许 tests 直接 INSERT INTO lots。
     这里通过 ensure_lot_full 造出一个合法 lot_id，再用于 mismatch 测试。
     """
+    requires_batch = await _requires_batch(session, int(item_id))
+    pd, ed = _required_lot_dates(requires_batch)
+
     return int(
         await ensure_lot_full(
             session,
             item_id=int(item_id),
             warehouse_id=int(warehouse_id),
             lot_code=str(lot_code),
-            production_date=None,
-            expiry_date=None,
+            production_date=pd,
+            expiry_date=ed,
         )
     )
 
@@ -348,6 +370,7 @@ async def test_adjust_rejects_lot_mismatch(session: AsyncSession):
     """
     svc = StockService()
     wh = 1
+    prod, exp = _required_lot_dates(True)
 
     bad_lot_id = await _insert_supplier_lot(session, warehouse_id=wh, item_id=3003, lot_code="UT-LOT-BAD-1")
     await session.commit()
@@ -364,7 +387,8 @@ async def test_adjust_rejects_lot_mismatch(session: AsyncSession):
             ref_line=1,
             occurred_at=datetime.now(UTC),
             batch_code="B-LOT",
-            production_date=date.today(),
+            production_date=prod,
+            expiry_date=exp,
         )
 
     assert "mismatch" in str(exc.value).lower() or "lot_mismatch" in str(exc.value).lower()
@@ -377,6 +401,7 @@ async def test_adjust_rejects_lot_not_found(session: AsyncSession):
     """
     svc = StockService()
     wh = 1
+    prod, exp = _required_lot_dates(True)
 
     with pytest.raises(ValueError) as exc:
         await svc.adjust_lot(
@@ -390,7 +415,8 @@ async def test_adjust_rejects_lot_not_found(session: AsyncSession):
             ref_line=1,
             occurred_at=datetime.now(UTC),
             batch_code="B-LOT2",
-            production_date=date.today(),
+            production_date=prod,
+            expiry_date=exp,
         )
 
     assert "not found" in str(exc.value).lower() or "lot_not_found" in str(exc.value).lower()

--- a/tests/utils/ensure_minimal.py
+++ b/tests/utils/ensure_minimal.py
@@ -1,6 +1,7 @@
 # tests/utils/ensure_minimal.py
 from __future__ import annotations
 
+import hashlib
 from datetime import date, datetime, timedelta, timezone
 from typing import Optional
 
@@ -20,6 +21,21 @@ def _as_lot_id(v: object) -> int:
     tests 侧用这个函数统一兼容，避免类型漂移导致的 AttributeError。
     """
     return int(getattr(v, "id", v))
+
+
+def _stable_required_dates_from_code(code_raw: str, *, days: int) -> tuple[date, date]:
+    """
+    REQUIRED lot helper：按 lot_code 稳定生成日期，避免不同批次都撞到同一天 production_date。
+    """
+    code = str(code_raw).strip()
+    if not code:
+        raise ValueError("lot_code empty")
+
+    digest = hashlib.sha1(code.encode("utf-8")).hexdigest()
+    offset_days = int(digest[:8], 16) % 73000  # ~200 years range
+    production_date = date(2000, 1, 1) + timedelta(days=offset_days)
+    expiry_date = production_date + timedelta(days=int(days))
+    return production_date, expiry_date
 
 
 # ---------- warehouses ----------
@@ -55,8 +71,8 @@ async def ensure_item(
     - lot_source_policy / expiry_policy / derivation_allowed / uom_governance_enabled 均 NOT NULL 且无默认
 
     使用方式：
-    - 默认（无有效期）：expiry_required=False -> expiry_policy='NONE'
-    - 需要有效期：expiry_required=True  -> expiry_policy='REQUIRED'
+    - 默认（无有效期）：expiry_required=False -> 不得把已有 REQUIRED 商品刷回 NONE
+    - 需要有效期：expiry_required=True  -> 若商品已存在，也要单向提升到 REQUIRED
 
     参数 uom：历史兼容参数（已不再写入 DB），保留以避免旧测试调用报错。
     """
@@ -65,6 +81,7 @@ async def ensure_item(
     _ = uom  # deprecated (items.uom removed)
 
     expiry_policy = "REQUIRED" if expiry_required else "NONE"
+    lot_source_policy = "SUPPLIER_ONLY" if expiry_required else "INTERNAL_ONLY"
 
     await session.execute(
         text(
@@ -75,21 +92,41 @@ async def ensure_item(
             )
             VALUES (
               :id, :sku, :name,
-              'SUPPLIER_ONLY'::lot_source_policy, CAST(:expiry_policy AS expiry_policy), TRUE, TRUE
+              CAST(:lot_source_policy AS lot_source_policy),
+              CAST(:expiry_policy AS expiry_policy),
+              TRUE,
+              TRUE
             )
             ON CONFLICT (id) DO UPDATE
                SET sku = EXCLUDED.sku,
                    name = EXCLUDED.name,
-                   lot_source_policy = EXCLUDED.lot_source_policy,
-                   expiry_policy = EXCLUDED.expiry_policy,
-                   derivation_allowed = EXCLUDED.derivation_allowed,
-                   uom_governance_enabled = EXCLUDED.uom_governance_enabled
+                   lot_source_policy = CASE
+                     WHEN EXCLUDED.expiry_policy = 'REQUIRED'::expiry_policy
+                       THEN 'SUPPLIER_ONLY'::lot_source_policy
+                     ELSE items.lot_source_policy
+                   END,
+                   expiry_policy = CASE
+                     WHEN EXCLUDED.expiry_policy = 'REQUIRED'::expiry_policy
+                       THEN 'REQUIRED'::expiry_policy
+                     ELSE items.expiry_policy
+                   END,
+                   derivation_allowed = CASE
+                     WHEN EXCLUDED.expiry_policy = 'REQUIRED'::expiry_policy
+                       THEN TRUE
+                     ELSE items.derivation_allowed
+                   END,
+                   uom_governance_enabled = CASE
+                     WHEN EXCLUDED.expiry_policy = 'REQUIRED'::expiry_policy
+                       THEN TRUE
+                     ELSE items.uom_governance_enabled
+                   END
             """
         ),
         {
             "id": int(id),
             "sku": str(sku),
             "name": str(name),
+            "lot_source_policy": str(lot_source_policy),
             "expiry_policy": str(expiry_policy),
         },
     )
@@ -121,18 +158,31 @@ async def ensure_supplier_lot(
 
     ✅ 工程收口：禁止 tests 里直接 INSERT INTO lots
     -> 统一走 app.services.lot_service.ensure_lot_full
+
+    语义收口：
+    - helper 名字就叫 ensure_supplier_lot，因此它必须保证商品策略至少提升到 REQUIRED
+    - REQUIRED lot 身份已切到 (warehouse_id, item_id, production_date)，
+      因此这里必须显式给 production_date
     """
     code_raw = str(lot_code).strip()
     if not code_raw:
         raise ValueError("lot_code empty")
 
+    await ensure_item(
+        session,
+        id=int(item_id),
+        sku=f"SKU-{item_id}",
+        name=f"ITEM-{item_id}",
+        expiry_required=True,
+    )
+
     expiry_policy = await _load_item_expiry_policy(session, item_id=int(item_id))
-    if expiry_policy == "REQUIRED":
-        expiry_date: Optional[date] = date.today() + timedelta(days=365)
-        production_date: Optional[date] = None
-    else:
-        expiry_date = None
-        production_date = None
+    if expiry_policy != "REQUIRED":
+        raise RuntimeError(
+            f"ensure_supplier_lot expected REQUIRED expiry_policy, got: {expiry_policy}"
+        )
+
+    production_date, expiry_date = _stable_required_dates_from_code(code_raw, days=365)
 
     got = await ensure_lot_full_svc(
         session,
@@ -217,8 +267,11 @@ async def set_stock_qty(session: AsyncSession, *, item_id: int, warehouse_id: in
 
     expiry_policy = await _load_item_expiry_policy(session, item_id=int(item_id))
     if expiry_policy == "REQUIRED" and int(delta) > 0:
-        expiry_date: Optional[date] = date.today() + timedelta(days=365)
-        production_date: Optional[date] = None
+        if bc_norm is None:
+            raise RuntimeError(
+                f"set_stock_qty requires batch_code for REQUIRED item: item_id={int(item_id)}"
+            )
+        production_date, expiry_date = _stable_required_dates_from_code(bc_norm, days=365)
     else:
         expiry_date = None
         production_date = None


### PR DESCRIPTION
## Summary
- harden REQUIRED supplier lot expiry at DB and app layers
- align canonical production/expiry date normalization across inbound, outbound, return, and reconciliation flows
- make the alembic/env warning path compatible with current SQLAlchemy deprecations
- update related tests, seeds, and date coercion behavior

## Validation
- make test
- seed-opening-ledger-test
- audit-three-books
- migration chain passed
