### PR TITLE
feat(wms): close outbound completion states and guard duplicate order submit

### DIFF
--- a/app/oms/orders/repos/order_outbound_options_repo.py
+++ b/app/oms/orders/repos/order_outbound_options_repo.py
@@ -34,7 +34,19 @@ async def list_order_outbound_options(
     platform_norm = _normalize_text(platform)
     shop_id_norm = _normalize_text(shop_id)
 
-    clauses: List[str] = []
+    clauses: List[str] = [
+        """
+        EXISTS (
+          SELECT 1
+          FROM order_lines ol
+          LEFT JOIN outbound_event_lines oel
+            ON oel.order_line_id = ol.id
+          WHERE ol.order_id = orders.id
+          GROUP BY ol.id, ol.req_qty
+          HAVING COALESCE(SUM(oel.qty_outbound), 0) < ol.req_qty
+        )
+        """
+    ]
     params: Dict[str, Any] = {
         "limit": int(limit),
         "offset": int(offset),

--- a/app/wms/outbound/contracts/manual_doc.py
+++ b/app/wms/outbound/contracts/manual_doc.py
@@ -30,7 +30,7 @@ class ManualOutboundDocLineOut(BaseModel):
 class ManualOutboundDocOut(BaseModel):
     """
     手动出库单据头：来源层
-    状态只保留 DRAFT / RELEASED / VOIDED
+    状态终态为 DRAFT / RELEASED / COMPLETED / VOIDED
     """
     model_config = ConfigDict(extra="ignore")
 

--- a/app/wms/outbound/repos/manual_doc_repo.py
+++ b/app/wms/outbound/repos/manual_doc_repo.py
@@ -244,6 +244,58 @@ async def get_manual_doc_lines(
     return [dict(r) for r in rows]
 
 
+async def list_manual_doc_progress(
+    session: AsyncSession,
+    *,
+    doc_id: int,
+) -> List[Dict[str, Any]]:
+    rows = (
+        (
+            await session.execute(
+                text(
+                    """
+                    SELECT
+                      l.id AS manual_doc_line_id,
+                      l.line_no,
+                      l.requested_qty,
+                      COALESCE(SUM(oel.qty_outbound), 0) AS submitted_qty
+                    FROM manual_outbound_lines l
+                    LEFT JOIN outbound_event_lines oel
+                      ON oel.manual_doc_line_id = l.id
+                    WHERE l.doc_id = :doc_id
+                    GROUP BY l.id, l.line_no, l.requested_qty
+                    ORDER BY l.line_no ASC, l.id ASC
+                    """
+                ),
+                {"doc_id": int(doc_id)},
+            )
+        )
+        .mappings()
+        .all()
+    )
+    return [dict(r) for r in rows]
+
+
+async def complete_manual_doc(
+    session: AsyncSession,
+    *,
+    doc_id: int,
+) -> None:
+    upd = await session.execute(
+        text(
+            """
+            UPDATE manual_outbound_docs
+            SET status = 'COMPLETED'
+            WHERE id = :doc_id
+              AND status = 'RELEASED'
+            """
+        ),
+        {"doc_id": int(doc_id)},
+    )
+    if upd.rowcount != 1:
+        raise ValueError(f"manual_doc_complete_reject: id={doc_id}")
+
+
 async def release_manual_doc(
     session: AsyncSession,
     *,

--- a/app/wms/outbound/routers/order_submit.py
+++ b/app/wms/outbound/routers/order_submit.py
@@ -1,7 +1,7 @@
 # app/wms/outbound/routers/order_submit.py
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.audit import new_trace
@@ -30,13 +30,20 @@ async def submit_order_outbound(
 ) -> OrderOutboundSubmitOut:
     trace = new_trace("http:/wms/outbound/orders/submit")
 
-    result = await submit_order_outbound_event(
-        session,
-        order_id=int(order_id),
-        warehouse_id=int(payload.warehouse_id),
-        operator_id=getattr(user, "id", None),
-        trace_id=trace.trace_id,
-        payload=payload,
-    )
-    await session.commit()
-    return result
+    try:
+        result = await submit_order_outbound_event(
+            session,
+            order_id=int(order_id),
+            warehouse_id=int(payload.warehouse_id),
+            operator_id=getattr(user, "id", None),
+            trace_id=trace.trace_id,
+            payload=payload,
+        )
+        await session.commit()
+        return result
+    except ValueError as exc:
+        await session.rollback()
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except Exception:
+        await session.rollback()
+        raise

--- a/app/wms/outbound/services/outbound_event_submit_service.py
+++ b/app/wms/outbound/services/outbound_event_submit_service.py
@@ -20,6 +20,10 @@ from app.wms.outbound.contracts.order_submit import (
     OrderOutboundSubmitIn,
     OrderOutboundSubmitOut,
 )
+from app.wms.outbound.repos.manual_doc_repo import (
+    complete_manual_doc,
+    list_manual_doc_progress,
+)
 from app.wms.outbound.repos.outbound_event_repo import (
     insert_outbound_event,
     insert_outbound_event_lines,
@@ -141,6 +145,80 @@ async def load_manual_submit_context(
         source_ref=str(head["doc_no"]),
         warehouse_id=int(head["warehouse_id"]),
     )
+
+
+async def load_order_submit_progress(
+    session: AsyncSession,
+    *,
+    order_id: int,
+) -> Dict[int, Dict[str, int]]:
+    rows = (
+        (
+            await session.execute(
+                text(
+                    """
+                    SELECT
+                      ol.id AS order_line_id,
+                      ol.req_qty,
+                      COALESCE(SUM(oel.qty_outbound), 0) AS submitted_qty
+                    FROM order_lines ol
+                    LEFT JOIN outbound_event_lines oel
+                      ON oel.order_line_id = ol.id
+                    WHERE ol.order_id = :order_id
+                    GROUP BY ol.id, ol.req_qty
+                    ORDER BY ol.id ASC
+                    """
+                ),
+                {"order_id": int(order_id)},
+            )
+        )
+        .mappings()
+        .all()
+    )
+    return {
+        int(r["order_line_id"]): {
+            "req_qty": int(r["req_qty"]),
+            "submitted_qty": int(r["submitted_qty"]),
+        }
+        for r in rows
+    }
+
+
+async def has_orphan_order_outbound_ledger(
+    session: AsyncSession,
+    *,
+    source_ref: str,
+    ref_line: int,
+    item_id: int,
+    warehouse_id: int,
+    lot_id: int,
+) -> bool:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT 1
+                FROM stock_ledger
+                WHERE reason = 'OUTBOUND_SHIP'
+                  AND ref = :source_ref
+                  AND ref_line = :ref_line
+                  AND item_id = :item_id
+                  AND warehouse_id = :warehouse_id
+                  AND lot_id = :lot_id
+                  AND event_id IS NULL
+                LIMIT 1
+                """
+            ),
+            {
+                "source_ref": str(source_ref),
+                "ref_line": int(ref_line),
+                "item_id": int(item_id),
+                "warehouse_id": int(warehouse_id),
+                "lot_id": int(lot_id),
+            },
+        )
+    ).first()
+    return row is not None
 
 
 def normalize_order_submit_lines(
@@ -343,6 +421,39 @@ async def submit_order_outbound_event(
         ctx=ctx,
     )
 
+    progress_by_line = await load_order_submit_progress(session, order_id=int(order_id))
+    for ln in normalized:
+        order_line_id = int(ln["order_line_id"])
+        req_qty = int(progress_by_line.get(order_line_id, {}).get("req_qty", 0))
+        submitted_qty = int(progress_by_line.get(order_line_id, {}).get("submitted_qty", 0))
+        submit_qty = int(ln["qty_outbound"])
+
+        if req_qty <= 0:
+            raise ValueError(f"order_line_not_found_or_invalid: order_line_id={order_line_id}")
+
+        if submitted_qty >= req_qty:
+            raise ValueError(
+                f"order_line_already_completed: order_line_id={order_line_id}, req_qty={req_qty}, submitted_qty={submitted_qty}"
+            )
+
+        if submitted_qty + submit_qty > req_qty:
+            raise ValueError(
+                f"order_line_over_submit: order_line_id={order_line_id}, req_qty={req_qty}, submitted_qty={submitted_qty}, submit_qty={submit_qty}"
+            )
+
+        orphan_conflict = await has_orphan_order_outbound_ledger(
+            session,
+            source_ref=ctx.source_ref,
+            ref_line=int(ln["ref_line"]),
+            item_id=int(ln["item_id"]),
+            warehouse_id=int(warehouse_id),
+            lot_id=int(ln["lot_id"]),
+        )
+        if orphan_conflict:
+            raise ValueError(
+                f"legacy_orphan_ledger_conflict: source_ref={ctx.source_ref}, ref_line={ln['ref_line']}, item_id={ln['item_id']}, warehouse_id={warehouse_id}, lot_id={ln['lot_id']}"
+            )
+
     event, saved_lines = await _write_event_and_ledger(
         session,
         warehouse_id=int(warehouse_id),
@@ -394,6 +505,13 @@ async def submit_manual_outbound_event(
         remark=payload.remark,
         normalized_lines=normalized,
     )
+
+    progress_rows = await list_manual_doc_progress(session, doc_id=int(doc_id))
+    if progress_rows and all(
+        int(row["submitted_qty"]) >= int(row["requested_qty"])
+        for row in progress_rows
+    ):
+        await complete_manual_doc(session, doc_id=int(doc_id))
 
     return ManualOutboundSubmitOut(
         status="OK",

--- a/tests/api/test_manual_outbound_submit_api.py
+++ b/tests/api/test_manual_outbound_submit_api.py
@@ -73,7 +73,11 @@ async def _ensure_warehouse(session: AsyncSession, warehouse_id: int = 1) -> int
     return int(warehouse_id)
 
 
-async def _seed_manual_doc_and_stock(session: AsyncSession) -> tuple[int, int, int, int, int]:
+async def _seed_manual_doc_and_stock(
+    session: AsyncSession,
+    *,
+    requested_qty: int = 2,
+) -> tuple[int, int, int, int, int]:
     warehouse_id = await _ensure_warehouse(session, 1)
     item_id, item_uom_id, uom_name, item_spec, requires_expiry = await _pick_any_item_and_uom(session)
     uniq = uuid4().hex[:10]
@@ -128,7 +132,7 @@ async def _seed_manual_doc_and_stock(session: AsyncSession) -> tuple[int, int, i
               1,
               :item_id,
               :item_uom_id,
-              2,
+              :requested_qty,
               '测试商品',
               :item_spec_snapshot,
               :uom_name_snapshot
@@ -140,6 +144,7 @@ async def _seed_manual_doc_and_stock(session: AsyncSession) -> tuple[int, int, i
             "doc_id": int(doc_id),
             "item_id": int(item_id),
             "item_uom_id": int(item_uom_id),
+            "requested_qty": int(requested_qty),
             "item_spec_snapshot": item_spec,
             "uom_name_snapshot": uom_name,
         },
@@ -304,3 +309,69 @@ async def test_manual_outbound_submit_writes_event_and_ledger(
         )
     ).scalar_one()
     assert int(qty_now) == 8
+
+    doc_status = (
+        await session.execute(
+            text(
+                """
+                SELECT status
+                FROM manual_outbound_docs
+                WHERE id = :doc_id
+                LIMIT 1
+                """
+            ),
+            {"doc_id": doc_id},
+        )
+    ).scalar_one()
+    assert str(doc_status) == "COMPLETED"
+
+
+async def test_manual_outbound_submit_keeps_doc_released_when_partially_submitted(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    doc_id, doc_line_id, warehouse_id, lot_id, item_id = await _seed_manual_doc_and_stock(
+        session,
+        requested_qty=5,
+    )
+
+    resp = await client.post(
+        f"/wms/outbound/manual/{doc_id}/submit",
+        headers=headers,
+        json={
+            "remark": "UT manual outbound partial submit",
+            "lines": [
+                {
+                    "manual_doc_line_id": doc_line_id,
+                    "item_id": item_id,
+                    "qty_outbound": 2,
+                    "lot_id": lot_id,
+                    "lot_code": None,
+                    "remark": "partial line remark",
+                }
+            ],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    assert data["status"] == "OK"
+    assert data["source_type"] == "MANUAL"
+    assert data["warehouse_id"] == warehouse_id
+    assert data["lines_count"] == 1
+
+    doc_status = (
+        await session.execute(
+            text(
+                """
+                SELECT status
+                FROM manual_outbound_docs
+                WHERE id = :doc_id
+                LIMIT 1
+                """
+            ),
+            {"doc_id": doc_id},
+        )
+    ).scalar_one()
+    assert str(doc_status) == "RELEASED"

--- a/tests/api/test_order_outbound_submit_api.py
+++ b/tests/api/test_order_outbound_submit_api.py
@@ -296,3 +296,52 @@ async def test_order_outbound_submit_writes_event_and_ledger(
         )
     ).scalar_one()
     assert int(qty_now) == 8
+
+    opts = await client.get(
+        "/oms/orders/outbound-options",
+        headers=headers,
+        params={"q": str(order_id)},
+    )
+    assert opts.status_code == 200, opts.text
+    opts_data = opts.json()
+    assert opts_data["items"] == []
+
+
+async def test_order_outbound_submit_rejects_duplicate_submit_with_409(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+
+    order_id, order_line_id, warehouse_id, lot_id, item_id = await _seed_order_and_stock(session)
+
+    payload = {
+        "warehouse_id": warehouse_id,
+        "remark": "UT order outbound duplicate submit",
+        "lines": [
+            {
+                "order_line_id": order_line_id,
+                "item_id": item_id,
+                "qty_outbound": 2,
+                "lot_id": lot_id,
+                "lot_code": None,
+                "remark": "line remark",
+            }
+        ],
+    }
+
+    first = await client.post(
+        f"/wms/outbound/orders/{order_id}/submit",
+        headers=headers,
+        json=payload,
+    )
+    assert first.status_code == 200, first.text
+
+    second = await client.post(
+        f"/wms/outbound/orders/{order_id}/submit",
+        headers=headers,
+        json=payload,
+    )
+    assert second.status_code == 409, second.text
+    body = second.json()
+    assert "order_line_already_completed" in str(body)


### PR DESCRIPTION
## Summary
- mark completed manual outbound docs as COMPLETED
- remove completed orders from outbound source options
- reject duplicate or over-submitted order outbound requests with 409 instead of 500
- keep outbound completion state aligned with backend truth

## Testing
- make test TESTS=tests/api/test_manual_outbound_submit_api.py
- make test TESTS=tests/api/test_order_outbound_submit_api.py