### PR TITLE
feat(wms-outbound): add sku snapshots to manual docs and event summary

### DIFF
--- a/alembic/versions/d75f3fa5b346_wms_outbound_add_item_sku_snapshot_to_.py
+++ b/alembic/versions/d75f3fa5b346_wms_outbound_add_item_sku_snapshot_to_.py
@@ -1,0 +1,56 @@
+"""wms_outbound_add_item_sku_snapshot_to_manual_doc_and_event_lines
+
+Revision ID: d75f3fa5b346
+Revises: 420e8062f56c
+Create Date: 2026-04-20 14:41:00.015820
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d75f3fa5b346"
+down_revision: Union[str, Sequence[str], None] = "420e8062f56c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "manual_outbound_lines",
+        sa.Column("item_sku_snapshot", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "outbound_event_lines",
+        sa.Column("item_sku_snapshot", sa.String(length=64), nullable=True),
+    )
+
+    op.execute(
+        """
+        UPDATE manual_outbound_lines AS l
+        SET item_sku_snapshot = i.sku
+        FROM items AS i
+        WHERE i.id = l.item_id
+          AND l.item_sku_snapshot IS NULL
+        """
+    )
+
+    op.execute(
+        """
+        UPDATE outbound_event_lines AS l
+        SET item_sku_snapshot = i.sku
+        FROM items AS i
+        WHERE i.id = l.item_id
+          AND l.item_sku_snapshot IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("outbound_event_lines", "item_sku_snapshot")
+    op.drop_column("manual_outbound_lines", "item_sku_snapshot")

--- a/app/wms/outbound/contracts/manual_doc.py
+++ b/app/wms/outbound/contracts/manual_doc.py
@@ -22,6 +22,7 @@ class ManualOutboundDocLineOut(BaseModel):
     requested_qty: int
 
     item_name_snapshot: Optional[str] = None
+    item_sku_snapshot: Optional[str] = None
     item_spec_snapshot: Optional[str] = None
     uom_name_snapshot: Optional[str] = None
 
@@ -64,6 +65,7 @@ class ManualOutboundDocCreateLineIn(BaseModel):
     requested_qty: int = Field(..., gt=0)
 
     item_name_snapshot: Optional[str] = Field(default=None, max_length=255)
+    item_sku_snapshot: Optional[str] = Field(default=None, max_length=64)
     item_spec_snapshot: Optional[str] = Field(default=None, max_length=255)
     uom_name_snapshot: Optional[str] = Field(default=None, max_length=64)
 

--- a/app/wms/outbound/contracts/outbound_summary.py
+++ b/app/wms/outbound/contracts/outbound_summary.py
@@ -42,6 +42,7 @@ class OutboundSummaryLineOut(BaseModel):
     order_line_id: Optional[int] = None
     manual_doc_line_id: Optional[int] = None
     item_name_snapshot: Optional[str] = None
+    item_sku_snapshot: Optional[str] = None
     item_spec_snapshot: Optional[str] = None
     remark: Optional[str] = None
     created_at: datetime

--- a/app/wms/outbound/models/outbound_event.py
+++ b/app/wms/outbound/models/outbound_event.py
@@ -4,7 +4,16 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import BigInteger, DateTime, ForeignKey, Integer, String, CheckConstraint, UniqueConstraint, func
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    UniqueConstraint,
+    func,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
@@ -56,6 +65,7 @@ class OutboundEventLine(Base):
     )
 
     item_name_snapshot: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    item_sku_snapshot: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
     item_spec_snapshot: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     remark: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
 

--- a/app/wms/outbound/repos/manual_doc_repo.py
+++ b/app/wms/outbound/repos/manual_doc_repo.py
@@ -79,6 +79,7 @@ async def create_manual_doc(
                   item_uom_id,
                   requested_qty,
                   item_name_snapshot,
+                  item_sku_snapshot,
                   item_spec_snapshot,
                   uom_name_snapshot
                 )
@@ -89,6 +90,7 @@ async def create_manual_doc(
                   :item_uom_id,
                   :requested_qty,
                   :item_name_snapshot,
+                  :item_sku_snapshot,
                   :item_spec_snapshot,
                   :uom_name_snapshot
                 )
@@ -103,6 +105,11 @@ async def create_manual_doc(
                 "item_name_snapshot": (
                     str(ln["item_name_snapshot"]).strip()
                     if ln.get("item_name_snapshot")
+                    else None
+                ),
+                "item_sku_snapshot": (
+                    str(ln["item_sku_snapshot"]).strip()
+                    if ln.get("item_sku_snapshot")
                     else None
                 ),
                 "item_spec_snapshot": (
@@ -220,6 +227,7 @@ async def get_manual_doc_lines(
                       l.item_uom_id,
                       l.requested_qty,
                       l.item_name_snapshot,
+                      l.item_sku_snapshot,
                       l.item_spec_snapshot,
                       l.uom_name_snapshot
                     FROM manual_outbound_lines l

--- a/app/wms/outbound/repos/outbound_event_repo.py
+++ b/app/wms/outbound/repos/outbound_event_repo.py
@@ -66,7 +66,6 @@ async def insert_outbound_event(
                     """
                 ),
                 {
-                    # event_no 直接复用 trace_id，避免超长
                     "event_no": str(trace_id)[:64],
                     "warehouse_id": int(warehouse_id),
                     "source_type": str(source_type),
@@ -110,6 +109,7 @@ async def insert_outbound_event_lines(
                           order_line_id,
                           manual_doc_line_id,
                           item_name_snapshot,
+                          item_sku_snapshot,
                           item_spec_snapshot,
                           remark
                         )
@@ -123,6 +123,7 @@ async def insert_outbound_event_lines(
                           :order_line_id,
                           :manual_doc_line_id,
                           :item_name_snapshot,
+                          :item_sku_snapshot,
                           :item_spec_snapshot,
                           :remark
                         )
@@ -137,6 +138,7 @@ async def insert_outbound_event_lines(
                           order_line_id,
                           manual_doc_line_id,
                           item_name_snapshot,
+                          item_sku_snapshot,
                           item_spec_snapshot,
                           remark,
                           created_at
@@ -152,6 +154,7 @@ async def insert_outbound_event_lines(
                         "order_line_id": ln.get("order_line_id"),
                         "manual_doc_line_id": ln.get("manual_doc_line_id"),
                         "item_name_snapshot": ln.get("item_name_snapshot"),
+                        "item_sku_snapshot": ln.get("item_sku_snapshot"),
                         "item_spec_snapshot": ln.get("item_spec_snapshot"),
                         "remark": ln.get("remark"),
                     },

--- a/app/wms/outbound/repos/outbound_summary_repo.py
+++ b/app/wms/outbound/repos/outbound_summary_repo.py
@@ -190,6 +190,7 @@ async def get_outbound_summary_lines(
                       order_line_id,
                       manual_doc_line_id,
                       item_name_snapshot,
+                      item_sku_snapshot,
                       item_spec_snapshot,
                       remark,
                       created_at

--- a/app/wms/outbound/services/outbound_event_submit_service.py
+++ b/app/wms/outbound/services/outbound_event_submit_service.py
@@ -12,13 +12,13 @@ from app.oms.orders.repos.order_outbound_view_repo import (
     load_order_outbound_head,
     load_order_outbound_lines,
 )
-from app.wms.outbound.contracts.order_submit import (
-    OrderOutboundSubmitIn,
-    OrderOutboundSubmitOut,
-)
 from app.wms.outbound.contracts.manual_submit import (
     ManualOutboundSubmitIn,
     ManualOutboundSubmitOut,
+)
+from app.wms.outbound.contracts.order_submit import (
+    OrderOutboundSubmitIn,
+    OrderOutboundSubmitOut,
 )
 from app.wms.outbound.repos.outbound_event_repo import (
     insert_outbound_event,
@@ -29,6 +29,13 @@ from app.wms.outbound.repos.outbound_event_repo import (
 )
 
 UTC = timezone.utc
+
+
+def _clean_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    s = str(value).strip()
+    return s or None
 
 
 @dataclass(frozen=True)
@@ -110,7 +117,10 @@ async def load_manual_submit_context(
                       doc_id,
                       line_no,
                       item_id,
-                      requested_qty
+                      requested_qty,
+                      item_name_snapshot,
+                      item_sku_snapshot,
+                      item_spec_snapshot
                     FROM manual_outbound_lines
                     WHERE doc_id = :doc_id
                     ORDER BY line_no ASC, id ASC
@@ -149,8 +159,8 @@ def normalize_order_submit_lines(
         item_id = int(raw["item_id"])
         qty_outbound = int(raw["qty_outbound"])
         lot_id = int(raw["lot_id"])
-        lot_code = str(raw["lot_code"]).strip() if raw.get("lot_code") else None
-        remark = str(raw["remark"]).strip() if raw.get("remark") else None
+        lot_code = _clean_text(raw.get("lot_code"))
+        remark = _clean_text(raw.get("remark"))
 
         src = ctx.order_lines_by_id.get(order_line_id)
         if src is None:
@@ -174,8 +184,9 @@ def normalize_order_submit_lines(
                 "qty_outbound": qty_outbound,
                 "lot_id": lot_id,
                 "lot_code": lot_code,
-                "item_name_snapshot": None,
-                "item_spec_snapshot": None,
+                "item_name_snapshot": _clean_text(src.get("item_name")),
+                "item_sku_snapshot": _clean_text(src.get("item_sku")),
+                "item_spec_snapshot": _clean_text(src.get("item_spec")),
                 "remark": remark,
             }
         )
@@ -200,8 +211,8 @@ def normalize_manual_submit_lines(
         item_id = int(raw["item_id"])
         qty_outbound = int(raw["qty_outbound"])
         lot_id = int(raw["lot_id"])
-        lot_code = str(raw["lot_code"]).strip() if raw.get("lot_code") else None
-        remark = str(raw["remark"]).strip() if raw.get("remark") else None
+        lot_code = _clean_text(raw.get("lot_code"))
+        remark = _clean_text(raw.get("remark"))
 
         src = ctx.doc_lines_by_id.get(manual_doc_line_id)
         if src is None:
@@ -227,8 +238,9 @@ def normalize_manual_submit_lines(
                 "qty_outbound": qty_outbound,
                 "lot_id": lot_id,
                 "lot_code": lot_code,
-                "item_name_snapshot": None,
-                "item_spec_snapshot": None,
+                "item_name_snapshot": _clean_text(src.get("item_name_snapshot")),
+                "item_sku_snapshot": _clean_text(src.get("item_sku_snapshot")),
+                "item_spec_snapshot": _clean_text(src.get("item_spec_snapshot")),
                 "remark": remark,
             }
         )


### PR DESCRIPTION
## Summary
- add item_sku_snapshot to manual_outbound_lines and outbound_event_lines
- wire sku snapshot through manual doc contracts/repos and outbound summary read model
- carry sku/name/spec snapshots through outbound event submit flow

## Validation
- python3 -m compileall alembic/versions/d75f3fa5b346_wms_outbound_add_item_sku_snapshot_to_.py app/wms/outbound/contracts/manual_doc.py app/wms/outbound/contracts/outbound_summary.py app/wms/outbound/models/outbound_event.py app/wms/outbound/repos/manual_doc_repo.py app/wms/outbound/repos/outbound_event_repo.py app/wms/outbound/repos/outbound_summary_repo.py app/wms/outbound/services/outbound_event_submit_service.py
- make upgrade-dev