### PR TITLE
feat(wms): implement inbound and outbound reversal under inventory_adjustment

### DIFF
--- a/app/router_mount.py
+++ b/app/router_mount.py
@@ -44,10 +44,16 @@ def mount_routers(app: FastAPI, *, enable_dev_routes: bool) -> None:
     from app.analytics.routers.orders_stats_routes import router as orders_stats_router
     from app.wms.inbound.routers.inbound_events import router as inbound_events_router
     from app.wms.inbound.routers.inbound_commit import router as inbound_commit_router
+    from app.wms.inventory_adjustment.inbound_reversal.routers.inbound_reversal import (
+        router as inbound_reversal_router,
+    )
     from app.wms.outbound.routers.order_submit import router as order_submit_router
     from app.wms.outbound.routers.manual_docs import router as manual_docs_router
     from app.wms.outbound.routers.manual_submit import router as manual_submit_router
     from app.wms.outbound.routers.outbound_summary import router as outbound_summary_router
+    from app.wms.inventory_adjustment.outbound_reversal.routers.outbound_reversal import (
+        router as outbound_reversal_router,
+    )
     from app.wms.outbound.routers.lot_candidates import router as outbound_lot_candidates_router
     from app.wms.outbound.routers.print_jobs import router as print_jobs_router
     from app.procurement.routers.purchase_orders import router as purchase_orders_router
@@ -113,6 +119,7 @@ def mount_routers(app: FastAPI, *, enable_dev_routes: bool) -> None:
     app.include_router(manual_submit_router)
     app.include_router(outbound_lot_candidates_router)
     app.include_router(outbound_summary_router)
+    app.include_router(outbound_reversal_router)
     app.include_router(tms_shipment_router)
 
     app.include_router(purchase_orders_router)
@@ -121,6 +128,7 @@ def mount_routers(app: FastAPI, *, enable_dev_routes: bool) -> None:
     app.include_router(inbound_operations_router)
     app.include_router(inbound_events_router)
     app.include_router(inbound_commit_router)
+    app.include_router(inbound_reversal_router)
     app.include_router(return_tasks_router)
     app.include_router(print_jobs_router)
 

--- a/app/wms/inventory_adjustment/inbound_reversal/contracts/__init__.py
+++ b/app/wms/inventory_adjustment/inbound_reversal/contracts/__init__.py
@@ -1,4 +1,11 @@
-# Split note:
-# 本目录是 inventory_adjustment 模块的物理收口层。
-# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
-# 后续如确认稳定，再逐步把真实实现迁入本目录。
+from .inbound_reversal import (
+    InboundReversalIn,
+    InboundReversalOut,
+    InboundReversalRowOut,
+)
+
+__all__ = [
+    "InboundReversalIn",
+    "InboundReversalOut",
+    "InboundReversalRowOut",
+]

--- a/app/wms/inventory_adjustment/inbound_reversal/contracts/inbound_reversal.py
+++ b/app/wms/inventory_adjustment/inbound_reversal/contracts/inbound_reversal.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.wms.inbound.contracts.inbound_commit import InboundSourceType
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+        str_strip_whitespace=True,
+        populate_by_name=True,
+    )
+
+
+class InboundReversalIn(_Base):
+    occurred_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        description="冲回业务发生时间",
+    )
+    remark: Annotated[str | None, Field(default=None, max_length=500, description="冲回备注")]
+
+    @model_validator(mode="after")
+    def _normalize_time(self) -> "InboundReversalIn":
+        if self.occurred_at.tzinfo is None:
+            self.occurred_at = self.occurred_at.replace(tzinfo=timezone.utc)
+        return self
+
+
+class InboundReversalRowOut(_Base):
+    line_no: Annotated[int, Field(ge=1, description="事件行号")]
+    item_id: Annotated[int, Field(ge=1, description="商品 ID")]
+    lot_id: Annotated[int, Field(ge=1, description="lot_id")]
+    qty_base: Annotated[int, Field(ge=1, description="冲回 base 数量")]
+
+
+class InboundReversalOut(_Base):
+    ok: bool = Field(default=True, description="是否成功")
+    event_id: Annotated[int, Field(ge=1, description="冲回事件 ID")]
+    event_no: Annotated[str, Field(min_length=1, max_length=64, description="冲回事件单号")]
+    trace_id: Annotated[str, Field(min_length=1, max_length=128, description="技术链路追踪号")]
+    target_event_id: Annotated[int, Field(ge=1, description="被冲回的原事件 ID")]
+    warehouse_id: Annotated[int, Field(ge=1, description="仓库 ID")]
+    source_type: InboundSourceType
+    source_ref: Annotated[str | None, Field(default=None, max_length=128, description="来源单号/外部引用号")]
+    occurred_at: datetime = Field(description="冲回业务发生时间")
+    remark: Annotated[str | None, Field(default=None, max_length=500, description="冲回备注")]
+    rows: list[InboundReversalRowOut] = Field(default_factory=list, description="冲回结果行")
+
+
+__all__ = [
+    "InboundReversalIn",
+    "InboundReversalRowOut",
+    "InboundReversalOut",
+]

--- a/app/wms/inventory_adjustment/inbound_reversal/repos/__init__.py
+++ b/app/wms/inventory_adjustment/inbound_reversal/repos/__init__.py
@@ -1,4 +1,13 @@
-# Split note:
-# 本目录是 inventory_adjustment 模块的物理收口层。
-# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
-# 后续如确认稳定，再逐步把真实实现迁入本目录。
+from .inbound_reversal_repo import (
+    find_committed_inbound_reversal,
+    get_inbound_event_for_reversal,
+    list_inbound_event_lines_for_reversal,
+    mark_inbound_event_superseded,
+)
+
+__all__ = [
+    "find_committed_inbound_reversal",
+    "get_inbound_event_for_reversal",
+    "list_inbound_event_lines_for_reversal",
+    "mark_inbound_event_superseded",
+]

--- a/app/wms/inventory_adjustment/inbound_reversal/repos/inbound_reversal_repo.py
+++ b/app/wms/inventory_adjustment/inbound_reversal/repos/inbound_reversal_repo.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def _norm_text(v: object) -> str | None:
+    if v is None:
+        return None
+    s = str(v).strip()
+    return s or None
+
+
+async def get_inbound_event_for_reversal(
+    session: AsyncSession,
+    *,
+    event_id: int,
+) -> dict[str, Any]:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  id AS event_id,
+                  event_no,
+                  warehouse_id,
+                  source_type,
+                  source_ref,
+                  occurred_at,
+                  committed_at,
+                  event_kind,
+                  target_event_id,
+                  status,
+                  remark
+                FROM wms_events
+                WHERE id = :event_id
+                  AND event_type = 'INBOUND'
+                LIMIT 1
+                """
+            ),
+            {"event_id": int(event_id)},
+        )
+    ).mappings().first()
+
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"inbound_event_not_found:{int(event_id)}")
+
+    if str(row["event_kind"]) != "COMMIT":
+        raise HTTPException(
+            status_code=409,
+            detail=f"inbound_event_not_reversible_kind:{row['event_kind']}",
+        )
+
+    if str(row["status"]) != "COMMITTED":
+        raise HTTPException(
+            status_code=409,
+            detail=f"inbound_event_not_reversible_status:{row['status']}",
+        )
+
+    return dict(row)
+
+
+async def find_committed_inbound_reversal(
+    session: AsyncSession,
+    *,
+    target_event_id: int,
+) -> dict[str, Any] | None:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  id,
+                  event_no,
+                  status
+                FROM wms_events
+                WHERE event_type = 'INBOUND'
+                  AND event_kind = 'REVERSAL'
+                  AND target_event_id = :target_event_id
+                  AND status = 'COMMITTED'
+                ORDER BY id DESC
+                LIMIT 1
+                """
+            ),
+            {"target_event_id": int(target_event_id)},
+        )
+    ).mappings().first()
+    return dict(row) if row is not None else None
+
+
+async def list_inbound_event_lines_for_reversal(
+    session: AsyncSession,
+    *,
+    event_id: int,
+) -> list[dict[str, Any]]:
+    rows = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  line_no,
+                  item_id,
+                  actual_uom_id,
+                  barcode_input,
+                  actual_qty_input,
+                  actual_ratio_to_base_snapshot,
+                  qty_base,
+                  lot_code_input,
+                  production_date,
+                  expiry_date,
+                  lot_id,
+                  po_line_id,
+                  remark
+                FROM inbound_event_lines
+                WHERE event_id = :event_id
+                ORDER BY line_no ASC, id ASC
+                """
+            ),
+            {"event_id": int(event_id)},
+        )
+    ).mappings().all()
+
+    if not rows:
+        raise HTTPException(
+            status_code=409,
+            detail=f"inbound_event_has_no_lines:{int(event_id)}",
+        )
+
+    return [dict(r) for r in rows]
+
+
+async def mark_inbound_event_superseded(
+    session: AsyncSession,
+    *,
+    event_id: int,
+) -> None:
+    await session.execute(
+        text(
+            """
+            UPDATE wms_events
+            SET status = 'SUPERSEDED'
+            WHERE id = :event_id
+              AND event_type = 'INBOUND'
+              AND event_kind = 'COMMIT'
+              AND status = 'COMMITTED'
+            """
+        ),
+        {"event_id": int(event_id)},
+    )
+
+
+__all__ = [
+    "get_inbound_event_for_reversal",
+    "find_committed_inbound_reversal",
+    "list_inbound_event_lines_for_reversal",
+    "mark_inbound_event_superseded",
+]

--- a/app/wms/inventory_adjustment/inbound_reversal/routers/__init__.py
+++ b/app/wms/inventory_adjustment/inbound_reversal/routers/__init__.py
@@ -1,4 +1,5 @@
-# Split note:
-# 本目录是 inventory_adjustment 模块的物理收口层。
-# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
-# 后续如确认稳定，再逐步把真实实现迁入本目录。
+from .inbound_reversal import router
+
+__all__ = [
+    "router",
+]

--- a/app/wms/inventory_adjustment/inbound_reversal/routers/inbound_reversal.py
+++ b/app/wms/inventory_adjustment/inbound_reversal/routers/inbound_reversal.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_session
+from app.wms.inventory_adjustment.inbound_reversal.contracts.inbound_reversal import (
+    InboundReversalIn,
+    InboundReversalOut,
+)
+from app.wms.inventory_adjustment.inbound_reversal.services.inbound_reversal_service import (
+    reverse_inbound_event,
+)
+
+router = APIRouter(prefix="/wms/inbound", tags=["wms-inbound-reversal"])
+
+
+@router.post("/events/{event_id}/reverse", response_model=InboundReversalOut)
+async def reverse_inbound_event_endpoint(
+    event_id: int,
+    payload: InboundReversalIn,
+    session: AsyncSession = Depends(get_session),
+) -> InboundReversalOut:
+    try:
+        out = await reverse_inbound_event(
+            session,
+            event_id=int(event_id),
+            payload=payload,
+            user_id=None,
+        )
+        await session.commit()
+        return out
+    except HTTPException:
+        await session.rollback()
+        raise
+    except Exception as e:
+        await session.rollback()
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+__all__ = ["router"]

--- a/app/wms/inventory_adjustment/inbound_reversal/services/__init__.py
+++ b/app/wms/inventory_adjustment/inbound_reversal/services/__init__.py
@@ -1,4 +1,5 @@
-# Split note:
-# 本目录是 inventory_adjustment 模块的物理收口层。
-# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
-# 后续如确认稳定，再逐步把真实实现迁入本目录。
+from .inbound_reversal_service import reverse_inbound_event
+
+__all__ = [
+    "reverse_inbound_event",
+]

--- a/app/wms/inventory_adjustment/inbound_reversal/services/inbound_reversal_service.py
+++ b/app/wms/inventory_adjustment/inbound_reversal/services/inbound_reversal_service.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.enums import MovementType
+from app.wms.inbound.models.inbound_event import InboundEventLine, WmsEvent
+from app.wms.inventory_adjustment.inbound_reversal.contracts.inbound_reversal import (
+    InboundReversalIn,
+    InboundReversalOut,
+    InboundReversalRowOut,
+)
+from app.wms.inventory_adjustment.inbound_reversal.repos.inbound_reversal_repo import (
+    find_committed_inbound_reversal,
+    get_inbound_event_for_reversal,
+    list_inbound_event_lines_for_reversal,
+    mark_inbound_event_superseded,
+)
+from app.wms.stock.services.stock_service import StockService
+
+UTC = timezone.utc
+
+
+def _new_trace_id() -> str:
+    return f"IN-REV-{uuid4().hex[:20]}"
+
+
+def _new_event_no() -> str:
+    stamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
+    return f"IER-{stamp}-{uuid4().hex[:8].upper()}"
+
+
+def _norm_text(v: object) -> str | None:
+    if v is None:
+        return None
+    s = str(v).strip()
+    return s or None
+
+
+async def reverse_inbound_event(
+    session: AsyncSession,
+    *,
+    event_id: int,
+    payload: InboundReversalIn,
+    user_id: int | None = None,
+) -> InboundReversalOut:
+    existing = await find_committed_inbound_reversal(
+        session,
+        target_event_id=int(event_id),
+    )
+    existing = await find_committed_inbound_reversal(
+        session,
+        target_event_id=int(event_id),
+    )
+    if existing is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=f"inbound_event_already_reversed:{int(existing['id'])}",
+        )
+
+    original = await get_inbound_event_for_reversal(session, event_id=int(event_id))
+    if existing is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=f"inbound_event_already_reversed:{int(existing['id'])}",
+        )
+
+    source_lines = await list_inbound_event_lines_for_reversal(
+        session,
+        event_id=int(original["event_id"]),
+    )
+
+    occurred_at = payload.occurred_at
+    trace_id = _new_trace_id()
+    event_no = _new_event_no()
+
+    event = WmsEvent(
+        event_no=str(event_no),
+        event_type="INBOUND",
+        warehouse_id=int(original["warehouse_id"]),
+        source_type=str(original["source_type"]),
+        source_ref=_norm_text(original["source_ref"]),
+        occurred_at=occurred_at,
+        trace_id=str(trace_id),
+        event_kind="REVERSAL",
+        target_event_id=int(original["event_id"]),
+        status="COMMITTED",
+        created_by=int(user_id) if user_id is not None else None,
+        remark=_norm_text(payload.remark) or f"reversal of {original['event_no']}",
+    )
+    session.add(event)
+    await session.flush()
+
+    stock = StockService()
+    rows: list[InboundReversalRowOut] = []
+
+    for src in source_lines:
+        line_no = int(src["line_no"])
+        item_id = int(src["item_id"])
+        lot_id = src["lot_id"]
+        qty_base = int(src["qty_base"])
+
+        if lot_id is None:
+            raise HTTPException(
+                status_code=409,
+                detail=f"inbound_event_line_missing_lot:{line_no}",
+            )
+        if qty_base <= 0:
+            raise HTTPException(
+                status_code=409,
+                detail=f"inbound_event_line_invalid_qty_base:{line_no}",
+            )
+
+        event_line = InboundEventLine(
+            event_id=int(event.id),
+            line_no=line_no,
+            item_id=item_id,
+            actual_uom_id=int(src["actual_uom_id"]),
+            barcode_input=_norm_text(src["barcode_input"]),
+            actual_qty_input=int(src["actual_qty_input"]),
+            actual_ratio_to_base_snapshot=int(src["actual_ratio_to_base_snapshot"]),
+            qty_base=qty_base,
+            lot_code_input=_norm_text(src["lot_code_input"]),
+            production_date=src["production_date"],
+            expiry_date=src["expiry_date"],
+            lot_id=int(lot_id),
+            po_line_id=(int(src["po_line_id"]) if src["po_line_id"] is not None else None),
+            remark=_norm_text(src["remark"]),
+        )
+        session.add(event_line)
+        await session.flush()
+
+        await stock.adjust_lot(
+            session=session,
+            item_id=item_id,
+            warehouse_id=int(original["warehouse_id"]),
+            lot_id=int(lot_id),
+            delta=-qty_base,
+            reason=MovementType.ADJUSTMENT,
+            ref=str(event.event_no),
+            ref_line=line_no,
+            occurred_at=occurred_at,
+            batch_code=None,
+            production_date=None,
+            expiry_date=None,
+            trace_id=str(trace_id),
+            meta={
+                "sub_reason": "INBOUND_REVERSAL",
+                "event_id": int(event.id),
+                "target_event_id": int(original["event_id"]),
+                "source_type": str(original["source_type"]),
+                "source_ref": _norm_text(original["source_ref"]),
+                "remark": _norm_text(event.remark),
+            },
+            shadow_write_stocks=False,
+        )
+
+        rows.append(
+            InboundReversalRowOut(
+                line_no=line_no,
+                item_id=item_id,
+                lot_id=int(lot_id),
+                qty_base=qty_base,
+            )
+        )
+
+    await mark_inbound_event_superseded(
+        session,
+        event_id=int(original["event_id"]),
+    )
+
+    return InboundReversalOut(
+        ok=True,
+        event_id=int(event.id),
+        event_no=str(event.event_no),
+        trace_id=str(trace_id),
+        target_event_id=int(original["event_id"]),
+        warehouse_id=int(original["warehouse_id"]),
+        source_type=str(original["source_type"]),
+        source_ref=_norm_text(original["source_ref"]),
+        occurred_at=occurred_at,
+        remark=_norm_text(event.remark),
+        rows=rows,
+    )
+
+
+__all__ = [
+    "reverse_inbound_event",
+]

--- a/app/wms/inventory_adjustment/outbound_reversal/contracts/__init__.py
+++ b/app/wms/inventory_adjustment/outbound_reversal/contracts/__init__.py
@@ -1,4 +1,13 @@
-# Split note:
-# 本目录是 inventory_adjustment 模块的物理收口层。
-# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
-# 后续如确认稳定，再逐步把真实实现迁入本目录。
+from .outbound_reversal import (
+    OutboundReversalIn,
+    OutboundReversalOut,
+    OutboundReversalRowOut,
+    OutboundReversalSourceType,
+)
+
+__all__ = [
+    "OutboundReversalSourceType",
+    "OutboundReversalIn",
+    "OutboundReversalOut",
+    "OutboundReversalRowOut",
+]

--- a/app/wms/inventory_adjustment/outbound_reversal/contracts/outbound_reversal.py
+++ b/app/wms/inventory_adjustment/outbound_reversal/contracts/outbound_reversal.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+        str_strip_whitespace=True,
+        populate_by_name=True,
+    )
+
+
+OutboundReversalSourceType = Literal["ORDER", "MANUAL"]
+
+
+class OutboundReversalIn(_Base):
+    occurred_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        description="冲回业务发生时间",
+    )
+    remark: Annotated[str | None, Field(default=None, max_length=500, description="冲回备注")]
+
+    @model_validator(mode="after")
+    def _normalize_time(self) -> "OutboundReversalIn":
+        if self.occurred_at.tzinfo is None:
+            self.occurred_at = self.occurred_at.replace(tzinfo=timezone.utc)
+        return self
+
+
+class OutboundReversalRowOut(_Base):
+    ref_line: Annotated[int, Field(ge=1, description="事件行号")]
+    item_id: Annotated[int, Field(ge=1, description="商品 ID")]
+    lot_id: Annotated[int, Field(ge=1, description="lot_id")]
+    qty_outbound: Annotated[int, Field(ge=1, description="原出库数量")]
+
+
+class OutboundReversalOut(_Base):
+    ok: bool = Field(default=True, description="是否成功")
+    event_id: Annotated[int, Field(ge=1, description="冲回事件 ID")]
+    event_no: Annotated[str, Field(min_length=1, max_length=64, description="冲回事件单号")]
+    trace_id: Annotated[str, Field(min_length=1, max_length=128, description="技术链路追踪号")]
+    target_event_id: Annotated[int, Field(ge=1, description="被冲回的原事件 ID")]
+    warehouse_id: Annotated[int, Field(ge=1, description="仓库 ID")]
+    source_type: OutboundReversalSourceType
+    source_ref: Annotated[str | None, Field(default=None, max_length=128, description="来源单号/外部引用号")]
+    occurred_at: datetime = Field(description="冲回业务发生时间")
+    remark: Annotated[str | None, Field(default=None, max_length=500, description="冲回备注")]
+    rows: list[OutboundReversalRowOut] = Field(default_factory=list, description="冲回结果行")
+
+
+__all__ = [
+    "OutboundReversalSourceType",
+    "OutboundReversalIn",
+    "OutboundReversalRowOut",
+    "OutboundReversalOut",
+]

--- a/app/wms/inventory_adjustment/outbound_reversal/repos/__init__.py
+++ b/app/wms/inventory_adjustment/outbound_reversal/repos/__init__.py
@@ -1,4 +1,13 @@
-# Split note:
-# 本目录是 inventory_adjustment 模块的物理收口层。
-# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
-# 后续如确认稳定，再逐步把真实实现迁入本目录。
+from .outbound_reversal_repo import (
+    find_committed_outbound_reversal,
+    get_outbound_event_for_reversal,
+    list_outbound_event_lines_for_reversal,
+    mark_outbound_event_superseded,
+)
+
+__all__ = [
+    "find_committed_outbound_reversal",
+    "get_outbound_event_for_reversal",
+    "list_outbound_event_lines_for_reversal",
+    "mark_outbound_event_superseded",
+]

--- a/app/wms/inventory_adjustment/outbound_reversal/repos/outbound_reversal_repo.py
+++ b/app/wms/inventory_adjustment/outbound_reversal/repos/outbound_reversal_repo.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def get_outbound_event_for_reversal(
+    session: AsyncSession,
+    *,
+    event_id: int,
+) -> dict[str, Any]:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  id AS event_id,
+                  event_no,
+                  warehouse_id,
+                  source_type,
+                  source_ref,
+                  occurred_at,
+                  committed_at,
+                  event_kind,
+                  target_event_id,
+                  status,
+                  remark
+                FROM wms_events
+                WHERE id = :event_id
+                  AND event_type = 'OUTBOUND'
+                LIMIT 1
+                """
+            ),
+            {"event_id": int(event_id)},
+        )
+    ).mappings().first()
+
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"outbound_event_not_found:{int(event_id)}")
+
+    if str(row["event_kind"]) != "COMMIT":
+        raise HTTPException(
+            status_code=409,
+            detail=f"outbound_event_not_reversible_kind:{row['event_kind']}",
+        )
+
+    if str(row["status"]) != "COMMITTED":
+        raise HTTPException(
+            status_code=409,
+            detail=f"outbound_event_not_reversible_status:{row['status']}",
+        )
+
+    return dict(row)
+
+
+async def find_committed_outbound_reversal(
+    session: AsyncSession,
+    *,
+    target_event_id: int,
+) -> dict[str, Any] | None:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  id,
+                  event_no,
+                  status
+                FROM wms_events
+                WHERE event_type = 'OUTBOUND'
+                  AND event_kind = 'REVERSAL'
+                  AND target_event_id = :target_event_id
+                  AND status = 'COMMITTED'
+                ORDER BY id DESC
+                LIMIT 1
+                """
+            ),
+            {"target_event_id": int(target_event_id)},
+        )
+    ).mappings().first()
+    return dict(row) if row is not None else None
+
+
+async def list_outbound_event_lines_for_reversal(
+    session: AsyncSession,
+    *,
+    event_id: int,
+) -> list[dict[str, Any]]:
+    rows = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  id,
+                  event_id,
+                  ref_line,
+                  item_id,
+                  qty_outbound,
+                  lot_id,
+                  lot_code_snapshot,
+                  order_line_id,
+                  manual_doc_line_id,
+                  item_name_snapshot,
+                  item_sku_snapshot,
+                  item_spec_snapshot,
+                  remark,
+                  created_at
+                FROM outbound_event_lines
+                WHERE event_id = :event_id
+                ORDER BY ref_line ASC, id ASC
+                """
+            ),
+            {"event_id": int(event_id)},
+        )
+    ).mappings().all()
+
+    if not rows:
+        raise HTTPException(
+            status_code=409,
+            detail=f"outbound_event_has_no_lines:{int(event_id)}",
+        )
+
+    return [dict(r) for r in rows]
+
+
+async def mark_outbound_event_superseded(
+    session: AsyncSession,
+    *,
+    event_id: int,
+) -> None:
+    await session.execute(
+        text(
+            """
+            UPDATE wms_events
+            SET status = 'SUPERSEDED'
+            WHERE id = :event_id
+              AND event_type = 'OUTBOUND'
+              AND event_kind = 'COMMIT'
+              AND status = 'COMMITTED'
+            """
+        ),
+        {"event_id": int(event_id)},
+    )
+
+
+__all__ = [
+    "get_outbound_event_for_reversal",
+    "find_committed_outbound_reversal",
+    "list_outbound_event_lines_for_reversal",
+    "mark_outbound_event_superseded",
+]

--- a/app/wms/inventory_adjustment/outbound_reversal/routers/__init__.py
+++ b/app/wms/inventory_adjustment/outbound_reversal/routers/__init__.py
@@ -1,4 +1,5 @@
-# Split note:
-# 本目录是 inventory_adjustment 模块的物理收口层。
-# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
-# 后续如确认稳定，再逐步把真实实现迁入本目录。
+from .outbound_reversal import router
+
+__all__ = [
+    "router",
+]

--- a/app/wms/inventory_adjustment/outbound_reversal/routers/outbound_reversal.py
+++ b/app/wms/inventory_adjustment/outbound_reversal/routers/outbound_reversal.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_session
+from app.wms.inventory_adjustment.outbound_reversal.contracts.outbound_reversal import (
+    OutboundReversalIn,
+    OutboundReversalOut,
+)
+from app.wms.inventory_adjustment.outbound_reversal.services.outbound_reversal_service import (
+    reverse_outbound_event,
+)
+
+router = APIRouter(prefix="/wms/outbound", tags=["wms-outbound-reversal"])
+
+
+@router.post("/events/{event_id}/reverse", response_model=OutboundReversalOut)
+async def reverse_outbound_event_endpoint(
+    event_id: int,
+    payload: OutboundReversalIn,
+    session: AsyncSession = Depends(get_session),
+) -> OutboundReversalOut:
+    try:
+        out = await reverse_outbound_event(
+            session,
+            event_id=int(event_id),
+            payload=payload,
+            user_id=None,
+        )
+        await session.commit()
+        return out
+    except HTTPException:
+        await session.rollback()
+        raise
+    except Exception as e:
+        await session.rollback()
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+__all__ = ["router"]

--- a/app/wms/inventory_adjustment/outbound_reversal/services/__init__.py
+++ b/app/wms/inventory_adjustment/outbound_reversal/services/__init__.py
@@ -1,4 +1,5 @@
-# Split note:
-# 本目录是 inventory_adjustment 模块的物理收口层。
-# 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / repo / router / service。
-# 后续如确认稳定，再逐步把真实实现迁入本目录。
+from .outbound_reversal_service import reverse_outbound_event
+
+__all__ = [
+    "reverse_outbound_event",
+]

--- a/app/wms/inventory_adjustment/outbound_reversal/services/outbound_reversal_service.py
+++ b/app/wms/inventory_adjustment/outbound_reversal/services/outbound_reversal_service.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.enums import MovementType
+from app.wms.inbound.models.inbound_event import WmsEvent
+from app.wms.inventory_adjustment.outbound_reversal.contracts.outbound_reversal import (
+    OutboundReversalIn,
+    OutboundReversalOut,
+    OutboundReversalRowOut,
+)
+from app.wms.inventory_adjustment.outbound_reversal.repos.outbound_reversal_repo import (
+    find_committed_outbound_reversal,
+    get_outbound_event_for_reversal,
+    list_outbound_event_lines_for_reversal,
+    mark_outbound_event_superseded,
+)
+from app.wms.outbound.models.outbound_event import OutboundEventLine
+from app.wms.stock.services.stock_service import StockService
+
+UTC = timezone.utc
+
+
+def _new_trace_id() -> str:
+    return f"OUT-REV-{uuid4().hex[:20]}"
+
+
+def _new_event_no() -> str:
+    stamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
+    return f"OER-{stamp}-{uuid4().hex[:8].upper()}"
+
+
+def _norm_text(v: object) -> str | None:
+    if v is None:
+        return None
+    s = str(v).strip()
+    return s or None
+
+
+async def reverse_outbound_event(
+    session: AsyncSession,
+    *,
+    event_id: int,
+    payload: OutboundReversalIn,
+    user_id: int | None = None,
+) -> OutboundReversalOut:
+    existing = await find_committed_outbound_reversal(
+        session,
+        target_event_id=int(event_id),
+    )
+    if existing is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=f"outbound_event_already_reversed:{int(existing['id'])}",
+        )
+
+    original = await get_outbound_event_for_reversal(session, event_id=int(event_id))
+    source_lines = await list_outbound_event_lines_for_reversal(
+        session,
+        event_id=int(original["event_id"]),
+    )
+
+    occurred_at = payload.occurred_at
+    trace_id = _new_trace_id()
+    event_no = _new_event_no()
+
+    event = WmsEvent(
+        event_no=str(event_no),
+        event_type="OUTBOUND",
+        warehouse_id=int(original["warehouse_id"]),
+        source_type=str(original["source_type"]),
+        source_ref=_norm_text(original["source_ref"]),
+        occurred_at=occurred_at,
+        trace_id=str(trace_id),
+        event_kind="REVERSAL",
+        target_event_id=int(original["event_id"]),
+        status="COMMITTED",
+        created_by=int(user_id) if user_id is not None else None,
+        remark=_norm_text(payload.remark) or f"reversal of {original['event_no']}",
+    )
+    session.add(event)
+    await session.flush()
+
+    stock = StockService()
+    rows: list[OutboundReversalRowOut] = []
+
+    for src in source_lines:
+        ref_line = int(src["ref_line"])
+        item_id = int(src["item_id"])
+        lot_id = src["lot_id"]
+        qty_outbound = int(src["qty_outbound"])
+
+        if lot_id is None:
+            raise HTTPException(
+                status_code=409,
+                detail=f"outbound_event_line_missing_lot:{ref_line}",
+            )
+        if qty_outbound <= 0:
+            raise HTTPException(
+                status_code=409,
+                detail=f"outbound_event_line_invalid_qty:{ref_line}",
+            )
+
+        event_line = OutboundEventLine(
+            event_id=int(event.id),
+            ref_line=ref_line,
+            item_id=item_id,
+            qty_outbound=qty_outbound,
+            lot_id=int(lot_id),
+            lot_code_snapshot=_norm_text(src["lot_code_snapshot"]),
+            order_line_id=(int(src["order_line_id"]) if src["order_line_id"] is not None else None),
+            manual_doc_line_id=(int(src["manual_doc_line_id"]) if src["manual_doc_line_id"] is not None else None),
+            item_name_snapshot=_norm_text(src["item_name_snapshot"]),
+            item_sku_snapshot=_norm_text(src["item_sku_snapshot"]),
+            item_spec_snapshot=_norm_text(src["item_spec_snapshot"]),
+            remark=_norm_text(src["remark"]),
+        )
+        session.add(event_line)
+        await session.flush()
+
+        await stock.adjust_lot(
+            session=session,
+            item_id=item_id,
+            warehouse_id=int(original["warehouse_id"]),
+            lot_id=int(lot_id),
+            delta=qty_outbound,
+            reason=MovementType.ADJUSTMENT,
+            ref=str(event.event_no),
+            ref_line=ref_line,
+            occurred_at=occurred_at,
+            batch_code=None,
+            production_date=None,
+            expiry_date=None,
+            trace_id=str(trace_id),
+            meta={
+                "sub_reason": "OUTBOUND_REVERSAL",
+                "event_id": int(event.id),
+                "target_event_id": int(original["event_id"]),
+                "source_type": str(original["source_type"]),
+                "source_ref": _norm_text(original["source_ref"]),
+                "remark": _norm_text(event.remark),
+            },
+            shadow_write_stocks=False,
+        )
+
+        rows.append(
+            OutboundReversalRowOut(
+                ref_line=ref_line,
+                item_id=item_id,
+                lot_id=int(lot_id),
+                qty_outbound=qty_outbound,
+            )
+        )
+
+    await mark_outbound_event_superseded(
+        session,
+        event_id=int(original["event_id"]),
+    )
+
+    return OutboundReversalOut(
+        ok=True,
+        event_id=int(event.id),
+        event_no=str(event.event_no),
+        trace_id=str(trace_id),
+        target_event_id=int(original["event_id"]),
+        warehouse_id=int(original["warehouse_id"]),
+        source_type=str(original["source_type"]),
+        source_ref=_norm_text(original["source_ref"]),
+        occurred_at=occurred_at,
+        remark=_norm_text(event.remark),
+        rows=rows,
+    )
+
+
+__all__ = [
+    "reverse_outbound_event",
+]

--- a/tests/services/test_inbound_reversal_service.py
+++ b/tests/services/test_inbound_reversal_service.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+
+from app.wms.inbound.contracts.inbound_commit import InboundCommitIn
+from app.wms.inbound.services.inbound_commit_service import commit_inbound
+from app.wms.inventory_adjustment.inbound_reversal.contracts.inbound_reversal import (
+    InboundReversalIn,
+)
+from app.wms.inventory_adjustment.inbound_reversal.services.inbound_reversal_service import (
+    reverse_inbound_event,
+)
+
+
+async def _pick_seed_item_uom(session):
+    wh_row = await session.execute(
+        text(
+            """
+            SELECT id
+            FROM warehouses
+            ORDER BY id ASC
+            LIMIT 1
+            """
+        )
+    )
+    warehouse_id = wh_row.scalar_one()
+
+    row = await session.execute(
+        text(
+            """
+            SELECT
+              i.id AS item_id,
+              u.id AS uom_id,
+              i.lot_source_policy::text AS lot_source_policy,
+              i.expiry_policy::text AS expiry_policy
+            FROM item_uoms u
+            JOIN items i
+              ON i.id = u.item_id
+            ORDER BY
+              CASE
+                WHEN i.lot_source_policy::text IN ('SUPPLIER_ONLY', 'SUPPLIER') THEN 0
+                ELSE 1
+              END,
+              u.id ASC
+            LIMIT 1
+            """
+        )
+    )
+    picked = row.mappings().first()
+    assert picked is not None, "expected seeded item_uoms to exist"
+
+    return {
+        "warehouse_id": int(warehouse_id),
+        "item_id": int(picked["item_id"]),
+        "uom_id": int(picked["uom_id"]),
+        "lot_source_policy": str(picked["lot_source_policy"] or "INTERNAL_ONLY"),
+        "expiry_policy": str(picked["expiry_policy"] or "NONE"),
+    }
+
+
+async def _load_event(session, *, event_id: int):
+    row = await session.execute(
+        text(
+            """
+            SELECT
+              id,
+              event_no,
+              event_type,
+              warehouse_id,
+              source_type,
+              source_ref,
+              trace_id,
+              event_kind,
+              target_event_id,
+              status
+            FROM wms_events
+            WHERE id = :event_id
+            """
+        ),
+        {"event_id": int(event_id)},
+    )
+    m = row.mappings().first()
+    return dict(m) if m else None
+
+
+async def _load_ledger_by_event(session, *, event_id: int):
+    row = await session.execute(
+        text(
+            """
+            SELECT
+              id,
+              event_id,
+              trace_id,
+              ref,
+              ref_line,
+              warehouse_id,
+              item_id,
+              lot_id,
+              delta,
+              after_qty,
+              reason,
+              reason_canon,
+              sub_reason
+            FROM stock_ledger
+            WHERE event_id = :event_id
+            ORDER BY id ASC
+            LIMIT 1
+            """
+        ),
+        {"event_id": int(event_id)},
+    )
+    m = row.mappings().first()
+    return dict(m) if m else None
+
+
+def _date_to_utc_datetime(d: date) -> datetime:
+    return datetime(d.year, d.month, d.day, tzinfo=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_inbound_reversal_creates_reversal_event_and_supersedes_original(session):
+    picked = await _pick_seed_item_uom(session)
+
+    warehouse_id = int(picked["warehouse_id"])
+    item_id = int(picked["item_id"])
+    uom_id = int(picked["uom_id"])
+    lot_source_policy = str(picked["lot_source_policy"])
+
+    qty_input = 3
+    production_date = date.today()
+    expiry_date = production_date + timedelta(days=30)
+
+    lot_code_input = None
+    if lot_source_policy in {"SUPPLIER_ONLY", "SUPPLIER"}:
+        lot_code_input = f"UT-IN-REV-{item_id}-{uom_id}"
+
+    payload = InboundCommitIn.model_validate(
+        {
+            "warehouse_id": warehouse_id,
+            "source_type": "MANUAL",
+            "source_ref": None,
+            "occurred_at": production_date.isoformat() + "T00:00:00Z",
+            "remark": "ut inbound reversal source",
+            "lines": [
+                {
+                    "item_id": item_id,
+                    "uom_id": uom_id,
+                    "qty_input": qty_input,
+                    "lot_code_input": lot_code_input,
+                    "production_date": production_date.isoformat(),
+                    "expiry_date": expiry_date.isoformat(),
+                    "remark": "ut source line",
+                }
+            ],
+        }
+    )
+
+    original = await commit_inbound(session, payload=payload, user_id=None)
+    assert original.ok is True
+    assert int(original.event_id) > 0
+    assert len(original.rows) == 1
+
+    reversal = await reverse_inbound_event(
+        session,
+        event_id=int(original.event_id),
+        payload=InboundReversalIn(
+            occurred_at=_date_to_utc_datetime(production_date),
+            remark="ut inbound reversal",
+        ),
+        user_id=None,
+    )
+
+    assert reversal.ok is True
+    assert int(reversal.target_event_id) == int(original.event_id)
+    assert int(reversal.event_id) > int(original.event_id)
+    assert reversal.source_type == original.source_type
+    assert reversal.warehouse_id == original.warehouse_id
+    assert len(reversal.rows) == 1
+
+    original_event = await _load_event(session, event_id=int(original.event_id))
+    reversal_event = await _load_event(session, event_id=int(reversal.event_id))
+    assert original_event is not None
+    assert reversal_event is not None
+
+    assert str(original_event["event_kind"]) == "COMMIT"
+    assert str(original_event["status"]) == "SUPERSEDED"
+
+    assert str(reversal_event["event_type"]) == "INBOUND"
+    assert str(reversal_event["event_kind"]) == "REVERSAL"
+    assert str(reversal_event["status"]) == "COMMITTED"
+    assert int(reversal_event["target_event_id"]) == int(original.event_id)
+
+    orig_ledger = await _load_ledger_by_event(session, event_id=int(original.event_id))
+    rev_ledger = await _load_ledger_by_event(session, event_id=int(reversal.event_id))
+    assert orig_ledger is not None
+    assert rev_ledger is not None
+
+    assert str(orig_ledger["reason"]) == "RECEIPT"
+    assert str(orig_ledger["sub_reason"]) in {"INBOUND_OPERATION", "ATOMIC_INBOUND"}
+
+    assert str(rev_ledger["reason"]) == "ADJUSTMENT"
+    assert str(rev_ledger["reason_canon"]) == "ADJUSTMENT"
+    assert str(rev_ledger["sub_reason"]) == "INBOUND_REVERSAL"
+
+    assert int(rev_ledger["item_id"]) == int(orig_ledger["item_id"])
+    assert int(rev_ledger["warehouse_id"]) == int(orig_ledger["warehouse_id"])
+    assert int(rev_ledger["lot_id"]) == int(orig_ledger["lot_id"])
+    assert int(rev_ledger["delta"]) == -int(orig_ledger["delta"])
+
+
+@pytest.mark.asyncio
+async def test_inbound_reversal_duplicate_returns_already_reversed(session):
+    picked = await _pick_seed_item_uom(session)
+
+    warehouse_id = int(picked["warehouse_id"])
+    item_id = int(picked["item_id"])
+    uom_id = int(picked["uom_id"])
+    lot_source_policy = str(picked["lot_source_policy"])
+
+    qty_input = 2
+    production_date = date.today()
+    expiry_date = production_date + timedelta(days=30)
+
+    lot_code_input = None
+    if lot_source_policy in {"SUPPLIER_ONLY", "SUPPLIER"}:
+        lot_code_input = f"UT-IN-REV-DUP-{item_id}-{uom_id}"
+
+    payload = InboundCommitIn.model_validate(
+        {
+            "warehouse_id": warehouse_id,
+            "source_type": "MANUAL",
+            "source_ref": None,
+            "occurred_at": production_date.isoformat() + "T00:00:00Z",
+            "remark": "ut inbound reversal duplicate source",
+            "lines": [
+                {
+                    "item_id": item_id,
+                    "uom_id": uom_id,
+                    "qty_input": qty_input,
+                    "lot_code_input": lot_code_input,
+                    "production_date": production_date.isoformat(),
+                    "expiry_date": expiry_date.isoformat(),
+                    "remark": "ut duplicate source line",
+                }
+            ],
+        }
+    )
+
+    original = await commit_inbound(session, payload=payload, user_id=None)
+
+    first = await reverse_inbound_event(
+        session,
+        event_id=int(original.event_id),
+        payload=InboundReversalIn(remark="ut first reversal"),
+        user_id=None,
+    )
+    assert first.ok is True
+
+    with pytest.raises(HTTPException) as exc:
+        await reverse_inbound_event(
+            session,
+            event_id=int(original.event_id),
+            payload=InboundReversalIn(remark="ut duplicate reversal"),
+            user_id=None,
+        )
+
+    assert exc.value.status_code == 409
+    assert str(exc.value.detail).startswith("inbound_event_already_reversed:")

--- a/tests/services/test_outbound_reversal_service.py
+++ b/tests/services/test_outbound_reversal_service.py
@@ -1,0 +1,372 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.wms.inbound.contracts.inbound_commit import InboundCommitIn
+from app.wms.inbound.models.inbound_event import WmsEvent
+from app.wms.inbound.services.inbound_commit_service import commit_inbound
+from app.wms.inventory_adjustment.outbound_reversal.contracts.outbound_reversal import (
+    OutboundReversalIn,
+)
+from app.wms.inventory_adjustment.outbound_reversal.services.outbound_reversal_service import (
+    reverse_outbound_event,
+)
+from app.wms.outbound.models.outbound_event import OutboundEventLine
+from app.wms.outbound.repos.outbound_event_repo import (
+    insert_outbound_stock_ledger,
+    load_stocks_lot_for_update,
+    update_stocks_lot_qty,
+)
+
+
+def _date_to_utc_datetime(d: date) -> datetime:
+    return datetime(d.year, d.month, d.day, tzinfo=timezone.utc)
+
+
+async def _pick_seed_item_uom(session: AsyncSession) -> dict[str, object]:
+    wh_row = await session.execute(
+        text(
+            """
+            SELECT id
+            FROM warehouses
+            ORDER BY id ASC
+            LIMIT 1
+            """
+        )
+    )
+    warehouse_id = wh_row.scalar_one()
+
+    row = await session.execute(
+        text(
+            """
+            SELECT
+              i.id AS item_id,
+              u.id AS uom_id,
+              COALESCE(i.lot_source_policy::text, 'INTERNAL_ONLY') AS lot_source_policy,
+              COALESCE(i.expiry_policy::text, 'NONE') AS expiry_policy
+            FROM item_uoms u
+            JOIN items i
+              ON i.id = u.item_id
+            ORDER BY
+              CASE
+                WHEN COALESCE(i.lot_source_policy::text, 'INTERNAL_ONLY') IN ('SUPPLIER_ONLY', 'SUPPLIER') THEN 0
+                ELSE 1
+              END,
+              u.id ASC
+            LIMIT 1
+            """
+        )
+    )
+    picked = row.mappings().first()
+    if picked is None:
+        raise RuntimeError("测试库没有 item_uoms 种子数据，无法运行 outbound reversal 测试")
+
+    return {
+        "warehouse_id": int(warehouse_id),
+        "item_id": int(picked["item_id"]),
+        "uom_id": int(picked["uom_id"]),
+        "lot_source_policy": str(picked["lot_source_policy"] or "INTERNAL_ONLY"),
+        "expiry_policy": str(picked["expiry_policy"] or "NONE"),
+    }
+
+
+async def _load_stocks_lot_qty(
+    session: AsyncSession,
+    *,
+    item_id: int,
+    warehouse_id: int,
+    lot_id: int,
+) -> int:
+    row = await session.execute(
+        text(
+            """
+            SELECT qty
+            FROM stocks_lot
+            WHERE item_id = :item_id
+              AND warehouse_id = :warehouse_id
+              AND lot_id = :lot_id
+            LIMIT 1
+            """
+        ),
+        {
+            "item_id": int(item_id),
+            "warehouse_id": int(warehouse_id),
+            "lot_id": int(lot_id),
+        },
+    )
+    qty = row.scalar_one_or_none()
+    if qty is None:
+        raise RuntimeError("未找到刚生成的 stocks_lot 槽位")
+    return int(qty)
+
+
+async def _seed_outbound_source_event(session: AsyncSession) -> dict[str, object]:
+    picked = await _pick_seed_item_uom(session)
+
+    warehouse_id = int(picked["warehouse_id"])
+    item_id = int(picked["item_id"])
+    uom_id = int(picked["uom_id"])
+    lot_source_policy = str(picked["lot_source_policy"])
+    expiry_policy = str(picked["expiry_policy"])
+
+    occurred_at = datetime.now(timezone.utc)
+    production_date = occurred_at.date()
+    expiry_date = production_date + timedelta(days=30)
+
+    lot_code_input = None
+    if lot_source_policy in {"SUPPLIER_ONLY", "SUPPLIER"}:
+        lot_code_input = f"UT-OUT-REV-{item_id}-{uom_id}-{uuid4().hex[:8].upper()}"
+
+    inbound_payload = InboundCommitIn.model_validate(
+        {
+            "warehouse_id": warehouse_id,
+            "source_type": "MANUAL",
+            "source_ref": None,
+            "occurred_at": occurred_at.isoformat(),
+            "remark": "ut outbound reversal stock seed",
+            "lines": [
+                {
+                    "item_id": item_id,
+                    "uom_id": uom_id,
+                    "qty_input": 5,
+                    "lot_code_input": lot_code_input,
+                    "production_date": production_date.isoformat() if expiry_policy != "NONE" else None,
+                    "expiry_date": expiry_date.isoformat() if expiry_policy != "NONE" else None,
+                    "remark": "ut outbound reversal inbound seed line",
+                }
+            ],
+        }
+    )
+
+    inbound = await commit_inbound(session, payload=inbound_payload, user_id=None)
+    if not inbound.rows:
+        raise RuntimeError("入库造数失败：没有生成结果行")
+
+    seeded_row = inbound.rows[0]
+    lot_id = getattr(seeded_row, "lot_id", None)
+    if lot_id is None:
+        raise RuntimeError("入库造数失败：没有生成 lot_id")
+
+    current_qty = await _load_stocks_lot_qty(
+        session,
+        item_id=item_id,
+        warehouse_id=warehouse_id,
+        lot_id=int(lot_id),
+    )
+    qty_outbound = 2 if current_qty >= 2 else 1
+    if qty_outbound <= 0:
+        raise RuntimeError("入库造数后库存不足，无法运行 outbound reversal 测试")
+
+    event = WmsEvent(
+        event_no=f"UT-OE-{uuid4().hex[:12].upper()}",
+        event_type="OUTBOUND",
+        warehouse_id=int(warehouse_id),
+        source_type="MANUAL",
+        source_ref=f"UT-MOB-{uuid4().hex[:10].upper()}",
+        occurred_at=occurred_at,
+        trace_id=f"UT-OUT-{uuid4().hex[:20]}",
+        event_kind="COMMIT",
+        status="COMMITTED",
+        created_by=None,
+        remark="ut outbound reversal source",
+    )
+    session.add(event)
+    await session.flush()
+
+    line = OutboundEventLine(
+        event_id=int(event.id),
+        ref_line=1,
+        item_id=int(item_id),
+        qty_outbound=int(qty_outbound),
+        lot_id=int(lot_id),
+        lot_code_snapshot=lot_code_input,
+        order_line_id=None,
+        manual_doc_line_id=1,
+        item_name_snapshot="ut item",
+        item_sku_snapshot="ut-sku",
+        item_spec_snapshot="ut-spec",
+        remark="ut outbound line",
+    )
+    session.add(line)
+    await session.flush()
+
+    slot_qty = await load_stocks_lot_for_update(
+        session,
+        warehouse_id=int(warehouse_id),
+        item_id=int(item_id),
+        lot_id=int(lot_id),
+    )
+    if slot_qty is None:
+        raise RuntimeError("未找到 stocks_lot 槽位，无法构造 outbound source event")
+    if int(slot_qty) < int(qty_outbound):
+        raise RuntimeError("库存不足，无法构造 outbound source event")
+
+    after_qty = int(slot_qty) - int(qty_outbound)
+
+    await insert_outbound_stock_ledger(
+        session,
+        item_id=int(item_id),
+        warehouse_id=int(warehouse_id),
+        lot_id=int(lot_id),
+        qty_outbound=int(qty_outbound),
+        after_qty=int(after_qty),
+        occurred_at=occurred_at,
+        source_ref=str(event.source_ref),
+        ref_line=1,
+        trace_id=str(event.trace_id),
+        event_id=int(event.id),
+    )
+    await update_stocks_lot_qty(
+        session,
+        warehouse_id=int(warehouse_id),
+        item_id=int(item_id),
+        lot_id=int(lot_id),
+        qty=int(after_qty),
+    )
+
+    return {
+        "event_id": int(event.id),
+        "event_no": str(event.event_no),
+        "source_ref": str(event.source_ref),
+        "trace_id": str(event.trace_id),
+        "occurred_at": occurred_at,
+        "warehouse_id": int(warehouse_id),
+        "item_id": int(item_id),
+        "lot_id": int(lot_id),
+        "qty_outbound": int(qty_outbound),
+    }
+
+
+async def _load_event(session: AsyncSession, *, event_id: int):
+    row = await session.execute(
+        text(
+            """
+            SELECT
+              id,
+              event_no,
+              event_type,
+              warehouse_id,
+              source_type,
+              source_ref,
+              trace_id,
+              event_kind,
+              target_event_id,
+              status
+            FROM wms_events
+            WHERE id = :event_id
+            """
+        ),
+        {"event_id": int(event_id)},
+    )
+    m = row.mappings().first()
+    return dict(m) if m else None
+
+
+async def _load_ledger_by_event(session: AsyncSession, *, event_id: int):
+    row = await session.execute(
+        text(
+            """
+            SELECT
+              id,
+              event_id,
+              trace_id,
+              ref,
+              ref_line,
+              item_id,
+              warehouse_id,
+              lot_id,
+              delta,
+              after_qty,
+              reason,
+              reason_canon,
+              sub_reason
+            FROM stock_ledger
+            WHERE event_id = :event_id
+            ORDER BY id ASC
+            LIMIT 1
+            """
+        ),
+        {"event_id": int(event_id)},
+    )
+    m = row.mappings().first()
+    return dict(m) if m else None
+
+
+@pytest.mark.asyncio
+async def test_outbound_reversal_creates_reversal_event_and_supersedes_original(session: AsyncSession):
+    original = await _seed_outbound_source_event(session)
+
+    reversal = await reverse_outbound_event(
+        session,
+        event_id=int(original["event_id"]),
+        payload=OutboundReversalIn(remark="ut outbound reversal"),
+        user_id=None,
+    )
+
+    assert reversal.ok is True
+    assert int(reversal.target_event_id) == int(original["event_id"])
+    assert int(reversal.event_id) > int(original["event_id"])
+    assert reversal.source_type == "MANUAL"
+    assert reversal.warehouse_id == int(original["warehouse_id"])
+    assert len(reversal.rows) == 1
+
+    original_event = await _load_event(session, event_id=int(original["event_id"]))
+    reversal_event = await _load_event(session, event_id=int(reversal.event_id))
+    assert original_event is not None
+    assert reversal_event is not None
+
+    assert str(original_event["event_kind"]) == "COMMIT"
+    assert str(original_event["status"]) == "SUPERSEDED"
+
+    assert str(reversal_event["event_type"]) == "OUTBOUND"
+    assert str(reversal_event["event_kind"]) == "REVERSAL"
+    assert str(reversal_event["status"]) == "COMMITTED"
+    assert int(reversal_event["target_event_id"]) == int(original["event_id"])
+
+    orig_ledger = await _load_ledger_by_event(session, event_id=int(original["event_id"]))
+    rev_ledger = await _load_ledger_by_event(session, event_id=int(reversal.event_id))
+    assert orig_ledger is not None
+    assert rev_ledger is not None
+
+    assert str(orig_ledger["reason"]) == "OUTBOUND_SHIP"
+    assert str(orig_ledger["reason_canon"]) == "OUTBOUND"
+    assert str(orig_ledger["sub_reason"]) == "ORDER_OUTBOUND"
+
+    assert str(rev_ledger["reason"]) == "ADJUSTMENT"
+    assert str(rev_ledger["reason_canon"]) == "ADJUSTMENT"
+    assert str(rev_ledger["sub_reason"]) == "OUTBOUND_REVERSAL"
+
+    assert int(rev_ledger["item_id"]) == int(orig_ledger["item_id"])
+    assert int(rev_ledger["warehouse_id"]) == int(orig_ledger["warehouse_id"])
+    assert int(rev_ledger["lot_id"]) == int(orig_ledger["lot_id"])
+    assert int(rev_ledger["delta"]) == -int(orig_ledger["delta"])
+
+
+@pytest.mark.asyncio
+async def test_outbound_reversal_duplicate_returns_already_reversed(session: AsyncSession):
+    original = await _seed_outbound_source_event(session)
+
+    first = await reverse_outbound_event(
+        session,
+        event_id=int(original["event_id"]),
+        payload=OutboundReversalIn(remark="ut first outbound reversal"),
+        user_id=None,
+    )
+    assert first.ok is True
+
+    with pytest.raises(HTTPException) as exc:
+        await reverse_outbound_event(
+            session,
+            event_id=int(original["event_id"]),
+            payload=OutboundReversalIn(remark="ut duplicate outbound reversal"),
+            user_id=None,
+        )
+
+    assert exc.value.status_code == 409
+    assert str(exc.value.detail).startswith("outbound_event_already_reversed:")


### PR DESCRIPTION
## Summary
- implement inbound_reversal under inventory_adjustment
- implement outbound_reversal under inventory_adjustment
- mount reversal routers in router_mount
- add service tests for inbound/outbound reversal

## Verification
- python3 -m compileall app tests alembic
- make test TESTS="tests/services/test_inbound_reversal_service.py"
- make test TESTS="tests/services/test_outbound_reversal_service.py"
- make test TESTS="tests/test_phase3_three_books_count_contract.py"