### PR TITLE
feat(wms-inbound): add event read api and procurement source options

### DIFF
--- a/app/procurement/contracts/purchase_order_source_options.py
+++ b/app/procurement/contracts/purchase_order_source_options.py
@@ -1,0 +1,58 @@
+# app/procurement/contracts/purchase_order_source_options.py
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+PurchaseOrderSourceCompletionStatus = Literal[
+    "NOT_RECEIVED",
+    "PARTIAL",
+    "RECEIVED",
+]
+
+
+class PurchaseOrderSourceOptionOut(BaseModel):
+    """
+    采购来源下拉项（给 WMS 入库页来源区使用）。
+
+    设计原则：
+    - procurement 负责提供“可选采购来源”的窄读面
+    - WMS 前端只消费这份合同，不自行聚合 /purchase-orders/completion
+    - 一条 option = 一张采购单，而不是采购单行
+    """
+
+    po_id: int = Field(..., gt=0)
+    po_no: str = Field(..., min_length=1, max_length=64)
+
+    warehouse_id: int = Field(..., gt=0)
+
+    supplier_id: int = Field(..., gt=0)
+    supplier_name: str = Field(..., min_length=1, max_length=255)
+
+    purchase_time: datetime = Field(...)
+
+    po_status: str = Field(..., min_length=1, max_length=32)
+    completion_status: PurchaseOrderSourceCompletionStatus = Field(...)
+    last_received_at: datetime | None = Field(default=None)
+
+    model_config = ConfigDict(from_attributes=True, extra="forbid")
+
+
+class PurchaseOrderSourceOptionsOut(BaseModel):
+    """
+    采购来源下拉列表返回。
+    """
+
+    items: list[PurchaseOrderSourceOptionOut] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True, extra="forbid")
+
+
+__all__ = [
+    "PurchaseOrderSourceCompletionStatus",
+    "PurchaseOrderSourceOptionOut",
+    "PurchaseOrderSourceOptionsOut",
+]

--- a/app/procurement/repos/purchase_order_source_options_repo.py
+++ b/app/procurement/repos/purchase_order_source_options_repo.py
@@ -1,0 +1,99 @@
+# app/procurement/repos/purchase_order_source_options_repo.py
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def _normalize_limit(limit: int | None) -> int:
+    x = int(limit or 20)
+    if x < 1:
+        return 1
+    if x > 50:
+        return 50
+    return x
+
+
+async def list_purchase_order_source_options(
+    session: AsyncSession,
+    *,
+    warehouse_id: int | None = None,
+    q: str | None = None,
+    limit: int | None = 20,
+) -> list[dict[str, Any]]:
+    """
+    采购来源下拉窄读面。
+
+    口径：
+    - 一条 option = 一张采购单
+    - 只返回仍可作为“采购入库来源”的采购单：
+      * po.status = CREATED
+      * 聚合后 total_remaining_base > 0
+    - completion_status 由 purchase_order_line_completion 聚合得出
+    """
+    where_clauses = ["po.status = 'CREATED'"]
+    params: dict[str, Any] = {
+        "limit": _normalize_limit(limit),
+    }
+
+    if warehouse_id is not None:
+        where_clauses.append("plc.warehouse_id = :warehouse_id")
+        params["warehouse_id"] = int(warehouse_id)
+
+    qv = (q or "").strip()
+    if qv:
+        where_clauses.append(
+            """
+            (
+              plc.po_no ILIKE :q_like
+              OR plc.supplier_name ILIKE :q_like
+            )
+            """.strip()
+        )
+        params["q_like"] = f"%{qv}%"
+
+    where_sql = " AND ".join(where_clauses)
+
+    sql = text(
+        f"""
+        SELECT
+          plc.po_id AS po_id,
+          plc.po_no AS po_no,
+          plc.warehouse_id AS warehouse_id,
+          plc.supplier_id AS supplier_id,
+          plc.supplier_name AS supplier_name,
+          plc.purchase_time AS purchase_time,
+          po.status AS po_status,
+          CASE
+            WHEN COALESCE(SUM(plc.qty_received_base), 0) <= 0 THEN 'NOT_RECEIVED'
+            WHEN COALESCE(SUM(plc.qty_remaining_base), 0) <= 0 THEN 'RECEIVED'
+            ELSE 'PARTIAL'
+          END AS completion_status,
+          MAX(plc.last_received_at) AS last_received_at
+        FROM purchase_order_line_completion plc
+        JOIN purchase_orders po
+          ON po.id = plc.po_id
+        WHERE {where_sql}
+        GROUP BY
+          plc.po_id,
+          plc.po_no,
+          plc.warehouse_id,
+          plc.supplier_id,
+          plc.supplier_name,
+          plc.purchase_time,
+          po.status
+        HAVING COALESCE(SUM(plc.qty_remaining_base), 0) > 0
+        ORDER BY plc.purchase_time DESC, plc.po_id DESC
+        LIMIT :limit
+        """
+    )
+
+    rows = (await session.execute(sql, params)).mappings().all()
+    return [dict(r) for r in rows]
+
+
+__all__ = [
+    "list_purchase_order_source_options",
+]

--- a/app/procurement/routers/purchase_orders_routes.py
+++ b/app/procurement/routers/purchase_orders_routes.py
@@ -6,12 +6,14 @@ from fastapi import APIRouter
 from app.procurement.routers import purchase_orders_routes_completion
 from app.procurement.routers import purchase_orders_routes_core
 from app.procurement.routers import purchase_orders_routes_list
+from app.procurement.routers import purchase_orders_routes_source_options
 from app.procurement.services.purchase_order_service import PurchaseOrderService
 
 
 def register(router: APIRouter, svc: PurchaseOrderService) -> None:
-    # completion 必须先于 /{po_id} 注册，
-    # 否则 /purchase-orders/completion 会被 /purchase-orders/{po_id} 吃掉并触发 422
+    # 静态路径必须先于 /{po_id} 注册，
+    # 否则会被 /purchase-orders/{po_id} 吃掉并触发 422。
+    purchase_orders_routes_source_options.register(router, svc)
     purchase_orders_routes_completion.register(router, svc)
 
     purchase_orders_routes_core.register(router, svc)

--- a/app/procurement/routers/purchase_orders_routes_source_options.py
+++ b/app/procurement/routers/purchase_orders_routes_source_options.py
@@ -1,0 +1,46 @@
+# app/procurement/routers/purchase_orders_routes_source_options.py
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_session
+from app.procurement.contracts.purchase_order_source_options import (
+    PurchaseOrderSourceOptionOut,
+    PurchaseOrderSourceOptionsOut,
+)
+from app.procurement.repos.purchase_order_source_options_repo import (
+    list_purchase_order_source_options,
+)
+
+
+def register(router: APIRouter, _svc: object | None = None) -> None:
+    @router.get("/source-options", response_model=PurchaseOrderSourceOptionsOut)
+    async def get_purchase_order_source_options(
+        session: AsyncSession = Depends(get_session),
+        warehouse_id: int | None = Query(None, ge=1),
+        q: str | None = Query(None),
+        limit: int = Query(20, ge=1, le=50),
+    ) -> PurchaseOrderSourceOptionsOut:
+        rows = await list_purchase_order_source_options(
+            session,
+            warehouse_id=warehouse_id,
+            q=q,
+            limit=limit,
+        )
+        return PurchaseOrderSourceOptionsOut(
+            items=[
+                PurchaseOrderSourceOptionOut(
+                    po_id=int(r["po_id"]),
+                    po_no=str(r["po_no"]),
+                    warehouse_id=int(r["warehouse_id"]),
+                    supplier_id=int(r["supplier_id"]),
+                    supplier_name=str(r["supplier_name"]),
+                    purchase_time=r["purchase_time"],
+                    po_status=str(r["po_status"]),
+                    completion_status=str(r["completion_status"]),
+                    last_received_at=r.get("last_received_at"),
+                )
+                for r in rows
+            ]
+        )

--- a/app/router_mount.py
+++ b/app/router_mount.py
@@ -42,6 +42,7 @@ def mount_routers(app: FastAPI, *, enable_dev_routes: bool) -> None:
     )
     from app.analytics.routers.orders_sla_stats_routes import router as orders_sla_stats_router
     from app.analytics.routers.orders_stats_routes import router as orders_stats_router
+    from app.wms.inbound.routers.inbound_events import router as inbound_events_router
     from app.wms.inbound.routers.inbound_commit import router as inbound_commit_router
     from app.wms.outbound.routers.outbound import router as outbound_router
     from app.wms.outbound.routers.pick import router as pick_router
@@ -114,6 +115,7 @@ def mount_routers(app: FastAPI, *, enable_dev_routes: bool) -> None:
 
     app.include_router(purchase_orders_router)
     app.include_router(purchase_reports_router)
+    app.include_router(inbound_events_router)
     app.include_router(inbound_commit_router)
     app.include_router(return_tasks_router)
     app.include_router(pick_tasks_router)

--- a/app/wms/inbound/contracts/inbound_event_read.py
+++ b/app/wms/inbound/contracts/inbound_event_read.py
@@ -1,0 +1,108 @@
+# app/wms/inbound/contracts/inbound_event_read.py
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.wms.inbound.contracts.inbound_commit import InboundSourceType
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+        str_strip_whitespace=True,
+        populate_by_name=True,
+    )
+
+
+class InboundEventSummaryOut(_Base):
+    """
+    入库事件列表 / 详情共用的事件头摘要。
+
+    说明：
+    - 直接对应 wms_events 的稳定读面
+    - event_id 是业务事件锚点
+    - trace_id 是技术链路锚点
+    - 不把 receipt 语义重新混进来
+    """
+
+    event_id: Annotated[int, Field(ge=1, description="入库事件 ID")]
+    event_no: Annotated[str, Field(min_length=1, max_length=64, description="入库事件单号")]
+
+    event_type: Annotated[str, Field(min_length=1, max_length=16, description="事件大类，当前应为 INBOUND")]
+    warehouse_id: Annotated[int, Field(ge=1, description="仓库 ID")]
+
+    source_type: Annotated[InboundSourceType, Field(description="入库来源类型")]
+    source_ref: Annotated[str | None, Field(default=None, max_length=128, description="来源单号/外部引用号")]
+
+    occurred_at: datetime = Field(..., description="业务发生时间")
+    committed_at: datetime = Field(..., description="事件提交时间")
+
+    trace_id: Annotated[str, Field(min_length=1, max_length=128, description="技术链路追踪号")]
+    event_kind: Annotated[str, Field(min_length=1, max_length=16, description="事件形态，如 COMMIT")]
+    status: Annotated[str, Field(min_length=1, max_length=16, description="事件状态，如 COMMITTED")]
+
+    remark: Annotated[str | None, Field(default=None, max_length=500, description="整单备注")]
+
+
+class InboundEventLineOut(_Base):
+    """
+    入库事件详情中的明细行。
+
+    说明：
+    - 直接对应 inbound_event_lines 的稳定读面
+    - qty_base / ratio_to_base_snapshot 为交易快照
+    - item_name / item_sku / uom_name / lot_code 为展示字段，可由 service 拼装
+    """
+
+    line_no: Annotated[int, Field(ge=1, description="事件内行号")]
+
+    item_id: Annotated[int, Field(ge=1, description="商品 ID")]
+    item_name: Annotated[str | None, Field(default=None, max_length=255, description="商品名称（展示字段）")]
+    item_sku: Annotated[str | None, Field(default=None, max_length=64, description="商品 SKU（展示字段）")]
+
+    uom_id: Annotated[int, Field(ge=1, description="包装单位 ID")]
+    uom_name: Annotated[str | None, Field(default=None, max_length=64, description="包装单位名称（展示字段）")]
+
+    barcode_input: Annotated[str | None, Field(default=None, max_length=128, description="条码输入")]
+    qty_input: Annotated[int, Field(gt=0, description="输入数量")]
+    ratio_to_base_snapshot: Annotated[int, Field(ge=1, description="提交时冻结的换算倍率")]
+    qty_base: Annotated[int, Field(gt=0, description="提交时冻结的 base 数量")]
+
+    lot_id: Annotated[int | None, Field(default=None, ge=1, description="实际落账 lot_id")]
+    lot_code_input: Annotated[str | None, Field(default=None, max_length=128, description="业务批号/生产批号输入")]
+    lot_code: Annotated[str | None, Field(default=None, max_length=128, description="实际 lot_code（展示字段）")]
+
+    production_date: date | None = Field(default=None, description="生产日期")
+    expiry_date: date | None = Field(default=None, description="到期日期")
+
+    po_line_id: Annotated[int | None, Field(default=None, ge=1, description="采购来源时的采购单行 ID")]
+    remark: Annotated[str | None, Field(default=None, max_length=255, description="行备注")]
+
+
+class InboundEventListOut(_Base):
+    """
+    入库事件列表返回。
+    """
+
+    total: Annotated[int, Field(ge=0, description="总条数")]
+    items: list[InboundEventSummaryOut] = Field(default_factory=list, description="事件摘要列表")
+
+
+class InboundEventDetailOut(_Base):
+    """
+    入库事件详情返回。
+    """
+
+    event: InboundEventSummaryOut = Field(..., description="事件头摘要")
+    lines: list[InboundEventLineOut] = Field(default_factory=list, description="事件明细行")
+
+
+__all__ = [
+    "InboundEventSummaryOut",
+    "InboundEventLineOut",
+    "InboundEventListOut",
+    "InboundEventDetailOut",
+]

--- a/app/wms/inbound/routers/inbound_events.py
+++ b/app/wms/inbound/routers/inbound_events.py
@@ -1,0 +1,66 @@
+# app/wms/inbound/routers/inbound_events.py
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_session
+from app.wms.inbound.contracts.inbound_event_read import (
+    InboundEventDetailOut,
+    InboundEventListOut,
+)
+from app.wms.inbound.services.inbound_event_read_service import (
+    get_inbound_event_detail,
+    list_inbound_events,
+)
+
+router = APIRouter(prefix="/wms/inbound", tags=["wms-inbound-events"])
+
+
+@router.get("/events", response_model=InboundEventListOut)
+async def list_inbound_events_endpoint(
+    warehouse_id: int | None = Query(default=None, ge=1, description="仓库 ID"),
+    source_type: str | None = Query(default=None, description="来源类型"),
+    source_ref: str | None = Query(default=None, description="来源单号/外部引用号"),
+    date_from: datetime | None = Query(default=None, description="业务发生时间起点（含）"),
+    date_to: datetime | None = Query(default=None, description="业务发生时间终点（含）"),
+    limit: int = Query(default=20, ge=1, le=200, description="分页大小"),
+    offset: int = Query(default=0, ge=0, description="分页偏移"),
+    session: AsyncSession = Depends(get_session),
+) -> InboundEventListOut:
+    try:
+        return await list_inbound_events(
+            session,
+            warehouse_id=warehouse_id,
+            source_type=source_type,
+            source_ref=source_ref,
+            date_from=date_from,
+            date_to=date_to,
+            limit=limit,
+            offset=offset,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+@router.get("/events/{event_id}", response_model=InboundEventDetailOut)
+async def get_inbound_event_detail_endpoint(
+    event_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> InboundEventDetailOut:
+    try:
+        return await get_inbound_event_detail(
+            session,
+            event_id=int(event_id),
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+__all__ = ["router"]

--- a/app/wms/inbound/services/inbound_event_read_service.py
+++ b/app/wms/inbound/services/inbound_event_read_service.py
@@ -1,0 +1,249 @@
+# app/wms/inbound/services/inbound_event_read_service.py
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.wms.inbound.contracts.inbound_event_read import (
+    InboundEventDetailOut,
+    InboundEventLineOut,
+    InboundEventListOut,
+    InboundEventSummaryOut,
+)
+
+
+def _norm_text(v: object) -> str | None:
+    if v is None:
+        return None
+    s = str(v).strip()
+    return s or None
+
+
+def _normalize_limit(limit: int | None) -> int:
+    x = int(limit or 20)
+    if x < 1:
+        return 1
+    if x > 200:
+        return 200
+    return x
+
+
+def _normalize_offset(offset: int | None) -> int:
+    x = int(offset or 0)
+    if x < 0:
+        return 0
+    return x
+
+
+def _build_event_filters(
+    *,
+    warehouse_id: int | None,
+    source_type: str | None,
+    source_ref: str | None,
+    date_from: datetime | None,
+    date_to: datetime | None,
+) -> tuple[str, dict[str, Any]]:
+    clauses = ["event_type = 'INBOUND'"]
+    params: dict[str, Any] = {}
+
+    if warehouse_id is not None:
+        clauses.append("warehouse_id = :warehouse_id")
+        params["warehouse_id"] = int(warehouse_id)
+
+    norm_source_type = _norm_text(source_type)
+    if norm_source_type is not None:
+        clauses.append("source_type = :source_type")
+        params["source_type"] = norm_source_type
+
+    norm_source_ref = _norm_text(source_ref)
+    if norm_source_ref is not None:
+        clauses.append("source_ref = :source_ref")
+        params["source_ref"] = norm_source_ref
+
+    if date_from is not None:
+        clauses.append("occurred_at >= :date_from")
+        params["date_from"] = date_from
+
+    if date_to is not None:
+        clauses.append("occurred_at <= :date_to")
+        params["date_to"] = date_to
+
+    return " AND ".join(clauses), params
+
+
+async def list_inbound_events(
+    session: AsyncSession,
+    *,
+    warehouse_id: int | None = None,
+    source_type: str | None = None,
+    source_ref: str | None = None,
+    date_from: datetime | None = None,
+    date_to: datetime | None = None,
+    limit: int | None = 20,
+    offset: int | None = 0,
+) -> InboundEventListOut:
+    """
+    入库事件列表。
+
+    当前目标：
+    - 直接以 wms_events 为真相源
+    - 不混入旧 receipt/task 语义
+    - 仅返回前端工作台下卡所需的事件头摘要
+    """
+    limit_n = _normalize_limit(limit)
+    offset_n = _normalize_offset(offset)
+
+    where_sql, params = _build_event_filters(
+        warehouse_id=warehouse_id,
+        source_type=source_type,
+        source_ref=source_ref,
+        date_from=date_from,
+        date_to=date_to,
+    )
+
+    total_sql = text(
+        f"""
+        SELECT COUNT(*) AS total
+          FROM wms_events
+         WHERE {where_sql}
+        """
+    )
+    total_row = await session.execute(total_sql, params)
+    total = int(total_row.scalar_one() or 0)
+
+    list_sql = text(
+        f"""
+        SELECT
+            id AS event_id,
+            event_no,
+            event_type,
+            warehouse_id,
+            source_type,
+            source_ref,
+            occurred_at,
+            committed_at,
+            trace_id,
+            event_kind,
+            status,
+            remark
+          FROM wms_events
+         WHERE {where_sql}
+         ORDER BY occurred_at DESC, id DESC
+         LIMIT :limit
+        OFFSET :offset
+        """
+    )
+    rows = await session.execute(
+        list_sql,
+        {
+            **params,
+            "limit": limit_n,
+            "offset": offset_n,
+        },
+    )
+
+    items = [
+        InboundEventSummaryOut.model_validate(dict(r))
+        for r in rows.mappings().all()
+    ]
+
+    return InboundEventListOut(
+        total=total,
+        items=items,
+    )
+
+
+async def get_inbound_event_detail(
+    session: AsyncSession,
+    *,
+    event_id: int,
+) -> InboundEventDetailOut:
+    """
+    入库事件详情。
+
+    当前目标：
+    - event 头来自 wms_events
+    - line 明细来自 inbound_event_lines
+    - 展示字段通过 items / item_uoms / lots 补齐
+    """
+    event_sql = text(
+        """
+        SELECT
+            id AS event_id,
+            event_no,
+            event_type,
+            warehouse_id,
+            source_type,
+            source_ref,
+            occurred_at,
+            committed_at,
+            trace_id,
+            event_kind,
+            status,
+            remark
+          FROM wms_events
+         WHERE id = :event_id
+           AND event_type = 'INBOUND'
+         LIMIT 1
+        """
+    )
+    event_row = await session.execute(event_sql, {"event_id": int(event_id)})
+    event_map = event_row.mappings().first()
+    if event_map is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"入库事件不存在：event_id={int(event_id)}",
+        )
+
+    lines_sql = text(
+        """
+        SELECT
+            iel.line_no,
+            iel.item_id,
+            it.name AS item_name,
+            it.sku AS item_sku,
+            iel.uom_id,
+            COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS uom_name,
+            iel.barcode_input,
+            iel.qty_input,
+            iel.ratio_to_base_snapshot,
+            iel.qty_base,
+            iel.lot_id,
+            iel.lot_code_input,
+            lo.lot_code,
+            iel.production_date,
+            iel.expiry_date,
+            iel.po_line_id,
+            iel.remark
+          FROM inbound_event_lines AS iel
+          LEFT JOIN items AS it
+            ON it.id = iel.item_id
+          LEFT JOIN item_uoms AS iu
+            ON iu.id = iel.uom_id
+          LEFT JOIN lots AS lo
+            ON lo.id = iel.lot_id
+         WHERE iel.event_id = :event_id
+         ORDER BY iel.line_no ASC, iel.id ASC
+        """
+    )
+    line_rows = await session.execute(lines_sql, {"event_id": int(event_id)})
+
+    lines = [
+        InboundEventLineOut.model_validate(dict(r))
+        for r in line_rows.mappings().all()
+    ]
+
+    return InboundEventDetailOut(
+        event=InboundEventSummaryOut.model_validate(dict(event_map)),
+        lines=lines,
+    )
+
+
+__all__ = [
+    "list_inbound_events",
+    "get_inbound_event_detail",
+]


### PR DESCRIPTION
## Summary
- add inbound event read contracts, service and router under `app/wms/inbound`
- mount `/wms/inbound/events` and `/wms/inbound/events/{event_id}`
- add procurement source-options narrow read api for WMS inbound source dropdown
- register procurement source-options route ahead of dynamic purchase order routes

## Verification
- python3 -m compileall app/procurement/... app/wms/inbound/... app/router_mount.py
- source-options api smoke check
- inbound events api smoke check