### PR TITLE
feat(wms-inbound): close completion state and align receiving summaries

### DIFF
--- a/alembic/versions/f05df0c90c55_wms_inbound_add_completed_status_to_.py
+++ b/alembic/versions/f05df0c90c55_wms_inbound_add_completed_status_to_.py
@@ -1,0 +1,45 @@
+"""wms_inbound_add_completed_status_to_inbound_receipts
+
+Revision ID: f05df0c90c55
+Revises: d75f3fa5b346
+Create Date: 2026-04-20 18:21:58.723174
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f05df0c90c55"
+down_revision: Union[str, Sequence[str], None] = "d75f3fa5b346"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.drop_constraint(
+        "ck_inbound_receipts_status",
+        "inbound_receipts",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_inbound_receipts_status",
+        "inbound_receipts",
+        "status IN ('DRAFT', 'RELEASED', 'COMPLETED', 'VOIDED')",
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint(
+        "ck_inbound_receipts_status",
+        "inbound_receipts",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_inbound_receipts_status",
+        "inbound_receipts",
+        "status IN ('DRAFT', 'RELEASED', 'VOIDED')",
+    )

--- a/app/inbound_receipts/contracts/enums.py
+++ b/app/inbound_receipts/contracts/enums.py
@@ -11,6 +11,7 @@ InboundReceiptSourceType = Literal[
 InboundReceiptStatus = Literal[
     "DRAFT",
     "RELEASED",
+    "COMPLETED",
     "VOIDED",
 ]
 

--- a/app/inbound_receipts/contracts/receipt_read.py
+++ b/app/inbound_receipts/contracts/receipt_read.py
@@ -63,6 +63,11 @@ class InboundReceiptListItemOut(_Base):
     status: InboundReceiptStatus
     remark: Annotated[str | None, Field(default=None, max_length=500, description="头备注")]
     released_at: datetime | None = Field(default=None, description="发布时间")
+    last_operated_at: datetime | None = Field(default=None, description="最近收货时间")
+    line_count: Annotated[int, Field(ge=0, description="任务行数")]
+    total_planned_qty: Annotated[int, Field(ge=0, description="总任务数量（整数）")]
+    total_received_qty: Annotated[Decimal, Field(ge=0, description="累计已收（按计划包装折算）")]
+    total_remaining_qty: Annotated[Decimal, Field(ge=0, description="剩余待收（按计划包装折算）")]
 
 
 class InboundReceiptListOut(_Base):

--- a/app/inbound_receipts/models/inbound_receipt.py
+++ b/app/inbound_receipts/models/inbound_receipt.py
@@ -22,7 +22,7 @@ class InboundReceipt(Base):
             name="ck_inbound_receipts_source_type",
         ),
         CheckConstraint(
-            "status IN ('DRAFT', 'RELEASED', 'VOIDED')",
+            "status IN ('DRAFT', 'RELEASED', 'COMPLETED', 'VOIDED')",
             name="ck_inbound_receipts_status",
         ),
     )

--- a/app/inbound_receipts/repos/inbound_receipt_read_repo.py
+++ b/app/inbound_receipts/repos/inbound_receipt_read_repo.py
@@ -225,39 +225,86 @@ async def get_inbound_return_source_repo(
 async def list_inbound_receipts_repo(
     session: AsyncSession,
 ) -> InboundReceiptListOut:
-    total = int(
-        (
-            await session.execute(
-                text("SELECT COUNT(*) FROM inbound_receipts")
-            )
-        ).scalar_one()
-    )
-
     rows = (
         await session.execute(
             text(
                 """
+                WITH line_received AS (
+                  SELECT
+                    o.receipt_no_snapshot AS receipt_no,
+                    ol.receipt_line_no_snapshot AS line_no,
+                    COALESCE(SUM(ol.qty_base), 0) AS received_qty_base
+                  FROM wms_inbound_operations o
+                  JOIN wms_inbound_operation_lines ol
+                    ON ol.wms_inbound_operation_id = o.id
+                  GROUP BY
+                    o.receipt_no_snapshot,
+                    ol.receipt_line_no_snapshot
+                ),
+                latest_operation AS (
+                  SELECT
+                    receipt_no_snapshot AS receipt_no,
+                    MAX(operated_at) AS last_operated_at
+                  FROM wms_inbound_operations
+                  GROUP BY receipt_no_snapshot
+                )
                 SELECT
-                  id,
-                  receipt_no,
-                  source_type,
-                  source_doc_no_snapshot,
-                  warehouse_id,
-                  warehouse_name_snapshot,
-                  supplier_id,
-                  counterparty_name_snapshot,
-                  status,
-                  remark,
-                  released_at
-                FROM inbound_receipts
-                ORDER BY id DESC
+                  r.id,
+                  r.receipt_no,
+                  r.source_type,
+                  r.source_doc_no_snapshot,
+                  r.warehouse_id,
+                  r.warehouse_name_snapshot,
+                  r.supplier_id,
+                  r.counterparty_name_snapshot,
+                  r.status,
+                  r.remark,
+                  r.released_at,
+                  lo.last_operated_at,
+                  COUNT(l.id) AS line_count,
+                  COALESCE(SUM(l.planned_qty), 0) AS total_planned_qty,
+                  COALESCE(
+                    SUM(COALESCE(lr.received_qty_base, 0)::numeric / NULLIF(l.ratio_to_base_snapshot, 0)::numeric),
+                    0
+                  ) AS total_received_qty,
+                  COALESCE(
+                    SUM(
+                      GREATEST(
+                        (l.planned_qty * l.ratio_to_base_snapshot) - COALESCE(lr.received_qty_base, 0),
+                        0
+                      )::numeric / NULLIF(l.ratio_to_base_snapshot, 0)::numeric
+                    ),
+                    0
+                  ) AS total_remaining_qty
+                FROM inbound_receipts r
+                LEFT JOIN inbound_receipt_lines l
+                  ON l.inbound_receipt_id = r.id
+                LEFT JOIN line_received lr
+                  ON lr.receipt_no = r.receipt_no
+                 AND lr.line_no = l.line_no
+                LEFT JOIN latest_operation lo
+                  ON lo.receipt_no = r.receipt_no
+                GROUP BY
+                  r.id,
+                  r.receipt_no,
+                  r.source_type,
+                  r.source_doc_no_snapshot,
+                  r.warehouse_id,
+                  r.warehouse_name_snapshot,
+                  r.supplier_id,
+                  r.counterparty_name_snapshot,
+                  r.status,
+                  r.remark,
+                  r.released_at,
+                  lo.last_operated_at
+                ORDER BY r.id DESC
                 """
             )
         )
     ).mappings().all()
 
     return InboundReceiptListOut(
-        total=total,
+        total=len(rows),
         items=[
             InboundReceiptListItemOut(
                 id=int(r["id"]),
@@ -271,6 +318,11 @@ async def list_inbound_receipts_repo(
                 status=str(r["status"]),
                 remark=r["remark"],
                 released_at=r["released_at"],
+                last_operated_at=r["last_operated_at"],
+                line_count=int(r["line_count"] or 0),
+                total_planned_qty=int(r["total_planned_qty"] or 0),
+                total_received_qty=r["total_received_qty"] or 0,
+                total_remaining_qty=r["total_remaining_qty"] or 0,
             )
             for r in rows
         ],

--- a/app/wms/receiving/contracts/inbound_task_read.py
+++ b/app/wms/receiving/contracts/inbound_task_read.py
@@ -45,6 +45,7 @@ class InboundTaskListItemOut(_Base):
     ]
     status: InboundReceiptStatus
     released_at: datetime | None = Field(default=None, description="发布时间")
+    last_operated_at: datetime | None = Field(default=None, description="最近收货时间")
     line_count: Annotated[int, Field(ge=0, description="任务行数")]
     total_planned_qty: Annotated[int, Field(ge=0, description="总任务数量（按计划包装，整数）")]
     total_received_qty: Annotated[Decimal, Field(ge=0, description="累计已收总数（按计划包装折算）")]

--- a/app/wms/receiving/repos/inbound_operation_write_repo.py
+++ b/app/wms/receiving/repos/inbound_operation_write_repo.py
@@ -210,6 +210,14 @@ async def submit_inbound_operation_repo(
     ).mappings().all()
 
     line_map = {int(r["line_no"]): r for r in task_lines}
+    line_progress_by_no: dict[int, int] = {
+        int(r["line_no"]): int(r["received_qty_base"])
+        for r in task_lines
+    }
+    line_planned_base_by_no: dict[int, int] = {
+        int(r["line_no"]): int(r["planned_qty_base"])
+        for r in task_lines
+    }
 
     operated_at = datetime.now(UTC)
 
@@ -326,7 +334,9 @@ async def submit_inbound_operation_repo(
         task_uom_name_snapshot = task_line["uom_name_snapshot"]
         task_ratio = int(task_line["ratio_to_base_snapshot"])
         planned_qty_base = int(task_line["planned_qty_base"])
-        received_qty_base_running = int(task_line["received_qty_base"])
+        received_qty_base_running = int(
+            line_progress_by_no[int(line.receipt_line_no)]
+        )
 
         item_policy = await get_item_policy_by_id(
             session,
@@ -643,6 +653,23 @@ async def submit_inbound_operation_repo(
             )
 
             received_qty_base_running += qty_base
+            line_progress_by_no[int(line.receipt_line_no)] = received_qty_base_running
+
+    if line_progress_by_no and all(
+        int(line_progress_by_no.get(line_no, 0)) >= int(line_planned_base_by_no[line_no])
+        for line_no in line_planned_base_by_no
+    ):
+        await session.execute(
+            text(
+                """
+                UPDATE inbound_receipts
+                SET status = 'COMPLETED'
+                WHERE id = :receipt_id
+                  AND status = 'RELEASED'
+                """
+            ),
+            {"receipt_id": int(task["id"])},
+        )
 
     return InboundOperationSubmitOut(
         id=operation_id,

--- a/app/wms/receiving/repos/inbound_task_read_repo.py
+++ b/app/wms/receiving/repos/inbound_task_read_repo.py
@@ -29,6 +29,13 @@ async def list_inbound_tasks_repo(session: AsyncSession) -> InboundTaskListOut:
                   GROUP BY
                     o.receipt_no_snapshot,
                     ol.receipt_line_no_snapshot
+                ),
+                latest_operation AS (
+                  SELECT
+                    receipt_no_snapshot AS receipt_no,
+                    MAX(operated_at) AS last_operated_at
+                  FROM wms_inbound_operations
+                  GROUP BY receipt_no_snapshot
                 )
                 SELECT
                   r.id AS receipt_id,
@@ -41,6 +48,7 @@ async def list_inbound_tasks_repo(session: AsyncSession) -> InboundTaskListOut:
                   r.counterparty_name_snapshot,
                   r.status,
                   r.released_at,
+                  lo.last_operated_at,
                   r.remark,
                   COUNT(l.id) AS line_count,
                   COALESCE(SUM(l.planned_qty), 0) AS total_planned_qty,
@@ -63,7 +71,9 @@ async def list_inbound_tasks_repo(session: AsyncSession) -> InboundTaskListOut:
                 LEFT JOIN line_received lr
                   ON lr.receipt_no = r.receipt_no
                  AND lr.line_no = l.line_no
-                WHERE r.status = 'RELEASED'
+                LEFT JOIN latest_operation lo
+                  ON lo.receipt_no = r.receipt_no
+                WHERE r.status IN ('RELEASED', 'COMPLETED')
                 GROUP BY
                   r.id,
                   r.receipt_no,
@@ -75,9 +85,10 @@ async def list_inbound_tasks_repo(session: AsyncSession) -> InboundTaskListOut:
                   r.counterparty_name_snapshot,
                   r.status,
                   r.released_at,
+                  lo.last_operated_at,
                   r.remark
                 ORDER BY
-                  r.released_at DESC NULLS LAST,
+                  COALESCE(lo.last_operated_at, r.released_at) DESC NULLS LAST,
                   r.id DESC
                 """
             )
@@ -97,6 +108,7 @@ async def list_inbound_tasks_repo(session: AsyncSession) -> InboundTaskListOut:
                 counterparty_name_snapshot=r["counterparty_name_snapshot"],
                 status=str(r["status"]),
                 released_at=r["released_at"],
+                last_operated_at=r["last_operated_at"],
                 line_count=int(r["line_count"]),
                 total_planned_qty=r["total_planned_qty"],
                 total_received_qty=r["total_received_qty"],
@@ -141,10 +153,10 @@ async def get_inbound_task_repo(
     if header is None:
         raise HTTPException(status_code=404, detail="inbound_task_not_found")
 
-    if str(header["status"]) != "RELEASED":
+    if str(header["status"]) not in {"RELEASED", "COMPLETED"}:
         raise HTTPException(
             status_code=409,
-            detail=f"inbound_task_not_released:{header['status']}",
+            detail=f"inbound_task_not_readable:{header['status']}",
         )
 
     rows = (


### PR DESCRIPTION
## Summary
- add COMPLETED to inbound receipt status contract and migration
- close inbound receipt completion after receiving submit
- align inbound receipt summary and receiving summary time/progress read models

## Validation
- python3 -m compileall
- make test TESTS=...
