### PR TITLE
refactor(wms): aggregate inventory adjustment backend files by module layout

### DIFF
--- a/alembic/versions/3ac042b64340_wms_inventory_adjustment_followup_fix_.py
+++ b/alembic/versions/3ac042b64340_wms_inventory_adjustment_followup_fix_.py
@@ -1,0 +1,118 @@
+"""wms_inventory_adjustment_followup_fix_inbound_manual_navigation
+
+Revision ID: 3ac042b64340
+Revises: e39546a3ae97
+Create Date: 2026-04-21 18:07:00.940183
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "3ac042b64340"
+down_revision: Union[str, Sequence[str], None] = "e39546a3ae97"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+
+    # 1) 补齐 WMS 入库树缺失的手动收货页
+    op.execute(
+        """
+        INSERT INTO page_registry (
+          code,
+          name,
+          parent_code,
+          level,
+          domain_code,
+          show_in_topbar,
+          show_in_sidebar,
+          inherit_permissions,
+          read_permission_id,
+          write_permission_id,
+          sort_order,
+          is_active
+        )
+        VALUES (
+          'wms.inbound.manual',
+          '手动收货',
+          'wms.inbound',
+          3,
+          'wms',
+          FALSE,
+          TRUE,
+          TRUE,
+          NULL,
+          NULL,
+          30,
+          TRUE
+        )
+        ON CONFLICT (code) DO UPDATE
+        SET
+          name = EXCLUDED.name,
+          parent_code = EXCLUDED.parent_code,
+          level = EXCLUDED.level,
+          domain_code = EXCLUDED.domain_code,
+          show_in_topbar = EXCLUDED.show_in_topbar,
+          show_in_sidebar = EXCLUDED.show_in_sidebar,
+          inherit_permissions = EXCLUDED.inherit_permissions,
+          read_permission_id = EXCLUDED.read_permission_id,
+          write_permission_id = EXCLUDED.write_permission_id,
+          sort_order = EXCLUDED.sort_order,
+          is_active = EXCLUDED.is_active
+        """
+    )
+
+    # 2) 补齐手动收货路由归属
+    op.execute(
+        """
+        INSERT INTO page_route_prefixes (
+          page_code,
+          route_prefix,
+          sort_order,
+          is_active
+        )
+        VALUES (
+          'wms.inbound.manual',
+          '/receiving/manual',
+          30,
+          TRUE
+        )
+        ON CONFLICT (route_prefix) DO UPDATE
+        SET
+          page_code = EXCLUDED.page_code,
+          sort_order = EXCLUDED.sort_order,
+          is_active = EXCLUDED.is_active
+        """
+    )
+
+    # 3) 再次收正历史残留：
+    #    operations 不是当前可见导航页，且若历史前缀误挂到它，统一改挂 atomic
+    op.execute(
+        """
+        UPDATE page_route_prefixes
+           SET page_code = 'wms.inbound.atomic'
+         WHERE page_code = 'wms.inbound.operations'
+        """
+    )
+
+    op.execute(
+        """
+        UPDATE page_registry
+           SET is_active = FALSE
+         WHERE code = 'wms.inbound.operations'
+        """
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    raise RuntimeError(
+        "Downgrade not supported: inventory adjustment navigation cutover follow-up is intentionally one-way."
+    )

--- a/alembic/versions/e39546a3ae97_wms_inventory_adjustment_cutover_retire_.py
+++ b/alembic/versions/e39546a3ae97_wms_inventory_adjustment_cutover_retire_.py
@@ -1,0 +1,428 @@
+"""wms_inventory_adjustment_cutover_retire_legacy_count_and_return_inbound_navigation
+
+Revision ID: e39546a3ae97
+Revises: f05df0c90c55
+Create Date: 2026-04-21 16:54:23.027665
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "e39546a3ae97"
+down_revision: Union[str, Sequence[str], None] = "f05df0c90c55"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+
+    # 1) 注册 WMS 二级页：库存调节
+    op.execute(
+        """
+        INSERT INTO page_registry (
+          code,
+          name,
+          parent_code,
+          level,
+          domain_code,
+          show_in_topbar,
+          show_in_sidebar,
+          inherit_permissions,
+          read_permission_id,
+          write_permission_id,
+          sort_order,
+          is_active
+        )
+        VALUES (
+          'wms.inventory_adjustment',
+          '库存调节',
+          'wms',
+          2,
+          'wms',
+          FALSE,
+          TRUE,
+          TRUE,
+          NULL,
+          NULL,
+          40,
+          TRUE
+        )
+        ON CONFLICT (code) DO UPDATE
+        SET
+          name = EXCLUDED.name,
+          parent_code = EXCLUDED.parent_code,
+          level = EXCLUDED.level,
+          domain_code = EXCLUDED.domain_code,
+          show_in_topbar = EXCLUDED.show_in_topbar,
+          show_in_sidebar = EXCLUDED.show_in_sidebar,
+          inherit_permissions = EXCLUDED.inherit_permissions,
+          read_permission_id = EXCLUDED.read_permission_id,
+          write_permission_id = EXCLUDED.write_permission_id,
+          sort_order = EXCLUDED.sort_order,
+          is_active = EXCLUDED.is_active
+        """
+    )
+
+    # 2) 注册 WMS 三级页：库存调节汇总 / 盘点作业 / 入库冲回 / 出库冲回 / 退单入库
+    op.execute(
+        """
+        INSERT INTO page_registry (
+          code,
+          name,
+          parent_code,
+          level,
+          domain_code,
+          show_in_topbar,
+          show_in_sidebar,
+          inherit_permissions,
+          read_permission_id,
+          write_permission_id,
+          sort_order,
+          is_active
+        )
+        VALUES
+          (
+            'wms.inventory_adjustment.summary',
+            '库存调节汇总',
+            'wms.inventory_adjustment',
+            3,
+            'wms',
+            FALSE,
+            TRUE,
+            TRUE,
+            NULL,
+            NULL,
+            10,
+            TRUE
+          ),
+          (
+            'wms.inventory_adjustment.count',
+            '盘点作业',
+            'wms.inventory_adjustment',
+            3,
+            'wms',
+            FALSE,
+            TRUE,
+            TRUE,
+            NULL,
+            NULL,
+            20,
+            TRUE
+          ),
+          (
+            'wms.inventory_adjustment.inbound_reversal',
+            '入库冲回',
+            'wms.inventory_adjustment',
+            3,
+            'wms',
+            FALSE,
+            TRUE,
+            TRUE,
+            NULL,
+            NULL,
+            30,
+            TRUE
+          ),
+          (
+            'wms.inventory_adjustment.outbound_reversal',
+            '出库冲回',
+            'wms.inventory_adjustment',
+            3,
+            'wms',
+            FALSE,
+            TRUE,
+            TRUE,
+            NULL,
+            NULL,
+            40,
+            TRUE
+          ),
+          (
+            'wms.inventory_adjustment.return_inbound',
+            '退单入库',
+            'wms.inventory_adjustment',
+            3,
+            'wms',
+            FALSE,
+            TRUE,
+            TRUE,
+            NULL,
+            NULL,
+            50,
+            TRUE
+          )
+        ON CONFLICT (code) DO UPDATE
+        SET
+          name = EXCLUDED.name,
+          parent_code = EXCLUDED.parent_code,
+          level = EXCLUDED.level,
+          domain_code = EXCLUDED.domain_code,
+          show_in_topbar = EXCLUDED.show_in_topbar,
+          show_in_sidebar = EXCLUDED.show_in_sidebar,
+          inherit_permissions = EXCLUDED.inherit_permissions,
+          read_permission_id = EXCLUDED.read_permission_id,
+          write_permission_id = EXCLUDED.write_permission_id,
+          sort_order = EXCLUDED.sort_order,
+          is_active = EXCLUDED.is_active
+        """
+    )
+
+    # 3) 注册新路由前缀
+    op.execute(
+        """
+        INSERT INTO page_route_prefixes (
+          page_code,
+          route_prefix,
+          sort_order,
+          is_active
+        )
+        VALUES
+          ('wms.inventory_adjustment.summary', '/inventory-adjustment', 10, TRUE),
+          ('wms.inventory_adjustment.count', '/inventory-adjustment/count', 20, TRUE),
+          ('wms.inventory_adjustment.inbound_reversal', '/inventory-adjustment/inbound-reversal', 30, TRUE),
+          ('wms.inventory_adjustment.outbound_reversal', '/inventory-adjustment/outbound-reversal', 40, TRUE),
+          ('wms.inventory_adjustment.return_inbound', '/inventory-adjustment/return-inbound', 50, TRUE)
+        ON CONFLICT (route_prefix) DO UPDATE
+        SET
+          page_code = EXCLUDED.page_code,
+          sort_order = EXCLUDED.sort_order,
+          is_active = EXCLUDED.is_active
+        """
+    )
+
+    # 4) 收正 WMS 入库树残留：
+    #    历史环境里 wms.inbound.operations 可能被误置为 active。
+    op.execute(
+        """
+        UPDATE page_route_prefixes
+           SET page_code = 'wms.inbound.atomic'
+         WHERE page_code = 'wms.inbound.operations'
+        """
+    )
+    op.execute(
+        """
+        UPDATE page_registry
+           SET is_active = FALSE
+         WHERE code = 'wms.inbound.operations'
+        """
+    )
+
+    # 5) 退役旧三级页
+    op.execute(
+        """
+        DELETE FROM page_registry
+        WHERE code IN (
+          'wms.count.tasks',
+          'wms.count.adjustments',
+          'wms.inbound.returns',
+          'inbound.returns'
+        )
+        """
+    )
+
+    # 6) 退役旧二级页：wms.count
+    op.execute(
+        """
+        DELETE FROM page_registry
+        WHERE code = 'wms.count'
+        """
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+
+    # 1) 恢复旧二级页：盘点
+    op.execute(
+        """
+        INSERT INTO page_registry (
+          code,
+          name,
+          parent_code,
+          level,
+          domain_code,
+          show_in_topbar,
+          show_in_sidebar,
+          inherit_permissions,
+          read_permission_id,
+          write_permission_id,
+          sort_order,
+          is_active
+        )
+        VALUES (
+          'wms.count',
+          '盘点',
+          'wms',
+          2,
+          'wms',
+          FALSE,
+          TRUE,
+          TRUE,
+          NULL,
+          NULL,
+          40,
+          TRUE
+        )
+        ON CONFLICT (code) DO UPDATE
+        SET
+          name = EXCLUDED.name,
+          parent_code = EXCLUDED.parent_code,
+          level = EXCLUDED.level,
+          domain_code = EXCLUDED.domain_code,
+          show_in_topbar = EXCLUDED.show_in_topbar,
+          show_in_sidebar = EXCLUDED.show_in_sidebar,
+          inherit_permissions = EXCLUDED.inherit_permissions,
+          read_permission_id = EXCLUDED.read_permission_id,
+          write_permission_id = EXCLUDED.write_permission_id,
+          sort_order = EXCLUDED.sort_order,
+          is_active = EXCLUDED.is_active
+        """
+    )
+
+    # 2) 恢复旧三级页：盘点作业 / 库存调整 / 退货入库单 / 退货收货
+    op.execute(
+        """
+        INSERT INTO page_registry (
+          code,
+          name,
+          parent_code,
+          level,
+          domain_code,
+          show_in_topbar,
+          show_in_sidebar,
+          inherit_permissions,
+          read_permission_id,
+          write_permission_id,
+          sort_order,
+          is_active
+        )
+        VALUES
+          (
+            'wms.count.tasks',
+            '盘点作业',
+            'wms.count',
+            3,
+            'wms',
+            FALSE,
+            TRUE,
+            TRUE,
+            NULL,
+            NULL,
+            10,
+            TRUE
+          ),
+          (
+            'wms.count.adjustments',
+            '库存调整',
+            'wms.count',
+            3,
+            'wms',
+            FALSE,
+            TRUE,
+            TRUE,
+            NULL,
+            NULL,
+            20,
+            FALSE
+          ),
+          (
+            'inbound.returns',
+            '退货入库单',
+            'inbound',
+            2,
+            'inbound',
+            FALSE,
+            TRUE,
+            TRUE,
+            NULL,
+            NULL,
+            30,
+            TRUE
+          ),
+          (
+            'wms.inbound.returns',
+            '退货收货',
+            'wms.inbound',
+            3,
+            'wms',
+            FALSE,
+            TRUE,
+            TRUE,
+            NULL,
+            NULL,
+            40,
+            TRUE
+          )
+        ON CONFLICT (code) DO UPDATE
+        SET
+          name = EXCLUDED.name,
+          parent_code = EXCLUDED.parent_code,
+          level = EXCLUDED.level,
+          domain_code = EXCLUDED.domain_code,
+          show_in_topbar = EXCLUDED.show_in_topbar,
+          show_in_sidebar = EXCLUDED.show_in_sidebar,
+          inherit_permissions = EXCLUDED.inherit_permissions,
+          read_permission_id = EXCLUDED.read_permission_id,
+          write_permission_id = EXCLUDED.write_permission_id,
+          sort_order = EXCLUDED.sort_order,
+          is_active = EXCLUDED.is_active
+        """
+    )
+
+    # 3) 恢复旧路由前缀
+    op.execute(
+        """
+        INSERT INTO page_route_prefixes (
+          page_code,
+          route_prefix,
+          sort_order,
+          is_active
+        )
+        VALUES
+          ('wms.count.tasks', '/count', 10, TRUE),
+          ('inbound.returns', '/inbound-receipts/returns', 30, TRUE),
+          ('wms.inbound.returns', '/receiving/returns', 40, TRUE)
+        ON CONFLICT (route_prefix) DO UPDATE
+        SET
+          page_code = EXCLUDED.page_code,
+          sort_order = EXCLUDED.sort_order,
+          is_active = EXCLUDED.is_active
+        """
+    )
+
+    # 4) 恢复隐藏页状态（维持当前真实口径：operations 默认不展示）
+    op.execute(
+        """
+        UPDATE page_registry
+           SET is_active = FALSE
+         WHERE code = 'wms.inbound.operations'
+        """
+    )
+
+    # 5) 删除库存调节新三级页；对应新 route_prefix 自动级联删除
+    op.execute(
+        """
+        DELETE FROM page_registry
+        WHERE code IN (
+          'wms.inventory_adjustment.summary',
+          'wms.inventory_adjustment.count',
+          'wms.inventory_adjustment.inbound_reversal',
+          'wms.inventory_adjustment.outbound_reversal',
+          'wms.inventory_adjustment.return_inbound'
+        )
+        """
+    )
+
+    # 6) 删除库存调节新二级页
+    op.execute(
+        """
+        DELETE FROM page_registry
+        WHERE code = 'wms.inventory_adjustment'
+        """
+    )

--- a/app/router_mount.py
+++ b/app/router_mount.py
@@ -10,8 +10,8 @@ def mount_routers(app: FastAPI, *, enable_dev_routes: bool) -> None:
     # ---------------------------------------------------------------------------
     from app.admin.router import router as admin_router
     from app.diagnostics.routers.autoheal_execute import router as autoheal_execute_router
-    from app.wms.count.routers.count import router as count_router
-    from app.wms.reconciliation.routers.stock_inventory_recount import router as stock_inventory_recount_router
+    from app.wms.inventory_adjustment.count.routers.count import router as count_router
+    from app.wms.inventory_adjustment.count.routers.stock_inventory_recount import router as stock_inventory_recount_router
     from app.diagnostics.routers.debug_trace import router as debug_trace_router
     from app.devtools.routers.dev_seed_ledger import router as dev_seed_ledger_router
     from app.devtools.routers.dev_stock_adjust import router as dev_stock_adjust_router
@@ -54,7 +54,7 @@ def mount_routers(app: FastAPI, *, enable_dev_routes: bool) -> None:
     from app.procurement.routers.purchase_reports import router as purchase_reports_router
     from app.inbound_receipts.routers.inbound_receipts import router as inbound_receipts_router
     from app.wms.receiving.routers.inbound_operations import router as inbound_operations_router
-    from app.wms.outbound.routers.return_tasks import router as return_tasks_router
+    from app.wms.inventory_adjustment.return_inbound.routers.return_tasks import router as return_tasks_router
     from app.wms.stock.routers.inventory import router as stock_inventory_router
     from app.wms.snapshot.routers.snapshot_v3 import router as snapshot_v3_router
     from app.wms.ledger.routers.stock_ledger import router as stock_ledger_router

--- a/app/wms/inventory_adjustment/__init__.py
+++ b/app/wms/inventory_adjustment/__init__.py
@@ -1,0 +1,4 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。

--- a/app/wms/inventory_adjustment/count/__init__.py
+++ b/app/wms/inventory_adjustment/count/__init__.py
@@ -1,0 +1,4 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。

--- a/app/wms/inventory_adjustment/count/contracts/__init__.py
+++ b/app/wms/inventory_adjustment/count/contracts/__init__.py
@@ -1,0 +1,4 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。

--- a/app/wms/inventory_adjustment/count/contracts/count.py
+++ b/app/wms/inventory_adjustment/count/contracts/count.py
@@ -1,0 +1,20 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_SRC: ModuleType = import_module("app.wms.count.contracts.count")
+__all__ = list(getattr(_SRC, "__all__", ()))
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_SRC, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(dir(_SRC)))

--- a/app/wms/inventory_adjustment/count/models/__init__.py
+++ b/app/wms/inventory_adjustment/count/models/__init__.py
@@ -1,0 +1,4 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。

--- a/app/wms/inventory_adjustment/count/repos/__init__.py
+++ b/app/wms/inventory_adjustment/count/repos/__init__.py
@@ -1,0 +1,4 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。

--- a/app/wms/inventory_adjustment/count/repos/count_repo.py
+++ b/app/wms/inventory_adjustment/count/repos/count_repo.py
@@ -1,0 +1,20 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_SRC: ModuleType = import_module("app.wms.count.repos.count_repo")
+__all__ = list(getattr(_SRC, "__all__", ()))
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_SRC, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(dir(_SRC)))

--- a/app/wms/inventory_adjustment/count/routers/__init__.py
+++ b/app/wms/inventory_adjustment/count/routers/__init__.py
@@ -1,0 +1,4 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。

--- a/app/wms/inventory_adjustment/count/routers/count.py
+++ b/app/wms/inventory_adjustment/count/routers/count.py
@@ -1,0 +1,8 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+from app.wms.count.routers.count import router
+
+__all__ = ["router"]

--- a/app/wms/inventory_adjustment/count/routers/stock_inventory_recount.py
+++ b/app/wms/inventory_adjustment/count/routers/stock_inventory_recount.py
@@ -1,0 +1,8 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+from app.wms.reconciliation.routers.stock_inventory_recount import router
+
+__all__ = ["router"]

--- a/app/wms/inventory_adjustment/count/services/__init__.py
+++ b/app/wms/inventory_adjustment/count/services/__init__.py
@@ -1,0 +1,4 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。

--- a/app/wms/inventory_adjustment/count/services/count_service.py
+++ b/app/wms/inventory_adjustment/count/services/count_service.py
@@ -1,0 +1,20 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_SRC: ModuleType = import_module("app.wms.count.services.count_service")
+__all__ = list(getattr(_SRC, "__all__", ()))
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_SRC, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(dir(_SRC)))

--- a/app/wms/inventory_adjustment/inbound_reversal/__init__.py
+++ b/app/wms/inventory_adjustment/inbound_reversal/__init__.py
@@ -1,0 +1,4 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。

--- a/app/wms/inventory_adjustment/inbound_reversal/contracts/__init__.py
+++ b/app/wms/inventory_adjustment/inbound_reversal/contracts/__init__.py
@@ -1,0 +1,4 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。

--- a/app/wms/inventory_adjustment/inbound_reversal/models/__init__.py
+++ b/app/wms/inventory_adjustment/inbound_reversal/models/__init__.py
@@ -1,0 +1,4 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。

--- a/app/wms/inventory_adjustment/inbound_reversal/repos/__init__.py
+++ b/app/wms/inventory_adjustment/inbound_reversal/repos/__init__.py
@@ -1,0 +1,4 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。

--- a/app/wms/inventory_adjustment/inbound_reversal/routers/__init__.py
+++ b/app/wms/inventory_adjustment/inbound_reversal/routers/__init__.py
@@ -1,0 +1,4 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。

--- a/app/wms/inventory_adjustment/inbound_reversal/services/__init__.py
+++ b/app/wms/inventory_adjustment/inbound_reversal/services/__init__.py
@@ -1,0 +1,4 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。

--- a/app/wms/inventory_adjustment/outbound_reversal/__init__.py
+++ b/app/wms/inventory_adjustment/outbound_reversal/__init__.py
@@ -1,0 +1,4 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。

--- a/app/wms/inventory_adjustment/outbound_reversal/contracts/__init__.py
+++ b/app/wms/inventory_adjustment/outbound_reversal/contracts/__init__.py
@@ -1,0 +1,4 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。

--- a/app/wms/inventory_adjustment/outbound_reversal/models/__init__.py
+++ b/app/wms/inventory_adjustment/outbound_reversal/models/__init__.py
@@ -1,0 +1,4 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。

--- a/app/wms/inventory_adjustment/outbound_reversal/repos/__init__.py
+++ b/app/wms/inventory_adjustment/outbound_reversal/repos/__init__.py
@@ -1,0 +1,4 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。

--- a/app/wms/inventory_adjustment/outbound_reversal/routers/__init__.py
+++ b/app/wms/inventory_adjustment/outbound_reversal/routers/__init__.py
@@ -1,0 +1,4 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。

--- a/app/wms/inventory_adjustment/outbound_reversal/services/__init__.py
+++ b/app/wms/inventory_adjustment/outbound_reversal/services/__init__.py
@@ -1,0 +1,4 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。

--- a/app/wms/inventory_adjustment/return_inbound/__init__.py
+++ b/app/wms/inventory_adjustment/return_inbound/__init__.py
@@ -1,0 +1,4 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。

--- a/app/wms/inventory_adjustment/return_inbound/contracts/__init__.py
+++ b/app/wms/inventory_adjustment/return_inbound/contracts/__init__.py
@@ -1,0 +1,4 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。

--- a/app/wms/inventory_adjustment/return_inbound/contracts/inbound_task_read.py
+++ b/app/wms/inventory_adjustment/return_inbound/contracts/inbound_task_read.py
@@ -1,0 +1,20 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_SRC: ModuleType = import_module("app.wms.receiving.contracts.inbound_task_read")
+__all__ = list(getattr(_SRC, "__all__", ()))
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_SRC, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(dir(_SRC)))

--- a/app/wms/inventory_adjustment/return_inbound/contracts/operation_submit.py
+++ b/app/wms/inventory_adjustment/return_inbound/contracts/operation_submit.py
@@ -1,0 +1,20 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_SRC: ModuleType = import_module("app.wms.receiving.contracts.operation_submit")
+__all__ = list(getattr(_SRC, "__all__", ()))
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_SRC, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(dir(_SRC)))

--- a/app/wms/inventory_adjustment/return_inbound/contracts/probe.py
+++ b/app/wms/inventory_adjustment/return_inbound/contracts/probe.py
@@ -1,0 +1,20 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_SRC: ModuleType = import_module("app.wms.receiving.contracts.probe")
+__all__ = list(getattr(_SRC, "__all__", ()))
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_SRC, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(dir(_SRC)))

--- a/app/wms/inventory_adjustment/return_inbound/contracts/receipt_create_from_return_order.py
+++ b/app/wms/inventory_adjustment/return_inbound/contracts/receipt_create_from_return_order.py
@@ -1,0 +1,20 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_SRC: ModuleType = import_module("app.inbound_receipts.contracts.receipt_create_from_return_order")
+__all__ = list(getattr(_SRC, "__all__", ()))
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_SRC, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(dir(_SRC)))

--- a/app/wms/inventory_adjustment/return_inbound/contracts/receipt_return_source.py
+++ b/app/wms/inventory_adjustment/return_inbound/contracts/receipt_return_source.py
@@ -1,0 +1,20 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_SRC: ModuleType = import_module("app.inbound_receipts.contracts.receipt_return_source")
+__all__ = list(getattr(_SRC, "__all__", ()))
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_SRC, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(dir(_SRC)))

--- a/app/wms/inventory_adjustment/return_inbound/contracts/return_task.py
+++ b/app/wms/inventory_adjustment/return_inbound/contracts/return_task.py
@@ -1,0 +1,20 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_SRC: ModuleType = import_module("app.wms.outbound.contracts.return_task")
+__all__ = list(getattr(_SRC, "__all__", ()))
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_SRC, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(dir(_SRC)))

--- a/app/wms/inventory_adjustment/return_inbound/models/__init__.py
+++ b/app/wms/inventory_adjustment/return_inbound/models/__init__.py
@@ -1,0 +1,4 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。

--- a/app/wms/inventory_adjustment/return_inbound/models/inbound_operation.py
+++ b/app/wms/inventory_adjustment/return_inbound/models/inbound_operation.py
@@ -1,0 +1,20 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_SRC: ModuleType = import_module("app.wms.receiving.models.inbound_operation")
+__all__ = list(getattr(_SRC, "__all__", ()))
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_SRC, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(dir(_SRC)))

--- a/app/wms/inventory_adjustment/return_inbound/models/inbound_receipt.py
+++ b/app/wms/inventory_adjustment/return_inbound/models/inbound_receipt.py
@@ -1,0 +1,20 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_SRC: ModuleType = import_module("app.inbound_receipts.models.inbound_receipt")
+__all__ = list(getattr(_SRC, "__all__", ()))
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_SRC, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(dir(_SRC)))

--- a/app/wms/inventory_adjustment/return_inbound/models/return_task.py
+++ b/app/wms/inventory_adjustment/return_inbound/models/return_task.py
@@ -1,0 +1,20 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_SRC: ModuleType = import_module("app.models.return_task")
+__all__ = list(getattr(_SRC, "__all__", ()))
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_SRC, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(dir(_SRC)))

--- a/app/wms/inventory_adjustment/return_inbound/repos/__init__.py
+++ b/app/wms/inventory_adjustment/return_inbound/repos/__init__.py
@@ -1,0 +1,4 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。

--- a/app/wms/inventory_adjustment/return_inbound/repos/inbound_operation_write_repo.py
+++ b/app/wms/inventory_adjustment/return_inbound/repos/inbound_operation_write_repo.py
@@ -1,0 +1,20 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_SRC: ModuleType = import_module("app.wms.receiving.repos.inbound_operation_write_repo")
+__all__ = list(getattr(_SRC, "__all__", ()))
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_SRC, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(dir(_SRC)))

--- a/app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_read_repo.py
+++ b/app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_read_repo.py
@@ -1,0 +1,20 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_SRC: ModuleType = import_module("app.inbound_receipts.repos.inbound_receipt_read_repo")
+__all__ = list(getattr(_SRC, "__all__", ()))
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_SRC, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(dir(_SRC)))

--- a/app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_write_repo.py
+++ b/app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_write_repo.py
@@ -1,0 +1,20 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_SRC: ModuleType = import_module("app.inbound_receipts.repos.inbound_receipt_write_repo")
+__all__ = list(getattr(_SRC, "__all__", ()))
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_SRC, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(dir(_SRC)))

--- a/app/wms/inventory_adjustment/return_inbound/repos/inbound_task_probe_repo.py
+++ b/app/wms/inventory_adjustment/return_inbound/repos/inbound_task_probe_repo.py
@@ -1,0 +1,20 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_SRC: ModuleType = import_module("app.wms.receiving.repos.inbound_task_probe_repo")
+__all__ = list(getattr(_SRC, "__all__", ()))
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_SRC, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(dir(_SRC)))

--- a/app/wms/inventory_adjustment/return_inbound/repos/inbound_task_read_repo.py
+++ b/app/wms/inventory_adjustment/return_inbound/repos/inbound_task_read_repo.py
@@ -1,0 +1,20 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_SRC: ModuleType = import_module("app.wms.receiving.repos.inbound_task_read_repo")
+__all__ = list(getattr(_SRC, "__all__", ()))
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_SRC, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(dir(_SRC)))

--- a/app/wms/inventory_adjustment/return_inbound/routers/__init__.py
+++ b/app/wms/inventory_adjustment/return_inbound/routers/__init__.py
@@ -1,0 +1,4 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。

--- a/app/wms/inventory_adjustment/return_inbound/routers/inbound_operations.py
+++ b/app/wms/inventory_adjustment/return_inbound/routers/inbound_operations.py
@@ -1,0 +1,8 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+from app.wms.receiving.routers.inbound_operations import router
+
+__all__ = ["router"]

--- a/app/wms/inventory_adjustment/return_inbound/routers/inbound_receipts.py
+++ b/app/wms/inventory_adjustment/return_inbound/routers/inbound_receipts.py
@@ -1,0 +1,8 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+from app.inbound_receipts.routers.inbound_receipts import router
+
+__all__ = ["router"]

--- a/app/wms/inventory_adjustment/return_inbound/routers/return_tasks.py
+++ b/app/wms/inventory_adjustment/return_inbound/routers/return_tasks.py
@@ -1,0 +1,8 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+from app.wms.outbound.routers.return_tasks import router
+
+__all__ = ["router"]

--- a/app/wms/inventory_adjustment/return_inbound/services/__init__.py
+++ b/app/wms/inventory_adjustment/return_inbound/services/__init__.py
@@ -1,0 +1,4 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。

--- a/app/wms/inventory_adjustment/return_inbound/services/create_from_return_order_service.py
+++ b/app/wms/inventory_adjustment/return_inbound/services/create_from_return_order_service.py
@@ -1,0 +1,20 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_SRC: ModuleType = import_module("app.inbound_receipts.services.create_from_return_order_service")
+__all__ = list(getattr(_SRC, "__all__", ()))
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_SRC, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(dir(_SRC)))

--- a/app/wms/inventory_adjustment/return_inbound/services/inbound_operation_submit_service.py
+++ b/app/wms/inventory_adjustment/return_inbound/services/inbound_operation_submit_service.py
@@ -1,0 +1,20 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_SRC: ModuleType = import_module("app.wms.receiving.services.inbound_operation_submit_service")
+__all__ = list(getattr(_SRC, "__all__", ()))
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_SRC, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(dir(_SRC)))

--- a/app/wms/inventory_adjustment/return_inbound/services/inbound_task_probe_service.py
+++ b/app/wms/inventory_adjustment/return_inbound/services/inbound_task_probe_service.py
@@ -1,0 +1,20 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_SRC: ModuleType = import_module("app.wms.receiving.services.inbound_task_probe_service")
+__all__ = list(getattr(_SRC, "__all__", ()))
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_SRC, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(dir(_SRC)))

--- a/app/wms/inventory_adjustment/return_inbound/services/inbound_task_read_service.py
+++ b/app/wms/inventory_adjustment/return_inbound/services/inbound_task_read_service.py
@@ -1,0 +1,20 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_SRC: ModuleType = import_module("app.wms.receiving.services.inbound_task_read_service")
+__all__ = list(getattr(_SRC, "__all__", ()))
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_SRC, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(dir(_SRC)))

--- a/app/wms/inventory_adjustment/return_inbound/services/return_source_service.py
+++ b/app/wms/inventory_adjustment/return_inbound/services/return_source_service.py
@@ -1,0 +1,20 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_SRC: ModuleType = import_module("app.inbound_receipts.services.return_source_service")
+__all__ = list(getattr(_SRC, "__all__", ()))
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_SRC, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(dir(_SRC)))

--- a/app/wms/inventory_adjustment/return_inbound/services/return_task_service.py
+++ b/app/wms/inventory_adjustment/return_inbound/services/return_task_service.py
@@ -1,0 +1,20 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_SRC: ModuleType = import_module("app.wms.outbound.services.return_task_service")
+__all__ = list(getattr(_SRC, "__all__", ()))
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_SRC, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(dir(_SRC)))

--- a/app/wms/inventory_adjustment/return_inbound/services/return_task_service_impl.py
+++ b/app/wms/inventory_adjustment/return_inbound/services/return_task_service_impl.py
@@ -1,0 +1,20 @@
+# Split note:
+# 本目录是 inventory_adjustment 模块的物理收口层。
+# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
+# 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_SRC: ModuleType = import_module("app.wms.outbound.services.return_task_service_impl")
+__all__ = list(getattr(_SRC, "__all__", ()))
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_SRC, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(dir(_SRC)))

--- a/tests/api/test_user_navigation_api.py
+++ b/tests/api/test_user_navigation_api.py
@@ -17,7 +17,10 @@ async def _reset_navigation_registry_state(session: AsyncSession) -> None:
 
     当前主线要求：
     - tms 下子页在相关测试前恢复为可见
-    - wms.count.adjustments 仍保持 is_active = FALSE
+    - wms.inventory_adjustment 下子页保持可见
+    - wms.inbound 只保留 atomic / purchase / manual 可见
+    - wms.inbound.operations / wms.inbound.returns 保持隐藏
+    - inbound 只保留 summary / purchase / manual 可见
     """
     await session.execute(
         text(
@@ -28,24 +31,59 @@ async def _reset_navigation_registry_state(session: AsyncSession) -> None:
             """
         )
     )
+
+    await session.execute(
+        text(
+            """
+            UPDATE page_registry
+               SET is_active = TRUE
+             WHERE parent_code = 'wms.inventory_adjustment'
+            """
+        )
+    )
+
+    await session.execute(
+        text(
+            """
+            UPDATE page_registry
+               SET is_active = TRUE
+             WHERE code IN (
+               'wms.inbound.atomic',
+               'wms.inbound.purchase',
+               'wms.inbound.manual',
+               'inbound.summary',
+               'inbound.purchase',
+               'inbound.manual'
+             )
+            """
+        )
+    )
+
     await session.execute(
         text(
             """
             UPDATE page_registry
                SET is_active = FALSE
-             WHERE code = 'wms.count.adjustments'
+             WHERE code IN (
+               'wms.inbound.operations',
+               'wms.inbound.returns',
+               'inbound.returns'
+             )
             """
         )
     )
+
     await session.execute(
         text(
             """
             UPDATE page_route_prefixes
                SET is_active = TRUE
              WHERE route_prefix LIKE '/tms/%'
+                OR route_prefix LIKE '/inventory-adjustment%'
             """
         )
     )
+
     await session.commit()
 
 
@@ -173,13 +211,14 @@ async def test_my_navigation_admin_contains_new_wms_tree_and_filters_legacy_shel
 
     root_codes = [page["code"] for page in pages]
     assert "wms" in root_codes
+    assert "inbound" in root_codes
 
     wms = nodes["wms"]
     assert _child_codes(wms) == [
         "wms.inventory",
         "wms.inbound",
         "wms.outbound",
-        "wms.count",
+        "wms.inventory_adjustment",
         "wms.warehouses",
     ]
 
@@ -190,8 +229,7 @@ async def test_my_navigation_admin_contains_new_wms_tree_and_filters_legacy_shel
     assert _child_codes(nodes["wms.inbound"]) == [
         "wms.inbound.atomic",
         "wms.inbound.purchase",
-        "wms.inbound.returns",
-        "wms.inbound.operations",
+        "wms.inbound.manual",
     ]
     assert _child_codes(nodes["wms.outbound"]) == [
         "wms.outbound.summary",
@@ -199,10 +237,26 @@ async def test_my_navigation_admin_contains_new_wms_tree_and_filters_legacy_shel
         "wms.outbound.manual_docs",
         "wms.outbound.manual",
     ]
-    assert _child_codes(nodes["wms.count"]) == [
-        "wms.count.tasks",
+    assert _child_codes(nodes["wms.inventory_adjustment"]) == [
+        "wms.inventory_adjustment.summary",
+        "wms.inventory_adjustment.count",
+        "wms.inventory_adjustment.inbound_reversal",
+        "wms.inventory_adjustment.outbound_reversal",
+        "wms.inventory_adjustment.return_inbound",
     ]
     assert _child_codes(nodes["wms.warehouses"]) == []
+
+    assert _child_codes(nodes["inbound"]) == [
+        "inbound.summary",
+        "inbound.purchase",
+        "inbound.manual",
+    ]
+
+    assert "wms.count" not in nodes
+    assert "wms.count.tasks" not in nodes
+    assert "wms.count.adjustments" not in nodes
+    assert "wms.inbound.returns" not in nodes
+    assert "inbound.returns" not in nodes
 
     assert "wms.order_outbound" not in nodes
     assert "wms.order_management" not in nodes
@@ -288,6 +342,8 @@ async def test_my_navigation_route_prefix_mapping_and_effective_permissions(clie
     suppliers_page = nodes["wms.masterdata.suppliers"]
     inventory_page = nodes["wms.inventory.main"]
     warehouses_page = nodes["wms.warehouses"]
+    inventory_adjustment_page = nodes["wms.inventory_adjustment.summary"]
+    inventory_return_inbound_page = nodes["wms.inventory_adjustment.return_inbound"]
 
     assert pricing_page["effective_read_permission"] == "page.tms.read"
     assert pricing_page["effective_write_permission"] == "page.tms.write"
@@ -304,23 +360,35 @@ async def test_my_navigation_route_prefix_mapping_and_effective_permissions(clie
     assert warehouses_page["effective_read_permission"] == "page.wms.read"
     assert warehouses_page["effective_write_permission"] == "page.wms.write"
 
+    assert inventory_adjustment_page["effective_read_permission"] == "page.wms.read"
+    assert inventory_adjustment_page["effective_write_permission"] == "page.wms.write"
+
+    assert inventory_return_inbound_page["effective_read_permission"] == "page.wms.read"
+    assert inventory_return_inbound_page["effective_write_permission"] == "page.wms.write"
+
     pricing_route = route_map.get("/tms/pricing")
     items_route = route_map.get("/items")
     suppliers_route = route_map.get("/suppliers")
     inventory_route = route_map.get("/inventory")
     warehouses_route = route_map.get("/warehouses")
+    inventory_adjustment_route = route_map.get("/inventory-adjustment")
+    inventory_return_inbound_route = route_map.get("/inventory-adjustment/return-inbound")
 
     assert pricing_route is not None, "/tms/pricing should exist in route_prefixes"
     assert items_route is not None, "/items should exist in route_prefixes"
     assert suppliers_route is not None, "/suppliers should exist in route_prefixes"
     assert inventory_route is not None, "/inventory should exist in route_prefixes"
     assert warehouses_route is not None, "/warehouses should exist in route_prefixes"
+    assert inventory_adjustment_route is not None, "/inventory-adjustment should exist in route_prefixes"
+    assert inventory_return_inbound_route is not None, "/inventory-adjustment/return-inbound should exist in route_prefixes"
 
     assert pricing_route["page_code"] == "wms.logistics.pricing"
     assert items_route["page_code"] == "wms.masterdata.items"
     assert suppliers_route["page_code"] == "wms.masterdata.suppliers"
     assert inventory_route["page_code"] == "wms.inventory.main"
     assert warehouses_route["page_code"] == "wms.warehouses"
+    assert inventory_adjustment_route["page_code"] == "wms.inventory_adjustment.summary"
+    assert inventory_return_inbound_route["page_code"] == "wms.inventory_adjustment.return_inbound"
 
     assert pricing_route["effective_read_permission"] == "page.tms.read"
     assert pricing_route["effective_write_permission"] == "page.tms.write"
@@ -336,6 +404,12 @@ async def test_my_navigation_route_prefix_mapping_and_effective_permissions(clie
 
     assert warehouses_route["effective_read_permission"] == "page.wms.read"
     assert warehouses_route["effective_write_permission"] == "page.wms.write"
+
+    assert inventory_adjustment_route["effective_read_permission"] == "page.wms.read"
+    assert inventory_adjustment_route["effective_write_permission"] == "page.wms.write"
+
+    assert inventory_return_inbound_route["effective_read_permission"] == "page.wms.read"
+    assert inventory_return_inbound_route["effective_write_permission"] == "page.wms.write"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- aggregate inventory adjustment backend files under app/wms/inventory_adjustment
- add inventory adjustment navigation migrations
- include contracts / models / repos / routers / services layout
- rebind router_mount imports to the new aggregation layer
- update navigation tests for inventory adjustment tree

## Validation
- python3 -m compileall app/router_mount.py app/wms/inventory_adjustment tests/api/test_user_navigation_api.py
- ruff check app/wms/inventory_adjustment app/router_mount.py tests/api/test_user_navigation_api.py
- make test TESTS=tests/api/test_user_navigation_api.py
- make alembic-check