### PR TITLE
feat(wms-outbound): add lot candidates and upgrade manual doc contract

### DIFF
--- a/alembic/versions/420e8062f56c_manual_outbound_uom_and_snapshots.py
+++ b/alembic/versions/420e8062f56c_manual_outbound_uom_and_snapshots.py
@@ -1,0 +1,160 @@
+"""manual_outbound_uom_and_snapshots
+
+Revision ID: 420e8062f56c
+Revises: d77c6eba9c7e
+Create Date: 2026-04-20 12:10:17.630567
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "420e8062f56c"
+down_revision: Union[str, Sequence[str], None] = "d77c6eba9c7e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1) docs：去掉来源层不再需要的字段
+    op.drop_column("manual_outbound_docs", "recipient_type")
+    op.drop_column("manual_outbound_docs", "recipient_note")
+
+    # 2) lines：增加包装单位与展示快照
+    op.add_column(
+        "manual_outbound_lines",
+        sa.Column("item_uom_id", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "manual_outbound_lines",
+        sa.Column("item_name_snapshot", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "manual_outbound_lines",
+        sa.Column("item_spec_snapshot", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "manual_outbound_lines",
+        sa.Column("uom_name_snapshot", sa.Text(), nullable=True),
+    )
+
+    # 3) 用 item 的 outbound 默认包装 / base 包装回填历史数据
+    op.execute(
+        """
+        UPDATE manual_outbound_lines AS l
+        SET
+          item_uom_id = src.item_uom_id,
+          item_name_snapshot = src.item_name_snapshot,
+          item_spec_snapshot = src.item_spec_snapshot,
+          uom_name_snapshot = src.uom_name_snapshot
+        FROM (
+          SELECT
+            l2.id AS line_id,
+            iu.id AS item_uom_id,
+            i.name AS item_name_snapshot,
+            i.spec AS item_spec_snapshot,
+            COALESCE(iu.display_name, iu.uom) AS uom_name_snapshot
+          FROM manual_outbound_lines AS l2
+          JOIN items AS i
+            ON i.id = l2.item_id
+          JOIN LATERAL (
+            SELECT
+              id,
+              uom,
+              display_name
+            FROM item_uoms
+            WHERE item_id = l2.item_id
+            ORDER BY
+              is_outbound_default DESC,
+              is_base DESC,
+              id ASC
+            LIMIT 1
+          ) AS iu
+            ON TRUE
+        ) AS src
+        WHERE src.line_id = l.id
+        """
+    )
+
+    # 4) 守护：若仍有未回填行，直接失败，避免半吊子迁移
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF EXISTS (
+            SELECT 1
+            FROM manual_outbound_lines
+            WHERE item_uom_id IS NULL
+          ) THEN
+            RAISE EXCEPTION
+              'manual_outbound_lines.item_uom_id backfill failed: some rows have no item_uom';
+          END IF;
+        END
+        $$;
+        """
+    )
+
+    op.alter_column(
+        "manual_outbound_lines",
+        "item_uom_id",
+        existing_type=sa.BigInteger(),
+        nullable=False,
+    )
+
+    op.create_foreign_key(
+        "fk_manual_outbound_lines_item_uom_id",
+        "manual_outbound_lines",
+        "item_uoms",
+        ["item_uom_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.create_index(
+        "ix_manual_outbound_lines_item_uom_id",
+        "manual_outbound_lines",
+        ["item_uom_id"],
+        unique=False,
+    )
+
+    # 5) 行备注不再保留
+    op.drop_column("manual_outbound_lines", "remark")
+
+
+def downgrade() -> None:
+    # 1) 恢复行备注
+    op.add_column(
+        "manual_outbound_lines",
+        sa.Column("remark", sa.Text(), nullable=True),
+    )
+
+    # 2) 去掉包装单位 FK / 索引
+    op.drop_index(
+        "ix_manual_outbound_lines_item_uom_id",
+        table_name="manual_outbound_lines",
+    )
+    op.drop_constraint(
+        "fk_manual_outbound_lines_item_uom_id",
+        "manual_outbound_lines",
+        type_="foreignkey",
+    )
+
+    # 3) 删除新增的行字段
+    op.drop_column("manual_outbound_lines", "uom_name_snapshot")
+    op.drop_column("manual_outbound_lines", "item_spec_snapshot")
+    op.drop_column("manual_outbound_lines", "item_name_snapshot")
+    op.drop_column("manual_outbound_lines", "item_uom_id")
+
+    # 4) 恢复 docs 上的旧字段
+    op.add_column(
+        "manual_outbound_docs",
+        sa.Column("recipient_note", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "manual_outbound_docs",
+        sa.Column("recipient_type", sa.Text(), nullable=True),
+    )

--- a/alembic/versions/97cad3594e6c_tms_pricing_templates_fix_indexes_and_.py
+++ b/alembic/versions/97cad3594e6c_tms_pricing_templates_fix_indexes_and_.py
@@ -5,7 +5,7 @@ Revises: 02a284d9351c
 Create Date: 2026-03-20 13:29:35.143663
 """
 
-from typing import Sequence, Union
+from typing import Any,  Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
@@ -25,17 +25,17 @@ T_MEMBERS = "shipping_provider_pricing_template_destination_group_members"
 T_MATRIX = "shipping_provider_pricing_template_matrix"
 
 
-def _table_exists(insp: sa.Inspector, table_name: str) -> bool:
+def _table_exists(insp: Any, table_name: str) -> bool:
     return table_name in insp.get_table_names()
 
 
-def _index_exists(insp: sa.Inspector, table_name: str, index_name: str) -> bool:
+def _index_exists(insp: Any, table_name: str, index_name: str) -> bool:
     if not _table_exists(insp, table_name):
         return False
     return index_name in {idx["name"] for idx in insp.get_indexes(table_name)}
 
 
-def _unique_exists(insp: sa.Inspector, table_name: str, name: str) -> bool:
+def _unique_exists(insp: Any, table_name: str, name: str) -> bool:
     if not _table_exists(insp, table_name):
         return False
     return name in {c["name"] for c in insp.get_unique_constraints(table_name)}

--- a/alembic/versions/d77c6eba9c7e_manual_outbound_schema_cutover.py
+++ b/alembic/versions/d77c6eba9c7e_manual_outbound_schema_cutover.py
@@ -1,0 +1,183 @@
+"""manual outbound schema cutover
+
+Revision ID: d77c6eba9c7e
+Revises: 9f320f159245
+Create Date: 2026-04-20 11:41:20.908229
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d77c6eba9c7e"
+down_revision: Union[str, Sequence[str], None] = "9f320f159245"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "manual_outbound_docs",
+        "note",
+        new_column_name="remark",
+        existing_type=sa.Text(),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "manual_outbound_docs",
+        "confirmed_by",
+        new_column_name="released_by",
+        existing_type=sa.BigInteger(),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "manual_outbound_docs",
+        "confirmed_at",
+        new_column_name="released_at",
+        existing_type=sa.DateTime(timezone=True),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "manual_outbound_docs",
+        "canceled_by",
+        new_column_name="voided_by",
+        existing_type=sa.BigInteger(),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "manual_outbound_docs",
+        "canceled_at",
+        new_column_name="voided_at",
+        existing_type=sa.DateTime(timezone=True),
+        existing_nullable=True,
+    )
+
+    op.alter_column(
+        "manual_outbound_lines",
+        "note",
+        new_column_name="remark",
+        existing_type=sa.Text(),
+        existing_nullable=True,
+    )
+    op.drop_column("manual_outbound_lines", "batch_code")
+    op.drop_column("manual_outbound_lines", "confirmed_qty")
+
+    for name in (
+        "internal_outbound_docs_created_by_fkey",
+        "internal_outbound_docs_recipient_id_fkey",
+        "internal_outbound_docs_confirmed_by_fkey",
+        "internal_outbound_docs_canceled_by_fkey",
+    ):
+        try:
+            op.drop_constraint(name, "manual_outbound_docs", type_="foreignkey")
+        except Exception:
+            pass
+
+    op.execute(
+        "ALTER SEQUENCE IF EXISTS internal_outbound_docs_id_seq "
+        "RENAME TO manual_outbound_docs_id_seq"
+    )
+    op.execute(
+        "ALTER SEQUENCE IF EXISTS internal_outbound_lines_id_seq "
+        "RENAME TO manual_outbound_lines_id_seq"
+    )
+
+    try:
+        op.execute(
+            "ALTER TABLE manual_outbound_docs "
+            "RENAME CONSTRAINT internal_outbound_docs_pkey TO manual_outbound_docs_pkey"
+        )
+    except Exception:
+        pass
+
+    try:
+        op.execute(
+            "ALTER TABLE manual_outbound_lines "
+            "RENAME CONSTRAINT internal_outbound_lines_pkey TO manual_outbound_lines_pkey"
+        )
+    except Exception:
+        pass
+
+
+def downgrade() -> None:
+    try:
+        op.execute(
+            "ALTER TABLE manual_outbound_docs "
+            "RENAME CONSTRAINT manual_outbound_docs_pkey TO internal_outbound_docs_pkey"
+        )
+    except Exception:
+        pass
+
+    try:
+        op.execute(
+            "ALTER TABLE manual_outbound_lines "
+            "RENAME CONSTRAINT manual_outbound_lines_pkey TO internal_outbound_lines_pkey"
+        )
+    except Exception:
+        pass
+
+    op.execute(
+        "ALTER SEQUENCE IF EXISTS manual_outbound_docs_id_seq "
+        "RENAME TO internal_outbound_docs_id_seq"
+    )
+    op.execute(
+        "ALTER SEQUENCE IF EXISTS manual_outbound_lines_id_seq "
+        "RENAME TO internal_outbound_lines_id_seq"
+    )
+
+    op.add_column(
+        "manual_outbound_lines",
+        sa.Column("batch_code", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "manual_outbound_lines",
+        sa.Column("confirmed_qty", sa.Integer(), nullable=True),
+    )
+    op.alter_column(
+        "manual_outbound_lines",
+        "remark",
+        new_column_name="note",
+        existing_type=sa.Text(),
+        existing_nullable=True,
+    )
+
+    op.alter_column(
+        "manual_outbound_docs",
+        "remark",
+        new_column_name="note",
+        existing_type=sa.Text(),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "manual_outbound_docs",
+        "released_by",
+        new_column_name="confirmed_by",
+        existing_type=sa.BigInteger(),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "manual_outbound_docs",
+        "released_at",
+        new_column_name="confirmed_at",
+        existing_type=sa.DateTime(timezone=True),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "manual_outbound_docs",
+        "voided_by",
+        new_column_name="canceled_by",
+        existing_type=sa.BigInteger(),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "manual_outbound_docs",
+        "voided_at",
+        new_column_name="canceled_at",
+        existing_type=sa.DateTime(timezone=True),
+        existing_nullable=True,
+    )

--- a/app/router_mount.py
+++ b/app/router_mount.py
@@ -48,6 +48,7 @@ def mount_routers(app: FastAPI, *, enable_dev_routes: bool) -> None:
     from app.wms.outbound.routers.manual_docs import router as manual_docs_router
     from app.wms.outbound.routers.manual_submit import router as manual_submit_router
     from app.wms.outbound.routers.outbound_summary import router as outbound_summary_router
+    from app.wms.outbound.routers.lot_candidates import router as outbound_lot_candidates_router
     from app.wms.outbound.routers.print_jobs import router as print_jobs_router
     from app.procurement.routers.purchase_orders import router as purchase_orders_router
     from app.procurement.routers.purchase_reports import router as purchase_reports_router
@@ -110,6 +111,7 @@ def mount_routers(app: FastAPI, *, enable_dev_routes: bool) -> None:
     app.include_router(order_submit_router)
     app.include_router(manual_docs_router)
     app.include_router(manual_submit_router)
+    app.include_router(outbound_lot_candidates_router)
     app.include_router(outbound_summary_router)
     app.include_router(tms_shipment_router)
 

--- a/app/wms/outbound/contracts/lot_candidates.py
+++ b/app/wms/outbound/contracts/lot_candidates.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(
+        from_attributes=True,
+        extra="ignore",
+        populate_by_name=True,
+    )
+
+
+class OutboundLotCandidateOut(_Base):
+    lot_id: Annotated[int, Field(ge=1)]
+    lot_code: str | None = None
+    production_date: date | None = None
+    expiry_date: date | None = None
+    available_qty: Annotated[int, Field(ge=0)]
+
+
+class OutboundLotCandidatesOut(_Base):
+    warehouse_id: Annotated[int, Field(ge=1)]
+    item_id: Annotated[int, Field(ge=1)]
+    candidates: list[OutboundLotCandidateOut] = Field(default_factory=list)
+
+
+__all__ = [
+    "OutboundLotCandidateOut",
+    "OutboundLotCandidatesOut",
+]

--- a/app/wms/outbound/contracts/manual_doc.py
+++ b/app/wms/outbound/contracts/manual_doc.py
@@ -10,15 +10,20 @@ from pydantic import BaseModel, ConfigDict, Field
 class ManualOutboundDocLineOut(BaseModel):
     """
     手动出库单据行：来源层
-    - 不承载 batch / confirmed_qty
+    - 只承载商品、包装单位、计划数量
+    - lot / 实际出库数量不在来源层
     """
     model_config = ConfigDict(extra="ignore")
 
     id: int
     line_no: int
     item_id: int
+    item_uom_id: int
     requested_qty: int
-    remark: Optional[str] = None
+
+    item_name_snapshot: Optional[str] = None
+    item_spec_snapshot: Optional[str] = None
+    uom_name_snapshot: Optional[str] = None
 
 
 class ManualOutboundDocOut(BaseModel):
@@ -36,8 +41,6 @@ class ManualOutboundDocOut(BaseModel):
 
     recipient_name: Optional[str] = None
     recipient_id: Optional[int] = None
-    recipient_type: Optional[str] = None
-    recipient_note: Optional[str] = None
 
     remark: Optional[str] = None
 
@@ -57,8 +60,12 @@ class ManualOutboundDocCreateLineIn(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     item_id: int = Field(..., ge=1)
+    item_uom_id: int = Field(..., ge=1)
     requested_qty: int = Field(..., gt=0)
-    remark: Optional[str] = Field(default=None, max_length=255)
+
+    item_name_snapshot: Optional[str] = Field(default=None, max_length=255)
+    item_spec_snapshot: Optional[str] = Field(default=None, max_length=255)
+    uom_name_snapshot: Optional[str] = Field(default=None, max_length=64)
 
 
 class ManualOutboundDocCreateIn(BaseModel):
@@ -68,9 +75,6 @@ class ManualOutboundDocCreateIn(BaseModel):
     doc_type: str = Field(..., min_length=1, max_length=64)
 
     recipient_name: str = Field(..., min_length=1, max_length=255)
-    recipient_type: Optional[str] = Field(default=None, max_length=64)
-    recipient_note: Optional[str] = Field(default=None, max_length=255)
-
     remark: Optional[str] = Field(default=None, max_length=255)
 
     lines: List[ManualOutboundDocCreateLineIn] = Field(default_factory=list)

--- a/app/wms/outbound/repos/manual_doc_repo.py
+++ b/app/wms/outbound/repos/manual_doc_repo.py
@@ -21,8 +21,6 @@ async def create_manual_doc(
     warehouse_id: int,
     doc_type: str,
     recipient_name: str,
-    recipient_type: str | None,
-    recipient_note: str | None,
     remark: str | None,
     created_by: int | None,
     lines: List[Dict[str, Any]],
@@ -37,9 +35,7 @@ async def create_manual_doc(
                   doc_type,
                   status,
                   recipient_name,
-                  recipient_type,
-                  recipient_note,
-                  note,
+                  remark,
                   created_by,
                   created_at
                 )
@@ -49,9 +45,7 @@ async def create_manual_doc(
                   :doc_type,
                   'DRAFT',
                   :recipient_name,
-                  :recipient_type,
-                  :recipient_note,
-                  :note,
+                  :remark,
                   :created_by,
                   now()
                 )
@@ -63,9 +57,7 @@ async def create_manual_doc(
                 "doc_no": _gen_doc_no(),
                 "doc_type": str(doc_type).strip(),
                 "recipient_name": str(recipient_name).strip(),
-                "recipient_type": str(recipient_type).strip() if recipient_type else None,
-                "recipient_note": str(recipient_note).strip() if recipient_note else None,
-                "note": str(remark).strip() if remark else None,
+                "remark": str(remark).strip() if remark else None,
                 "created_by": int(created_by) if created_by is not None else None,
             },
         )
@@ -84,15 +76,21 @@ async def create_manual_doc(
                   doc_id,
                   line_no,
                   item_id,
+                  item_uom_id,
                   requested_qty,
-                  note
+                  item_name_snapshot,
+                  item_spec_snapshot,
+                  uom_name_snapshot
                 )
                 VALUES (
                   :doc_id,
                   :line_no,
                   :item_id,
+                  :item_uom_id,
                   :requested_qty,
-                  :note
+                  :item_name_snapshot,
+                  :item_spec_snapshot,
+                  :uom_name_snapshot
                 )
                 """
             ),
@@ -100,8 +98,23 @@ async def create_manual_doc(
                 "doc_id": doc_id,
                 "line_no": int(line_no),
                 "item_id": int(ln["item_id"]),
+                "item_uom_id": int(ln["item_uom_id"]),
                 "requested_qty": int(ln["requested_qty"]),
-                "note": str(ln["remark"]).strip() if ln.get("remark") else None,
+                "item_name_snapshot": (
+                    str(ln["item_name_snapshot"]).strip()
+                    if ln.get("item_name_snapshot")
+                    else None
+                ),
+                "item_spec_snapshot": (
+                    str(ln["item_spec_snapshot"]).strip()
+                    if ln.get("item_spec_snapshot")
+                    else None
+                ),
+                "uom_name_snapshot": (
+                    str(ln["uom_name_snapshot"]).strip()
+                    if ln.get("uom_name_snapshot")
+                    else None
+                ),
             },
         )
         line_no += 1
@@ -128,15 +141,13 @@ async def list_manual_docs(
                       d.status,
                       d.recipient_name,
                       d.recipient_id,
-                      d.recipient_type,
-                      d.recipient_note,
-                      d.note AS remark,
+                      d.remark,
                       d.created_by,
                       d.created_at,
-                      d.confirmed_by AS released_by,
-                      d.confirmed_at AS released_at,
-                      d.canceled_by AS voided_by,
-                      d.canceled_at AS voided_at
+                      d.released_by,
+                      d.released_at,
+                      d.voided_by,
+                      d.voided_at
                     FROM manual_outbound_docs d
                     ORDER BY d.created_at DESC, d.id DESC
                     LIMIT :limit OFFSET :offset
@@ -169,15 +180,13 @@ async def get_manual_doc_head(
                       d.status,
                       d.recipient_name,
                       d.recipient_id,
-                      d.recipient_type,
-                      d.recipient_note,
-                      d.note AS remark,
+                      d.remark,
                       d.created_by,
                       d.created_at,
-                      d.confirmed_by AS released_by,
-                      d.confirmed_at AS released_at,
-                      d.canceled_by AS voided_by,
-                      d.canceled_at AS voided_at
+                      d.released_by,
+                      d.released_at,
+                      d.voided_by,
+                      d.voided_at
                     FROM manual_outbound_docs d
                     WHERE d.id = :doc_id
                     LIMIT 1
@@ -208,8 +217,11 @@ async def get_manual_doc_lines(
                       l.id,
                       l.line_no,
                       l.item_id,
+                      l.item_uom_id,
                       l.requested_qty,
-                      l.note AS remark
+                      l.item_name_snapshot,
+                      l.item_spec_snapshot,
+                      l.uom_name_snapshot
                     FROM manual_outbound_lines l
                     WHERE l.doc_id = :doc_id
                     ORDER BY l.line_no ASC, l.id ASC
@@ -230,7 +242,6 @@ async def release_manual_doc(
     doc_id: int,
     released_by: int | None,
 ) -> None:
-    # 至少一行
     row = (
         await session.execute(
             text(
@@ -252,8 +263,8 @@ async def release_manual_doc(
             UPDATE manual_outbound_docs
             SET
               status = 'RELEASED',
-              confirmed_by = :released_by,
-              confirmed_at = now()
+              released_by = :released_by,
+              released_at = now()
             WHERE id = :doc_id
               AND status = 'DRAFT'
             """
@@ -279,8 +290,8 @@ async def void_manual_doc(
             UPDATE manual_outbound_docs
             SET
               status = 'VOIDED',
-              canceled_by = :voided_by,
-              canceled_at = now()
+              voided_by = :voided_by,
+              voided_at = now()
             WHERE id = :doc_id
               AND status IN ('DRAFT', 'RELEASED')
             """

--- a/app/wms/outbound/repos/outbound_lot_candidate_repo.py
+++ b/app/wms/outbound/repos/outbound_lot_candidate_repo.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def query_outbound_lot_candidates(
+    session: AsyncSession,
+    *,
+    warehouse_id: int,
+    item_id: int,
+) -> list[dict[str, Any]]:
+    sql = text(
+        """
+        SELECT
+          s.lot_id,
+          l.lot_code AS lot_code,
+          l.production_date AS production_date,
+          l.expiry_date AS expiry_date,
+          s.qty AS available_qty
+        FROM stocks_lot AS s
+        LEFT JOIN lots AS l
+          ON l.id = s.lot_id
+        WHERE s.warehouse_id = :warehouse_id
+          AND s.item_id = :item_id
+          AND s.qty > 0
+        ORDER BY
+          l.expiry_date ASC NULLS LAST,
+          l.production_date ASC NULLS LAST,
+          l.lot_code ASC NULLS LAST,
+          s.lot_id ASC
+        """
+    )
+    rows = (
+        await session.execute(
+            sql,
+            {
+                "warehouse_id": int(warehouse_id),
+                "item_id": int(item_id),
+            },
+        )
+    ).mappings().all()
+    return [dict(r) for r in rows]
+
+
+__all__ = ["query_outbound_lot_candidates"]

--- a/app/wms/outbound/routers/lot_candidates.py
+++ b/app/wms/outbound/routers/lot_candidates.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.deps import get_async_session as get_session
+from app.user.deps.auth import get_current_user
+from app.wms.outbound.contracts.lot_candidates import OutboundLotCandidatesOut
+from app.wms.outbound.services.outbound_lot_candidate_service import (
+    OutboundLotCandidateService,
+)
+
+router = APIRouter(prefix="/wms/outbound", tags=["wms-outbound-lot-candidates"])
+
+
+@router.get("/lot-candidates", response_model=OutboundLotCandidatesOut)
+async def get_outbound_lot_candidates(
+    warehouse_id: int = Query(..., ge=1),
+    item_id: int = Query(..., ge=1),
+    session: AsyncSession = Depends(get_session),
+    user=Depends(get_current_user),
+) -> OutboundLotCandidatesOut:
+    return await OutboundLotCandidateService.get_candidates(
+        session,
+        warehouse_id=int(warehouse_id),
+        item_id=int(item_id),
+    )

--- a/app/wms/outbound/routers/manual_docs.py
+++ b/app/wms/outbound/routers/manual_docs.py
@@ -44,8 +44,6 @@ async def create_manual_outbound_doc(
         warehouse_id=int(payload.warehouse_id),
         doc_type=payload.doc_type,
         recipient_name=payload.recipient_name,
-        recipient_type=payload.recipient_type,
-        recipient_note=payload.recipient_note,
         remark=payload.remark,
         created_by=getattr(user, "id", None),
         lines=[x.model_dump() for x in payload.lines],

--- a/app/wms/outbound/services/outbound_lot_candidate_service.py
+++ b/app/wms/outbound/services/outbound_lot_candidate_service.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.wms.outbound.contracts.lot_candidates import (
+    OutboundLotCandidateOut,
+    OutboundLotCandidatesOut,
+)
+from app.wms.outbound.repos.outbound_lot_candidate_repo import (
+    query_outbound_lot_candidates,
+)
+
+
+class OutboundLotCandidateService:
+    @classmethod
+    async def get_candidates(
+        cls,
+        session: AsyncSession,
+        *,
+        warehouse_id: int,
+        item_id: int,
+    ) -> OutboundLotCandidatesOut:
+        rows = await query_outbound_lot_candidates(
+            session,
+            warehouse_id=int(warehouse_id),
+            item_id=int(item_id),
+        )
+        return OutboundLotCandidatesOut(
+            warehouse_id=int(warehouse_id),
+            item_id=int(item_id),
+            candidates=[OutboundLotCandidateOut(**row) for row in rows],
+        )
+
+
+__all__ = ["OutboundLotCandidateService"]

--- a/tests/api/test_manual_outbound_docs_api.py
+++ b/tests/api/test_manual_outbound_docs_api.py
@@ -18,21 +18,27 @@ async def _login_admin_headers(client: AsyncClient) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
-async def _pick_any_item_id(session: AsyncSession) -> int:
+async def _pick_any_item_and_uom(session: AsyncSession) -> tuple[int, int, str, str | None]:
     row = (
         await session.execute(
             text(
                 """
-                SELECT id
-                FROM items
-                ORDER BY id ASC
+                SELECT
+                  i.id AS item_id,
+                  iu.id AS item_uom_id,
+                  COALESCE(iu.display_name, iu.uom) AS uom_name,
+                  i.spec AS item_spec
+                FROM items i
+                JOIN item_uoms iu
+                  ON iu.item_id = i.id
+                ORDER BY iu.is_outbound_default DESC, iu.is_base DESC, i.id ASC, iu.id ASC
                 LIMIT 1
                 """
             )
         )
-    ).first()
-    assert row is not None, "expected at least one item in baseline"
-    return int(row[0])
+    ).mappings().first()
+    assert row is not None, "expected at least one item_uom in baseline"
+    return int(row["item_id"]), int(row["item_uom_id"]), str(row["uom_name"]), row["item_spec"]
 
 
 async def _ensure_warehouse(session: AsyncSession, warehouse_id: int = 1) -> int:
@@ -56,9 +62,8 @@ async def test_manual_outbound_docs_create_release_void(
 ) -> None:
     headers = await _login_admin_headers(client)
     warehouse_id = await _ensure_warehouse(session, 1)
-    item_id = await _pick_any_item_id(session)
+    item_id, item_uom_id, uom_name, item_spec = await _pick_any_item_and_uom(session)
 
-    # 1) create
     resp = await client.post(
         "/wms/outbound/manual-docs",
         headers=headers,
@@ -66,14 +71,15 @@ async def test_manual_outbound_docs_create_release_void(
             "warehouse_id": warehouse_id,
             "doc_type": "MANUAL_OUTBOUND",
             "recipient_name": f"张三-{uuid4().hex[:6]}",
-            "recipient_type": "EMPLOYEE",
-            "recipient_note": "测试领用",
             "remark": "整单备注",
             "lines": [
                 {
                     "item_id": item_id,
+                    "item_uom_id": item_uom_id,
                     "requested_qty": 2,
-                    "remark": "行备注"
+                    "item_name_snapshot": "测试商品",
+                    "item_spec_snapshot": item_spec,
+                    "uom_name_snapshot": uom_name,
                 }
             ],
         },
@@ -87,7 +93,6 @@ async def test_manual_outbound_docs_create_release_void(
     assert len(data["lines"]) == 1
     doc_id = int(data["id"])
 
-    # 2) get detail
     resp2 = await client.get(
         f"/wms/outbound/manual-docs/{doc_id}",
         headers=headers,
@@ -98,9 +103,10 @@ async def test_manual_outbound_docs_create_release_void(
     assert data2["status"] == "DRAFT"
     assert len(data2["lines"]) == 1
     assert int(data2["lines"][0]["item_id"]) == item_id
+    assert int(data2["lines"][0]["item_uom_id"]) == item_uom_id
     assert int(data2["lines"][0]["requested_qty"]) == 2
+    assert data2["lines"][0]["uom_name_snapshot"] == uom_name
 
-    # 3) release
     resp3 = await client.post(
         f"/wms/outbound/manual-docs/{doc_id}/release",
         headers=headers,
@@ -110,7 +116,6 @@ async def test_manual_outbound_docs_create_release_void(
     assert data3["id"] == doc_id
     assert data3["status"] == "RELEASED"
 
-    # 4) list
     resp4 = await client.get(
         "/wms/outbound/manual-docs?limit=20&offset=0",
         headers=headers,
@@ -120,7 +125,6 @@ async def test_manual_outbound_docs_create_release_void(
     assert isinstance(items, list)
     assert any(int(x["id"]) == doc_id for x in items)
 
-    # 5) void
     resp5 = await client.post(
         f"/wms/outbound/manual-docs/{doc_id}/void",
         headers=headers,
@@ -130,7 +134,6 @@ async def test_manual_outbound_docs_create_release_void(
     assert data5["id"] == doc_id
     assert data5["status"] == "VOIDED"
 
-    # 6) DB evidence
     row = (
         await session.execute(
             text(

--- a/tests/api/test_manual_outbound_submit_api.py
+++ b/tests/api/test_manual_outbound_submit_api.py
@@ -23,25 +23,39 @@ async def _login_admin_headers(client: AsyncClient) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
-async def _pick_any_item_id(session: AsyncSession) -> tuple[int, bool]:
+async def _pick_any_item_and_uom(session: AsyncSession) -> tuple[int, int, str, str | None, bool]:
     row = (
         await session.execute(
             text(
                 """
-                SELECT id, expiry_policy::text
-                FROM items
+                SELECT
+                  i.id AS item_id,
+                  iu.id AS item_uom_id,
+                  COALESCE(iu.display_name, iu.uom) AS uom_name,
+                  i.spec AS item_spec,
+                  i.expiry_policy::text AS expiry_policy
+                FROM items i
+                JOIN item_uoms iu
+                  ON iu.item_id = i.id
                 ORDER BY
-                  CASE WHEN expiry_policy::text = 'NONE' THEN 0 ELSE 1 END,
-                  id ASC
+                  CASE WHEN i.expiry_policy::text = 'NONE' THEN 0 ELSE 1 END,
+                  iu.is_outbound_default DESC,
+                  iu.is_base DESC,
+                  i.id ASC,
+                  iu.id ASC
                 LIMIT 1
                 """
             )
         )
-    ).first()
+    ).mappings().first()
     assert row is not None
-    item_id = int(row[0])
-    requires_expiry = str(row[1]).strip().upper() == "REQUIRED"
-    return item_id, requires_expiry
+    return (
+        int(row["item_id"]),
+        int(row["item_uom_id"]),
+        str(row["uom_name"]),
+        row["item_spec"],
+        str(row["expiry_policy"]).strip().upper() == "REQUIRED",
+    )
 
 
 async def _ensure_warehouse(session: AsyncSession, warehouse_id: int = 1) -> int:
@@ -61,10 +75,9 @@ async def _ensure_warehouse(session: AsyncSession, warehouse_id: int = 1) -> int
 
 async def _seed_manual_doc_and_stock(session: AsyncSession) -> tuple[int, int, int, int, int]:
     warehouse_id = await _ensure_warehouse(session, 1)
-    item_id, requires_expiry = await _pick_any_item_id(session)
+    item_id, item_uom_id, uom_name, item_spec, requires_expiry = await _pick_any_item_and_uom(session)
     uniq = uuid4().hex[:10]
 
-    # 手动单据头
     row = await session.execute(
         text(
             """
@@ -74,9 +87,7 @@ async def _seed_manual_doc_and_stock(session: AsyncSession) -> tuple[int, int, i
               doc_type,
               status,
               recipient_name,
-              recipient_type,
-              recipient_note,
-              note,
+              remark,
               created_at
             )
             VALUES (
@@ -85,8 +96,6 @@ async def _seed_manual_doc_and_stock(session: AsyncSession) -> tuple[int, int, i
               'MANUAL_OUTBOUND',
               'RELEASED',
               :recipient_name,
-              'EMPLOYEE',
-              '测试领用',
               '整单备注',
               now()
             )
@@ -108,15 +117,21 @@ async def _seed_manual_doc_and_stock(session: AsyncSession) -> tuple[int, int, i
               doc_id,
               line_no,
               item_id,
+              item_uom_id,
               requested_qty,
-              note
+              item_name_snapshot,
+              item_spec_snapshot,
+              uom_name_snapshot
             )
             VALUES (
               :doc_id,
               1,
               :item_id,
+              :item_uom_id,
               2,
-              '行备注'
+              '测试商品',
+              :item_spec_snapshot,
+              :uom_name_snapshot
             )
             RETURNING id
             """
@@ -124,6 +139,9 @@ async def _seed_manual_doc_and_stock(session: AsyncSession) -> tuple[int, int, i
         {
             "doc_id": int(doc_id),
             "item_id": int(item_id),
+            "item_uom_id": int(item_uom_id),
+            "item_spec_snapshot": item_spec,
+            "uom_name_snapshot": uom_name,
         },
     )
     doc_line_id = int(row2.scalar_one())

--- a/tests/api/test_outbound_lot_candidates_api.py
+++ b/tests/api/test_outbound_lot_candidates_api.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests.utils.ensure_minimal import ensure_batch_with_stock
+
+
+async def _login_admin_headers(client: AsyncClient) -> dict[str, str]:
+    r = await client.post("/users/login", json={"username": "admin", "password": "admin123"})
+    assert r.status_code == 200, r.text
+    token = r.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_outbound_lot_candidates_returns_seeded_positive_supplier_lot(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    warehouse_id = 1
+    item_id = 910001
+    batch_code = "UT-OUTBOUND-LOT-CAND-1"
+    qty = 7
+
+    await ensure_batch_with_stock(
+        session,
+        item_id=item_id,
+        warehouse_id=warehouse_id,
+        batch_code=batch_code,
+        qty=qty,
+    )
+    await session.commit()
+
+    headers = await _login_admin_headers(client)
+
+    r = await client.get(
+        "/wms/outbound/lot-candidates",
+        params={"warehouse_id": warehouse_id, "item_id": item_id},
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+
+    data = r.json()
+    assert data["warehouse_id"] == warehouse_id
+    assert data["item_id"] == item_id
+    assert isinstance(data["candidates"], list)
+    assert data["candidates"], "seeded positive supplier lot should be returned"
+
+    matched = next(
+        (row for row in data["candidates"] if row["lot_code"] == batch_code),
+        None,
+    )
+    assert matched is not None, data
+
+    assert isinstance(matched["lot_id"], int)
+    assert matched["lot_id"] >= 1
+    assert matched["available_qty"] == qty
+    assert matched["production_date"] is not None
+    assert matched["expiry_date"] is not None
+
+
+@pytest.mark.asyncio
+async def test_outbound_lot_candidates_rejects_invalid_params(
+    client: AsyncClient,
+) -> None:
+    headers = await _login_admin_headers(client)
+
+    r = await client.get(
+        "/wms/outbound/lot-candidates",
+        params={"warehouse_id": 0, "item_id": 0},
+        headers=headers,
+    )
+    assert r.status_code == 422, r.text

--- a/tests/api/test_outbound_summary_api.py
+++ b/tests/api/test_outbound_summary_api.py
@@ -34,26 +34,32 @@ async def _ensure_warehouse(session: AsyncSession, warehouse_id: int = 1) -> int
     return int(warehouse_id)
 
 
-async def _pick_any_item_id(session: AsyncSession) -> int:
+async def _pick_any_item_and_uom(session: AsyncSession) -> tuple[int, int, str, str | None]:
     row = (
         await session.execute(
             text(
                 """
-                SELECT id
-                FROM items
-                ORDER BY id ASC
+                SELECT
+                  i.id AS item_id,
+                  iu.id AS item_uom_id,
+                  COALESCE(iu.display_name, iu.uom) AS uom_name,
+                  i.spec AS item_spec
+                FROM items i
+                JOIN item_uoms iu
+                  ON iu.item_id = i.id
+                ORDER BY iu.is_outbound_default DESC, iu.is_base DESC, i.id ASC, iu.id ASC
                 LIMIT 1
                 """
             )
         )
-    ).first()
+    ).mappings().first()
     assert row is not None
-    return int(row[0])
+    return int(row["item_id"]), int(row["item_uom_id"]), str(row["uom_name"]), row["item_spec"]
 
 
 async def _seed_order_event(session: AsyncSession, warehouse_id: int) -> int:
     uniq = uuid4().hex[:8]
-    item_id = await _pick_any_item_id(session)
+    item_id, _, _, _ = await _pick_any_item_and_uom(session)
 
     store_id = await ensure_store(
         session,
@@ -140,7 +146,7 @@ async def _seed_order_event(session: AsyncSession, warehouse_id: int) -> int:
 
 async def _seed_manual_event(session: AsyncSession, warehouse_id: int) -> int:
     uniq = uuid4().hex[:8]
-    item_id = await _pick_any_item_id(session)
+    item_id, item_uom_id, uom_name, item_spec = await _pick_any_item_and_uom(session)
 
     row = await session.execute(
         text(
@@ -165,10 +171,12 @@ async def _seed_manual_event(session: AsyncSession, warehouse_id: int) -> int:
         text(
             """
             INSERT INTO manual_outbound_lines (
-              doc_id, line_no, item_id, requested_qty, note
+              doc_id, line_no, item_id, item_uom_id, requested_qty,
+              item_name_snapshot, item_spec_snapshot, uom_name_snapshot
             )
             VALUES (
-              :doc_id, 1, :item_id, 1, 'manual line'
+              :doc_id, 1, :item_id, :item_uom_id, 1,
+              '测试商品', :item_spec_snapshot, :uom_name_snapshot
             )
             RETURNING id
             """
@@ -176,6 +184,9 @@ async def _seed_manual_event(session: AsyncSession, warehouse_id: int) -> int:
         {
             "doc_id": int(doc_id),
             "item_id": int(item_id),
+            "item_uom_id": int(item_uom_id),
+            "item_spec_snapshot": item_spec,
+            "uom_name_snapshot": uom_name,
         },
     )
     doc_line_id = int(row2.scalar_one())


### PR DESCRIPTION
## Summary
- add dedicated `/wms/outbound/lot-candidates` read API
- add outbound lot-candidates API test
- cut manual outbound docs schema over to `remark / released_* / voided_*`
- upgrade manual outbound lines to `item_uom_id + snapshots`
- align manual outbound repo/router/contracts with new source-layer contract
- update outbound summary and manual submit related tests
- patch broken historical alembic revision import so alembic can load revisions normally

## Testing
- make upgrade-dev
- make alembic-check
- make test TESTS=tests/api/test_outbound_lot_candidates_api.py
- make test TESTS=tests/api/test_manual_outbound_docs_api.py
- make test TESTS=tests/api/test_manual_outbound_submit_api.py
- make test TESTS=tests/api/test_outbound_summary_api.py