### PR TITLE
feat(inbound): add manual receipts, return-source contracts and inbound nav updates

### DIFF
--- a/alembic/versions/d761227be296_seed_inbound_root_pages_and_wms_inbound_.py
+++ b/alembic/versions/d761227be296_seed_inbound_root_pages_and_wms_inbound_.py
@@ -1,0 +1,371 @@
+"""seed inbound root pages and wms inbound operations navigation
+
+Revision ID: d761227be296
+Revises: 0e6706881685
+Create Date: 2026-04-17 19:58:59.730708
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d761227be296"
+down_revision: Union[str, Sequence[str], None] = "0e6706881685"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+
+    # 1) 扩 page_registry.domain_code，纳入 inbound 独立模块
+    op.execute(
+        """
+        ALTER TABLE page_registry
+        DROP CONSTRAINT IF EXISTS ck_page_registry_domain_code
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE page_registry
+        ADD CONSTRAINT ck_page_registry_domain_code
+        CHECK (
+          domain_code IN (
+            'analytics',
+            'oms',
+            'pms',
+            'procurement',
+            'wms',
+            'tms',
+            'admin',
+            'inbound'
+          )
+        )
+        """
+    )
+
+    # 2) 新增 inbound 一级页权限
+    op.execute(
+        """
+        INSERT INTO permissions (name)
+        VALUES
+          ('page.inbound.read'),
+          ('page.inbound.write')
+        ON CONFLICT (name) DO NOTHING
+        """
+    )
+
+    # 3) 过渡期权限回填：
+    #    当前已有 page.wms.* 的用户，补发 page.inbound.*，避免新模块上线后不可见
+    op.execute(
+        """
+        WITH mappings AS (
+          SELECT 'page.wms.read' AS source_name, 'page.inbound.read' AS target_name
+          UNION ALL
+          SELECT 'page.wms.write', 'page.inbound.write'
+        ),
+        pairs AS (
+          SELECT DISTINCT
+            up.user_id AS user_id,
+            tp.id AS permission_id
+          FROM mappings m
+          JOIN permissions sp
+            ON sp.name = m.source_name
+          JOIN user_permissions up
+            ON up.permission_id = sp.id
+          JOIN permissions tp
+            ON tp.name = m.target_name
+        )
+        INSERT INTO user_permissions (user_id, permission_id)
+        SELECT user_id, permission_id
+        FROM pairs
+        ON CONFLICT (user_id, permission_id) DO NOTHING
+        """
+    )
+
+    # 4) 新增 inbound 一级页
+    op.execute(
+        """
+        INSERT INTO page_registry (
+          code,
+          name,
+          parent_code,
+          level,
+          domain_code,
+          show_in_topbar,
+          show_in_sidebar,
+          inherit_permissions,
+          read_permission_id,
+          write_permission_id,
+          sort_order,
+          is_active
+        )
+        VALUES (
+          'inbound',
+          '入库单据',
+          NULL,
+          1,
+          'inbound',
+          TRUE,
+          FALSE,
+          FALSE,
+          (SELECT id FROM permissions WHERE name = 'page.inbound.read'),
+          (SELECT id FROM permissions WHERE name = 'page.inbound.write'),
+          26,
+          TRUE
+        )
+        ON CONFLICT (code) DO UPDATE
+        SET
+          name = EXCLUDED.name,
+          parent_code = EXCLUDED.parent_code,
+          level = EXCLUDED.level,
+          domain_code = EXCLUDED.domain_code,
+          show_in_topbar = EXCLUDED.show_in_topbar,
+          show_in_sidebar = EXCLUDED.show_in_sidebar,
+          inherit_permissions = EXCLUDED.inherit_permissions,
+          read_permission_id = EXCLUDED.read_permission_id,
+          write_permission_id = EXCLUDED.write_permission_id,
+          sort_order = EXCLUDED.sort_order,
+          is_active = EXCLUDED.is_active
+        """
+    )
+
+    # 5) 新增 inbound 二级页：汇总 / 采购 / 退货 / 手动
+    op.execute(
+        """
+        INSERT INTO page_registry (
+          code,
+          name,
+          parent_code,
+          level,
+          domain_code,
+          show_in_topbar,
+          show_in_sidebar,
+          inherit_permissions,
+          read_permission_id,
+          write_permission_id,
+          sort_order,
+          is_active
+        )
+        VALUES
+          (
+            'inbound.summary',
+            '入库单汇总',
+            'inbound',
+            2,
+            'inbound',
+            FALSE,
+            TRUE,
+            TRUE,
+            NULL,
+            NULL,
+            10,
+            TRUE
+          ),
+          (
+            'inbound.purchase',
+            '采购入库单',
+            'inbound',
+            2,
+            'inbound',
+            FALSE,
+            TRUE,
+            TRUE,
+            NULL,
+            NULL,
+            20,
+            TRUE
+          ),
+          (
+            'inbound.returns',
+            '退货入库单',
+            'inbound',
+            2,
+            'inbound',
+            FALSE,
+            TRUE,
+            TRUE,
+            NULL,
+            NULL,
+            30,
+            TRUE
+          ),
+          (
+            'inbound.manual',
+            '手动入库单',
+            'inbound',
+            2,
+            'inbound',
+            FALSE,
+            TRUE,
+            TRUE,
+            NULL,
+            NULL,
+            40,
+            TRUE
+          )
+        ON CONFLICT (code) DO UPDATE
+        SET
+          name = EXCLUDED.name,
+          parent_code = EXCLUDED.parent_code,
+          level = EXCLUDED.level,
+          domain_code = EXCLUDED.domain_code,
+          show_in_topbar = EXCLUDED.show_in_topbar,
+          show_in_sidebar = EXCLUDED.show_in_sidebar,
+          inherit_permissions = EXCLUDED.inherit_permissions,
+          read_permission_id = EXCLUDED.read_permission_id,
+          write_permission_id = EXCLUDED.write_permission_id,
+          sort_order = EXCLUDED.sort_order,
+          is_active = EXCLUDED.is_active
+        """
+    )
+
+    # 6) WMS 入库树下新增“收货操作”页
+    op.execute(
+        """
+        INSERT INTO page_registry (
+          code,
+          name,
+          parent_code,
+          level,
+          domain_code,
+          show_in_topbar,
+          show_in_sidebar,
+          inherit_permissions,
+          read_permission_id,
+          write_permission_id,
+          sort_order,
+          is_active
+        )
+        VALUES (
+          'wms.inbound.operations',
+          '收货操作',
+          'wms.inbound',
+          3,
+          'wms',
+          FALSE,
+          TRUE,
+          TRUE,
+          NULL,
+          NULL,
+          40,
+          TRUE
+        )
+        ON CONFLICT (code) DO UPDATE
+        SET
+          name = EXCLUDED.name,
+          parent_code = EXCLUDED.parent_code,
+          level = EXCLUDED.level,
+          domain_code = EXCLUDED.domain_code,
+          show_in_topbar = EXCLUDED.show_in_topbar,
+          show_in_sidebar = EXCLUDED.show_in_sidebar,
+          inherit_permissions = EXCLUDED.inherit_permissions,
+          read_permission_id = EXCLUDED.read_permission_id,
+          write_permission_id = EXCLUDED.write_permission_id,
+          sort_order = EXCLUDED.sort_order,
+          is_active = EXCLUDED.is_active
+        """
+    )
+
+    # 7) 补 route_prefix：
+    #    - 入库单详情先挂到 inbound.summary，保持二级页高亮稳定
+    #    - WMS 收货操作按 receiptNo 路径进入
+    #    - 动态段里的冒号必须写成 \\:param，避免被 SQLAlchemy 当绑定参数解析
+    op.execute(
+        """
+        INSERT INTO page_route_prefixes (
+          page_code,
+          route_prefix,
+          sort_order,
+          is_active
+        )
+        VALUES
+          ('inbound.summary', '/inbound-receipts', 10, TRUE),
+          ('inbound.summary', '/inbound-receipts/\\:receiptId', 11, TRUE),
+          ('inbound.purchase', '/inbound-receipts/purchase', 20, TRUE),
+          ('inbound.returns', '/inbound-receipts/returns', 30, TRUE),
+          ('inbound.manual', '/inbound-receipts/manual', 40, TRUE),
+          ('wms.inbound.operations', '/inbound-operations', 40, TRUE),
+          ('wms.inbound.operations', '/inbound-operations/\\:receiptNo', 41, TRUE)
+        ON CONFLICT (route_prefix) DO UPDATE
+        SET
+          page_code = EXCLUDED.page_code,
+          sort_order = EXCLUDED.sort_order,
+          is_active = EXCLUDED.is_active
+        """
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+
+    # 1) 先删本次新增页面。
+    #    page_route_prefixes.page_code -> page_registry.code 是 ON DELETE CASCADE，
+    #    所以对应 route_prefix 会自动删除。
+    op.execute(
+        """
+        DELETE FROM page_registry
+        WHERE code = 'wms.inbound.operations'
+        """
+    )
+
+    op.execute(
+        """
+        DELETE FROM page_registry
+        WHERE code IN (
+          'inbound.summary',
+          'inbound.purchase',
+          'inbound.returns',
+          'inbound.manual'
+        )
+        """
+    )
+
+    op.execute(
+        """
+        DELETE FROM page_registry
+        WHERE code = 'inbound'
+        """
+    )
+
+    # 2) 删除 inbound 权限定义。
+    #    user_permissions.permission_id -> permissions.id 是 ON DELETE CASCADE，
+    #    用户上的 page.inbound.* 残留会自动清掉。
+    op.execute(
+        """
+        DELETE FROM permissions
+        WHERE name IN (
+          'page.inbound.read',
+          'page.inbound.write'
+        )
+        """
+    )
+
+    # 3) 恢复 page_registry.domain_code 约束，移除 inbound
+    op.execute(
+        """
+        ALTER TABLE page_registry
+        DROP CONSTRAINT IF EXISTS ck_page_registry_domain_code
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE page_registry
+        ADD CONSTRAINT ck_page_registry_domain_code
+        CHECK (
+          domain_code IN (
+            'analytics',
+            'oms',
+            'pms',
+            'procurement',
+            'wms',
+            'tms',
+            'admin'
+          )
+        )
+        """
+    )

--- a/app/inbound_receipts/contracts/receipt_create_from_return_order.py
+++ b/app/inbound_receipts/contracts/receipt_create_from_return_order.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.inbound_receipts.contracts.receipt_read import InboundReceiptReadOut
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+        str_strip_whitespace=True,
+        populate_by_name=True,
+    )
+
+
+class InboundReceiptCreateFromReturnOrderLineIn(_Base):
+    order_line_id: Annotated[int, Field(ge=1, description="订单行 ID")]
+    item_id: Annotated[int, Field(ge=1, description="商品 ID")]
+    planned_qty: Annotated[Decimal, Field(gt=0, description="本次退货入库数量")]
+    remark: Annotated[str | None, Field(default=None, max_length=500, description="行备注")]
+
+
+class InboundReceiptCreateFromReturnOrderIn(_Base):
+    order_key: Annotated[
+        str,
+        Field(
+            min_length=1,
+            max_length=128,
+            description="订单键：支持 ORD:PLAT:SHOP:EXT / PLAT:SHOP:EXT / 唯一 ext_order_no",
+        ),
+    ]
+    remark: Annotated[str | None, Field(default=None, max_length=500, description="头备注")]
+    lines: Annotated[list[InboundReceiptCreateFromReturnOrderLineIn], Field(min_length=1, description="本次生成行")]
+
+
+InboundReceiptCreateFromReturnOrderOut = InboundReceiptReadOut

--- a/app/inbound_receipts/contracts/receipt_create_manual.py
+++ b/app/inbound_receipts/contracts/receipt_create_manual.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.inbound_receipts.contracts.receipt_read import InboundReceiptReadOut
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+        str_strip_whitespace=True,
+        populate_by_name=True,
+    )
+
+
+class InboundReceiptCreateManualLineIn(_Base):
+    item_id: Annotated[int, Field(ge=1, description="商品 ID")]
+    item_uom_id: Annotated[int, Field(ge=1, description="包装单位 ID")]
+    planned_qty: Annotated[Decimal, Field(gt=0, description="任务数量")]
+    item_name_snapshot: Annotated[str | None, Field(default=None, max_length=255, description="商品名（前端展示传入，可空）")]
+    item_spec_snapshot: Annotated[str | None, Field(default=None, max_length=255, description="规格（前端展示传入，可空）")]
+    uom_name_snapshot: Annotated[str | None, Field(default=None, max_length=64, description="单位名（前端展示传入，可空）")]
+    remark: Annotated[str | None, Field(default=None, max_length=500, description="行备注")]
+
+
+class InboundReceiptCreateManualIn(_Base):
+    warehouse_id: Annotated[int, Field(ge=1, description="仓库 ID")]
+    supplier_id: Annotated[int | None, Field(default=None, ge=1, description="供应商 ID")]
+    remark: Annotated[str | None, Field(default=None, max_length=500, description="头备注")]
+    lines: Annotated[list[InboundReceiptCreateManualLineIn], Field(min_length=1, description="手动入库任务行")]
+
+
+InboundReceiptCreateManualOut = InboundReceiptReadOut
+
+
+__all__ = [
+    "InboundReceiptCreateManualLineIn",
+    "InboundReceiptCreateManualIn",
+    "InboundReceiptCreateManualOut",
+]

--- a/app/inbound_receipts/contracts/receipt_return_source.py
+++ b/app/inbound_receipts/contracts/receipt_return_source.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.inbound_receipts.contracts.enums import InboundReceiptStatus
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+        str_strip_whitespace=True,
+        populate_by_name=True,
+    )
+
+
+class InboundReceiptReturnSourceLineOut(_Base):
+    order_line_id: Annotated[int, Field(ge=1, description="订单行 ID")]
+    item_id: Annotated[int, Field(ge=1, description="商品 ID")]
+    item_name_snapshot: Annotated[str | None, Field(default=None, max_length=255, description="商品名快照")]
+    item_spec_snapshot: Annotated[str | None, Field(default=None, max_length=255, description="规格快照")]
+    item_uom_id: Annotated[int, Field(ge=1, description="建议入库包装单位 ID")]
+    uom_name_snapshot: Annotated[str | None, Field(default=None, max_length=64, description="建议入库单位名")]
+    ratio_to_base_snapshot: Annotated[Decimal, Field(gt=0, description="建议入库倍率快照")]
+    qty_ordered: Annotated[Decimal, Field(ge=0, description="下单数量")]
+    qty_shipped: Annotated[Decimal, Field(ge=0, description="已发数量")]
+    qty_returned: Annotated[Decimal, Field(ge=0, description="已退数量")]
+    qty_remaining_refundable: Annotated[Decimal, Field(ge=0, description="剩余可退数量")]
+    suggested_planned_qty: Annotated[Decimal, Field(ge=0, description="建议本次生成数量")]
+
+
+class InboundReceiptReturnSourceOut(_Base):
+    order_id: Annotated[int, Field(ge=1, description="OMS 订单 ID")]
+    order_ref: Annotated[str, Field(min_length=1, max_length=128, description="规范订单键")]
+    platform: Annotated[str | None, Field(default=None, max_length=32, description="平台")]
+    shop_id: Annotated[str | None, Field(default=None, max_length=64, description="店铺 ID")]
+    ext_order_no: Annotated[str | None, Field(default=None, max_length=128, description="原订单号")]
+    warehouse_id: Annotated[int, Field(ge=1, description="退货入库仓库 ID")]
+    warehouse_name_snapshot: Annotated[str | None, Field(default=None, max_length=255, description="仓库名快照")]
+    remaining_qty: Annotated[Decimal, Field(ge=0, description="整单剩余可退数量")]
+    existing_receipt_id: Annotated[int | None, Field(default=None, ge=1, description="已存在退货入库单 ID")]
+    existing_receipt_no: Annotated[str | None, Field(default=None, max_length=64, description="已存在退货入库单号")]
+    existing_receipt_status: InboundReceiptStatus | None = Field(default=None, description="已存在退货入库单状态")
+    lines: list[InboundReceiptReturnSourceLineOut] = Field(default_factory=list, description="退货来源行")

--- a/app/inbound_receipts/repos/inbound_receipt_read_repo.py
+++ b/app/inbound_receipts/repos/inbound_receipt_read_repo.py
@@ -12,6 +12,214 @@ from app.inbound_receipts.contracts.receipt_read import (
     InboundReceiptProgressOut,
     InboundReceiptReadOut,
 )
+from app.inbound_receipts.contracts.receipt_return_source import (
+    InboundReceiptReturnSourceLineOut,
+    InboundReceiptReturnSourceOut,
+)
+from app.oms.services.order_ref_resolver import resolve_order_id
+
+
+RETURN_SHIP_REASONS = ("SHIPMENT", "OUTBOUND_SHIP")
+
+
+async def _resolve_order_identity(
+    session: AsyncSession,
+    *,
+    order_key: str,
+) -> dict[str, object]:
+    order_id = int(await resolve_order_id(session, order_ref=order_key))
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT id, platform, shop_id, ext_order_no
+                FROM orders
+                WHERE id = :order_id
+                LIMIT 1
+                """
+            ),
+            {"order_id": order_id},
+        )
+    ).mappings().first()
+
+    if row is None:
+        raise HTTPException(status_code=404, detail="return_order_not_found")
+
+    platform = str(row["platform"])
+    shop_id = str(row["shop_id"])
+    ext_order_no = str(row["ext_order_no"])
+    return {
+        "order_id": int(row["id"]),
+        "platform": platform,
+        "shop_id": shop_id,
+        "ext_order_no": ext_order_no,
+        "order_ref": f"ORD:{platform}:{shop_id}:{ext_order_no}",
+    }
+
+
+async def _load_return_source_warehouse(
+    session: AsyncSession,
+    *,
+    order_ref: str,
+) -> tuple[int, str | None]:
+    wh_rows = (
+        await session.execute(
+            text(
+                """
+                SELECT DISTINCT warehouse_id
+                FROM stock_ledger
+                WHERE ref = :ref
+                  AND delta < 0
+                  AND reason = ANY(:reasons)
+                ORDER BY warehouse_id ASC
+                LIMIT 2
+                """
+            ),
+            {"ref": str(order_ref), "reasons": list(RETURN_SHIP_REASONS)},
+        )
+    ).mappings().all()
+
+    if not wh_rows:
+        raise HTTPException(status_code=409, detail="return_order_has_no_shipped_facts")
+
+    if len(wh_rows) > 1:
+        ids = ",".join(str(int(x["warehouse_id"])) for x in wh_rows)
+        raise HTTPException(status_code=409, detail=f"return_order_multi_warehouse:{ids}")
+
+    warehouse_id = int(wh_rows[0]["warehouse_id"])
+    warehouse_name = (
+        await session.execute(
+            text("SELECT name FROM warehouses WHERE id = :warehouse_id LIMIT 1"),
+            {"warehouse_id": warehouse_id},
+        )
+    ).scalar_one_or_none()
+    return warehouse_id, warehouse_name
+
+
+async def get_inbound_return_source_repo(
+    session: AsyncSession,
+    *,
+    order_key: str,
+) -> InboundReceiptReturnSourceOut:
+    ident = await _resolve_order_identity(session, order_key=order_key)
+    order_id = int(ident["order_id"])
+    order_ref = str(ident["order_ref"])
+    warehouse_id, warehouse_name_snapshot = await _load_return_source_warehouse(
+        session,
+        order_ref=order_ref,
+    )
+
+    line_rows = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  oi.id AS order_line_id,
+                  oi.item_id AS item_id,
+                  COALESCE(i.name, oi.title) AS item_name_snapshot,
+                  i.spec AS item_spec_snapshot,
+                  (
+                    SELECT u.id
+                    FROM item_uoms u
+                    WHERE u.item_id = oi.item_id
+                    ORDER BY
+                      CASE WHEN u.is_inbound_default THEN 0 WHEN u.is_base THEN 1 ELSE 2 END,
+                      u.id
+                    LIMIT 1
+                  ) AS item_uom_id,
+                  (
+                    SELECT COALESCE(NULLIF(u.display_name, ''), u.uom)
+                    FROM item_uoms u
+                    WHERE u.item_id = oi.item_id
+                    ORDER BY
+                      CASE WHEN u.is_inbound_default THEN 0 WHEN u.is_base THEN 1 ELSE 2 END,
+                      u.id
+                    LIMIT 1
+                  ) AS uom_name_snapshot,
+                  (
+                    SELECT u.ratio_to_base::numeric
+                    FROM item_uoms u
+                    WHERE u.item_id = oi.item_id
+                    ORDER BY
+                      CASE WHEN u.is_inbound_default THEN 0 WHEN u.is_base THEN 1 ELSE 2 END,
+                      u.id
+                    LIMIT 1
+                  ) AS ratio_to_base_snapshot,
+                  COALESCE(oi.qty, 0)::numeric AS qty_ordered,
+                  COALESCE(oi.shipped_qty, 0)::numeric AS qty_shipped,
+                  COALESCE(oi.returned_qty, 0)::numeric AS qty_returned,
+                  GREATEST(COALESCE(oi.shipped_qty, 0) - COALESCE(oi.returned_qty, 0), 0)::numeric AS qty_remaining_refundable
+                FROM order_items oi
+                LEFT JOIN items i ON i.id = oi.item_id
+                WHERE oi.order_id = :order_id
+                  AND GREATEST(COALESCE(oi.shipped_qty, 0) - COALESCE(oi.returned_qty, 0), 0) > 0
+                ORDER BY oi.id ASC
+                """
+            ),
+            {"order_id": order_id},
+        )
+    ).mappings().all()
+
+    if not line_rows:
+        raise HTTPException(status_code=409, detail="return_order_has_no_refundable_lines")
+
+    lines: list[InboundReceiptReturnSourceLineOut] = []
+    remaining_qty = 0
+
+    for row in line_rows:
+        item_id = int(row["item_id"])
+        item_uom_id = int(row["item_uom_id"] or 0)
+        if item_uom_id <= 0:
+            raise HTTPException(status_code=409, detail=f"item_has_no_inbound_uom:item_id={item_id}")
+
+        line = InboundReceiptReturnSourceLineOut(
+            order_line_id=int(row["order_line_id"]),
+            item_id=item_id,
+            item_name_snapshot=row["item_name_snapshot"],
+            item_spec_snapshot=row["item_spec_snapshot"],
+            item_uom_id=item_uom_id,
+            uom_name_snapshot=row["uom_name_snapshot"],
+            ratio_to_base_snapshot=row["ratio_to_base_snapshot"] or 1,
+            qty_ordered=row["qty_ordered"] or 0,
+            qty_shipped=row["qty_shipped"] or 0,
+            qty_returned=row["qty_returned"] or 0,
+            qty_remaining_refundable=row["qty_remaining_refundable"] or 0,
+            suggested_planned_qty=row["qty_remaining_refundable"] or 0,
+        )
+        lines.append(line)
+        remaining_qty += int(row["qty_remaining_refundable"] or 0)
+
+    existing = (
+        await session.execute(
+            text(
+                """
+                SELECT id, receipt_no, status
+                FROM inbound_receipts
+                WHERE source_type = 'RETURN_ORDER'
+                  AND source_doc_id = :order_id
+                  AND status <> 'VOIDED'
+                ORDER BY id DESC
+                LIMIT 1
+                """
+            ),
+            {"order_id": order_id},
+        )
+    ).mappings().first()
+
+    return InboundReceiptReturnSourceOut(
+        order_id=order_id,
+        order_ref=order_ref,
+        platform=str(ident["platform"]),
+        shop_id=str(ident["shop_id"]),
+        ext_order_no=str(ident["ext_order_no"]),
+        warehouse_id=warehouse_id,
+        warehouse_name_snapshot=warehouse_name_snapshot,
+        remaining_qty=remaining_qty,
+        existing_receipt_id=int(existing["id"]) if existing is not None else None,
+        existing_receipt_no=str(existing["receipt_no"]) if existing is not None else None,
+        existing_receipt_status=str(existing["status"]) if existing is not None else None,
+        lines=lines,
+    )
 
 
 async def list_inbound_receipts_repo(
@@ -230,4 +438,5 @@ __all__ = [
     "list_inbound_receipts_repo",
     "get_inbound_receipt_repo",
     "get_inbound_receipt_progress_repo",
+    "get_inbound_return_source_repo",
 ]

--- a/app/inbound_receipts/repos/inbound_receipt_write_repo.py
+++ b/app/inbound_receipts/repos/inbound_receipt_write_repo.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from decimal import Decimal
 from uuid import uuid4
 
 from fastapi import HTTPException
@@ -11,11 +12,20 @@ from app.inbound_receipts.contracts.receipt_create_from_purchase import (
     InboundReceiptCreateFromPurchaseIn,
     InboundReceiptCreateFromPurchaseOut,
 )
+from app.inbound_receipts.contracts.receipt_create_manual import (
+    InboundReceiptCreateManualIn,
+    InboundReceiptCreateManualOut,
+)
+from app.inbound_receipts.contracts.receipt_create_from_return_order import (
+    InboundReceiptCreateFromReturnOrderIn,
+    InboundReceiptCreateFromReturnOrderOut,
+)
 from app.inbound_receipts.contracts.receipt_release import (
     InboundReceiptReleaseOut,
 )
 from app.inbound_receipts.repos.inbound_receipt_read_repo import (
     get_inbound_receipt_repo,
+    get_inbound_return_source_repo,
 )
 
 UTC = timezone.utc
@@ -25,6 +35,18 @@ def _new_receipt_no(po_id: int) -> str:
     stamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
     suffix = uuid4().hex[:6].upper()
     return f"IR-PO-{po_id}-{stamp}-{suffix}"
+
+
+def _new_manual_receipt_no() -> str:
+    stamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
+    suffix = uuid4().hex[:6].upper()
+    return f"IR-MA-{stamp}-{suffix}"
+
+
+def _new_return_receipt_no(order_id: int) -> str:
+    stamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
+    suffix = uuid4().hex[:6].upper()
+    return f"IR-RO-{order_id}-{stamp}-{suffix}"
 
 
 async def _load_warehouse_name_snapshot(
@@ -83,6 +105,81 @@ async def _load_warehouse_name_snapshot(
         ).scalar_one_or_none()
 
     return None
+
+
+async def _load_supplier_name_snapshot(
+    session: AsyncSession,
+    *,
+    supplier_id: int,
+) -> str:
+    row = (
+        await session.execute(
+            text("SELECT name FROM suppliers WHERE id = :supplier_id LIMIT 1"),
+            {"supplier_id": int(supplier_id)},
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="supplier_not_found")
+    return str(row)
+
+
+async def _load_manual_line_snapshot(
+    session: AsyncSession,
+    *,
+    item_id: int,
+    item_uom_id: int,
+) -> dict[str, object]:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  i.id AS item_id,
+                  i.name AS item_name,
+                  i.spec AS item_spec,
+                  u.id AS item_uom_id,
+                  COALESCE(NULLIF(u.display_name, ''), u.uom) AS uom_name,
+                  u.ratio_to_base AS ratio_to_base
+                FROM items i
+                JOIN item_uoms u
+                  ON u.item_id = i.id
+                WHERE i.id = :item_id
+                  AND u.id = :item_uom_id
+                LIMIT 1
+                """
+            ),
+            {
+                "item_id": int(item_id),
+                "item_uom_id": int(item_uom_id),
+            },
+        )
+    ).mappings().first()
+
+    if row is not None:
+        return dict(row)
+
+    item_exists = (
+        await session.execute(
+            text("SELECT 1 FROM items WHERE id = :item_id LIMIT 1"),
+            {"item_id": int(item_id)},
+        )
+    ).scalar_one_or_none()
+    if item_exists is None:
+        raise HTTPException(status_code=404, detail="item_not_found")
+
+    uom_exists = (
+        await session.execute(
+            text("SELECT 1 FROM item_uoms WHERE id = :item_uom_id LIMIT 1"),
+            {"item_uom_id": int(item_uom_id)},
+        )
+    ).scalar_one_or_none()
+    if uom_exists is None:
+        raise HTTPException(status_code=404, detail="item_uom_not_found")
+
+    raise HTTPException(
+        status_code=409,
+        detail=f"item_uom_item_mismatch:item_id={int(item_id)},item_uom_id={int(item_uom_id)}",
+    )
 
 
 async def create_inbound_receipt_from_purchase_repo(
@@ -287,6 +384,307 @@ async def create_inbound_receipt_from_purchase_repo(
     return await get_inbound_receipt_repo(session, receipt_id=receipt_id)
 
 
+async def create_inbound_receipt_manual_repo(
+    session: AsyncSession,
+    *,
+    payload: InboundReceiptCreateManualIn,
+    created_by: int | None,
+) -> InboundReceiptCreateManualOut:
+    warehouse_exists = (
+        await session.execute(
+            text("SELECT 1 FROM warehouses WHERE id = :warehouse_id LIMIT 1"),
+            {"warehouse_id": int(payload.warehouse_id)},
+        )
+    ).scalar_one_or_none()
+    if warehouse_exists is None:
+        raise HTTPException(status_code=404, detail="warehouse_not_found")
+
+    warehouse_name_snapshot = await _load_warehouse_name_snapshot(
+        session,
+        warehouse_id=int(payload.warehouse_id),
+    )
+
+    supplier_name_snapshot: str | None = None
+    if payload.supplier_id is not None:
+        supplier_name_snapshot = await _load_supplier_name_snapshot(
+            session,
+            supplier_id=int(payload.supplier_id),
+        )
+
+    receipt_no = _new_manual_receipt_no()
+
+    header = (
+        await session.execute(
+            text(
+                """
+                INSERT INTO inbound_receipts (
+                  receipt_no,
+                  source_type,
+                  source_doc_id,
+                  source_doc_no_snapshot,
+                  warehouse_id,
+                  warehouse_name_snapshot,
+                  supplier_id,
+                  counterparty_name_snapshot,
+                  status,
+                  remark,
+                  created_by,
+                  released_at
+                )
+                VALUES (
+                  :receipt_no,
+                  'MANUAL',
+                  NULL,
+                  NULL,
+                  :warehouse_id,
+                  :warehouse_name_snapshot,
+                  :supplier_id,
+                  :counterparty_name_snapshot,
+                  'DRAFT',
+                  :remark,
+                  :created_by,
+                  NULL
+                )
+                RETURNING id
+                """
+            ),
+            {
+                "receipt_no": receipt_no,
+                "warehouse_id": int(payload.warehouse_id),
+                "warehouse_name_snapshot": warehouse_name_snapshot,
+                "supplier_id": int(payload.supplier_id) if payload.supplier_id is not None else None,
+                "counterparty_name_snapshot": supplier_name_snapshot,
+                "remark": payload.remark,
+                "created_by": created_by,
+            },
+        )
+    ).mappings().first()
+
+    receipt_id = int(header["id"])
+
+    for idx, line in enumerate(payload.lines, start=1):
+        snap = await _load_manual_line_snapshot(
+            session,
+            item_id=int(line.item_id),
+            item_uom_id=int(line.item_uom_id),
+        )
+
+        await session.execute(
+            text(
+                """
+                INSERT INTO inbound_receipt_lines (
+                  inbound_receipt_id,
+                  line_no,
+                  source_line_id,
+                  item_id,
+                  item_uom_id,
+                  planned_qty,
+                  item_name_snapshot,
+                  item_spec_snapshot,
+                  uom_name_snapshot,
+                  ratio_to_base_snapshot,
+                  remark
+                )
+                VALUES (
+                  :inbound_receipt_id,
+                  :line_no,
+                  NULL,
+                  :item_id,
+                  :item_uom_id,
+                  :planned_qty,
+                  :item_name_snapshot,
+                  :item_spec_snapshot,
+                  :uom_name_snapshot,
+                  :ratio_to_base_snapshot,
+                  :remark
+                )
+                """
+            ),
+            {
+                "inbound_receipt_id": receipt_id,
+                "line_no": idx,
+                "item_id": int(line.item_id),
+                "item_uom_id": int(line.item_uom_id),
+                "planned_qty": line.planned_qty,
+                "item_name_snapshot": snap["item_name"],
+                "item_spec_snapshot": snap["item_spec"],
+                "uom_name_snapshot": snap["uom_name"],
+                "ratio_to_base_snapshot": snap["ratio_to_base"],
+                "remark": line.remark,
+            },
+        )
+
+    return await get_inbound_receipt_repo(session, receipt_id=receipt_id)
+
+
+async def create_inbound_receipt_from_return_order_repo(
+    session: AsyncSession,
+    *,
+    payload: InboundReceiptCreateFromReturnOrderIn,
+    created_by: int | None,
+) -> InboundReceiptCreateFromReturnOrderOut:
+    source = await get_inbound_return_source_repo(session, order_key=payload.order_key)
+
+    if source.existing_receipt_id is not None and source.existing_receipt_no is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=f"inbound_receipt_already_exists:{source.existing_receipt_no}",
+        )
+
+    if not source.lines:
+        raise HTTPException(status_code=409, detail="return_order_has_no_refundable_lines")
+
+    counterparty_name_snapshot = None
+    if source.platform and source.shop_id:
+        counterparty_name_snapshot = f"{source.platform}:{source.shop_id}"
+    elif source.platform:
+        counterparty_name_snapshot = source.platform
+    elif source.shop_id:
+        counterparty_name_snapshot = source.shop_id
+
+    receipt_no = _new_return_receipt_no(int(source.order_id))
+
+    header = (
+        await session.execute(
+            text(
+                """
+                INSERT INTO inbound_receipts (
+                  receipt_no,
+                  source_type,
+                  source_doc_id,
+                  source_doc_no_snapshot,
+                  warehouse_id,
+                  warehouse_name_snapshot,
+                  supplier_id,
+                  counterparty_name_snapshot,
+                  status,
+                  remark,
+                  created_by,
+                  released_at
+                )
+                VALUES (
+                  :receipt_no,
+                  'RETURN_ORDER',
+                  :source_doc_id,
+                  :source_doc_no_snapshot,
+                  :warehouse_id,
+                  :warehouse_name_snapshot,
+                  NULL,
+                  :counterparty_name_snapshot,
+                  'DRAFT',
+                  :remark,
+                  :created_by,
+                  NULL
+                )
+                RETURNING id
+                """
+            ),
+            {
+                "receipt_no": receipt_no,
+                "source_doc_id": int(source.order_id),
+                "source_doc_no_snapshot": source.ext_order_no or source.order_ref,
+                "warehouse_id": int(source.warehouse_id),
+                "warehouse_name_snapshot": source.warehouse_name_snapshot,
+                "counterparty_name_snapshot": counterparty_name_snapshot,
+                "remark": payload.remark,
+                "created_by": created_by,
+            },
+        )
+    ).mappings().first()
+
+    receipt_id = int(header["id"])
+    source_map = {int(line.order_line_id): line for line in source.lines}
+    seen_order_line_ids: set[int] = set()
+
+    for idx, line in enumerate(payload.lines, start=1):
+        order_line_id = int(line.order_line_id)
+        if order_line_id in seen_order_line_ids:
+            raise HTTPException(
+                status_code=409,
+                detail=f"duplicate_return_order_line:{order_line_id}",
+            )
+        seen_order_line_ids.add(order_line_id)
+
+        src = source_map.get(order_line_id)
+        if src is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"return_order_line_not_found:{order_line_id}",
+            )
+
+        if int(src.item_id) != int(line.item_id):
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"return_order_line_item_mismatch:"
+                    f"order_line_id={order_line_id},"
+                    f"source_item_id={int(src.item_id)},"
+                    f"payload_item_id={int(line.item_id)}"
+                ),
+            )
+
+        planned_qty = Decimal(str(line.planned_qty))
+        remaining_qty = Decimal(str(src.qty_remaining_refundable))
+        if planned_qty > remaining_qty:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"return_qty_exceeds_remaining:"
+                    f"order_line_id={order_line_id},"
+                    f"remaining={remaining_qty},"
+                    f"planned={planned_qty}"
+                ),
+            )
+
+        await session.execute(
+            text(
+                """
+                INSERT INTO inbound_receipt_lines (
+                  inbound_receipt_id,
+                  line_no,
+                  source_line_id,
+                  item_id,
+                  item_uom_id,
+                  planned_qty,
+                  item_name_snapshot,
+                  item_spec_snapshot,
+                  uom_name_snapshot,
+                  ratio_to_base_snapshot,
+                  remark
+                )
+                VALUES (
+                  :inbound_receipt_id,
+                  :line_no,
+                  :source_line_id,
+                  :item_id,
+                  :item_uom_id,
+                  :planned_qty,
+                  :item_name_snapshot,
+                  :item_spec_snapshot,
+                  :uom_name_snapshot,
+                  :ratio_to_base_snapshot,
+                  :remark
+                )
+                """
+            ),
+            {
+                "inbound_receipt_id": receipt_id,
+                "line_no": idx,
+                "source_line_id": order_line_id,
+                "item_id": int(src.item_id),
+                "item_uom_id": int(src.item_uom_id),
+                "planned_qty": line.planned_qty,
+                "item_name_snapshot": src.item_name_snapshot,
+                "item_spec_snapshot": src.item_spec_snapshot,
+                "uom_name_snapshot": src.uom_name_snapshot,
+                "ratio_to_base_snapshot": src.ratio_to_base_snapshot,
+                "remark": line.remark,
+            },
+        )
+
+    return await get_inbound_receipt_repo(session, receipt_id=receipt_id)
+
+
 async def release_inbound_receipt_repo(
     session: AsyncSession,
     *,
@@ -354,5 +752,7 @@ async def release_inbound_receipt_repo(
 
 __all__ = [
     "create_inbound_receipt_from_purchase_repo",
+    "create_inbound_receipt_manual_repo",
+    "create_inbound_receipt_from_return_order_repo",
     "release_inbound_receipt_repo",
 ]

--- a/app/inbound_receipts/routers/inbound_receipts.py
+++ b/app/inbound_receipts/routers/inbound_receipts.py
@@ -8,6 +8,17 @@ from app.inbound_receipts.contracts.receipt_create_from_purchase import (
     InboundReceiptCreateFromPurchaseIn,
     InboundReceiptCreateFromPurchaseOut,
 )
+from app.inbound_receipts.contracts.receipt_create_manual import (
+    InboundReceiptCreateManualIn,
+    InboundReceiptCreateManualOut,
+)
+from app.inbound_receipts.contracts.receipt_create_from_return_order import (
+    InboundReceiptCreateFromReturnOrderIn,
+    InboundReceiptCreateFromReturnOrderOut,
+)
+from app.inbound_receipts.contracts.receipt_return_source import (
+    InboundReceiptReturnSourceOut,
+)
 from app.inbound_receipts.contracts.receipt_read import (
     InboundReceiptListOut,
     InboundReceiptProgressOut,
@@ -18,6 +29,15 @@ from app.inbound_receipts.contracts.receipt_release import (
 )
 from app.inbound_receipts.services.create_from_purchase_service import (
     create_inbound_receipt_from_purchase,
+)
+from app.inbound_receipts.services.create_manual_service import (
+    create_inbound_receipt_manual,
+)
+from app.inbound_receipts.services.create_from_return_order_service import (
+    create_inbound_receipt_from_return_order,
+)
+from app.inbound_receipts.services.return_source_service import (
+    get_inbound_return_source,
 )
 from app.inbound_receipts.services.read_service import (
     get_inbound_receipt,
@@ -36,6 +56,69 @@ async def create_inbound_receipt_from_purchase_endpoint(
 ) -> InboundReceiptCreateFromPurchaseOut:
     try:
         out = await create_inbound_receipt_from_purchase(
+            session,
+            payload=payload,
+            created_by=None,
+        )
+        await session.commit()
+        return out
+    except NotImplementedError as e:
+        await session.rollback()
+        raise HTTPException(status_code=501, detail=str(e)) from e
+    except HTTPException:
+        await session.rollback()
+        raise
+    except Exception as e:
+        await session.rollback()
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+@router.post("/manual", response_model=InboundReceiptCreateManualOut)
+async def create_inbound_receipt_manual_endpoint(
+    payload: InboundReceiptCreateManualIn,
+    session: AsyncSession = Depends(get_session),
+) -> InboundReceiptCreateManualOut:
+    try:
+        out = await create_inbound_receipt_manual(
+            session,
+            payload=payload,
+            created_by=None,
+        )
+        await session.commit()
+        return out
+    except NotImplementedError as e:
+        await session.rollback()
+        raise HTTPException(status_code=501, detail=str(e)) from e
+    except HTTPException:
+        await session.rollback()
+        raise
+    except Exception as e:
+        await session.rollback()
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+@router.get("/return-source/{order_key}", response_model=InboundReceiptReturnSourceOut)
+async def get_inbound_return_source_endpoint(
+    order_key: str,
+    session: AsyncSession = Depends(get_session),
+) -> InboundReceiptReturnSourceOut:
+    try:
+        return await get_inbound_return_source(session, order_key=order_key)
+    except NotImplementedError as e:
+        raise HTTPException(status_code=501, detail=str(e)) from e
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+@router.post("/from-return-order", response_model=InboundReceiptCreateFromReturnOrderOut)
+async def create_inbound_receipt_from_return_order_endpoint(
+    payload: InboundReceiptCreateFromReturnOrderIn,
+    session: AsyncSession = Depends(get_session),
+) -> InboundReceiptCreateFromReturnOrderOut:
+    try:
+        out = await create_inbound_receipt_from_return_order(
             session,
             payload=payload,
             created_by=None,

--- a/app/inbound_receipts/services/create_from_return_order_service.py
+++ b/app/inbound_receipts/services/create_from_return_order_service.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.inbound_receipts.contracts.receipt_create_from_return_order import (
+    InboundReceiptCreateFromReturnOrderIn,
+    InboundReceiptCreateFromReturnOrderOut,
+)
+from app.inbound_receipts.repos.inbound_receipt_write_repo import (
+    create_inbound_receipt_from_return_order_repo,
+)
+
+
+async def create_inbound_receipt_from_return_order(
+    session: AsyncSession,
+    *,
+    payload: InboundReceiptCreateFromReturnOrderIn,
+    created_by: int | None = None,
+) -> InboundReceiptCreateFromReturnOrderOut:
+    return await create_inbound_receipt_from_return_order_repo(
+        session,
+        payload=payload,
+        created_by=created_by,
+    )

--- a/app/inbound_receipts/services/create_manual_service.py
+++ b/app/inbound_receipts/services/create_manual_service.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.inbound_receipts.contracts.receipt_create_manual import (
+    InboundReceiptCreateManualIn,
+    InboundReceiptCreateManualOut,
+)
+from app.inbound_receipts.repos.inbound_receipt_write_repo import (
+    create_inbound_receipt_manual_repo,
+)
+
+
+async def create_inbound_receipt_manual(
+    session: AsyncSession,
+    *,
+    payload: InboundReceiptCreateManualIn,
+    created_by: int | None = None,
+) -> InboundReceiptCreateManualOut:
+    return await create_inbound_receipt_manual_repo(
+        session,
+        payload=payload,
+        created_by=created_by,
+    )
+
+
+__all__ = [
+    "create_inbound_receipt_manual",
+]

--- a/app/inbound_receipts/services/return_source_service.py
+++ b/app/inbound_receipts/services/return_source_service.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.inbound_receipts.contracts.receipt_return_source import InboundReceiptReturnSourceOut
+from app.inbound_receipts.repos.inbound_receipt_read_repo import get_inbound_return_source_repo
+
+
+async def get_inbound_return_source(
+    session: AsyncSession,
+    *,
+    order_key: str,
+) -> InboundReceiptReturnSourceOut:
+    return await get_inbound_return_source_repo(session, order_key=order_key)

--- a/app/models/page_registry.py
+++ b/app/models/page_registry.py
@@ -23,7 +23,7 @@ class PageRegistry(Base):
 
     __table_args__ = (
         CheckConstraint(
-            "domain_code IN ('analytics', 'oms', 'pms', 'procurement', 'wms', 'tms', 'admin')",
+            "domain_code IN ('analytics', 'oms', 'pms', 'procurement', 'wms', 'tms', 'admin', 'inbound')",
             name="ck_page_registry_domain_code",
         ),
         CheckConstraint(

--- a/tests/api/test_inbound_receipts_manual_api.py
+++ b/tests/api/test_inbound_receipts_manual_api.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import httpx
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def _login_admin_headers(client: httpx.AsyncClient) -> dict[str, str]:
+    r = await client.post("/users/login", json={"username": "admin", "password": "admin123"})
+    assert r.status_code == 200, r.text
+    token = r.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _pick_active_warehouse_id(session: AsyncSession) -> int:
+    row = await session.execute(
+        text(
+            """
+            SELECT id
+              FROM warehouses
+             WHERE COALESCE(active, true) = true
+             ORDER BY id
+             LIMIT 1
+            """
+        )
+    )
+    wid = row.scalar_one_or_none()
+    assert wid is not None, "no active warehouse found"
+    return int(wid)
+
+
+async def _pick_enabled_item_with_uom(session: AsyncSession) -> dict[str, Any]:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  i.id AS item_id,
+                  i.name AS item_name,
+                  i.spec AS item_spec,
+                  u.id AS item_uom_id,
+                  COALESCE(NULLIF(u.display_name, ''), u.uom) AS uom_name,
+                  u.ratio_to_base AS ratio_to_base
+                FROM items i
+                JOIN item_uoms u
+                  ON u.item_id = i.id
+                WHERE COALESCE(i.enabled, true) = true
+                ORDER BY
+                  CASE WHEN u.is_inbound_default THEN 0 WHEN u.is_base THEN 1 ELSE 2 END,
+                  i.id,
+                  u.id
+                LIMIT 1
+                """
+            )
+        )
+    ).mappings().first()
+    assert row is not None, "no enabled item with uom found"
+    return dict(row)
+
+
+async def _pick_mismatched_item_and_uom(session: AsyncSession) -> tuple[int, int]:
+    first = await _pick_enabled_item_with_uom(session)
+
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  i.id AS item_id,
+                  u.id AS item_uom_id
+                FROM items i
+                JOIN item_uoms u
+                  ON u.item_id = i.id
+                WHERE COALESCE(i.enabled, true) = true
+                  AND i.id <> :item_id
+                ORDER BY i.id, u.id
+                LIMIT 1
+                """
+            ),
+            {"item_id": int(first["item_id"])},
+        )
+    ).mappings().first()
+
+    assert row is not None, "need at least two enabled items with uoms for mismatch test"
+    return int(first["item_id"]), int(row["item_uom_id"])
+
+
+def _assert_manual_line_snapshot(
+    line: dict[str, Any],
+    *,
+    picked: dict[str, Any],
+) -> None:
+    assert line["item_id"] == int(picked["item_id"]), line
+    assert line["item_uom_id"] == int(picked["item_uom_id"]), line
+
+    # ✅ 即使前端传错文案，后端也应以后端真实主数据回填 snapshot
+    assert line["item_name_snapshot"] == str(picked["item_name"]), line
+    assert line["item_spec_snapshot"] == picked["item_spec"], line
+    assert line["uom_name_snapshot"] == str(picked["uom_name"]), line
+
+    ratio = Decimal(str(picked["ratio_to_base"]))
+    assert Decimal(str(line["ratio_to_base_snapshot"])) == ratio, line
+
+
+@pytest.mark.asyncio
+async def test_manual_receipt_create_read_progress_release_contract(
+    client: httpx.AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    warehouse_id = await _pick_active_warehouse_id(session)
+    picked = await _pick_enabled_item_with_uom(session)
+
+    payload = {
+        "warehouse_id": int(warehouse_id),
+        "remark": "UT-MANUAL-RECEIPT",
+        "lines": [
+            {
+                "item_id": int(picked["item_id"]),
+                "item_uom_id": int(picked["item_uom_id"]),
+                "planned_qty": "12",
+                # 故意传错：应由后端真实主数据覆盖
+                "item_name_snapshot": "错误商品名",
+                "item_spec_snapshot": "错误规格",
+                "uom_name_snapshot": "错误单位",
+                "remark": "UT-LINE-1",
+            }
+        ],
+    }
+
+    r = await client.post("/inbound-receipts/manual", json=payload, headers=headers)
+    assert r.status_code == 200, r.text
+    body = r.json()
+
+    assert body["source_type"] == "MANUAL", body
+    assert body["status"] == "DRAFT", body
+    assert body["warehouse_id"] == int(warehouse_id), body
+    assert body["source_doc_id"] is None, body
+    assert body["source_doc_no_snapshot"] is None, body
+    assert body["released_at"] is None, body
+
+    receipt_id = int(body["id"])
+    assert receipt_id > 0, body
+    assert isinstance(body["lines"], list) and len(body["lines"]) == 1, body
+    _assert_manual_line_snapshot(body["lines"][0], picked=picked)
+
+    r2 = await client.get(f"/inbound-receipts/{receipt_id}", headers=headers)
+    assert r2.status_code == 200, r2.text
+    detail = r2.json()
+    assert detail["id"] == receipt_id, detail
+    assert detail["status"] == "DRAFT", detail
+    assert isinstance(detail["lines"], list) and len(detail["lines"]) == 1, detail
+    _assert_manual_line_snapshot(detail["lines"][0], picked=picked)
+
+    r3 = await client.get(f"/inbound-receipts/{receipt_id}/progress", headers=headers)
+    assert r3.status_code == 200, r3.text
+    progress = r3.json()
+
+    assert progress["receipt_id"] == receipt_id, progress
+    assert progress["receipt_no"] == body["receipt_no"], progress
+    assert isinstance(progress["lines"], list) and len(progress["lines"]) == 1, progress
+
+    p0 = progress["lines"][0]
+    assert p0["line_no"] == 1, progress
+    assert Decimal(str(p0["planned_qty"])) == Decimal("12"), progress
+    assert Decimal(str(p0["received_qty"])) == Decimal("0"), progress
+    assert Decimal(str(p0["remaining_qty"])) == Decimal("12"), progress
+
+    r4 = await client.post(f"/inbound-receipts/{receipt_id}/release", json={}, headers=headers)
+    assert r4.status_code == 200, r4.text
+    released = r4.json()
+    assert released["receipt_id"] == receipt_id, released
+    assert released["status"] == "RELEASED", released
+    assert released["released_at"], released
+
+    # ✅ 幂等：重复发布仍返回 RELEASED
+    r5 = await client.post(f"/inbound-receipts/{receipt_id}/release", json={}, headers=headers)
+    assert r5.status_code == 200, r5.text
+    released2 = r5.json()
+    assert released2["receipt_id"] == receipt_id, released2
+    assert released2["status"] == "RELEASED", released2
+    assert released2["released_at"], released2
+
+    r6 = await client.get(f"/inbound-receipts/{receipt_id}", headers=headers)
+    assert r6.status_code == 200, r6.text
+    detail2 = r6.json()
+    assert detail2["status"] == "RELEASED", detail2
+    assert detail2["released_at"], detail2
+    _assert_manual_line_snapshot(detail2["lines"][0], picked=picked)
+
+
+@pytest.mark.asyncio
+async def test_manual_receipt_create_rejects_missing_warehouse(
+    client: httpx.AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    picked = await _pick_enabled_item_with_uom(session)
+
+    payload = {
+        "warehouse_id": 99999999,
+        "remark": "UT-MANUAL-MISSING-WH",
+        "lines": [
+            {
+                "item_id": int(picked["item_id"]),
+                "item_uom_id": int(picked["item_uom_id"]),
+                "planned_qty": "5",
+                "item_name_snapshot": str(picked["item_name"]),
+                "item_spec_snapshot": picked["item_spec"],
+                "uom_name_snapshot": str(picked["uom_name"]),
+            }
+        ],
+    }
+
+    r = await client.post("/inbound-receipts/manual", json=payload, headers=headers)
+    assert r.status_code == 404, r.text
+    body = r.json()
+    assert body["http_status"] == 404, body
+    assert body["context"]["path"] == "/inbound-receipts/manual", body
+    reasons = [str(x.get("reason") or "") for x in body.get("details", [])]
+    assert "warehouse_not_found" in reasons, body
+
+
+@pytest.mark.asyncio
+async def test_manual_receipt_create_rejects_item_uom_item_mismatch(
+    client: httpx.AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    warehouse_id = await _pick_active_warehouse_id(session)
+    item_id, mismatched_uom_id = await _pick_mismatched_item_and_uom(session)
+
+    payload = {
+        "warehouse_id": int(warehouse_id),
+        "remark": "UT-MANUAL-UOM-MISMATCH",
+        "lines": [
+            {
+                "item_id": int(item_id),
+                "item_uom_id": int(mismatched_uom_id),
+                "planned_qty": "3",
+                "item_name_snapshot": "随便写",
+                "item_spec_snapshot": "随便写",
+                "uom_name_snapshot": "随便写",
+            }
+        ],
+    }
+
+    r = await client.post("/inbound-receipts/manual", json=payload, headers=headers)
+    assert r.status_code == 409, r.text
+    body = r.json()
+    assert body["http_status"] == 409, body
+    assert body["context"]["path"] == "/inbound-receipts/manual", body
+    reasons = [str(x.get("reason") or "") for x in body.get("details", [])]
+    assert any(x.startswith("item_uom_item_mismatch:") for x in reasons), body

--- a/tests/api/test_user_navigation_api.py
+++ b/tests/api/test_user_navigation_api.py
@@ -191,6 +191,7 @@ async def test_my_navigation_admin_contains_new_wms_tree_and_filters_legacy_shel
         "wms.inbound.atomic",
         "wms.inbound.purchase",
         "wms.inbound.returns",
+        "wms.inbound.operations",
     ]
     assert _child_codes(nodes["wms.outbound"]) == [
         "wms.outbound.atomic",


### PR DESCRIPTION
## Summary
- add manual inbound receipt create contracts, services and repo/router chain
- add return-source and return-order receipt backend contracts in inbound module
- update inbound root/navigation related backend seed/model expectations
- add/update API tests for inbound manual flow and navigation

## Validation
- make test
