### PR TITLE
refactor(procurement,wms): cut reports over to po lines and isolate completion sync

### DIFF
--- a/alembic/versions/4fb9df42573f_procurement_purchase_order_lines_add_.py
+++ b/alembic/versions/4fb9df42573f_procurement_purchase_order_lines_add_.py
@@ -1,0 +1,45 @@
+"""procurement_purchase_order_lines_add_uom_name_snapshot
+
+Revision ID: 4fb9df42573f
+Revises: 3c7600f922bd
+Create Date: 2026-04-17 13:33:25.898328
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '4fb9df42573f'
+down_revision: Union[str, Sequence[str], None] = '3c7600f922bd'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "purchase_order_lines",
+        sa.Column("purchase_uom_name_snapshot", sa.String(length=64), nullable=True),
+    )
+    op.execute(
+        """
+        UPDATE purchase_order_lines pol
+        SET purchase_uom_name_snapshot = COALESCE(iu.display_name, iu.uom)
+        FROM item_uoms iu
+        WHERE iu.id = pol.purchase_uom_id_snapshot
+        """
+    )
+    op.alter_column(
+        "purchase_order_lines",
+        "purchase_uom_name_snapshot",
+        existing_type=sa.String(length=64),
+        nullable=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("purchase_order_lines", "purchase_uom_name_snapshot")

--- a/app/procurement/contracts/purchase_report.py
+++ b/app/procurement/contracts/purchase_report.py
@@ -71,9 +71,6 @@ class ItemPurchaseReportLineItem(_Base):
     discount_amount_snapshot: Decimal
     planned_line_amount: Decimal
 
-    line_completion_status: str
-    last_received_at: datetime | None = None
-
 
 class DailyPurchaseReportItem(_Base):
     day: date

--- a/app/procurement/helpers/purchase_reports.py
+++ b/app/procurement/helpers/purchase_reports.py
@@ -1,18 +1,11 @@
 # app/procurement/helpers/purchase_reports.py
 from __future__ import annotations
 
-from datetime import date, datetime
 from typing import Optional
 
-from fastapi import Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.pms.public.items.services.item_read_service import ItemReadService
-from app.procurement.models.purchase_order import PurchaseOrder
-from app.procurement.models.purchase_order_line_completion import PurchaseOrderLineCompletion
-
-
-TimeMode = str  # "purchase_time" | "last_received"
 
 
 async def resolve_report_item_ids(
@@ -36,78 +29,3 @@ async def resolve_report_item_ids(
 
     svc = ItemReadService(session)
     return await svc.asearch_report_item_ids_by_keyword(keyword=kw)
-
-
-def apply_common_filters(
-    stmt,
-    *,
-    date_from: Optional[date],
-    date_to: Optional[date],
-    warehouse_id: Optional[int],
-    supplier_id: Optional[int],
-    status: Optional[str],
-    time_mode: TimeMode,
-):
-    """
-    采购报表通用过滤（completion 统一口径）：
-
-    - 统计来源：PurchaseOrderLineCompletion
-    - 时间口径（time_mode）：
-        * purchase_time（默认）：按 completion.purchase_time 过滤
-        * last_received：按 completion.last_received_at 过滤
-    - warehouse_id / supplier_id：按 completion 快照字段过滤
-    - status：按 PurchaseOrder.status 过滤
-    - DRAFT 永远不进采购报表主口径
-    """
-
-    normalized_time_mode = str(time_mode or "purchase_time").strip().lower()
-
-    stmt = stmt.where(PurchaseOrder.status != "DRAFT")
-
-    if normalized_time_mode == "last_received":
-        if date_from is not None:
-            stmt = stmt.where(
-                PurchaseOrderLineCompletion.last_received_at
-                >= datetime.combine(date_from, datetime.min.time())
-            )
-        if date_to is not None:
-            stmt = stmt.where(
-                PurchaseOrderLineCompletion.last_received_at
-                <= datetime.combine(date_to, datetime.max.time())
-            )
-    else:
-        if date_from is not None:
-            stmt = stmt.where(
-                PurchaseOrderLineCompletion.purchase_time
-                >= datetime.combine(date_from, datetime.min.time())
-            )
-        if date_to is not None:
-            stmt = stmt.where(
-                PurchaseOrderLineCompletion.purchase_time
-                <= datetime.combine(date_to, datetime.max.time())
-            )
-
-    if warehouse_id is not None:
-        stmt = stmt.where(PurchaseOrderLineCompletion.warehouse_id == warehouse_id)
-
-    if supplier_id is not None:
-        stmt = stmt.where(PurchaseOrderLineCompletion.supplier_id == supplier_id)
-
-    normalized_status = str(status or "").strip().upper()
-    if normalized_status:
-        stmt = stmt.where(PurchaseOrder.status == normalized_status)
-
-    return stmt
-
-
-def time_mode_query(default: str = "purchase_time"):
-    """
-    统一 Query 定义，避免每个路由散落文案。
-
-    purchase_time: 按采购时间（默认）
-    last_received: 按最后收货时间
-    """
-    return Query(
-        default,
-        description="时间口径：purchase_time=按采购时间（默认）；last_received=按最后收货时间",
-    )

--- a/app/procurement/models/purchase_order_line.py
+++ b/app/procurement/models/purchase_order_line.py
@@ -60,6 +60,10 @@ class PurchaseOrderLine(Base):
         sa.ForeignKey("item_uoms.id", name="fk_po_line_purchase_uom"),
         nullable=False,
     )
+    purchase_uom_name_snapshot: Mapped[str] = mapped_column(
+        sa.String(64),
+        nullable=False,
+    )
 
     purchase_ratio_to_base_snapshot: Mapped[int] = mapped_column(
         sa.Integer,

--- a/app/procurement/repos/purchase_order_create_repo.py
+++ b/app/procurement/repos/purchase_order_create_repo.py
@@ -28,11 +28,11 @@ async def require_item_uom_ratio_to_base(
     *,
     item_id: int,
     uom_id: int,
-) -> int:
+) -> tuple[int, str]:
     row = await session.execute(
         text(
             """
-            SELECT ratio_to_base
+            SELECT ratio_to_base, display_name, uom
             FROM item_uoms
             WHERE id = :uom_id AND item_id = :item_id
             """
@@ -49,25 +49,29 @@ async def require_item_uom_ratio_to_base(
     if ratio <= 0:
         raise ValueError("item_uoms.ratio_to_base 必须 >= 1")
 
-    return ratio
+    uom_name = str(r.get("display_name") or r.get("uom") or "").strip()
+    if not uom_name:
+        raise ValueError("item_uoms.display_name/uom 不能为空")
+
+    return ratio, uom_name
 
 
 async def pick_default_purchase_uom(
     session: AsyncSession,
     *,
     item_id: int,
-) -> tuple[int, int]:
+) -> tuple[int, int, str]:
     """
     选择商品默认采购单位：
     1) is_purchase_default = true
     2) is_base = true
     3) 最小 id
-    返回：(uom_id, ratio_to_base)
+    返回：(uom_id, ratio_to_base, uom_name_snapshot)
     """
     r1 = await session.execute(
         text(
             """
-            SELECT id, ratio_to_base
+            SELECT id, ratio_to_base, display_name, uom
               FROM item_uoms
              WHERE item_id = :i AND is_purchase_default = true
              LIMIT 1
@@ -77,12 +81,16 @@ async def pick_default_purchase_uom(
     )
     m1 = r1.mappings().first()
     if m1 is not None:
-        return int(m1["id"]), int(m1["ratio_to_base"])
+        return (
+            int(m1["id"]),
+            int(m1["ratio_to_base"]),
+            str(m1.get("display_name") or m1.get("uom") or "").strip(),
+        )
 
     r2 = await session.execute(
         text(
             """
-            SELECT id, ratio_to_base
+            SELECT id, ratio_to_base, display_name, uom
               FROM item_uoms
              WHERE item_id = :i AND is_base = true
              LIMIT 1
@@ -92,12 +100,16 @@ async def pick_default_purchase_uom(
     )
     m2 = r2.mappings().first()
     if m2 is not None:
-        return int(m2["id"]), int(m2["ratio_to_base"])
+        return (
+            int(m2["id"]),
+            int(m2["ratio_to_base"]),
+            str(m2.get("display_name") or m2.get("uom") or "").strip(),
+        )
 
     r3 = await session.execute(
         text(
             """
-            SELECT id, ratio_to_base
+            SELECT id, ratio_to_base, display_name, uom
               FROM item_uoms
              WHERE item_id = :i
              ORDER BY id
@@ -108,7 +120,11 @@ async def pick_default_purchase_uom(
     )
     m3 = r3.mappings().first()
     if m3 is not None:
-        return int(m3["id"]), int(m3["ratio_to_base"])
+        return (
+            int(m3["id"]),
+            int(m3["ratio_to_base"]),
+            str(m3.get("display_name") or m3.get("uom") or "").strip(),
+        )
 
     raise ValueError(f"商品缺少 item_uoms：item_id={int(item_id)}")
 

--- a/app/procurement/routers/purchase_reports_routes_daily.py
+++ b/app/procurement/routers/purchase_reports_routes_daily.py
@@ -1,7 +1,7 @@
 # app/procurement/routers/purchase_reports_routes_daily.py
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 from decimal import Decimal
 from typing import List, Optional
 
@@ -11,9 +11,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_session
 from app.procurement.contracts.purchase_report import DailyPurchaseReportItem
-from app.procurement.helpers.purchase_reports import apply_common_filters, resolve_report_item_ids
+from app.procurement.helpers.purchase_reports import resolve_report_item_ids
 from app.procurement.models.purchase_order import PurchaseOrder
-from app.procurement.models.purchase_order_line_completion import PurchaseOrderLineCompletion
+from app.procurement.models.purchase_order_line import PurchaseOrderLine
 
 
 def register(router: APIRouter) -> None:
@@ -36,42 +36,52 @@ def register(router: APIRouter) -> None:
         if report_item_ids is not None and not report_item_ids:
             return []
 
-        day_expr = func.date(PurchaseOrderLineCompletion.last_received_at).label("day")
+        day_expr = func.date(PurchaseOrder.purchase_time).label("day")
+        planned_line_amount_expr = (
+            func.coalesce(PurchaseOrderLine.supply_price, 0)
+            * PurchaseOrderLine.qty_ordered_base
+            - func.coalesce(PurchaseOrderLine.discount_amount, 0)
+        )
 
         stmt = (
             select(
                 day_expr,
-                func.count(distinct(PurchaseOrderLineCompletion.po_id)).label("order_count"),
+                func.count(distinct(PurchaseOrderLine.po_id)).label("order_count"),
                 func.coalesce(
-                    func.sum(PurchaseOrderLineCompletion.qty_ordered_input),
+                    func.sum(PurchaseOrderLine.qty_ordered_input),
                     0,
                 ).label("total_qty_cases"),
                 func.coalesce(
-                    func.sum(PurchaseOrderLineCompletion.qty_ordered_base),
+                    func.sum(PurchaseOrderLine.qty_ordered_base),
                     0,
                 ).label("total_units"),
                 func.coalesce(
-                    func.sum(PurchaseOrderLineCompletion.planned_line_amount),
+                    func.sum(planned_line_amount_expr),
                     0,
                 ).label("total_amount"),
             )
-            .select_from(PurchaseOrderLineCompletion)
-            .join(PurchaseOrder, PurchaseOrder.id == PurchaseOrderLineCompletion.po_id)
-            .where(PurchaseOrderLineCompletion.last_received_at.is_not(None))
+            .select_from(PurchaseOrderLine)
+            .join(PurchaseOrder, PurchaseOrder.id == PurchaseOrderLine.po_id)
         )
 
-        stmt = apply_common_filters(
-            stmt,
-            date_from=date_from,
-            date_to=date_to,
-            warehouse_id=warehouse_id,
-            supplier_id=supplier_id,
-            status=status,
-            time_mode="last_received",
-        )
+        normalized_status = str(status or "").strip().upper()
+        if normalized_status:
+            stmt = stmt.where(PurchaseOrder.status == normalized_status)
 
+        if date_from is not None:
+            stmt = stmt.where(
+                PurchaseOrder.purchase_time >= datetime.combine(date_from, datetime.min.time())
+            )
+        if date_to is not None:
+            stmt = stmt.where(
+                PurchaseOrder.purchase_time <= datetime.combine(date_to, datetime.max.time())
+            )
+        if warehouse_id is not None:
+            stmt = stmt.where(PurchaseOrder.warehouse_id == warehouse_id)
+        if supplier_id is not None:
+            stmt = stmt.where(PurchaseOrder.supplier_id == supplier_id)
         if report_item_ids is not None:
-            stmt = stmt.where(PurchaseOrderLineCompletion.item_id.in_(report_item_ids))
+            stmt = stmt.where(PurchaseOrderLine.item_id.in_(report_item_ids))
 
         stmt = stmt.group_by(day_expr).order_by(day_expr)
 

--- a/app/procurement/routers/purchase_reports_routes_item_lines.py
+++ b/app/procurement/routers/purchase_reports_routes_item_lines.py
@@ -1,19 +1,18 @@
 # app/procurement/routers/purchase_reports_routes_item_lines.py
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 from decimal import Decimal
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query
-from sqlalchemy import select
+from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_session
 from app.procurement.contracts.purchase_report import ItemPurchaseReportLineItem
-from app.procurement.helpers.purchase_reports import apply_common_filters, time_mode_query
 from app.procurement.models.purchase_order import PurchaseOrder
-from app.procurement.models.purchase_order_line_completion import PurchaseOrderLineCompletion
+from app.procurement.models.purchase_order_line import PurchaseOrderLine
 
 
 def register(router: APIRouter) -> None:
@@ -26,51 +25,59 @@ def register(router: APIRouter) -> None:
         warehouse_id: Optional[int] = Query(None),
         supplier_id: Optional[int] = Query(None),
         status: Optional[str] = Query(None),
-        time_mode: str = time_mode_query("purchase_time"),
     ) -> List[ItemPurchaseReportLineItem]:
+        planned_line_amount_expr = (
+            func.coalesce(PurchaseOrderLine.supply_price, 0)
+            * PurchaseOrderLine.qty_ordered_base
+            - func.coalesce(PurchaseOrderLine.discount_amount, 0)
+        )
+
         stmt = (
             select(
-                PurchaseOrderLineCompletion.po_id.label("po_id"),
-                PurchaseOrderLineCompletion.po_no.label("po_no"),
-                PurchaseOrderLineCompletion.po_line_id.label("po_line_id"),
-                PurchaseOrderLineCompletion.line_no.label("line_no"),
-                PurchaseOrderLineCompletion.warehouse_id.label("warehouse_id"),
-                PurchaseOrderLineCompletion.supplier_id.label("supplier_id"),
-                PurchaseOrderLineCompletion.supplier_name.label("supplier_name"),
-                PurchaseOrderLineCompletion.purchase_time.label("purchase_time"),
-                PurchaseOrderLineCompletion.purchase_uom_name_snapshot.label(
+                PurchaseOrder.id.label("po_id"),
+                PurchaseOrder.po_no.label("po_no"),
+                PurchaseOrderLine.id.label("po_line_id"),
+                PurchaseOrderLine.line_no.label("line_no"),
+                PurchaseOrder.warehouse_id.label("warehouse_id"),
+                PurchaseOrder.supplier_id.label("supplier_id"),
+                PurchaseOrder.supplier_name.label("supplier_name"),
+                PurchaseOrder.purchase_time.label("purchase_time"),
+                PurchaseOrderLine.purchase_uom_name_snapshot.label(
                     "purchase_uom_name_snapshot"
                 ),
-                PurchaseOrderLineCompletion.qty_ordered_input.label("qty_ordered_input"),
-                PurchaseOrderLineCompletion.qty_ordered_base.label("qty_ordered_base"),
-                PurchaseOrderLineCompletion.supply_price_snapshot.label("supply_price_snapshot"),
-                PurchaseOrderLineCompletion.discount_amount_snapshot.label(
-                    "discount_amount_snapshot"
-                ),
-                PurchaseOrderLineCompletion.planned_line_amount.label("planned_line_amount"),
-                PurchaseOrderLineCompletion.line_completion_status.label("line_completion_status"),
-                PurchaseOrderLineCompletion.last_received_at.label("last_received_at"),
+                PurchaseOrderLine.qty_ordered_input.label("qty_ordered_input"),
+                PurchaseOrderLine.qty_ordered_base.label("qty_ordered_base"),
+                PurchaseOrderLine.supply_price.label("supply_price_snapshot"),
+                PurchaseOrderLine.discount_amount.label("discount_amount_snapshot"),
+                planned_line_amount_expr.label("planned_line_amount"),
             )
-            .select_from(PurchaseOrderLineCompletion)
-            .join(PurchaseOrder, PurchaseOrder.id == PurchaseOrderLineCompletion.po_id)
-            .where(PurchaseOrderLineCompletion.item_id == int(item_id))
+            .select_from(PurchaseOrderLine)
+            .join(PurchaseOrder, PurchaseOrder.id == PurchaseOrderLine.po_id)
+            .where(PurchaseOrderLine.item_id == int(item_id))
         )
 
-        stmt = apply_common_filters(
-            stmt,
-            date_from=date_from,
-            date_to=date_to,
-            warehouse_id=warehouse_id,
-            supplier_id=supplier_id,
-            status=status,
-            time_mode=time_mode,
-        )
+        normalized_status = str(status or "").strip().upper()
+        if normalized_status:
+            stmt = stmt.where(PurchaseOrder.status == normalized_status)
+
+        if date_from is not None:
+            stmt = stmt.where(
+                PurchaseOrder.purchase_time >= datetime.combine(date_from, datetime.min.time())
+            )
+        if date_to is not None:
+            stmt = stmt.where(
+                PurchaseOrder.purchase_time <= datetime.combine(date_to, datetime.max.time())
+            )
+        if warehouse_id is not None:
+            stmt = stmt.where(PurchaseOrder.warehouse_id == warehouse_id)
+        if supplier_id is not None:
+            stmt = stmt.where(PurchaseOrder.supplier_id == supplier_id)
 
         stmt = stmt.order_by(
-            PurchaseOrderLineCompletion.purchase_time.desc(),
-            PurchaseOrderLineCompletion.po_id.desc(),
-            PurchaseOrderLineCompletion.line_no.asc(),
-            PurchaseOrderLineCompletion.po_line_id.asc(),
+            PurchaseOrder.purchase_time.desc(),
+            PurchaseOrder.id.desc(),
+            PurchaseOrderLine.line_no.asc(),
+            PurchaseOrderLine.id.asc(),
         )
 
         rows = (await session.execute(stmt)).mappings().all()
@@ -97,8 +104,6 @@ def register(router: APIRouter) -> None:
                     ),
                     discount_amount_snapshot=Decimal(str(r["discount_amount_snapshot"] or 0)),
                     planned_line_amount=Decimal(str(r["planned_line_amount"] or 0)),
-                    line_completion_status=str(r["line_completion_status"]),
-                    last_received_at=r["last_received_at"],
                 )
             )
 

--- a/app/procurement/routers/purchase_reports_routes_items.py
+++ b/app/procurement/routers/purchase_reports_routes_items.py
@@ -1,7 +1,7 @@
 # app/procurement/routers/purchase_reports_routes_items.py
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 from decimal import Decimal
 from typing import List, Optional
 
@@ -12,13 +12,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.db.session import get_session
 from app.pms.public.items.services.item_read_service import ItemReadService
 from app.procurement.contracts.purchase_report import ItemPurchaseReportItem
-from app.procurement.helpers.purchase_reports import (
-    apply_common_filters,
-    resolve_report_item_ids,
-    time_mode_query,
-)
+from app.procurement.helpers.purchase_reports import resolve_report_item_ids
 from app.procurement.models.purchase_order import PurchaseOrder
-from app.procurement.models.purchase_order_line_completion import PurchaseOrderLineCompletion
+from app.procurement.models.purchase_order_line import PurchaseOrderLine
 
 
 def _build_report_item(
@@ -67,7 +63,6 @@ def register(router: APIRouter) -> None:
         status: Optional[str] = Query(None),
         item_id: Optional[int] = Query(None),
         item_keyword: Optional[str] = Query(None),
-        time_mode: str = time_mode_query("purchase_time"),
     ) -> List[ItemPurchaseReportItem]:
         report_item_ids = await resolve_report_item_ids(
             session,
@@ -78,48 +73,59 @@ def register(router: APIRouter) -> None:
             return []
 
         item_read_svc = ItemReadService(session)
+        planned_line_amount_expr = (
+            func.coalesce(PurchaseOrderLine.supply_price, 0)
+            * PurchaseOrderLine.qty_ordered_base
+            - func.coalesce(PurchaseOrderLine.discount_amount, 0)
+        )
 
         stmt = (
             select(
-                PurchaseOrderLineCompletion.item_id.label("item_id"),
-                func.count(distinct(PurchaseOrderLineCompletion.po_id)).label("order_count"),
+                PurchaseOrderLine.item_id.label("item_id"),
+                func.count(distinct(PurchaseOrderLine.po_id)).label("order_count"),
                 func.coalesce(
-                    func.sum(PurchaseOrderLineCompletion.qty_ordered_input),
+                    func.sum(PurchaseOrderLine.qty_ordered_input),
                     0,
                 ).label("total_qty_cases"),
                 func.coalesce(
-                    func.sum(PurchaseOrderLineCompletion.qty_ordered_base),
+                    func.sum(PurchaseOrderLine.qty_ordered_base),
                     0,
                 ).label("total_units"),
                 func.coalesce(
-                    func.sum(PurchaseOrderLineCompletion.planned_line_amount),
+                    func.sum(planned_line_amount_expr),
                     0,
                 ).label("total_amount"),
-                func.min(PurchaseOrderLineCompletion.supplier_id).label("supplier_id_for_filtered"),
+                func.min(PurchaseOrder.supplier_id).label("supplier_id_for_filtered"),
                 func.min(
-                    func.coalesce(PurchaseOrderLineCompletion.supplier_name, "")
+                    func.coalesce(PurchaseOrder.supplier_name, "")
                 ).label("supplier_name_for_filtered"),
             )
-            .select_from(PurchaseOrderLineCompletion)
-            .join(PurchaseOrder, PurchaseOrder.id == PurchaseOrderLineCompletion.po_id)
+            .select_from(PurchaseOrderLine)
+            .join(PurchaseOrder, PurchaseOrder.id == PurchaseOrderLine.po_id)
         )
 
-        stmt = apply_common_filters(
-            stmt,
-            date_from=date_from,
-            date_to=date_to,
-            warehouse_id=warehouse_id,
-            supplier_id=supplier_id,
-            status=status,
-            time_mode=time_mode,
-        )
+        normalized_status = str(status or "").strip().upper()
+        if normalized_status:
+            stmt = stmt.where(PurchaseOrder.status == normalized_status)
 
+        if date_from is not None:
+            stmt = stmt.where(
+                PurchaseOrder.purchase_time >= datetime.combine(date_from, datetime.min.time())
+            )
+        if date_to is not None:
+            stmt = stmt.where(
+                PurchaseOrder.purchase_time <= datetime.combine(date_to, datetime.max.time())
+            )
+        if warehouse_id is not None:
+            stmt = stmt.where(PurchaseOrder.warehouse_id == warehouse_id)
+        if supplier_id is not None:
+            stmt = stmt.where(PurchaseOrder.supplier_id == supplier_id)
         if report_item_ids is not None:
-            stmt = stmt.where(PurchaseOrderLineCompletion.item_id.in_(report_item_ids))
+            stmt = stmt.where(PurchaseOrderLine.item_id.in_(report_item_ids))
 
         stmt = stmt.group_by(
-            PurchaseOrderLineCompletion.item_id,
-        ).order_by(PurchaseOrderLineCompletion.item_id.asc())
+            PurchaseOrderLine.item_id,
+        ).order_by(PurchaseOrderLine.item_id.asc())
 
         rows = (await session.execute(stmt)).mappings().all()
         if not rows:

--- a/app/procurement/routers/purchase_reports_routes_summary.py
+++ b/app/procurement/routers/purchase_reports_routes_summary.py
@@ -1,7 +1,7 @@
 # app/procurement/routers/purchase_reports_routes_summary.py
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 from decimal import Decimal
 from typing import Optional
 
@@ -11,13 +11,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_session
 from app.procurement.contracts.purchase_report import SummaryPurchaseReportItem
-from app.procurement.helpers.purchase_reports import (
-    apply_common_filters,
-    resolve_report_item_ids,
-    time_mode_query,
-)
+from app.procurement.helpers.purchase_reports import resolve_report_item_ids
 from app.procurement.models.purchase_order import PurchaseOrder
-from app.procurement.models.purchase_order_line_completion import PurchaseOrderLineCompletion
+from app.procurement.models.purchase_order_line import PurchaseOrderLine
 
 
 def _empty_summary() -> SummaryPurchaseReportItem:
@@ -43,7 +39,6 @@ def register(router: APIRouter) -> None:
         status: Optional[str] = Query(None),
         item_id: Optional[int] = Query(None),
         item_keyword: Optional[str] = Query(None),
-        time_mode: str = time_mode_query("purchase_time"),
     ) -> SummaryPurchaseReportItem:
         report_item_ids = await resolve_report_item_ids(
             session,
@@ -53,40 +48,52 @@ def register(router: APIRouter) -> None:
         if report_item_ids is not None and not report_item_ids:
             return _empty_summary()
 
+        planned_line_amount_expr = (
+            func.coalesce(PurchaseOrderLine.supply_price, 0)
+            * PurchaseOrderLine.qty_ordered_base
+            - func.coalesce(PurchaseOrderLine.discount_amount, 0)
+        )
+
         stmt = (
             select(
-                func.count(distinct(PurchaseOrderLineCompletion.po_id)).label("order_count"),
-                func.count(distinct(PurchaseOrderLineCompletion.supplier_id)).label("supplier_count"),
-                func.count(distinct(PurchaseOrderLineCompletion.item_id)).label("item_count"),
+                func.count(distinct(PurchaseOrderLine.po_id)).label("order_count"),
+                func.count(distinct(PurchaseOrder.supplier_id)).label("supplier_count"),
+                func.count(distinct(PurchaseOrderLine.item_id)).label("item_count"),
                 func.coalesce(
-                    func.sum(PurchaseOrderLineCompletion.qty_ordered_input),
+                    func.sum(PurchaseOrderLine.qty_ordered_input),
                     0,
                 ).label("total_qty_cases"),
                 func.coalesce(
-                    func.sum(PurchaseOrderLineCompletion.qty_ordered_base),
+                    func.sum(PurchaseOrderLine.qty_ordered_base),
                     0,
                 ).label("total_units"),
                 func.coalesce(
-                    func.sum(PurchaseOrderLineCompletion.planned_line_amount),
+                    func.sum(planned_line_amount_expr),
                     0,
                 ).label("total_amount"),
             )
-            .select_from(PurchaseOrderLineCompletion)
-            .join(PurchaseOrder, PurchaseOrder.id == PurchaseOrderLineCompletion.po_id)
+            .select_from(PurchaseOrderLine)
+            .join(PurchaseOrder, PurchaseOrder.id == PurchaseOrderLine.po_id)
         )
 
-        stmt = apply_common_filters(
-            stmt,
-            date_from=date_from,
-            date_to=date_to,
-            warehouse_id=warehouse_id,
-            supplier_id=supplier_id,
-            status=status,
-            time_mode=time_mode,
-        )
+        normalized_status = str(status or "").strip().upper()
+        if normalized_status:
+            stmt = stmt.where(PurchaseOrder.status == normalized_status)
 
+        if date_from is not None:
+            stmt = stmt.where(
+                PurchaseOrder.purchase_time >= datetime.combine(date_from, datetime.min.time())
+            )
+        if date_to is not None:
+            stmt = stmt.where(
+                PurchaseOrder.purchase_time <= datetime.combine(date_to, datetime.max.time())
+            )
+        if warehouse_id is not None:
+            stmt = stmt.where(PurchaseOrder.warehouse_id == warehouse_id)
+        if supplier_id is not None:
+            stmt = stmt.where(PurchaseOrder.supplier_id == supplier_id)
         if report_item_ids is not None:
-            stmt = stmt.where(PurchaseOrderLineCompletion.item_id.in_(report_item_ids))
+            stmt = stmt.where(PurchaseOrderLine.item_id.in_(report_item_ids))
 
         row = (await session.execute(stmt)).mappings().one()
 

--- a/app/procurement/routers/purchase_reports_routes_suppliers.py
+++ b/app/procurement/routers/purchase_reports_routes_suppliers.py
@@ -1,7 +1,7 @@
 # app/procurement/routers/purchase_reports_routes_suppliers.py
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 from decimal import Decimal
 from typing import List, Optional
 
@@ -11,13 +11,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_session
 from app.procurement.contracts.purchase_report import SupplierPurchaseReportItem
-from app.procurement.helpers.purchase_reports import (
-    apply_common_filters,
-    resolve_report_item_ids,
-    time_mode_query,
-)
+from app.procurement.helpers.purchase_reports import resolve_report_item_ids
 from app.procurement.models.purchase_order import PurchaseOrder
-from app.procurement.models.purchase_order_line_completion import PurchaseOrderLineCompletion
+from app.procurement.models.purchase_order_line import PurchaseOrderLine
 
 
 def register(router: APIRouter) -> None:
@@ -31,7 +27,6 @@ def register(router: APIRouter) -> None:
         status: Optional[str] = Query(None),
         item_id: Optional[int] = Query(None),
         item_keyword: Optional[str] = Query(None),
-        time_mode: str = time_mode_query("purchase_time"),
     ) -> List[SupplierPurchaseReportItem]:
         report_item_ids = await resolve_report_item_ids(
             session,
@@ -42,49 +37,60 @@ def register(router: APIRouter) -> None:
             return []
 
         supplier_name_expr = func.coalesce(
-            PurchaseOrderLineCompletion.supplier_name,
+            PurchaseOrder.supplier_name,
             "",
         ).label("supplier_name")
+        planned_line_amount_expr = (
+            func.coalesce(PurchaseOrderLine.supply_price, 0)
+            * PurchaseOrderLine.qty_ordered_base
+            - func.coalesce(PurchaseOrderLine.discount_amount, 0)
+        )
 
         stmt = (
             select(
-                PurchaseOrderLineCompletion.supplier_id.label("supplier_id"),
+                PurchaseOrder.supplier_id.label("supplier_id"),
                 supplier_name_expr,
-                func.count(distinct(PurchaseOrderLineCompletion.po_id)).label("order_count"),
+                func.count(distinct(PurchaseOrderLine.po_id)).label("order_count"),
                 func.coalesce(
-                    func.sum(PurchaseOrderLineCompletion.qty_ordered_input),
+                    func.sum(PurchaseOrderLine.qty_ordered_input),
                     0,
                 ).label("total_qty_cases"),
                 func.coalesce(
-                    func.sum(PurchaseOrderLineCompletion.qty_ordered_base),
+                    func.sum(PurchaseOrderLine.qty_ordered_base),
                     0,
                 ).label("total_units"),
                 func.coalesce(
-                    func.sum(PurchaseOrderLineCompletion.planned_line_amount),
+                    func.sum(planned_line_amount_expr),
                     0,
                 ).label("total_amount"),
             )
-            .select_from(PurchaseOrderLineCompletion)
-            .join(PurchaseOrder, PurchaseOrder.id == PurchaseOrderLineCompletion.po_id)
+            .select_from(PurchaseOrderLine)
+            .join(PurchaseOrder, PurchaseOrder.id == PurchaseOrderLine.po_id)
         )
 
-        stmt = apply_common_filters(
-            stmt,
-            date_from=date_from,
-            date_to=date_to,
-            warehouse_id=warehouse_id,
-            supplier_id=supplier_id,
-            status=status,
-            time_mode=time_mode,
-        )
+        normalized_status = str(status or "").strip().upper()
+        if normalized_status:
+            stmt = stmt.where(PurchaseOrder.status == normalized_status)
 
+        if date_from is not None:
+            stmt = stmt.where(
+                PurchaseOrder.purchase_time >= datetime.combine(date_from, datetime.min.time())
+            )
+        if date_to is not None:
+            stmt = stmt.where(
+                PurchaseOrder.purchase_time <= datetime.combine(date_to, datetime.max.time())
+            )
+        if warehouse_id is not None:
+            stmt = stmt.where(PurchaseOrder.warehouse_id == warehouse_id)
+        if supplier_id is not None:
+            stmt = stmt.where(PurchaseOrder.supplier_id == supplier_id)
         if report_item_ids is not None:
-            stmt = stmt.where(PurchaseOrderLineCompletion.item_id.in_(report_item_ids))
+            stmt = stmt.where(PurchaseOrderLine.item_id.in_(report_item_ids))
 
         stmt = stmt.group_by(
-            PurchaseOrderLineCompletion.supplier_id,
+            PurchaseOrder.supplier_id,
             supplier_name_expr,
-        ).order_by(supplier_name_expr.asc(), PurchaseOrderLineCompletion.supplier_id.asc())
+        ).order_by(supplier_name_expr.asc(), PurchaseOrder.supplier_id.asc())
 
         rows = (await session.execute(stmt)).mappings().all()
         items: List[SupplierPurchaseReportItem] = []

--- a/app/procurement/services/purchase_order_completion_sync.py
+++ b/app/procurement/services/purchase_order_completion_sync.py
@@ -1,0 +1,39 @@
+# app/procurement/services/purchase_order_completion_sync.py
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.procurement.repos.purchase_order_line_completion_repo import (
+    apply_completion_delta_for_event,
+)
+
+
+async def sync_purchase_completion_for_inbound_event(
+    session: AsyncSession,
+    *,
+    event_id: int,
+    occurred_at: datetime,
+) -> None:
+    """
+    procurement 域拥有 purchase_order_line_completion 读模型维护权。
+
+    当前阶段这条 service 边界只做一件事：
+    - 接收 WMS 已经落库成功的正式采购入库事件
+    - 依据 event_id，把本次新增 qty_base 同步进 completion 读表
+
+    注意：
+    - 这里是 procurement 对 WMS 事实事件的消费边界
+    - WMS 调到这一层即可，不再直接 import procurement repo
+    """
+    await apply_completion_delta_for_event(
+        session,
+        event_id=int(event_id),
+        occurred_at=occurred_at,
+    )
+
+
+__all__ = [
+    "sync_purchase_completion_for_inbound_event",
+]

--- a/app/procurement/services/purchase_order_create.py
+++ b/app/procurement/services/purchase_order_create.py
@@ -141,9 +141,13 @@ async def create_po_v2(
 
         uom_id = _maybe_uom_id_from_raw(raw)
         if uom_id is None:
-            uom_id, ratio_to_base = await pick_default_purchase_uom(session, item_id=item_id)
+            (
+                uom_id,
+                ratio_to_base,
+                purchase_uom_name_snapshot,
+            ) = await pick_default_purchase_uom(session, item_id=item_id)
         else:
-            ratio_to_base = await require_item_uom_ratio_to_base(
+            ratio_to_base, purchase_uom_name_snapshot = await require_item_uom_ratio_to_base(
                 session,
                 item_id=item_id,
                 uom_id=uom_id,
@@ -172,6 +176,7 @@ async def create_po_v2(
                 "item_sku": it.sku,
                 "spec_text": raw.get("spec_text"),
                 "purchase_uom_id_snapshot": uom_id,
+                "purchase_uom_name_snapshot": purchase_uom_name_snapshot,
                 "purchase_ratio_to_base_snapshot": ratio_to_base,
                 "qty_ordered_input": qty_input,
                 "qty_ordered_base": qty_ordered_base,

--- a/app/procurement/services/purchase_order_update.py
+++ b/app/procurement/services/purchase_order_update.py
@@ -85,9 +85,13 @@ async def _normalize_update_payload(
 
         uom_id = _maybe_uom_id_from_raw(raw)
         if uom_id is None:
-            uom_id, ratio_to_base = await pick_default_purchase_uom(session, item_id=item_id)
+            (
+                uom_id,
+                ratio_to_base,
+                purchase_uom_name_snapshot,
+            ) = await pick_default_purchase_uom(session, item_id=item_id)
         else:
-            ratio_to_base = await require_item_uom_ratio_to_base(
+            ratio_to_base, purchase_uom_name_snapshot = await require_item_uom_ratio_to_base(
                 session,
                 item_id=item_id,
                 uom_id=uom_id,
@@ -116,6 +120,7 @@ async def _normalize_update_payload(
                 "item_sku": it.sku,
                 "spec_text": raw.get("spec_text"),
                 "purchase_uom_id_snapshot": int(uom_id),
+                "purchase_uom_name_snapshot": purchase_uom_name_snapshot,
                 "purchase_ratio_to_base_snapshot": int(ratio_to_base),
                 "qty_ordered_input": int(qty_input),
                 "qty_ordered_base": int(qty_ordered_base),

--- a/app/wms/inbound/services/inbound_commit_service.py
+++ b/app/wms/inbound/services/inbound_commit_service.py
@@ -9,8 +9,8 @@ from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.procurement.repos.purchase_order_line_completion_repo import (
-    apply_completion_delta_for_event,
+from app.procurement.services.purchase_order_completion_sync import (
+    sync_purchase_completion_for_inbound_event,
 )
 from app.wms.inbound.contracts.inbound_commit import (
     InboundCommitIn,
@@ -354,9 +354,10 @@ async def commit_inbound(
 
     await session.flush()
 
-    # 采购来源：把本次正式事件的增量同步到采购行 completion 读表
+    # 采购来源：由 procurement service 边界消费本次正式事件，
+    # 同步其 completion 读模型；WMS 不再直接 import procurement repo。
     if str(payload.source_type) == "PURCHASE_ORDER":
-        await apply_completion_delta_for_event(
+        await sync_purchase_completion_for_inbound_event(
             session,
             event_id=int(event.id),
             occurred_at=payload.occurred_at,


### PR DESCRIPTION
## Summary
- add purchase_uom_name_snapshot onto purchase_order_lines
- move procurement reports off purchase_order_line_completion for summary/items/suppliers/item-lines/daily
- isolate completion sync behind a procurement service boundary
- keep price-analysis semantics in procurement while preparing completion retirement

## Validation
- python3 -m compileall on touched backend files
- make upgrade-dev