### PR TITLE
feat(wms): integerize receiving quantities and unify returned facts

### DIFF
--- a/alembic/versions/fd46309adb9d_receiving_receipt_qty_integer_cutover.py
+++ b/alembic/versions/fd46309adb9d_receiving_receipt_qty_integer_cutover.py
@@ -1,0 +1,282 @@
+"""receiving_receipt_qty_integer_cutover
+
+Revision ID: fd46309adb9d
+Revises: 2657d08d112c
+Create Date: 2026-04-19 16:37:10.776009
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "fd46309adb9d"
+down_revision: Union[str, Sequence[str], None] = "2657d08d112c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _assert_no_fractional_receipt_rows() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF EXISTS (
+            SELECT 1
+            FROM inbound_receipt_lines
+            WHERE planned_qty <> trunc(planned_qty)
+               OR ratio_to_base_snapshot <> trunc(ratio_to_base_snapshot)
+               OR (planned_qty * ratio_to_base_snapshot) <> trunc(planned_qty * ratio_to_base_snapshot)
+          ) THEN
+            RAISE EXCEPTION
+              'inbound_receipt_lines contains non-integer quantity data; abort integer cutover';
+          END IF;
+        END
+        $$;
+        """
+    )
+
+
+def _assert_no_fractional_operation_rows() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF EXISTS (
+            SELECT 1
+            FROM wms_inbound_operation_lines
+            WHERE actual_qty_input <> trunc(actual_qty_input)
+               OR actual_ratio_to_base_snapshot <> trunc(actual_ratio_to_base_snapshot)
+               OR qty_base <> trunc(qty_base)
+               OR qty_base <> (actual_qty_input * actual_ratio_to_base_snapshot)
+          ) THEN
+            RAISE EXCEPTION
+              'wms_inbound_operation_lines contains non-integer or inconsistent quantity data; abort integer cutover';
+          END IF;
+        END
+        $$;
+        """
+    )
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    _assert_no_fractional_receipt_rows()
+    _assert_no_fractional_operation_rows()
+
+    op.drop_constraint(
+        "ck_inbound_receipt_lines_planned_qty_positive",
+        "inbound_receipt_lines",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_inbound_receipt_lines_ratio_positive",
+        "inbound_receipt_lines",
+        type_="check",
+    )
+
+    op.drop_constraint(
+        "ck_wms_inbound_operation_lines_actual_ratio_positive",
+        "wms_inbound_operation_lines",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_wms_inbound_operation_lines_actual_qty_input_positive",
+        "wms_inbound_operation_lines",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_wms_inbound_operation_lines_actual_qty_base_positive",
+        "wms_inbound_operation_lines",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_wms_inbound_operation_lines_actual_qty_base_consistent",
+        "wms_inbound_operation_lines",
+        type_="check",
+    )
+
+    op.alter_column(
+        "inbound_receipt_lines",
+        "planned_qty",
+        existing_type=sa.Numeric(18, 6),
+        type_=sa.Integer(),
+        postgresql_using="planned_qty::integer",
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "inbound_receipt_lines",
+        "ratio_to_base_snapshot",
+        existing_type=sa.Numeric(18, 6),
+        type_=sa.Integer(),
+        postgresql_using="ratio_to_base_snapshot::integer",
+        existing_nullable=False,
+    )
+
+    op.alter_column(
+        "wms_inbound_operation_lines",
+        "actual_ratio_to_base_snapshot",
+        existing_type=sa.Numeric(18, 6),
+        type_=sa.Integer(),
+        postgresql_using="actual_ratio_to_base_snapshot::integer",
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "wms_inbound_operation_lines",
+        "actual_qty_input",
+        existing_type=sa.Numeric(18, 6),
+        type_=sa.Integer(),
+        postgresql_using="actual_qty_input::integer",
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "wms_inbound_operation_lines",
+        "qty_base",
+        existing_type=sa.Numeric(18, 6),
+        type_=sa.Integer(),
+        postgresql_using="qty_base::integer",
+        existing_nullable=False,
+    )
+
+    op.create_check_constraint(
+        "ck_inbound_receipt_lines_planned_qty_positive",
+        "inbound_receipt_lines",
+        "planned_qty > 0",
+    )
+    op.create_check_constraint(
+        "ck_inbound_receipt_lines_ratio_positive",
+        "inbound_receipt_lines",
+        "ratio_to_base_snapshot > 0",
+    )
+
+    op.create_check_constraint(
+        "ck_wms_inbound_operation_lines_actual_ratio_positive",
+        "wms_inbound_operation_lines",
+        "actual_ratio_to_base_snapshot > 0",
+    )
+    op.create_check_constraint(
+        "ck_wms_inbound_operation_lines_actual_qty_input_positive",
+        "wms_inbound_operation_lines",
+        "actual_qty_input > 0",
+    )
+    op.create_check_constraint(
+        "ck_wms_inbound_operation_lines_actual_qty_base_positive",
+        "wms_inbound_operation_lines",
+        "qty_base > 0",
+    )
+    op.create_check_constraint(
+        "ck_wms_inbound_operation_lines_actual_qty_base_consistent",
+        "wms_inbound_operation_lines",
+        "qty_base = (actual_qty_input * actual_ratio_to_base_snapshot)",
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint(
+        "ck_inbound_receipt_lines_planned_qty_positive",
+        "inbound_receipt_lines",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_inbound_receipt_lines_ratio_positive",
+        "inbound_receipt_lines",
+        type_="check",
+    )
+
+    op.drop_constraint(
+        "ck_wms_inbound_operation_lines_actual_ratio_positive",
+        "wms_inbound_operation_lines",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_wms_inbound_operation_lines_actual_qty_input_positive",
+        "wms_inbound_operation_lines",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_wms_inbound_operation_lines_actual_qty_base_positive",
+        "wms_inbound_operation_lines",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_wms_inbound_operation_lines_actual_qty_base_consistent",
+        "wms_inbound_operation_lines",
+        type_="check",
+    )
+
+    op.alter_column(
+        "inbound_receipt_lines",
+        "planned_qty",
+        existing_type=sa.Integer(),
+        type_=sa.Numeric(18, 6),
+        postgresql_using="planned_qty::numeric(18,6)",
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "inbound_receipt_lines",
+        "ratio_to_base_snapshot",
+        existing_type=sa.Integer(),
+        type_=sa.Numeric(18, 6),
+        postgresql_using="ratio_to_base_snapshot::numeric(18,6)",
+        existing_nullable=False,
+    )
+
+    op.alter_column(
+        "wms_inbound_operation_lines",
+        "actual_ratio_to_base_snapshot",
+        existing_type=sa.Integer(),
+        type_=sa.Numeric(18, 6),
+        postgresql_using="actual_ratio_to_base_snapshot::numeric(18,6)",
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "wms_inbound_operation_lines",
+        "actual_qty_input",
+        existing_type=sa.Integer(),
+        type_=sa.Numeric(18, 6),
+        postgresql_using="actual_qty_input::numeric(18,6)",
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "wms_inbound_operation_lines",
+        "qty_base",
+        existing_type=sa.Integer(),
+        type_=sa.Numeric(18, 6),
+        postgresql_using="qty_base::numeric(18,6)",
+        existing_nullable=False,
+    )
+
+    op.create_check_constraint(
+        "ck_inbound_receipt_lines_planned_qty_positive",
+        "inbound_receipt_lines",
+        "planned_qty > 0",
+    )
+    op.create_check_constraint(
+        "ck_inbound_receipt_lines_ratio_positive",
+        "inbound_receipt_lines",
+        "ratio_to_base_snapshot > 0",
+    )
+
+    op.create_check_constraint(
+        "ck_wms_inbound_operation_lines_actual_ratio_positive",
+        "wms_inbound_operation_lines",
+        "actual_ratio_to_base_snapshot > 0",
+    )
+    op.create_check_constraint(
+        "ck_wms_inbound_operation_lines_actual_qty_input_positive",
+        "wms_inbound_operation_lines",
+        "actual_qty_input > 0",
+    )
+    op.create_check_constraint(
+        "ck_wms_inbound_operation_lines_actual_qty_base_positive",
+        "wms_inbound_operation_lines",
+        "qty_base > 0",
+    )
+    op.create_check_constraint(
+        "ck_wms_inbound_operation_lines_actual_qty_base_consistent",
+        "wms_inbound_operation_lines",
+        "qty_base = (actual_qty_input * actual_ratio_to_base_snapshot)",
+    )

--- a/app/analytics/helpers/orders_stats.py
+++ b/app/analytics/helpers/orders_stats.py
@@ -20,12 +20,13 @@ async def calc_daily_stats(
     计算单日的：
     - 创建订单数（orders.created_at）
     - 发货订单数（ledger 中 ref=ORD:* 且 delta<0 的 distinct ref）
-    - 退货订单数（Receipt 口径：inbound_receipts.source_type='ORDER' 且 status='CONFIRMED' 的 distinct source_id）
+    - 退货订单数（RETURN_ORDER 收货口径：
+      inbound_receipts.source_type='RETURN_ORDER' 且 status='RELEASED'，
+      以 released_at 落在自然日内的 distinct source_doc_id 计数）
 
     ✅ PROD-only（简化口径）：
     - 排除测试店铺（platform_test_shops.code='DEFAULT'，以 store_id 为事实锚点）
     """
-    # 统一按 UTC 自然日计算
     start = datetime.combine(day, time(0, 0, 0), tzinfo=timezone.utc)
     end = start + timedelta(days=1)
 
@@ -42,7 +43,6 @@ async def calc_daily_stats(
         clauses.append("shop_id = :s")
         params["s"] = shop_id
 
-    # PROD-only：测试店铺门禁（store_id）
     clauses.append(
         """
         NOT EXISTS (
@@ -67,8 +67,6 @@ async def calc_daily_stats(
     orders_created = int(created_res.scalar() or 0)
 
     # ----------------- shipped: stock_ledger -> parse ref -> join orders -----------------
-    # ref 形态：ORD:{PLAT}:{shop_id}:{ext_order_no...}
-    # 用 split_part/regexp_replace 解析后 join orders(platform, shop_id, ext_order_no)
     shipped_clauses = [
         "l.occurred_at >= :start",
         "l.occurred_at < :end",
@@ -84,7 +82,6 @@ async def calc_daily_stats(
         shipped_clauses.append("btrim(CAST(o.shop_id AS text)) = btrim(CAST(:s AS text))")
         params2["s"] = shop_id
 
-    # PROD-only：测试店铺门禁（store_id）
     shipped_clauses.append(
         """
         NOT EXISTS (
@@ -112,18 +109,14 @@ async def calc_daily_stats(
     shipped_res = await session.execute(text(sql_shipped), params2)
     orders_shipped = int(shipped_res.scalar() or 0)
 
-    # ----------------- returned: inbound_receipts JOIN orders -----------------
-    # Receipt 终态口径：
-    # - source_type='ORDER'
-    # - status='CONFIRMED'
-    # - occurred_at 落在自然日内（事实发生时间）
+    # ----------------- returned: released RETURN_ORDER receipts -----------------
     params3: dict = {"start": start, "end": end}
     returned_clauses = [
-        "r.source_type = 'ORDER'",
-        "r.status = 'CONFIRMED'",
-        "r.source_id IS NOT NULL",
-        "r.occurred_at >= :start",
-        "r.occurred_at < :end",
+        "r.source_type = 'RETURN_ORDER'",
+        "r.status = 'RELEASED'",
+        "r.source_doc_id IS NOT NULL",
+        "r.released_at >= :start",
+        "r.released_at < :end",
     ]
     if plat:
         returned_clauses.append("o.platform = :p")
@@ -132,7 +125,6 @@ async def calc_daily_stats(
         returned_clauses.append("o.shop_id = :s")
         params3["s"] = shop_id
 
-    # PROD-only：测试店铺门禁（store_id）
     returned_clauses.append(
         """
         NOT EXISTS (
@@ -149,10 +141,10 @@ async def calc_daily_stats(
 
     where_sql3 = "WHERE " + " AND ".join(returned_clauses)
     sql_returned = f"""
-        SELECT COUNT(DISTINCT r.source_id) AS c
+        SELECT COUNT(DISTINCT r.source_doc_id) AS c
           FROM inbound_receipts AS r
           JOIN orders AS o
-            ON o.id = r.source_id
+            ON o.id = r.source_doc_id
           {where_sql3}
     """
     returned_res = await session.execute(text(sql_returned), params3)

--- a/app/inbound_receipts/contracts/receipt_create_from_return_order.py
+++ b/app/inbound_receipts/contracts/receipt_create_from_return_order.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from decimal import Decimal
 from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -19,7 +18,7 @@ class _Base(BaseModel):
 class InboundReceiptCreateFromReturnOrderLineIn(_Base):
     order_line_id: Annotated[int, Field(ge=1, description="订单行 ID")]
     item_id: Annotated[int, Field(ge=1, description="商品 ID")]
-    planned_qty: Annotated[Decimal, Field(gt=0, description="本次退货入库数量")]
+    planned_qty: Annotated[int, Field(ge=1, description="本次退货入库数量（整数）")]
     remark: Annotated[str | None, Field(default=None, max_length=500, description="行备注")]
 
 

--- a/app/inbound_receipts/contracts/receipt_create_manual.py
+++ b/app/inbound_receipts/contracts/receipt_create_manual.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from decimal import Decimal
 from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -19,7 +18,7 @@ class _Base(BaseModel):
 class InboundReceiptCreateManualLineIn(_Base):
     item_id: Annotated[int, Field(ge=1, description="商品 ID")]
     item_uom_id: Annotated[int, Field(ge=1, description="包装单位 ID")]
-    planned_qty: Annotated[Decimal, Field(gt=0, description="任务数量")]
+    planned_qty: Annotated[int, Field(ge=1, description="任务数量（整数）")]
     item_name_snapshot: Annotated[str | None, Field(default=None, max_length=255, description="商品名（前端展示传入，可空）")]
     item_spec_snapshot: Annotated[str | None, Field(default=None, max_length=255, description="规格（前端展示传入，可空）")]
     uom_name_snapshot: Annotated[str | None, Field(default=None, max_length=64, description="单位名（前端展示传入，可空）")]

--- a/app/inbound_receipts/contracts/receipt_read.py
+++ b/app/inbound_receipts/contracts/receipt_read.py
@@ -26,11 +26,11 @@ class InboundReceiptLineReadOut(_Base):
     source_line_id: Annotated[int | None, Field(default=None, ge=1, description="来源行 ID")]
     item_id: Annotated[int, Field(ge=1, description="商品 ID")]
     item_uom_id: Annotated[int, Field(ge=1, description="包装单位 ID")]
-    planned_qty: Annotated[Decimal, Field(gt=0, description="任务数量")]
+    planned_qty: Annotated[int, Field(ge=1, description="任务数量（整数）")]
     item_name_snapshot: Annotated[str | None, Field(default=None, max_length=255, description="商品名快照")]
     item_spec_snapshot: Annotated[str | None, Field(default=None, max_length=255, description="规格快照")]
     uom_name_snapshot: Annotated[str | None, Field(default=None, max_length=64, description="单位名快照")]
-    ratio_to_base_snapshot: Annotated[Decimal, Field(gt=0, description="倍率快照")]
+    ratio_to_base_snapshot: Annotated[int, Field(ge=1, description="倍率快照（整数）")]
     remark: Annotated[str | None, Field(default=None, max_length=500, description="行备注")]
 
 
@@ -72,9 +72,9 @@ class InboundReceiptListOut(_Base):
 
 class InboundReceiptProgressLineOut(_Base):
     line_no: Annotated[int, Field(ge=1, description="任务行号")]
-    planned_qty: Annotated[Decimal, Field(ge=0, description="任务数量")]
-    received_qty: Annotated[Decimal, Field(ge=0, description="累计已收")]
-    remaining_qty: Annotated[Decimal, Field(ge=0, description="剩余待收")]
+    planned_qty: Annotated[int, Field(ge=0, description="任务数量（整数）")]
+    received_qty: Annotated[Decimal, Field(ge=0, description="累计已收（按计划包装折算，可能为小数）")]
+    remaining_qty: Annotated[Decimal, Field(ge=0, description="剩余待收（按计划包装折算，可能为小数）")]
 
 
 class InboundReceiptProgressOut(_Base):

--- a/app/inbound_receipts/contracts/receipt_return_source.py
+++ b/app/inbound_receipts/contracts/receipt_return_source.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from decimal import Decimal
 from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -23,12 +22,12 @@ class InboundReceiptReturnSourceLineOut(_Base):
     item_spec_snapshot: Annotated[str | None, Field(default=None, max_length=255, description="规格快照")]
     item_uom_id: Annotated[int, Field(ge=1, description="建议入库包装单位 ID")]
     uom_name_snapshot: Annotated[str | None, Field(default=None, max_length=64, description="建议入库单位名")]
-    ratio_to_base_snapshot: Annotated[Decimal, Field(gt=0, description="建议入库倍率快照")]
-    qty_ordered: Annotated[Decimal, Field(ge=0, description="下单数量")]
-    qty_shipped: Annotated[Decimal, Field(ge=0, description="已发数量")]
-    qty_returned: Annotated[Decimal, Field(ge=0, description="已退数量")]
-    qty_remaining_refundable: Annotated[Decimal, Field(ge=0, description="剩余可退数量")]
-    suggested_planned_qty: Annotated[Decimal, Field(ge=0, description="建议本次生成数量")]
+    ratio_to_base_snapshot: Annotated[int, Field(ge=1, description="建议入库倍率快照（整数）")]
+    qty_ordered: Annotated[int, Field(ge=0, description="下单数量（整数）")]
+    qty_shipped: Annotated[int, Field(ge=0, description="已发数量（整数）")]
+    qty_returned: Annotated[int, Field(ge=0, description="已退数量（整数）")]
+    qty_remaining_refundable: Annotated[int, Field(ge=0, description="剩余可退数量（整数）")]
+    suggested_planned_qty: Annotated[int, Field(ge=0, description="建议本次生成数量（整数）")]
 
 
 class InboundReceiptReturnSourceOut(_Base):
@@ -39,7 +38,7 @@ class InboundReceiptReturnSourceOut(_Base):
     ext_order_no: Annotated[str | None, Field(default=None, max_length=128, description="原订单号")]
     warehouse_id: Annotated[int, Field(ge=1, description="退货入库仓库 ID")]
     warehouse_name_snapshot: Annotated[str | None, Field(default=None, max_length=255, description="仓库名快照")]
-    remaining_qty: Annotated[Decimal, Field(ge=0, description="整单剩余可退数量")]
+    remaining_qty: Annotated[int, Field(ge=0, description="整单剩余可退数量（整数）")]
     existing_receipt_id: Annotated[int | None, Field(default=None, ge=1, description="已存在退货入库单 ID")]
     existing_receipt_no: Annotated[str | None, Field(default=None, max_length=64, description="已存在退货入库单号")]
     existing_receipt_status: InboundReceiptStatus | None = Field(default=None, description="已存在退货入库单状态")

--- a/app/inbound_receipts/models/inbound_receipt.py
+++ b/app/inbound_receipts/models/inbound_receipt.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Integer, Numeric, String, UniqueConstraint
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
@@ -108,12 +108,12 @@ class InboundReceiptLine(Base):
         nullable=False,
     )
 
-    planned_qty: Mapped[float] = mapped_column(Numeric(18, 6), nullable=False)
+    planned_qty: Mapped[int] = mapped_column(Integer, nullable=False)
 
     item_name_snapshot: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     item_spec_snapshot: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     uom_name_snapshot: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
-    ratio_to_base_snapshot: Mapped[float] = mapped_column(Numeric(18, 6), nullable=False)
+    ratio_to_base_snapshot: Mapped[int] = mapped_column(Integer, nullable=False)
 
     remark: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)
 

--- a/app/inbound_receipts/repos/inbound_receipt_read_repo.py
+++ b/app/inbound_receipts/repos/inbound_receipt_read_repo.py
@@ -400,14 +400,14 @@ async def get_inbound_receipt_progress_repo(
                   l.line_no,
                   l.planned_qty,
                   COALESCE(
-                    SUM(COALESCE(ol.qty_base, 0) / l.ratio_to_base_snapshot),
+                    SUM(COALESCE(ol.qty_base, 0)::numeric / NULLIF(l.ratio_to_base_snapshot, 0)::numeric),
                     0
                   ) AS received_qty,
                   COALESCE(
                     GREATEST(
                       (l.planned_qty * l.ratio_to_base_snapshot) - COALESCE(SUM(ol.qty_base), 0),
                       0
-                    ) / l.ratio_to_base_snapshot,
+                    )::numeric / NULLIF(l.ratio_to_base_snapshot, 0)::numeric,
                     0
                   ) AS remaining_qty
                 FROM inbound_receipt_lines l

--- a/app/inbound_receipts/repos/inbound_receipt_write_repo.py
+++ b/app/inbound_receipts/repos/inbound_receipt_write_repo.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from decimal import Decimal
 from uuid import uuid4
 
 from fastapi import HTTPException
@@ -623,8 +622,8 @@ async def create_inbound_receipt_from_return_order_repo(
                 ),
             )
 
-        planned_qty = Decimal(str(line.planned_qty))
-        remaining_qty = Decimal(str(src.qty_remaining_refundable))
+        planned_qty = int(line.planned_qty)
+        remaining_qty = int(src.qty_remaining_refundable)
         if planned_qty > remaining_qty:
             raise HTTPException(
                 status_code=409,

--- a/app/oms/orders/contracts/orders_view_facts.py
+++ b/app/oms/orders/contracts/orders_view_facts.py
@@ -85,7 +85,7 @@ class OrderFactItemOut(BaseModel):
     含义：
     - qty_ordered：订单行要求数量
     - qty_shipped：已出库数量（按 stock_ledger 汇总）
-    - qty_returned：已回仓数量（按 inbound_receipts / lines 汇总）
+    - qty_returned：已回仓数量（按 RETURN_ORDER 收货执行事实汇总）
     - qty_remaining_refundable：剩余可退货数量
     """
 

--- a/app/oms/orders/repos/orders_view_facts_repo.py
+++ b/app/oms/orders/repos/orders_view_facts_repo.py
@@ -280,7 +280,7 @@ async def load_order_facts_full(
     口径：
     - qty_ordered   来自 order_items.qty
     - qty_shipped   来自 stock_ledger(ref=ORD:PLAT:SHOP:EXT, delta<0)
-    - qty_returned  来自 inbound_receipts(source_type='ORDER', status='CONFIRMED')
+    - qty_returned  来自 RETURN_ORDER 收货执行事实（inbound_receipts + wms_inbound_operations + wms_inbound_operation_lines.qty_base）
     - qty_remaining_refundable = max(min(qty_ordered, qty_shipped) - qty_returned, 0)
     """
     head = await load_order_head_by_id(session, order_id=order_id)
@@ -335,15 +335,17 @@ async def load_order_facts_full(
                 text(
                     """
                     SELECT
-                      rl.item_id,
-                      SUM(COALESCE(rl.qty_base, 0)) AS qty_returned
-                    FROM inbound_receipt_lines AS rl
-                    JOIN inbound_receipts AS r
-                      ON r.id = rl.receipt_id
-                    WHERE r.source_type = 'ORDER'
-                      AND r.source_id = :oid
-                      AND r.status = 'CONFIRMED'
-                    GROUP BY rl.item_id
+                      ol.item_id,
+                      SUM(COALESCE(ol.qty_base, 0)) AS qty_returned
+                    FROM inbound_receipts AS r
+                    JOIN wms_inbound_operations AS o
+                      ON o.receipt_no_snapshot = r.receipt_no
+                    JOIN wms_inbound_operation_lines AS ol
+                      ON ol.wms_inbound_operation_id = o.id
+                    WHERE r.source_type = 'RETURN_ORDER'
+                      AND r.source_doc_id = :oid
+                      AND r.status = 'RELEASED'
+                    GROUP BY ol.item_id
                     """
                 ),
                 {"oid": int(order_id)},

--- a/app/wms/receiving/contracts/inbound_task_read.py
+++ b/app/wms/receiving/contracts/inbound_task_read.py
@@ -46,9 +46,9 @@ class InboundTaskListItemOut(_Base):
     status: InboundReceiptStatus
     released_at: datetime | None = Field(default=None, description="发布时间")
     line_count: Annotated[int, Field(ge=0, description="任务行数")]
-    total_planned_qty: Annotated[Decimal, Field(ge=0, description="总任务数量")]
-    total_received_qty: Annotated[Decimal, Field(ge=0, description="累计已收总数")]
-    total_remaining_qty: Annotated[Decimal, Field(ge=0, description="总剩余待收")]
+    total_planned_qty: Annotated[int, Field(ge=0, description="总任务数量（按计划包装，整数）")]
+    total_received_qty: Annotated[Decimal, Field(ge=0, description="累计已收总数（按计划包装折算）")]
+    total_remaining_qty: Annotated[Decimal, Field(ge=0, description="总剩余待收（按计划包装折算）")]
     remark: Annotated[str | None, Field(default=None, max_length=500, description="头备注")]
 
 
@@ -61,8 +61,8 @@ class InboundTaskLineOut(_Base):
     line_no: Annotated[int, Field(ge=1, description="任务行号")]
     item_id: Annotated[int, Field(ge=1, description="商品 ID")]
     item_uom_id: Annotated[int, Field(ge=1, description="计划包装单位 ID")]
-    planned_qty: Annotated[Decimal, Field(ge=0, description="计划包装数量")]
-    planned_qty_base: Annotated[Decimal, Field(ge=0, description="计划基础数量")]
+    planned_qty: Annotated[int, Field(ge=0, description="计划包装数量（整数）")]
+    planned_qty_base: Annotated[int, Field(ge=0, description="计划基础数量（整数）")]
     item_name_snapshot: Annotated[
         str | None,
         Field(default=None, max_length=255, description="商品名快照"),
@@ -75,9 +75,8 @@ class InboundTaskLineOut(_Base):
         str | None,
         Field(default=None, max_length=64, description="计划单位名快照"),
     ]
-    ratio_to_base_snapshot: Annotated[Decimal, Field(gt=0, description="计划倍率快照")]
+    ratio_to_base_snapshot: Annotated[int, Field(ge=1, description="计划倍率快照（整数）")]
 
-    # PMS 执行策略投影
     expiry_policy: ExpiryPolicy = Field(description="有效期策略")
     lot_source_policy: LotSourcePolicy = Field(description="批次来源策略")
     derivation_allowed: bool = Field(description="是否允许按保质期推导日期")
@@ -87,13 +86,11 @@ class InboundTaskLineOut(_Base):
     ]
     shelf_life_unit: ShelfLifeUnit | None = Field(default=None, description="保质期单位")
 
-    # 兼容前端当前展示：把累计已收/待收折回计划包装单位
-    received_qty: Annotated[Decimal, Field(ge=0, description="累计已收（按计划包装折算）")]
-    remaining_qty: Annotated[Decimal, Field(ge=0, description="剩余待收（按计划包装折算）")]
+    received_qty: Annotated[Decimal, Field(ge=0, description="累计已收（按计划包装折算，可能为小数）")]
+    remaining_qty: Annotated[Decimal, Field(ge=0, description="剩余待收（按计划包装折算，可能为小数）")]
 
-    # 真正比较口径：统一按基础数量
-    received_qty_base: Annotated[Decimal, Field(ge=0, description="累计已收基础数量")]
-    remaining_qty_base: Annotated[Decimal, Field(ge=0, description="剩余待收基础数量")]
+    received_qty_base: Annotated[int, Field(ge=0, description="累计已收基础数量（整数）")]
+    remaining_qty_base: Annotated[int, Field(ge=0, description="剩余待收基础数量（整数）")]
 
     remark: Annotated[str | None, Field(default=None, max_length=500, description="行备注")]
 

--- a/app/wms/receiving/contracts/operation_submit.py
+++ b/app/wms/receiving/contracts/operation_submit.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import date, datetime
-from decimal import Decimal
 from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -16,7 +15,7 @@ class _Base(BaseModel):
 
 
 class InboundOperationEntryIn(_Base):
-    qty_inbound: Annotated[Decimal, Field(gt=0, description="本次收货数量（按实际包装）")]
+    qty_inbound: Annotated[int, Field(ge=1, description="本次收货数量（按实际包装，整数）")]
     barcode_input: Annotated[
         str | None,
         Field(default=None, max_length=128, description="扫码原始条码（可选）"),
@@ -69,9 +68,9 @@ class InboundOperationLineOut(_Base):
     item_spec_snapshot: Annotated[str | None, Field(default=None, max_length=255, description="规格快照")]
     actual_item_uom_id: Annotated[int, Field(ge=1, description="实际包装单位 ID")]
     actual_uom_name_snapshot: Annotated[str | None, Field(default=None, max_length=64, description="实际单位名快照")]
-    actual_ratio_to_base_snapshot: Annotated[Decimal, Field(gt=0, description="实际倍率快照")]
-    actual_qty_input: Annotated[Decimal, Field(gt=0, description="本次实际包装数量")]
-    qty_base: Annotated[Decimal, Field(gt=0, description="折算 base 数量")]
+    actual_ratio_to_base_snapshot: Annotated[int, Field(ge=1, description="实际倍率快照（整数）")]
+    actual_qty_input: Annotated[int, Field(ge=1, description="本次实际包装数量（整数）")]
+    qty_base: Annotated[int, Field(ge=1, description="折算 base 数量（整数）")]
     batch_no: Annotated[str | None, Field(default=None, max_length=128, description="批次号")]
     production_date: date | None = Field(default=None, description="生产日期")
     expiry_date: date | None = Field(default=None, description="到期日期")

--- a/app/wms/receiving/models/inbound_operation.py
+++ b/app/wms/receiving/models/inbound_operation.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date as date_type, datetime
 from typing import Optional
 
-from sqlalchemy import CheckConstraint, Date, DateTime, ForeignKey, Integer, Numeric, String
+from sqlalchemy import CheckConstraint, Date, DateTime, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
@@ -107,10 +107,10 @@ class WmsInboundOperationLine(Base):
         nullable=False,
     )
     actual_uom_name_snapshot: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
-    actual_ratio_to_base_snapshot: Mapped[float] = mapped_column(Numeric(18, 6), nullable=False)
+    actual_ratio_to_base_snapshot: Mapped[int] = mapped_column(Integer, nullable=False)
 
-    actual_qty_input: Mapped[float] = mapped_column(Numeric(18, 6), nullable=False)
-    qty_base: Mapped[float] = mapped_column(Numeric(18, 6), nullable=False)
+    actual_qty_input: Mapped[int] = mapped_column(Integer, nullable=False)
+    qty_base: Mapped[int] = mapped_column(Integer, nullable=False)
 
     batch_no: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
     production_date: Mapped[Optional[date_type]] = mapped_column(Date, nullable=True)

--- a/app/wms/receiving/repos/inbound_operation_write_repo.py
+++ b/app/wms/receiving/repos/inbound_operation_write_repo.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from decimal import Decimal
 from uuid import uuid4
 
 from fastapi import HTTPException
@@ -19,11 +18,11 @@ from app.wms.receiving.contracts.operation_submit import (
 UTC = timezone.utc
 
 
-def _to_int_exact(value: Decimal, *, label: str) -> int:
-    if value != value.to_integral_value():
+def _to_int_exact(value: int, *, label: str) -> int:
+    if int(value) < 0:
         raise HTTPException(
             status_code=409,
-            detail=f"{label}_must_be_integer_for_stock_sink:{value}",
+            detail=f"{label}_must_not_be_negative:{value}",
         )
     return int(value)
 
@@ -48,7 +47,7 @@ async def _load_item_uom_snapshot(
     *,
     item_id: int,
     item_uom_id: int,
-) -> tuple[int, str | None, Decimal]:
+) -> tuple[int, str | None, int]:
     row = (
         await session.execute(
             text(
@@ -79,7 +78,7 @@ async def _load_item_uom_snapshot(
     return (
         int(row["actual_item_uom_id"]),
         row["actual_uom_name_snapshot"],
-        Decimal(str(row["actual_ratio_to_base_snapshot"])),
+        int(row["actual_ratio_to_base_snapshot"]),
     )
 
 
@@ -88,7 +87,7 @@ async def _resolve_barcode_uom_snapshot(
     *,
     item_id: int,
     barcode: str,
-) -> tuple[int, str | None, Decimal]:
+) -> tuple[int, str | None, int]:
     code = (barcode or "").strip()
     row = (
         await session.execute(
@@ -125,7 +124,7 @@ async def _resolve_barcode_uom_snapshot(
     return (
         int(row["actual_item_uom_id"]),
         row["actual_uom_name_snapshot"],
-        Decimal(str(row["actual_ratio_to_base_snapshot"])),
+        int(row["actual_ratio_to_base_snapshot"]),
     )
 
 
@@ -325,9 +324,9 @@ async def submit_inbound_operation_repo(
         task_item_id = int(task_line["item_id"])
         task_item_uom_id = int(task_line["item_uom_id"])
         task_uom_name_snapshot = task_line["uom_name_snapshot"]
-        task_ratio = Decimal(str(task_line["ratio_to_base_snapshot"]))
-        planned_qty_base = Decimal(str(task_line["planned_qty_base"]))
-        received_qty_base_running = Decimal(str(task_line["received_qty_base"]))
+        task_ratio = int(task_line["ratio_to_base_snapshot"])
+        planned_qty_base = int(task_line["planned_qty_base"])
+        received_qty_base_running = int(task_line["received_qty_base"])
 
         item_policy = await get_item_policy_by_id(
             session,
@@ -340,7 +339,7 @@ async def submit_inbound_operation_repo(
             )
 
         for entry in line.entries:
-            qty_inbound = Decimal(str(entry.qty_inbound))
+            qty_inbound = int(entry.qty_inbound)
             barcode_input = (
                 str(entry.barcode_input).strip()
                 if entry.barcode_input is not None
@@ -461,9 +460,9 @@ async def submit_inbound_operation_repo(
                         "item_spec_snapshot": task_line["item_spec_snapshot"],
                         "actual_item_uom_id": actual_item_uom_id,
                         "actual_uom_name_snapshot": actual_uom_name_snapshot,
-                        "actual_ratio_to_base_snapshot": actual_ratio,
-                        "actual_qty_input": qty_inbound,
-                        "qty_base": qty_base,
+                        "actual_ratio_to_base_snapshot": actual_ratio_int,
+                        "actual_qty_input": qty_input_int,
+                        "qty_base": qty_base_int,
                         "batch_no": entry.batch_no,
                         "production_date": entry.production_date,
                         "expiry_date": entry.expiry_date,
@@ -632,9 +631,9 @@ async def submit_inbound_operation_repo(
                     item_spec_snapshot=task_line["item_spec_snapshot"],
                     actual_item_uom_id=actual_item_uom_id,
                     actual_uom_name_snapshot=actual_uom_name_snapshot,
-                    actual_ratio_to_base_snapshot=actual_ratio,
-                    actual_qty_input=qty_inbound,
-                    qty_base=qty_base,
+                    actual_ratio_to_base_snapshot=actual_ratio_int,
+                    actual_qty_input=qty_input_int,
+                    qty_base=qty_base_int,
                     batch_no=entry.batch_no,
                     production_date=entry.production_date,
                     expiry_date=entry.expiry_date,

--- a/app/wms/receiving/repos/inbound_task_read_repo.py
+++ b/app/wms/receiving/repos/inbound_task_read_repo.py
@@ -45,7 +45,7 @@ async def list_inbound_tasks_repo(session: AsyncSession) -> InboundTaskListOut:
                   COUNT(l.id) AS line_count,
                   COALESCE(SUM(l.planned_qty), 0) AS total_planned_qty,
                   COALESCE(
-                    SUM(COALESCE(lr.received_qty_base, 0) / l.ratio_to_base_snapshot),
+                    SUM(COALESCE(lr.received_qty_base, 0)::numeric / NULLIF(l.ratio_to_base_snapshot, 0)::numeric),
                     0
                   ) AS total_received_qty,
                   COALESCE(
@@ -53,7 +53,7 @@ async def list_inbound_tasks_repo(session: AsyncSession) -> InboundTaskListOut:
                       GREATEST(
                         (l.planned_qty * l.ratio_to_base_snapshot) - COALESCE(lr.received_qty_base, 0),
                         0
-                      ) / l.ratio_to_base_snapshot
+                      )::numeric / NULLIF(l.ratio_to_base_snapshot, 0)::numeric
                     ),
                     0
                   ) AS total_remaining_qty
@@ -161,11 +161,11 @@ async def get_inbound_task_repo(
                   l.item_spec_snapshot,
                   l.uom_name_snapshot,
                   l.ratio_to_base_snapshot,
-                  (COALESCE(SUM(ol.qty_base), 0) / l.ratio_to_base_snapshot) AS received_qty,
+                  (COALESCE(SUM(ol.qty_base), 0)::numeric / NULLIF(l.ratio_to_base_snapshot, 0)::numeric) AS received_qty,
                   GREATEST(
                     (l.planned_qty * l.ratio_to_base_snapshot) - COALESCE(SUM(ol.qty_base), 0),
                     0
-                  ) / l.ratio_to_base_snapshot AS remaining_qty,
+                  )::numeric / NULLIF(l.ratio_to_base_snapshot, 0)::numeric AS remaining_qty,
                   COALESCE(SUM(ol.qty_base), 0) AS received_qty_base,
                   GREATEST(
                     (l.planned_qty * l.ratio_to_base_snapshot) - COALESCE(SUM(ol.qty_base), 0),

--- a/app/wms/reconciliation/services/order_reconcile_service.py
+++ b/app/wms/reconciliation/services/order_reconcile_service.py
@@ -30,8 +30,8 @@ class OrderReconcileService:
     - 头信息来自 orders；
     - 行信息来自 order_items（qty）；
     - shipped 来自 stock_ledger(ref=ORD:PLAT:SHOP:ext_no, delta<0)；
-    - returned 来自 inbound_receipts(source_type='ORDER', status='CONFIRMED')
-      + inbound_receipt_lines.qty_received（按 item_id 聚合）；
+    - returned 来自 inbound_receipts(source_type='RETURN_ORDER', status='RELEASED')
+      + wms_inbound_operation_lines.qty_base（按 item_id 聚合）；
     - remaining_refundable = max(min(ordered, shipped) - returned, 0)。
 
     提供能力：

--- a/tests/services/test_order_rma_and_reconcile.py
+++ b/tests/services/test_order_rma_and_reconcile.py
@@ -107,13 +107,13 @@ async def _ensure_internal_lot_for_receipt(session: AsyncSession, *, warehouse_i
     )
 
 
-async def _insert_confirmed_order_return_receipt(
+async def _insert_released_return_receipt(
     session: AsyncSession,
     *,
     order_id: int,
     warehouse_id: int,
     item_id: int,
-    qty_received: int,
+    qty_returned: int,
     batch_code: Optional[str],
     production_date: Optional[date],
     expiry_date: Optional[date],
@@ -121,13 +121,13 @@ async def _insert_confirmed_order_return_receipt(
     trace_id: str,
 ) -> int:
     """
-    退货终态口径：用 confirmed InboundReceipt 事实表达 returned。
+    退货终态口径：用 released RETURN_ORDER 收货单与收货执行事实表达 returned。
 
     终态写入：
-    - inbound_receipts: source_type='ORDER', source_id=order_id, status='CONFIRMED'
-    - inbound_receipt_lines: 使用终态列（uom_id + qty_input + ratio_to_base_snapshot + qty_base + lot_id + warehouse_id）
-      且 receipt_status_snapshot='CONFIRMED'（lot_id 必填）
-    - batch_code 仅作为 lot_code_input 展示/输入码；lot_id 才是结构锚点
+    - inbound_receipts: source_type='RETURN_ORDER', source_doc_id=order_id, status='RELEASED'
+    - inbound_receipt_lines: 使用终态列（item_uom_id + planned_qty + ratio_to_base_snapshot）
+    - wms_inbound_operation_lines.qty_base 作为 returned 聚合的执行事实
+    - batch_no 仅作为展示/输入码；lot_id 才是结构锚点
     """
     ref = f"RMA-ORD-{order_id}-{trace_id}-{int(occurred_at.timestamp()*1000)}"
 
@@ -183,7 +183,7 @@ async def _insert_confirmed_order_return_receipt(
     )
 
     uom_id, ratio = await _pick_base_uom_and_ratio(session, item_id=int(item_id))
-    qty_input = int(qty_received)
+    qty_input = int(qty_returned)
     qty_base = int(qty_input) * int(ratio)
 
     if batch_code is not None:
@@ -351,7 +351,7 @@ async def test_rma_cannot_exceed_shipped(session: AsyncSession) -> None:
     场景：
       - 下单 qty=2（item_id=1）；
       - 入库 + 发货 shipped=2（ref=ORD:...）；
-      - 写入一张 confirmed Receipt returned=2 → remaining=0；
+      - 写入一张 released 退货入库单 returned=2 → remaining=0；
       - 再试图追加 returned=1（第二张 Receipt） -> returned>shipped 的问题被识别出来。
     """
     platform = "PDD"
@@ -424,13 +424,13 @@ async def test_rma_cannot_exceed_shipped(session: AsyncSession) -> None:
         expiry_date=ed,
     )
 
-    # 4) 写入一张 confirmed Receipt：returned=2（remaining 应为 0）
-    await _insert_confirmed_order_return_receipt(
+    # 4) 写入一张 released 退货入库单：returned=2（remaining 应为 0）
+    await _insert_released_return_receipt(
         session,
         order_id=order_id,
         warehouse_id=1,
         item_id=item_id,
-        qty_received=2,
+        qty_returned=2,
         batch_code=bc,
         production_date=pd,
         expiry_date=ed,
@@ -448,12 +448,12 @@ async def test_rma_cannot_exceed_shipped(session: AsyncSession) -> None:
     assert lf.remaining_refundable == 0
 
     # 5) 再追加一张 returned=1 的 Receipt → returned=3 > shipped=2
-    await _insert_confirmed_order_return_receipt(
+    await _insert_released_return_receipt(
         session,
         order_id=order_id,
         warehouse_id=1,
         item_id=item_id,
-        qty_received=1,
+        qty_returned=1,
         batch_code=bc,
         production_date=pd,
         expiry_date=ed,
@@ -478,13 +478,13 @@ async def test_rma_receipt_updates_counters_and_status(session: AsyncSession) ->
 
       - 订单 qty=2（item_id=1）；
       - 入库 + 发货 shipped=2；
-      - 写入 returned=1 的 confirmed Receipt；
+      - 写入 returned=1 的 released 退货入库单；
       - OrderReconcileService 能算出 ordered=2, shipped=2, returned=1, remaining=1；
       - apply_counters 将 shipped_qty=2 / returned_qty=1 写回 order_items；
       - orders.status 变为 PARTIALLY_RETURNED。
 
     说明：
-      - returned 的事实源不再是旧执行层 commit，而是 confirmed InboundReceipt。
+      - returned 的事实源不再是旧执行层 commit，而是 released RETURN_ORDER 收货单 + 收货执行事实。
 
     Phase 1A 批次两态：
       - NONE：batch_code=NULL 且 production/expiry=NULL
@@ -558,13 +558,13 @@ async def test_rma_receipt_updates_counters_and_status(session: AsyncSession) ->
         expiry_date=ed,
     )
 
-    # 3) 写入 returned=1 的 confirmed Receipt
-    await _insert_confirmed_order_return_receipt(
+    # 3) 写入 returned=1 的 released 退货入库单
+    await _insert_released_return_receipt(
         session,
         order_id=order_id,
         warehouse_id=1,
         item_id=item_id,
-        qty_received=1,
+        qty_returned=1,
         batch_code=bc,
         production_date=pd,
         expiry_date=ed,

--- a/tests/test_phase3_three_books_receive_commit.py
+++ b/tests/test_phase3_three_books_receive_commit.py
@@ -182,22 +182,22 @@ async def _ensure_internal_lot_for_receipt(
     return int(lot_id)
 
 
-async def _insert_confirmed_receipt_with_line(
+async def _insert_released_receipt_with_line(
     session: AsyncSession,
     *,
     warehouse_id: int,
     item_id: int,
     batch_code: Optional[str],
-    qty_received: int,
+    qty_input: int,
     occurred_at: datetime,
     trace_id: str,
     production_date: Optional[date],
     expiry_date: Optional[date],
 ) -> int:
     """
-    终态 receipt 事实（CONFIRMED）：
+    终态 receipt 事实（RELEASED）：
     - inbound_receipt_lines 使用终态列（uom_id + qty_input + ratio_to_base_snapshot + qty_base + lot_id + warehouse_id）
-    - lot_id 在 CONFIRMED 状态下必须非空
+    - lot_id 在 RELEASED 状态下必须非空
     """
     ref = "RCPT-PH3-UT"
 
@@ -252,7 +252,7 @@ async def _insert_confirmed_receipt_with_line(
     )
 
     uom_id, ratio = await _ensure_base_uom(session, item_id=int(item_id))
-    qty_input = int(qty_received)
+    qty_input = int(qty_input)
     qty_base = int(qty_input) * int(ratio)
 
     if batch_code is not None:
@@ -327,7 +327,7 @@ async def test_phase3_receive_commit_three_books_strict(session: AsyncSession):
     """
     Phase 3 合同测试（终态口径）：
 
-    - 以 Receipt(CONFIRMED) 作为事实锚点（终态不再有旧执行层）
+    - 以 Receipt(RELEASED) 作为事实锚点（终态不再有旧执行层）
     - 以 StockService.adjust(INBOUND) 作为“入库落账动作”写入 ledger+stocks_lot
     - snapshot(today) == stocks_lot（至少对 touched keys）
     - verify_receive_commit_three_books 对 touched effects 做三账一致性校验
@@ -354,13 +354,13 @@ async def test_phase3_receive_commit_three_books_strict(session: AsyncSession):
         prod = None
         exp = None
 
-    # 1) 写入 Receipt 事实（终态：CONFIRMED）
-    await _insert_confirmed_receipt_with_line(
+    # 1) 写入 Receipt 事实（终态：RELEASED）
+    await _insert_released_receipt_with_line(
         session,
         warehouse_id=1,
         item_id=item_id,
         batch_code=batch_code,
-        qty_received=scanned_qty,
+        qty_input=scanned_qty,
         occurred_at=now,
         trace_id="PH3-UT-TRACE",
         production_date=prod,


### PR DESCRIPTION
## Summary
- cut inbound receipt and receiving operation quantity fields over to integer semantics
- align ORM models and receiving/inbound contracts with integer quantity world
- fix receiving read-model packaging projection after integer cutover
- unify returned facts to RETURN_ORDER + RELEASED + qty_base execution facts
- clean remaining receiving-related comments, stats semantics, and tests

## Verification
- python3 -m compileall app/inbound_receipts/contracts/receipt_return_source.py app/inbound_receipts/repos/inbound_receipt_write_repo.py app/wms/receiving/repos/inbound_operation_write_repo.py app/analytics/helpers/orders_stats.py app/oms/orders/contracts/orders_view_facts.py tests/services/test_order_rma_and_reconcile.py tests/test_phase3_three_books_receive_commit.py
- make alembic-check
- make test TESTS="tests/services/test_order_rma_and_reconcile.py tests/test_phase3_three_books_receive_commit.py tests/services/test_inbound_commit_event_link.py tests/api/test_inbound_receipts_manual_api.py"