### PR TITLE
feat(inventory-adjustment): build count-doc mainline and freeze guard

### DIFF
--- a/alembic/versions/11c7f84c84b0_inventory_adjustment_rebuild_count_doc_.py
+++ b/alembic/versions/11c7f84c84b0_inventory_adjustment_rebuild_count_doc_.py
@@ -1,0 +1,454 @@
+"""inventory_adjustment_rebuild_count_doc_lines_item_anchor_and_add_lot_snapshots
+
+Revision ID: 11c7f84c84b0
+Revises: 265fe9d55bbd
+Create Date: 2026-04-22 15:44:41.216157
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "11c7f84c84b0"
+down_revision: Union[str, Sequence[str], None] = "265fe9d55bbd"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+
+    conn = op.get_bind()
+
+    # ------------------------------------------------------------------
+    # 0) 保护：本迁移会重建 count_doc_lines。
+    #    若已有真实数据，必须停下来做数据迁移，不能直接 drop/recreate。
+    # ------------------------------------------------------------------
+    line_rows = conn.execute(sa.text("SELECT COUNT(*) FROM count_doc_lines")).scalar()
+    if int(line_rows or 0) > 0:
+        raise RuntimeError(
+            "count_doc_lines contains data; this migration expects empty table and rebuilds line schema."
+        )
+
+    # ------------------------------------------------------------------
+    # 1) count_docs.status 扩为 5 态：增加 FROZEN
+    # ------------------------------------------------------------------
+    op.drop_constraint(
+        "ck_count_docs_status",
+        "count_docs",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_count_docs_status",
+        "count_docs",
+        "status IN ('DRAFT', 'FROZEN', 'COUNTED', 'POSTED', 'VOIDED')",
+    )
+
+    # ------------------------------------------------------------------
+    # 2) 重建 count_doc_lines：
+    #    从 lot 主锚点 -> item 主锚点
+    # ------------------------------------------------------------------
+    op.drop_table("count_doc_lines")
+
+    op.create_table(
+        "count_doc_lines",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("doc_id", sa.Integer(), nullable=False),
+        sa.Column("line_no", sa.Integer(), nullable=False),
+        sa.Column("item_id", sa.Integer(), nullable=False),
+
+        sa.Column("item_name_snapshot", sa.String(length=255), nullable=True),
+        sa.Column("item_spec_snapshot", sa.String(length=255), nullable=True),
+
+        sa.Column("snapshot_qty_base", sa.Integer(), nullable=False),
+
+        sa.Column("counted_item_uom_id", sa.Integer(), nullable=True),
+        sa.Column("counted_uom_name_snapshot", sa.String(length=64), nullable=True),
+        sa.Column("counted_ratio_to_base_snapshot", sa.Integer(), nullable=True),
+        sa.Column("counted_qty_input", sa.Integer(), nullable=True),
+
+        sa.Column("counted_qty_base", sa.Integer(), nullable=True),
+        sa.Column("diff_qty_base", sa.Integer(), nullable=True),
+
+        sa.Column("reason_code", sa.String(length=32), nullable=True),
+        sa.Column("disposition", sa.String(length=32), nullable=True),
+        sa.Column("remark", sa.String(length=255), nullable=True),
+
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+
+        sa.ForeignKeyConstraint(
+            ["doc_id"],
+            ["count_docs.id"],
+            name="fk_count_doc_lines_doc",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["item_id"],
+            ["items.id"],
+            name="fk_count_doc_lines_item",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["counted_item_uom_id", "item_id"],
+            ["item_uoms.id", "item_uoms.item_id"],
+            name="fk_count_doc_lines_counted_item_uom_pair",
+            ondelete="RESTRICT",
+        ),
+
+        sa.PrimaryKeyConstraint("id", name="pk_count_doc_lines"),
+        sa.UniqueConstraint("doc_id", "line_no", name="uq_count_doc_lines_doc_line"),
+        sa.UniqueConstraint("doc_id", "item_id", name="uq_count_doc_lines_doc_item"),
+
+        sa.CheckConstraint(
+            "line_no >= 1",
+            name="ck_count_doc_lines_line_no_positive",
+        ),
+        sa.CheckConstraint(
+            "snapshot_qty_base >= 0",
+            name="ck_count_doc_lines_snapshot_qty_base_nonneg",
+        ),
+        sa.CheckConstraint(
+            "counted_qty_input IS NULL OR counted_qty_input >= 0",
+            name="ck_count_doc_lines_counted_qty_input_nonneg",
+        ),
+        sa.CheckConstraint(
+            "counted_qty_base IS NULL OR counted_qty_base >= 0",
+            name="ck_count_doc_lines_counted_qty_base_nonneg",
+        ),
+        sa.CheckConstraint(
+            "counted_ratio_to_base_snapshot IS NULL OR counted_ratio_to_base_snapshot >= 1",
+            name="ck_count_doc_lines_counted_ratio_positive",
+        ),
+        sa.CheckConstraint(
+            """
+            (
+              counted_item_uom_id IS NULL
+              AND counted_uom_name_snapshot IS NULL
+              AND counted_ratio_to_base_snapshot IS NULL
+              AND counted_qty_input IS NULL
+              AND counted_qty_base IS NULL
+              AND diff_qty_base IS NULL
+            )
+            OR
+            (
+              counted_item_uom_id IS NOT NULL
+              AND counted_uom_name_snapshot IS NOT NULL
+              AND counted_ratio_to_base_snapshot IS NOT NULL
+              AND counted_qty_input IS NOT NULL
+              AND counted_qty_base IS NOT NULL
+              AND diff_qty_base IS NOT NULL
+              AND counted_qty_base = (counted_qty_input * counted_ratio_to_base_snapshot)
+              AND diff_qty_base = (counted_qty_base - snapshot_qty_base)
+            )
+            """,
+            name="ck_count_doc_lines_count_payload_consistent",
+        ),
+    )
+
+    op.create_index(
+        "ix_count_doc_lines_doc_id",
+        "count_doc_lines",
+        ["doc_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_count_doc_lines_item_id",
+        "count_doc_lines",
+        ["item_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_count_doc_lines_counted_item_uom_id",
+        "count_doc_lines",
+        ["counted_item_uom_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_count_doc_lines_reason_code",
+        "count_doc_lines",
+        ["reason_code"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_count_doc_lines_disposition",
+        "count_doc_lines",
+        ["disposition"],
+        unique=False,
+    )
+
+    # ------------------------------------------------------------------
+    # 3) 新建 lot 快照参考子表
+    # ------------------------------------------------------------------
+    op.create_table(
+        "count_doc_line_lot_snapshots",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("line_id", sa.Integer(), nullable=False),
+        sa.Column("lot_id", sa.Integer(), nullable=False),
+        sa.Column("lot_code_snapshot", sa.String(length=64), nullable=True),
+        sa.Column("snapshot_qty_base", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+
+        sa.ForeignKeyConstraint(
+            ["line_id"],
+            ["count_doc_lines.id"],
+            name="fk_count_doc_line_lot_snapshots_line",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["lot_id"],
+            ["lots.id"],
+            name="fk_count_doc_line_lot_snapshots_lot",
+            ondelete="RESTRICT",
+        ),
+
+        sa.PrimaryKeyConstraint("id", name="pk_count_doc_line_lot_snapshots"),
+        sa.UniqueConstraint(
+            "line_id",
+            "lot_id",
+            name="uq_count_doc_line_lot_snapshots_line_lot",
+        ),
+        sa.CheckConstraint(
+            "snapshot_qty_base >= 0",
+            name="ck_count_doc_line_lot_snapshots_snapshot_qty_base_nonneg",
+        ),
+    )
+
+    op.create_index(
+        "ix_count_doc_line_lot_snapshots_line_id",
+        "count_doc_line_lot_snapshots",
+        ["line_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_count_doc_line_lot_snapshots_lot_id",
+        "count_doc_line_lot_snapshots",
+        ["lot_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+
+    conn = op.get_bind()
+
+    # ------------------------------------------------------------------
+    # 0) 保护：降级会重建 count_doc_lines 并删除子表。
+    #    若已有数据，不允许直接回退，避免误删业务数据。
+    # ------------------------------------------------------------------
+    lot_rows = conn.execute(
+        sa.text("SELECT COUNT(*) FROM count_doc_line_lot_snapshots")
+    ).scalar()
+    if int(lot_rows or 0) > 0:
+        raise RuntimeError(
+            "count_doc_line_lot_snapshots contains data; downgrade would drop it."
+        )
+
+    line_rows = conn.execute(sa.text("SELECT COUNT(*) FROM count_doc_lines")).scalar()
+    if int(line_rows or 0) > 0:
+        raise RuntimeError(
+            "count_doc_lines contains data; downgrade would rebuild legacy schema and lose data."
+        )
+
+    frozen_rows = conn.execute(
+        sa.text("SELECT COUNT(*) FROM count_docs WHERE status = 'FROZEN'")
+    ).scalar()
+    if int(frozen_rows or 0) > 0:
+        raise RuntimeError(
+            "count_docs contains FROZEN rows; clear them before downgrade."
+        )
+
+    # ------------------------------------------------------------------
+    # 1) 回滚子表
+    # ------------------------------------------------------------------
+    op.drop_table("count_doc_line_lot_snapshots")
+
+    # ------------------------------------------------------------------
+    # 2) 回滚主行表：恢复到 lot 主锚点版本
+    # ------------------------------------------------------------------
+    op.drop_table("count_doc_lines")
+
+    op.create_table(
+        "count_doc_lines",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("doc_id", sa.Integer(), nullable=False),
+        sa.Column("line_no", sa.Integer(), nullable=False),
+        sa.Column("item_id", sa.Integer(), nullable=False),
+        sa.Column("lot_id", sa.Integer(), nullable=False),
+        sa.Column("lot_code_snapshot", sa.String(length=64), nullable=True),
+
+        sa.Column("item_name_snapshot", sa.String(length=255), nullable=True),
+        sa.Column("item_spec_snapshot", sa.String(length=255), nullable=True),
+
+        sa.Column("snapshot_qty_base", sa.Integer(), nullable=False),
+
+        sa.Column("counted_item_uom_id", sa.Integer(), nullable=True),
+        sa.Column("counted_uom_name_snapshot", sa.String(length=64), nullable=True),
+        sa.Column("counted_ratio_to_base_snapshot", sa.Integer(), nullable=True),
+        sa.Column("counted_qty_input", sa.Integer(), nullable=True),
+
+        sa.Column("counted_qty_base", sa.Integer(), nullable=True),
+        sa.Column("diff_qty_base", sa.Integer(), nullable=True),
+
+        sa.Column("reason_code", sa.String(length=32), nullable=True),
+        sa.Column("disposition", sa.String(length=32), nullable=True),
+        sa.Column("remark", sa.String(length=255), nullable=True),
+
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+
+        sa.ForeignKeyConstraint(
+            ["doc_id"],
+            ["count_docs.id"],
+            name="fk_count_doc_lines_doc",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["item_id"],
+            ["items.id"],
+            name="fk_count_doc_lines_item",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["lot_id"],
+            ["lots.id"],
+            name="fk_count_doc_lines_lot",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["counted_item_uom_id"],
+            ["item_uoms.id"],
+            name="fk_count_doc_lines_counted_item_uom",
+            ondelete="RESTRICT",
+        ),
+
+        sa.PrimaryKeyConstraint("id", name="pk_count_doc_lines"),
+        sa.UniqueConstraint("doc_id", "line_no", name="uq_count_doc_lines_doc_line"),
+
+        sa.CheckConstraint(
+            "line_no >= 1",
+            name="ck_count_doc_lines_line_no_positive",
+        ),
+        sa.CheckConstraint(
+            "snapshot_qty_base >= 0",
+            name="ck_count_doc_lines_snapshot_qty_base_nonneg",
+        ),
+        sa.CheckConstraint(
+            "counted_qty_input IS NULL OR counted_qty_input >= 0",
+            name="ck_count_doc_lines_counted_qty_input_nonneg",
+        ),
+        sa.CheckConstraint(
+            "counted_qty_base IS NULL OR counted_qty_base >= 0",
+            name="ck_count_doc_lines_counted_qty_base_nonneg",
+        ),
+        sa.CheckConstraint(
+            "counted_ratio_to_base_snapshot IS NULL OR counted_ratio_to_base_snapshot >= 1",
+            name="ck_count_doc_lines_counted_ratio_positive",
+        ),
+        sa.CheckConstraint(
+            """
+            (
+              counted_item_uom_id IS NULL
+              AND counted_uom_name_snapshot IS NULL
+              AND counted_ratio_to_base_snapshot IS NULL
+              AND counted_qty_input IS NULL
+              AND counted_qty_base IS NULL
+              AND diff_qty_base IS NULL
+            )
+            OR
+            (
+              counted_item_uom_id IS NOT NULL
+              AND counted_uom_name_snapshot IS NOT NULL
+              AND counted_ratio_to_base_snapshot IS NOT NULL
+              AND counted_qty_input IS NOT NULL
+              AND counted_qty_base IS NOT NULL
+              AND diff_qty_base IS NOT NULL
+              AND counted_qty_base = (counted_qty_input * counted_ratio_to_base_snapshot)
+              AND diff_qty_base = (counted_qty_base - snapshot_qty_base)
+            )
+            """,
+            name="ck_count_doc_lines_count_payload_consistent",
+        ),
+    )
+
+    op.create_index(
+        "ix_count_doc_lines_doc_id",
+        "count_doc_lines",
+        ["doc_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_count_doc_lines_item_id",
+        "count_doc_lines",
+        ["item_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_count_doc_lines_lot_id",
+        "count_doc_lines",
+        ["lot_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_count_doc_lines_counted_item_uom_id",
+        "count_doc_lines",
+        ["counted_item_uom_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_count_doc_lines_reason_code",
+        "count_doc_lines",
+        ["reason_code"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_count_doc_lines_disposition",
+        "count_doc_lines",
+        ["disposition"],
+        unique=False,
+    )
+
+    # ------------------------------------------------------------------
+    # 3) count_docs.status 回滚到 4 态
+    # ------------------------------------------------------------------
+    op.drop_constraint(
+        "ck_count_docs_status",
+        "count_docs",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_count_docs_status",
+        "count_docs",
+        "status IN ('DRAFT', 'COUNTED', 'POSTED', 'VOIDED')",
+    )

--- a/alembic/versions/265fe9d55bbd_inventory_adjustment_count_doc_lines_.py
+++ b/alembic/versions/265fe9d55bbd_inventory_adjustment_count_doc_lines_.py
@@ -1,0 +1,263 @@
+"""inventory_adjustment_count_doc_lines_add_uom_snapshots_and_base_qtys
+
+Revision ID: 265fe9d55bbd
+Revises: 8d4ecaaae5d4
+Create Date: 2026-04-22 14:07:12.042335
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "265fe9d55bbd"
+down_revision: Union[str, Sequence[str], None] = "8d4ecaaae5d4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+
+    # ------------------------------------------------------------------
+    # count_doc_lines 第二刀：
+    # 1) 数量字段显式收紧到 base 语义
+    # 2) 补盘点包装单位 / 倍率 / 输入数量 / 商品展示快照
+    #
+    # 终态口径：
+    # - snapshot_qty_base：冻结时点库存（基础数量）
+    # - counted_qty_input：按盘点包装单位录入的数量
+    # - counted_ratio_to_base_snapshot：盘点时冻结的倍率快照
+    # - counted_qty_base：换算后的基础数量
+    # - diff_qty_base：counted_qty_base - snapshot_qty_base
+    # ------------------------------------------------------------------
+
+    # 先删旧约束（旧约束名仍基于旧列名）
+    op.drop_constraint(
+        "ck_count_doc_lines_counted_qty_nonneg",
+        "count_doc_lines",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_count_doc_lines_diff_consistent",
+        "count_doc_lines",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_count_doc_lines_snapshot_qty_nonneg",
+        "count_doc_lines",
+        type_="check",
+    )
+
+    # 数量列改名：明确 base 语义
+    op.alter_column(
+        "count_doc_lines",
+        "snapshot_qty",
+        new_column_name="snapshot_qty_base",
+        existing_type=sa.Integer(),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "count_doc_lines",
+        "counted_qty",
+        new_column_name="counted_qty_base",
+        existing_type=sa.Integer(),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "count_doc_lines",
+        "diff_qty",
+        new_column_name="diff_qty_base",
+        existing_type=sa.Integer(),
+        existing_nullable=True,
+    )
+
+    # 商品展示快照
+    op.add_column(
+        "count_doc_lines",
+        sa.Column("item_name_snapshot", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "count_doc_lines",
+        sa.Column("item_spec_snapshot", sa.String(length=255), nullable=True),
+    )
+
+    # 盘点包装单位 / 倍率 / 输入数量
+    op.add_column(
+        "count_doc_lines",
+        sa.Column("counted_item_uom_id", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "count_doc_lines",
+        sa.Column("counted_uom_name_snapshot", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "count_doc_lines",
+        sa.Column("counted_ratio_to_base_snapshot", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "count_doc_lines",
+        sa.Column("counted_qty_input", sa.Integer(), nullable=True),
+    )
+
+    op.create_foreign_key(
+        "fk_count_doc_lines_counted_item_uom",
+        "count_doc_lines",
+        "item_uoms",
+        ["counted_item_uom_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.create_index(
+        "ix_count_doc_lines_counted_item_uom_id",
+        "count_doc_lines",
+        ["counted_item_uom_id"],
+        unique=False,
+    )
+
+    # 新约束：全部以 base 语义为准
+    op.create_check_constraint(
+        "ck_count_doc_lines_snapshot_qty_base_nonneg",
+        "count_doc_lines",
+        "snapshot_qty_base >= 0",
+    )
+    op.create_check_constraint(
+        "ck_count_doc_lines_counted_qty_input_nonneg",
+        "count_doc_lines",
+        "counted_qty_input IS NULL OR counted_qty_input >= 0",
+    )
+    op.create_check_constraint(
+        "ck_count_doc_lines_counted_qty_base_nonneg",
+        "count_doc_lines",
+        "counted_qty_base IS NULL OR counted_qty_base >= 0",
+    )
+    op.create_check_constraint(
+        "ck_count_doc_lines_counted_ratio_positive",
+        "count_doc_lines",
+        "counted_ratio_to_base_snapshot IS NULL OR counted_ratio_to_base_snapshot >= 1",
+    )
+
+    op.create_check_constraint(
+        "ck_count_doc_lines_count_payload_consistent",
+        "count_doc_lines",
+        """
+        (
+          counted_item_uom_id IS NULL
+          AND counted_uom_name_snapshot IS NULL
+          AND counted_ratio_to_base_snapshot IS NULL
+          AND counted_qty_input IS NULL
+          AND counted_qty_base IS NULL
+          AND diff_qty_base IS NULL
+        )
+        OR
+        (
+          counted_item_uom_id IS NOT NULL
+          AND counted_uom_name_snapshot IS NOT NULL
+          AND counted_ratio_to_base_snapshot IS NOT NULL
+          AND counted_qty_input IS NOT NULL
+          AND counted_qty_base IS NOT NULL
+          AND diff_qty_base IS NOT NULL
+          AND counted_qty_base = (counted_qty_input * counted_ratio_to_base_snapshot)
+          AND diff_qty_base = (counted_qty_base - snapshot_qty_base)
+        )
+        """,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+
+    # 先删新约束 / 索引 / FK
+    op.drop_constraint(
+        "ck_count_doc_lines_count_payload_consistent",
+        "count_doc_lines",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_count_doc_lines_counted_ratio_positive",
+        "count_doc_lines",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_count_doc_lines_counted_qty_base_nonneg",
+        "count_doc_lines",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_count_doc_lines_counted_qty_input_nonneg",
+        "count_doc_lines",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_count_doc_lines_snapshot_qty_base_nonneg",
+        "count_doc_lines",
+        type_="check",
+    )
+
+    op.drop_index(
+        "ix_count_doc_lines_counted_item_uom_id",
+        table_name="count_doc_lines",
+    )
+    op.drop_constraint(
+        "fk_count_doc_lines_counted_item_uom",
+        "count_doc_lines",
+        type_="foreignkey",
+    )
+
+    # 删新增列
+    op.drop_column("count_doc_lines", "counted_qty_input")
+    op.drop_column("count_doc_lines", "counted_ratio_to_base_snapshot")
+    op.drop_column("count_doc_lines", "counted_uom_name_snapshot")
+    op.drop_column("count_doc_lines", "counted_item_uom_id")
+    op.drop_column("count_doc_lines", "item_spec_snapshot")
+    op.drop_column("count_doc_lines", "item_name_snapshot")
+
+    # 列名改回旧语义
+    op.alter_column(
+        "count_doc_lines",
+        "diff_qty_base",
+        new_column_name="diff_qty",
+        existing_type=sa.Integer(),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "count_doc_lines",
+        "counted_qty_base",
+        new_column_name="counted_qty",
+        existing_type=sa.Integer(),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "count_doc_lines",
+        "snapshot_qty_base",
+        new_column_name="snapshot_qty",
+        existing_type=sa.Integer(),
+        existing_nullable=False,
+    )
+
+    # 恢复旧约束
+    op.create_check_constraint(
+        "ck_count_doc_lines_snapshot_qty_nonneg",
+        "count_doc_lines",
+        "snapshot_qty >= 0",
+    )
+    op.create_check_constraint(
+        "ck_count_doc_lines_counted_qty_nonneg",
+        "count_doc_lines",
+        "counted_qty IS NULL OR counted_qty >= 0",
+    )
+    op.create_check_constraint(
+        "ck_count_doc_lines_diff_consistent",
+        "count_doc_lines",
+        """
+        (
+          (counted_qty IS NULL AND diff_qty IS NULL)
+          OR
+          (counted_qty IS NOT NULL AND diff_qty = (counted_qty - snapshot_qty))
+        )
+        """,
+    )

--- a/alembic/versions/8d4ecaaae5d4_inventory_adjustment_create_count_docs_.py
+++ b/alembic/versions/8d4ecaaae5d4_inventory_adjustment_create_count_docs_.py
@@ -1,0 +1,215 @@
+"""inventory_adjustment_create_count_docs_and_count_doc_lines
+
+Revision ID: 8d4ecaaae5d4
+Revises: 3ac042b64340
+Create Date: 2026-04-22 13:44:16.452810
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "8d4ecaaae5d4"
+down_revision: Union[str, Sequence[str], None] = "3ac042b64340"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+
+    # ------------------------------------------------------------------
+    # 1) 盘点单头：count_docs
+    # ------------------------------------------------------------------
+    op.create_table(
+        "count_docs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("count_no", sa.String(length=64), nullable=False),
+        sa.Column("warehouse_id", sa.Integer(), nullable=False),
+        sa.Column("snapshot_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "status",
+            sa.String(length=16),
+            nullable=False,
+            server_default="DRAFT",
+        ),
+        sa.Column("posted_event_id", sa.Integer(), nullable=True),
+        sa.Column("created_by", sa.Integer(), nullable=True),
+        sa.Column("remark", sa.String(length=500), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("counted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("posted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["warehouse_id"],
+            ["warehouses.id"],
+            name="fk_count_docs_warehouse",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["posted_event_id"],
+            ["wms_events.id"],
+            name="fk_count_docs_posted_event",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["created_by"],
+            ["users.id"],
+            name="fk_count_docs_created_by",
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_count_docs"),
+        sa.UniqueConstraint("count_no", name="uq_count_docs_count_no"),
+        sa.CheckConstraint(
+            "status IN ('DRAFT', 'COUNTED', 'POSTED', 'VOIDED')",
+            name="ck_count_docs_status",
+        ),
+    )
+
+    op.create_index(
+        "ix_count_docs_status",
+        "count_docs",
+        ["status"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_count_docs_warehouse_snapshot_at",
+        "count_docs",
+        ["warehouse_id", "snapshot_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_count_docs_posted_event_id",
+        "count_docs",
+        ["posted_event_id"],
+        unique=False,
+    )
+
+    # ------------------------------------------------------------------
+    # 2) 盘点单明细：count_doc_lines
+    #
+    # 设计原则：
+    # - lot-world：结构锚点用 lot_id
+    # - lot_code_snapshot 只做展示快照
+    # - snapshot_qty 为冻结时点库存
+    # - counted_qty 为人工实盘数量，可先为空
+    # - diff_qty 由后端维护；当 counted_qty 为空时必须为空
+    # ------------------------------------------------------------------
+    op.create_table(
+        "count_doc_lines",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("doc_id", sa.Integer(), nullable=False),
+        sa.Column("line_no", sa.Integer(), nullable=False),
+        sa.Column("item_id", sa.Integer(), nullable=False),
+        sa.Column("lot_id", sa.Integer(), nullable=False),
+        sa.Column("lot_code_snapshot", sa.String(length=64), nullable=True),
+        sa.Column("snapshot_qty", sa.Integer(), nullable=False),
+        sa.Column("counted_qty", sa.Integer(), nullable=True),
+        sa.Column("diff_qty", sa.Integer(), nullable=True),
+        sa.Column("reason_code", sa.String(length=32), nullable=True),
+        sa.Column("disposition", sa.String(length=32), nullable=True),
+        sa.Column("remark", sa.String(length=255), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["doc_id"],
+            ["count_docs.id"],
+            name="fk_count_doc_lines_doc",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["item_id"],
+            ["items.id"],
+            name="fk_count_doc_lines_item",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["lot_id"],
+            ["lots.id"],
+            name="fk_count_doc_lines_lot",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_count_doc_lines"),
+        sa.UniqueConstraint(
+            "doc_id",
+            "line_no",
+            name="uq_count_doc_lines_doc_line",
+        ),
+        sa.CheckConstraint(
+            "line_no >= 1",
+            name="ck_count_doc_lines_line_no_positive",
+        ),
+        sa.CheckConstraint(
+            "snapshot_qty >= 0",
+            name="ck_count_doc_lines_snapshot_qty_nonneg",
+        ),
+        sa.CheckConstraint(
+            "counted_qty IS NULL OR counted_qty >= 0",
+            name="ck_count_doc_lines_counted_qty_nonneg",
+        ),
+        sa.CheckConstraint(
+            "("
+            "  (counted_qty IS NULL AND diff_qty IS NULL)"
+            "  OR"
+            "  (counted_qty IS NOT NULL AND diff_qty = counted_qty - snapshot_qty)"
+            ")",
+            name="ck_count_doc_lines_diff_consistent",
+        ),
+    )
+
+    op.create_index(
+        "ix_count_doc_lines_doc_id",
+        "count_doc_lines",
+        ["doc_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_count_doc_lines_item_id",
+        "count_doc_lines",
+        ["item_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_count_doc_lines_lot_id",
+        "count_doc_lines",
+        ["lot_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_count_doc_lines_reason_code",
+        "count_doc_lines",
+        ["reason_code"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_count_doc_lines_disposition",
+        "count_doc_lines",
+        ["disposition"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+
+    op.drop_table("count_doc_lines")
+    op.drop_table("count_docs")

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -114,6 +114,7 @@ def init_models(
         "app.procurement.models.purchase_order_line",
         "app.wms.inventory_adjustment.return_inbound.models.inbound_receipt",
         "app.wms.inventory_adjustment.return_inbound.models.inbound_operation",
+        "app.wms.inventory_adjustment.count.models.count_doc",
         "app.wms.stock.models.lot",
         "app.wms.stock.models.stock_lot",
         "app.wms.ledger.models.stock_ledger",
@@ -139,6 +140,7 @@ def init_models(
         "app.pms.items.models",
         "app.pms.suppliers.models",
         "app.wms.inventory_adjustment.return_inbound.models",
+        "app.wms.inventory_adjustment.count.models",
         "app.wms.inbound.models",
         "app.wms.outbound.models",
     ):

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -49,6 +49,11 @@ MODEL_SPECS = [
     ("app.wms.inbound.models.inbound_event", "WmsEvent"),
     ("app.wms.inbound.models.inbound_event", "InboundEventLine"),
     # ------------------------------------------------------------------
+    # 库存调节：盘点单（新主线）
+    # ------------------------------------------------------------------
+    ("app.wms.inventory_adjustment.count.models.count_doc", "CountDoc"),
+    ("app.wms.inventory_adjustment.count.models.count_doc", "CountDocLine"),
+    # ------------------------------------------------------------------
     # 订单 & 出库
     # ------------------------------------------------------------------
     ("app.models.order", "Order"),
@@ -177,6 +182,8 @@ __all__ = [
     "StockSnapshot",
     "WmsEvent",
     "InboundEventLine",
+    "CountDoc",
+    "CountDocLine",
     # ---- Orders ----
     "Order",
     "OrderItem",
@@ -222,7 +229,6 @@ __all__ = [
     # ---- Return ----
     "ReturnTask",
     "ReturnTaskLine",
-    # ---- Internal Outbound ----
     # ---- Shipping ----
     "TransportShipment",
     "ShippingRecord",

--- a/app/router_mount.py
+++ b/app/router_mount.py
@@ -11,6 +11,7 @@ def mount_routers(app: FastAPI, *, enable_dev_routes: bool) -> None:
     from app.admin.router import router as admin_router
     from app.diagnostics.routers.autoheal_execute import router as autoheal_execute_router
     from app.wms.inventory_adjustment.count.routers.count import router as count_router
+    from app.wms.inventory_adjustment.count.routers.count_docs import router as count_docs_router
     from app.wms.inventory_adjustment.count.routers.stock_inventory_recount import router as stock_inventory_recount_router
     from app.diagnostics.routers.debug_trace import router as debug_trace_router
     from app.devtools.routers.dev_seed_ledger import router as dev_seed_ledger_router
@@ -108,6 +109,7 @@ def mount_routers(app: FastAPI, *, enable_dev_routes: bool) -> None:
     # ===========================
     app.include_router(scan_router)
     app.include_router(count_router)
+    app.include_router(count_docs_router)
     app.include_router(stock_inventory_recount_router)
 
     app.include_router(orders_fulfillment_v2_router)

--- a/app/wms/inbound/repos/inbound_stock_write_repo.py
+++ b/app/wms/inbound/repos/inbound_stock_write_repo.py
@@ -6,6 +6,9 @@ from typing import Any
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.enums import MovementType
+from app.wms.inventory_adjustment.count.services.count_freeze_guard_service import (
+    ensure_warehouse_not_frozen,
+)
 from app.wms.stock.services.stock_service import StockService
 
 
@@ -40,6 +43,11 @@ async def apply_inbound_stock(
     - production_date / expiry_date 必须继续向下传，
       让 lot snapshot 与 RECEIPT ledger snapshot 使用同一决策输入
     """
+    await ensure_warehouse_not_frozen(
+        session,
+        warehouse_id=int(warehouse_id),
+    )
+
     stock_svc = StockService()
 
     return await stock_svc.adjust_lot(

--- a/app/wms/inventory_adjustment/count/contracts/count_doc.py
+++ b/app/wms/inventory_adjustment/count/contracts/count_doc.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+CountDocStatus = Literal["DRAFT", "FROZEN", "COUNTED", "POSTED", "VOIDED"]
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(
+        from_attributes=True,
+        populate_by_name=True,
+        extra="ignore",
+        str_strip_whitespace=True,
+    )
+
+
+# =========================================================
+# 出参：lot 快照参考明细
+# =========================================================
+class CountDocLineLotSnapshotOut(_Base):
+    id: int
+    lot_id: int
+    lot_code_snapshot: Optional[str] = None
+    snapshot_qty_base: int
+    created_at: datetime
+
+
+# =========================================================
+# 出参：盘点单明细
+# =========================================================
+class CountDocLineOut(_Base):
+    id: int
+    line_no: int
+
+    item_id: int
+    item_name_snapshot: Optional[str] = None
+    item_spec_snapshot: Optional[str] = None
+
+    snapshot_qty_base: int
+
+    counted_item_uom_id: Optional[int] = None
+    counted_uom_name_snapshot: Optional[str] = None
+    counted_ratio_to_base_snapshot: Optional[int] = None
+    counted_qty_input: Optional[int] = None
+
+    counted_qty_base: Optional[int] = None
+    diff_qty_base: Optional[int] = None
+
+    reason_code: Optional[str] = None
+    disposition: Optional[str] = None
+    remark: Optional[str] = None
+
+    created_at: datetime
+    updated_at: datetime
+
+    lot_snapshots: List[CountDocLineLotSnapshotOut] = Field(default_factory=list)
+
+
+# =========================================================
+# 出参：盘点单头
+# =========================================================
+class CountDocOut(_Base):
+    id: int
+    count_no: str
+    warehouse_id: int
+    snapshot_at: datetime
+    status: CountDocStatus
+
+    posted_event_id: Optional[int] = None
+    created_by: Optional[int] = None
+    remark: Optional[str] = None
+
+    created_at: datetime
+    counted_at: Optional[datetime] = None
+    posted_at: Optional[datetime] = None
+
+
+class CountDocDetailOut(CountDocOut):
+    lines: List[CountDocLineOut] = Field(default_factory=list)
+
+
+class CountDocListOut(_Base):
+    total: int
+    items: List[CountDocOut] = Field(default_factory=list)
+
+
+# =========================================================
+# 入参：创建盘点单
+# =========================================================
+class CountDocCreateIn(_Base):
+    warehouse_id: int = Field(..., ge=1, description="盘点仓库 ID")
+    snapshot_at: datetime = Field(..., description="盘点时点（UTC）")
+    remark: Optional[str] = Field(default=None, max_length=500, description="备注")
+
+    @field_validator("remark", mode="before")
+    @classmethod
+    def _trim_remark(cls, v):
+        return v.strip() if isinstance(v, str) else v
+
+
+# =========================================================
+# 出参：冻结结果
+# =========================================================
+class CountDocFreezeOut(_Base):
+    doc_id: int
+    status: CountDocStatus
+    snapshot_at: datetime
+    line_count: int
+    lot_snapshot_count: int
+
+
+# =========================================================
+# 入参：更新盘点明细（录入实盘数量）
+# 约定：
+# - 前端只传盘点包装单位 ID 和输入数量
+# - counted_uom_name_snapshot / counted_ratio_to_base_snapshot /
+#   counted_qty_base / diff_qty_base 由后端按 item_uoms 和 snapshot_qty_base 计算
+# =========================================================
+class CountDocLineCountPatch(_Base):
+    line_id: int = Field(..., ge=1)
+    counted_item_uom_id: int = Field(..., ge=1, description="盘点包装单位 ID")
+    counted_qty_input: int = Field(..., ge=0, description="按盘点包装单位输入的数量")
+
+    reason_code: Optional[str] = Field(default=None, max_length=32)
+    disposition: Optional[str] = Field(default=None, max_length=32)
+    remark: Optional[str] = Field(default=None, max_length=255)
+
+    @field_validator("reason_code", "disposition", "remark", mode="before")
+    @classmethod
+    def _trim_text(cls, v):
+        return v.strip() if isinstance(v, str) else v
+
+
+class CountDocLinesUpdateIn(_Base):
+    lines: List[CountDocLineCountPatch] = Field(default_factory=list, min_length=1)
+
+
+class CountDocLinesUpdateOut(_Base):
+    doc_id: int
+    status: CountDocStatus
+    updated_count: int
+    lines: List[CountDocLineOut] = Field(default_factory=list)
+
+
+# =========================================================
+# 出参：过账结果
+# =========================================================
+class CountDocPostOut(_Base):
+    doc_id: int
+    status: CountDocStatus
+    posted_event_id: int
+    posted_at: datetime
+
+
+__all__ = [
+    "CountDocStatus",
+    "CountDocLineLotSnapshotOut",
+    "CountDocLineOut",
+    "CountDocOut",
+    "CountDocDetailOut",
+    "CountDocListOut",
+    "CountDocCreateIn",
+    "CountDocFreezeOut",
+    "CountDocLineCountPatch",
+    "CountDocLinesUpdateIn",
+    "CountDocLinesUpdateOut",
+    "CountDocPostOut",
+]

--- a/app/wms/inventory_adjustment/count/models/__init__.py
+++ b/app/wms/inventory_adjustment/count/models/__init__.py
@@ -2,3 +2,11 @@
 # 本目录是 inventory_adjustment 模块的物理收口层。
 # 当前阶段先以 re-export / 聚合为主，方便按页面查看 contract / model / repo / router / service。
 # 后续如确认稳定，再逐步把真实实现迁入本目录。
+
+from .count_doc import CountDoc, CountDocLine, CountDocLineLotSnapshot
+
+__all__ = [
+    "CountDoc",
+    "CountDocLine",
+    "CountDocLineLotSnapshot",
+]

--- a/app/wms/inventory_adjustment/count/models/count_doc.py
+++ b/app/wms/inventory_adjustment/count/models/count_doc.py
@@ -1,0 +1,329 @@
+# app/wms/inventory_adjustment/count/models/count_doc.py
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class CountDoc(Base):
+    """
+    盘点单头（inventory_adjustment.count 主线）
+
+    设计原则：
+    - 盘点单头锚定 warehouse_id + snapshot_at
+    - snapshot_at 是盘点时点唯一真相源
+    - posted_event_id 是后续正式 COUNT 事件的桥接锚点
+    """
+
+    __tablename__ = "count_docs"
+
+    id: Mapped[int] = mapped_column(sa.Integer, primary_key=True, autoincrement=True)
+
+    count_no: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+
+    warehouse_id: Mapped[int] = mapped_column(
+        sa.Integer,
+        sa.ForeignKey("warehouses.id", name="fk_count_docs_warehouse", ondelete="RESTRICT"),
+        nullable=False,
+    )
+
+    snapshot_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+    )
+
+    status: Mapped[str] = mapped_column(
+        sa.String(16),
+        nullable=False,
+        default="DRAFT",
+        server_default="DRAFT",
+        index=True,
+    )
+
+    posted_event_id: Mapped[Optional[int]] = mapped_column(
+        sa.Integer,
+        sa.ForeignKey("wms_events.id", name="fk_count_docs_posted_event", ondelete="RESTRICT"),
+        nullable=True,
+        index=True,
+    )
+
+    created_by: Mapped[Optional[int]] = mapped_column(
+        sa.Integer,
+        sa.ForeignKey("users.id", name="fk_count_docs_created_by", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    remark: Mapped[Optional[str]] = mapped_column(sa.String(500), nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+    )
+
+    counted_at: Mapped[Optional[datetime]] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=True,
+    )
+
+    posted_at: Mapped[Optional[datetime]] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=True,
+    )
+
+    lines: Mapped[List["CountDocLine"]] = relationship(
+        "CountDocLine",
+        back_populates="doc",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
+
+    __table_args__ = (
+        sa.UniqueConstraint("count_no", name="uq_count_docs_count_no"),
+        sa.CheckConstraint(
+            "status IN ('DRAFT', 'FROZEN', 'COUNTED', 'POSTED', 'VOIDED')",
+            name="ck_count_docs_status",
+        ),
+        sa.Index("ix_count_docs_warehouse_snapshot_at", "warehouse_id", "snapshot_at"),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<CountDoc id={self.id} count_no={self.count_no} "
+            f"warehouse_id={self.warehouse_id} status={self.status} "
+            f"snapshot_at={self.snapshot_at} posted_event_id={self.posted_event_id}>"
+        )
+
+
+class CountDocLine(Base):
+    """
+    盘点单明细（商品级）
+
+    设计原则：
+    - 主锚点是 item_id，不再以 lot_id 作为盘点主行业务锚点
+    - 这是一张“商品级即时库存快照 + 实盘录入 + 差异处理”的单据行
+    - lot 分布下沉到 CountDocLineLotSnapshot
+    """
+
+    __tablename__ = "count_doc_lines"
+
+    id: Mapped[int] = mapped_column(sa.Integer, primary_key=True, autoincrement=True)
+
+    doc_id: Mapped[int] = mapped_column(
+        sa.Integer,
+        sa.ForeignKey("count_docs.id", name="fk_count_doc_lines_doc", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    line_no: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+
+    item_id: Mapped[int] = mapped_column(
+        sa.Integer,
+        sa.ForeignKey("items.id", name="fk_count_doc_lines_item", ondelete="RESTRICT"),
+        nullable=False,
+        index=True,
+    )
+
+    item_name_snapshot: Mapped[Optional[str]] = mapped_column(sa.String(255), nullable=True)
+    item_spec_snapshot: Mapped[Optional[str]] = mapped_column(sa.String(255), nullable=True)
+
+    snapshot_qty_base: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+
+    counted_item_uom_id: Mapped[Optional[int]] = mapped_column(
+        sa.Integer,
+        nullable=True,
+        index=True,
+    )
+    counted_uom_name_snapshot: Mapped[Optional[str]] = mapped_column(sa.String(64), nullable=True)
+    counted_ratio_to_base_snapshot: Mapped[Optional[int]] = mapped_column(sa.Integer, nullable=True)
+    counted_qty_input: Mapped[Optional[int]] = mapped_column(sa.Integer, nullable=True)
+
+    counted_qty_base: Mapped[Optional[int]] = mapped_column(sa.Integer, nullable=True)
+    diff_qty_base: Mapped[Optional[int]] = mapped_column(sa.Integer, nullable=True)
+
+    reason_code: Mapped[Optional[str]] = mapped_column(
+        sa.String(32),
+        nullable=True,
+        index=True,
+    )
+
+    disposition: Mapped[Optional[str]] = mapped_column(
+        sa.String(32),
+        nullable=True,
+        index=True,
+    )
+
+    remark: Mapped[Optional[str]] = mapped_column(sa.String(255), nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+    )
+
+    updated_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+    )
+
+    doc: Mapped["CountDoc"] = relationship(
+        "CountDoc",
+        back_populates="lines",
+        lazy="selectin",
+    )
+
+    lot_snapshots: Mapped[List["CountDocLineLotSnapshot"]] = relationship(
+        "CountDocLineLotSnapshot",
+        back_populates="line",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
+
+    __table_args__ = (
+        sa.ForeignKeyConstraint(
+            ["counted_item_uom_id", "item_id"],
+            ["item_uoms.id", "item_uoms.item_id"],
+            name="fk_count_doc_lines_counted_item_uom_pair",
+            ondelete="RESTRICT",
+        ),
+        sa.UniqueConstraint("doc_id", "line_no", name="uq_count_doc_lines_doc_line"),
+        sa.UniqueConstraint("doc_id", "item_id", name="uq_count_doc_lines_doc_item"),
+        sa.CheckConstraint(
+            "line_no >= 1",
+            name="ck_count_doc_lines_line_no_positive",
+        ),
+        sa.CheckConstraint(
+            "snapshot_qty_base >= 0",
+            name="ck_count_doc_lines_snapshot_qty_base_nonneg",
+        ),
+        sa.CheckConstraint(
+            "counted_qty_input IS NULL OR counted_qty_input >= 0",
+            name="ck_count_doc_lines_counted_qty_input_nonneg",
+        ),
+        sa.CheckConstraint(
+            "counted_qty_base IS NULL OR counted_qty_base >= 0",
+            name="ck_count_doc_lines_counted_qty_base_nonneg",
+        ),
+        sa.CheckConstraint(
+            "counted_ratio_to_base_snapshot IS NULL OR counted_ratio_to_base_snapshot >= 1",
+            name="ck_count_doc_lines_counted_ratio_positive",
+        ),
+        sa.CheckConstraint(
+            """
+            (
+              counted_item_uom_id IS NULL
+              AND counted_uom_name_snapshot IS NULL
+              AND counted_ratio_to_base_snapshot IS NULL
+              AND counted_qty_input IS NULL
+              AND counted_qty_base IS NULL
+              AND diff_qty_base IS NULL
+            )
+            OR
+            (
+              counted_item_uom_id IS NOT NULL
+              AND counted_uom_name_snapshot IS NOT NULL
+              AND counted_ratio_to_base_snapshot IS NOT NULL
+              AND counted_qty_input IS NOT NULL
+              AND counted_qty_base IS NOT NULL
+              AND diff_qty_base IS NOT NULL
+              AND counted_qty_base = (counted_qty_input * counted_ratio_to_base_snapshot)
+              AND diff_qty_base = (counted_qty_base - snapshot_qty_base)
+            )
+            """,
+            name="ck_count_doc_lines_count_payload_consistent",
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<CountDocLine id={self.id} doc_id={self.doc_id} line_no={self.line_no} "
+            f"item_id={self.item_id} snapshot_qty_base={self.snapshot_qty_base} "
+            f"counted_item_uom_id={self.counted_item_uom_id} "
+            f"counted_qty_input={self.counted_qty_input} "
+            f"counted_qty_base={self.counted_qty_base} "
+            f"diff_qty_base={self.diff_qty_base}>"
+        )
+
+
+class CountDocLineLotSnapshot(Base):
+    """
+    盘点单行下的 lot 快照参考明细
+
+    设计原则：
+    - 不作为盘点主行业务锚点
+    - 只保存 snapshot_at 时点该商品的 lot 分布
+    - 供页面参考与后续过账分摊使用
+    """
+
+    __tablename__ = "count_doc_line_lot_snapshots"
+
+    id: Mapped[int] = mapped_column(sa.Integer, primary_key=True, autoincrement=True)
+
+    line_id: Mapped[int] = mapped_column(
+        sa.Integer,
+        sa.ForeignKey(
+            "count_doc_lines.id",
+            name="fk_count_doc_line_lot_snapshots_line",
+            ondelete="CASCADE",
+        ),
+        nullable=False,
+        index=True,
+    )
+
+    lot_id: Mapped[int] = mapped_column(
+        sa.Integer,
+        sa.ForeignKey(
+            "lots.id",
+            name="fk_count_doc_line_lot_snapshots_lot",
+            ondelete="RESTRICT",
+        ),
+        nullable=False,
+        index=True,
+    )
+
+    lot_code_snapshot: Mapped[Optional[str]] = mapped_column(sa.String(64), nullable=True)
+    snapshot_qty_base: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+
+    created_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+    )
+
+    line: Mapped["CountDocLine"] = relationship(
+        "CountDocLine",
+        back_populates="lot_snapshots",
+        lazy="selectin",
+    )
+
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "line_id",
+            "lot_id",
+            name="uq_count_doc_line_lot_snapshots_line_lot",
+        ),
+        sa.CheckConstraint(
+            "snapshot_qty_base >= 0",
+            name="ck_count_doc_line_lot_snapshots_snapshot_qty_base_nonneg",
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<CountDocLineLotSnapshot id={self.id} line_id={self.line_id} "
+            f"lot_id={self.lot_id} snapshot_qty_base={self.snapshot_qty_base}>"
+        )
+
+
+__all__ = [
+    "CountDoc",
+    "CountDocLine",
+    "CountDocLineLotSnapshot",
+]

--- a/app/wms/inventory_adjustment/count/repos/count_doc_repo.py
+++ b/app/wms/inventory_adjustment/count/repos/count_doc_repo.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Sequence
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.wms.inventory_adjustment.count.models.count_doc import (
+    CountDoc,
+    CountDocLine,
+)
+
+
+class CountDocRepo:
+    async def create_doc(
+        self,
+        session: AsyncSession,
+        *,
+        count_no: str,
+        warehouse_id: int,
+        snapshot_at: datetime,
+        created_by: int | None,
+        remark: str | None,
+    ) -> CountDoc:
+        obj = CountDoc(
+            count_no=str(count_no),
+            warehouse_id=int(warehouse_id),
+            snapshot_at=snapshot_at,
+            created_by=int(created_by) if created_by is not None else None,
+            remark=remark,
+            status="DRAFT",
+        )
+        session.add(obj)
+        await session.flush()
+        return obj
+
+    async def get_doc(
+        self,
+        session: AsyncSession,
+        *,
+        doc_id: int,
+    ) -> CountDoc | None:
+        stmt = select(CountDoc).where(CountDoc.id == int(doc_id))
+        return (await session.execute(stmt)).scalar_one_or_none()
+
+    async def get_doc_detail(
+        self,
+        session: AsyncSession,
+        *,
+        doc_id: int,
+    ) -> CountDoc | None:
+        stmt = (
+            select(CountDoc)
+            .where(CountDoc.id == int(doc_id))
+            .options(
+                selectinload(CountDoc.lines).selectinload(CountDocLine.lot_snapshots),
+            )
+        )
+        return (await session.execute(stmt)).scalar_one_or_none()
+
+    async def list_docs(
+        self,
+        session: AsyncSession,
+        *,
+        warehouse_id: int | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> tuple[int, list[CountDoc]]:
+        where_sql = ""
+        params: dict[str, object] = {
+            "limit": int(limit),
+            "offset": int(offset),
+        }
+        if warehouse_id is not None:
+            where_sql = "WHERE warehouse_id = :warehouse_id"
+            params["warehouse_id"] = int(warehouse_id)
+
+        total_sql = text(
+            f"""
+            SELECT COUNT(*)
+              FROM count_docs
+              {where_sql}
+            """
+        )
+        total = int((await session.execute(total_sql, params)).scalar_one() or 0)
+
+        stmt = (
+            select(CountDoc)
+            .order_by(CountDoc.snapshot_at.desc(), CountDoc.id.desc())
+            .limit(int(limit))
+            .offset(int(offset))
+        )
+        if warehouse_id is not None:
+            stmt = stmt.where(CountDoc.warehouse_id == int(warehouse_id))
+
+        items = list((await session.execute(stmt)).scalars().all())
+        return total, items
+
+    async def freeze_doc_lines_from_current_stock(
+        self,
+        session: AsyncSession,
+        *,
+        doc_id: int,
+    ) -> tuple[int, int]:
+        """
+        当前一版盘点采用“盘点时冻结该仓库存动作”的方案，因此：
+        - snapshot_at 即冻结时点；
+        - 冻结明细直接从当前 stocks_lot 聚合；
+        - 主行按 item 粒度生成；
+        - lot 分布下沉到 count_doc_line_lot_snapshots。
+        """
+        doc = await self.get_doc(session, doc_id=int(doc_id))
+        if doc is None:
+            raise LookupError(f"count_doc_not_found:{int(doc_id)}")
+
+        # 先清旧冻结结果（当前阶段允许在 DRAFT 下重冻）
+        await session.execute(
+            text(
+                """
+                DELETE FROM count_doc_line_lot_snapshots
+                 WHERE line_id IN (
+                    SELECT id
+                      FROM count_doc_lines
+                     WHERE doc_id = :doc_id
+                 )
+                """
+            ),
+            {"doc_id": int(doc_id)},
+        )
+        await session.execute(
+            text("DELETE FROM count_doc_lines WHERE doc_id = :doc_id"),
+            {"doc_id": int(doc_id)},
+        )
+
+        # 1) 生成商品级盘点主行
+        await session.execute(
+            text(
+                """
+                INSERT INTO count_doc_lines (
+                  doc_id,
+                  line_no,
+                  item_id,
+                  item_name_snapshot,
+                  item_spec_snapshot,
+                  snapshot_qty_base
+                )
+                SELECT
+                  :doc_id AS doc_id,
+                  ROW_NUMBER() OVER (ORDER BY s.item_id ASC) AS line_no,
+                  s.item_id,
+                  MAX(i.name) AS item_name_snapshot,
+                  MAX(i.spec) AS item_spec_snapshot,
+                  SUM(s.qty) AS snapshot_qty_base
+                  FROM stocks_lot s
+                  JOIN items i
+                    ON i.id = s.item_id
+                 WHERE s.warehouse_id = :warehouse_id
+                 GROUP BY s.item_id
+                HAVING SUM(s.qty) > 0
+                """
+            ),
+            {
+                "doc_id": int(doc_id),
+                "warehouse_id": int(doc.warehouse_id),
+            },
+        )
+
+        # 2) 生成该商品行下的 lot 快照参考
+        await session.execute(
+            text(
+                """
+                INSERT INTO count_doc_line_lot_snapshots (
+                  line_id,
+                  lot_id,
+                  lot_code_snapshot,
+                  snapshot_qty_base
+                )
+                SELECT
+                  l.id AS line_id,
+                  sl.lot_id,
+                  MAX(lo.lot_code) AS lot_code_snapshot,
+                  SUM(sl.qty) AS snapshot_qty_base
+                  FROM count_doc_lines l
+                  JOIN count_docs d
+                    ON d.id = l.doc_id
+                  JOIN stocks_lot sl
+                    ON sl.item_id = l.item_id
+                   AND sl.warehouse_id = d.warehouse_id
+                  JOIN lots lo
+                    ON lo.id = sl.lot_id
+                 WHERE l.doc_id = :doc_id
+                 GROUP BY l.id, sl.lot_id
+                HAVING SUM(sl.qty) > 0
+                """
+            ),
+            {"doc_id": int(doc_id)},
+        )
+
+        await session.execute(
+            text(
+                """
+                UPDATE count_docs
+                   SET status = 'FROZEN'
+                 WHERE id = :doc_id
+                """
+            ),
+            {"doc_id": int(doc_id)},
+        )
+
+        line_count = int(
+            (
+                await session.execute(
+                    text("SELECT COUNT(*) FROM count_doc_lines WHERE doc_id = :doc_id"),
+                    {"doc_id": int(doc_id)},
+                )
+            ).scalar_one()
+            or 0
+        )
+
+        lot_snapshot_count = int(
+            (
+                await session.execute(
+                    text(
+                        """
+                        SELECT COUNT(*)
+                          FROM count_doc_line_lot_snapshots
+                         WHERE line_id IN (
+                            SELECT id
+                              FROM count_doc_lines
+                             WHERE doc_id = :doc_id
+                         )
+                        """
+                    ),
+                    {"doc_id": int(doc_id)},
+                )
+            ).scalar_one()
+            or 0
+        )
+
+        return line_count, lot_snapshot_count
+
+    async def update_line_counts(
+        self,
+        session: AsyncSession,
+        *,
+        doc_id: int,
+        lines: Sequence[dict[str, object]],
+    ) -> int:
+        """
+        入参 lines 约定每项至少包含：
+        - line_id
+        - counted_item_uom_id
+        - counted_qty_input
+        可选：
+        - reason_code
+        - disposition
+        - remark
+        """
+        updated = 0
+
+        for raw in lines:
+            line_id = int(raw["line_id"])
+            counted_item_uom_id = int(raw["counted_item_uom_id"])
+            counted_qty_input = int(raw["counted_qty_input"])
+
+            line = (
+                await session.execute(
+                    select(CountDocLine).where(
+                        CountDocLine.id == line_id,
+                        CountDocLine.doc_id == int(doc_id),
+                    )
+                )
+            ).scalar_one_or_none()
+            if line is None:
+                raise LookupError(f"count_doc_line_not_found:{line_id}")
+
+            uom_row = (
+                await session.execute(
+                    text(
+                        """
+                        SELECT
+                          iu.id,
+                          iu.ratio_to_base,
+                          COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS uom_name_snapshot
+                          FROM item_uoms iu
+                         WHERE iu.id = :uom_id
+                           AND iu.item_id = :item_id
+                         LIMIT 1
+                        """
+                    ),
+                    {
+                        "uom_id": int(counted_item_uom_id),
+                        "item_id": int(line.item_id),
+                    },
+                )
+            ).mappings().first()
+            if uom_row is None:
+                raise LookupError(
+                    f"count_doc_line_invalid_item_uom_pair: line_id={line_id}, item_uom_id={counted_item_uom_id}"
+                )
+
+            ratio = int(uom_row["ratio_to_base"])
+            uom_name_snapshot = str(uom_row["uom_name_snapshot"])
+            counted_qty_base = int(counted_qty_input) * int(ratio)
+            diff_qty_base = int(counted_qty_base) - int(line.snapshot_qty_base)
+
+            line.counted_item_uom_id = int(counted_item_uom_id)
+            line.counted_uom_name_snapshot = uom_name_snapshot
+            line.counted_ratio_to_base_snapshot = int(ratio)
+            line.counted_qty_input = int(counted_qty_input)
+            line.counted_qty_base = int(counted_qty_base)
+            line.diff_qty_base = int(diff_qty_base)
+
+            reason_code = raw.get("reason_code")
+            disposition = raw.get("disposition")
+            remark = raw.get("remark")
+
+            line.reason_code = str(reason_code).strip() if isinstance(reason_code, str) and reason_code.strip() else None
+            line.disposition = (
+                str(disposition).strip() if isinstance(disposition, str) and disposition.strip() else None
+            )
+            line.remark = str(remark).strip() if isinstance(remark, str) and remark.strip() else None
+            line.updated_at = datetime.now(timezone.utc)
+
+            updated += 1
+
+        await session.flush()
+        return updated
+
+    async def try_mark_doc_counted(
+        self,
+        session: AsyncSession,
+        *,
+        doc_id: int,
+    ) -> bool:
+        """
+        当且仅当：
+        - 当前为 FROZEN
+        - 至少存在一条明细
+        - 所有明细都已有 counted_qty_base
+        才推进到 COUNTED。
+        """
+        result = await session.execute(
+            text(
+                """
+                UPDATE count_docs
+                   SET status = 'COUNTED',
+                       counted_at = COALESCE(counted_at, now())
+                 WHERE id = :doc_id
+                   AND status = 'FROZEN'
+                   AND EXISTS (
+                       SELECT 1
+                         FROM count_doc_lines
+                        WHERE doc_id = :doc_id
+                   )
+                   AND NOT EXISTS (
+                       SELECT 1
+                         FROM count_doc_lines
+                        WHERE doc_id = :doc_id
+                          AND counted_qty_base IS NULL
+                   )
+                """
+            ),
+            {"doc_id": int(doc_id)},
+        )
+        return bool(result.rowcount and int(result.rowcount) > 0)
+
+    async def mark_doc_posted(
+        self,
+        session: AsyncSession,
+        *,
+        doc_id: int,
+        posted_event_id: int,
+        posted_at: datetime,
+    ) -> None:
+        result = await session.execute(
+            text(
+                """
+                UPDATE count_docs
+                   SET status = 'POSTED',
+                       posted_event_id = :posted_event_id,
+                       posted_at = :posted_at
+                 WHERE id = :doc_id
+                   AND status = 'COUNTED'
+                """
+            ),
+            {
+                "doc_id": int(doc_id),
+                "posted_event_id": int(posted_event_id),
+                "posted_at": posted_at,
+            },
+        )
+        if not result.rowcount:
+            raise LookupError(f"count_doc_not_counted_or_not_found:{int(doc_id)}")
+
+    async def mark_doc_voided(
+        self,
+        session: AsyncSession,
+        *,
+        doc_id: int,
+    ) -> None:
+        result = await session.execute(
+            text(
+                """
+                UPDATE count_docs
+                   SET status = 'VOIDED'
+                 WHERE id = :doc_id
+                   AND status IN ('DRAFT', 'FROZEN', 'COUNTED')
+                """
+            ),
+            {"doc_id": int(doc_id)},
+        )
+        if not result.rowcount:
+            raise LookupError(f"count_doc_not_voidable_or_not_found:{int(doc_id)}")
+
+
+__all__ = [
+    "CountDocRepo",
+]

--- a/app/wms/inventory_adjustment/count/repos/count_freeze_guard_repo.py
+++ b/app/wms/inventory_adjustment/count/repos/count_freeze_guard_repo.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def get_frozen_count_doc_brief(
+    session: AsyncSession,
+    *,
+    warehouse_id: int,
+) -> dict[str, Any] | None:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  id,
+                  count_no,
+                  warehouse_id,
+                  snapshot_at,
+                  status
+                FROM count_docs
+                WHERE warehouse_id = :warehouse_id
+                  AND status = 'FROZEN'
+                ORDER BY snapshot_at DESC, id DESC
+                LIMIT 1
+                """
+            ),
+            {"warehouse_id": int(warehouse_id)},
+        )
+    ).mappings().first()
+
+    if row is None:
+        return None
+
+    return {
+        "id": int(row["id"]),
+        "count_no": str(row["count_no"]),
+        "warehouse_id": int(row["warehouse_id"]),
+        "snapshot_at": row["snapshot_at"],
+        "status": str(row["status"]),
+    }
+
+
+__all__ = [
+    "get_frozen_count_doc_brief",
+]

--- a/app/wms/inventory_adjustment/count/routers/count_docs.py
+++ b/app/wms/inventory_adjustment/count/routers/count_docs.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.deps import get_async_session
+from app.wms.inventory_adjustment.count.contracts.count_doc import (
+    CountDocCreateIn,
+    CountDocDetailOut,
+    CountDocFreezeOut,
+    CountDocLinesUpdateIn,
+    CountDocLinesUpdateOut,
+    CountDocListOut,
+    CountDocOut,
+)
+from app.wms.inventory_adjustment.count.services.count_doc_service import CountDocService
+
+router = APIRouter(
+    prefix="/inventory-adjustment/count-docs",
+    tags=["inventory-adjustment-count-docs"],
+)
+
+
+@router.post("", response_model=CountDocOut, status_code=status.HTTP_201_CREATED)
+async def create_count_doc(
+    payload: CountDocCreateIn,
+    session: AsyncSession = Depends(get_async_session),
+) -> CountDocOut:
+    service = CountDocService()
+    try:
+        out = await service.create_doc(
+            session,
+            payload=payload,
+            actor_user_id=None,  # 当前阶段先不接 user runtime；created_by 允许为空
+        )
+        await session.commit()
+        return out
+    except ValueError as e:
+        await session.rollback()
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except LookupError as e:
+        await session.rollback()
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except HTTPException:
+        await session.rollback()
+        raise
+    except Exception as e:
+        await session.rollback()
+        raise HTTPException(status_code=500, detail=f"create_count_doc_failed: {e}") from e
+
+
+@router.get("", response_model=CountDocListOut, status_code=status.HTTP_200_OK)
+async def list_count_docs(
+    warehouse_id: int | None = Query(default=None, ge=1),
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    session: AsyncSession = Depends(get_async_session),
+) -> CountDocListOut:
+    service = CountDocService()
+    try:
+        return await service.list_docs(
+            session,
+            warehouse_id=warehouse_id,
+            limit=limit,
+            offset=offset,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except LookupError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"list_count_docs_failed: {e}") from e
+
+
+@router.get("/{doc_id}", response_model=CountDocDetailOut, status_code=status.HTTP_200_OK)
+async def get_count_doc_detail(
+    doc_id: int,
+    session: AsyncSession = Depends(get_async_session),
+) -> CountDocDetailOut:
+    service = CountDocService()
+    try:
+        return await service.get_doc_detail(session, doc_id=int(doc_id))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except LookupError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"get_count_doc_detail_failed: {e}") from e
+
+
+@router.post("/{doc_id}/freeze", response_model=CountDocFreezeOut, status_code=status.HTTP_200_OK)
+async def freeze_count_doc(
+    doc_id: int,
+    session: AsyncSession = Depends(get_async_session),
+) -> CountDocFreezeOut:
+    service = CountDocService()
+    try:
+        out = await service.freeze_doc(session, doc_id=int(doc_id))
+        await session.commit()
+        return out
+    except ValueError as e:
+        await session.rollback()
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except LookupError as e:
+        await session.rollback()
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except HTTPException:
+        await session.rollback()
+        raise
+    except Exception as e:
+        await session.rollback()
+        raise HTTPException(status_code=500, detail=f"freeze_count_doc_failed: {e}") from e
+
+
+@router.put("/{doc_id}/lines", response_model=CountDocLinesUpdateOut, status_code=status.HTTP_200_OK)
+async def update_count_doc_lines(
+    doc_id: int,
+    payload: CountDocLinesUpdateIn,
+    session: AsyncSession = Depends(get_async_session),
+) -> CountDocLinesUpdateOut:
+    service = CountDocService()
+    try:
+        out = await service.update_doc_lines(
+            session,
+            doc_id=int(doc_id),
+            payload=payload,
+        )
+        await session.commit()
+        return out
+    except ValueError as e:
+        await session.rollback()
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except LookupError as e:
+        await session.rollback()
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except HTTPException:
+        await session.rollback()
+        raise
+    except Exception as e:
+        await session.rollback()
+        raise HTTPException(status_code=500, detail=f"update_count_doc_lines_failed: {e}") from e

--- a/app/wms/inventory_adjustment/count/routers/stock_inventory_recount.py
+++ b/app/wms/inventory_adjustment/count/routers/stock_inventory_recount.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import json
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -10,6 +11,9 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.deps import get_async_session as get_session
+from app.wms.inventory_adjustment.count.services.count_freeze_guard_service import (
+    ensure_warehouse_not_frozen,
+)
 
 router = APIRouter()
 
@@ -31,6 +35,7 @@ class StockRecountRequest(BaseModel):
 
 
 async def _insert_event(session: AsyncSession, *, source: str, message: str, occurred_at: datetime) -> int:
+    payload = json.dumps({"scan_ref": message}, ensure_ascii=False)
     row = await session.execute(
         text(
             """
@@ -39,7 +44,7 @@ async def _insert_event(session: AsyncSession, *, source: str, message: str, occ
             RETURNING id
             """
         ),
-        {"src": source, "msg": message, "ts": occurred_at},
+        {"src": source, "msg": payload, "ts": occurred_at},
     )
     return int(row.scalar_one())
 
@@ -71,7 +76,12 @@ async def stock_recount(
 
     svc = StockService()
 
-    async with session.begin():
+    try:
+        await ensure_warehouse_not_frozen(
+            session,
+            warehouse_id=int(req.warehouse_id),
+        )
+
         row = await session.execute(
             text(
                 """
@@ -100,13 +110,27 @@ async def stock_recount(
                 batch_code=code,
             )
 
-        ev_id = await _insert_event(session, source="stock_recount", message=scan_ref, occurred_at=occurred_at)
+        ev_id = await _insert_event(
+            session,
+            source="stock_recount",
+            message=scan_ref,
+            occurred_at=occurred_at,
+        )
 
-    return {
-        "scan_ref": scan_ref,
-        "event_id": ev_id,
-        "on_hand": on_hand,
-        "actual": int(req.actual),
-        "delta": delta,
-        "committed": True,
-    }
+        await session.commit()
+
+        return {
+            "scan_ref": scan_ref,
+            "event_id": ev_id,
+            "on_hand": on_hand,
+            "actual": int(req.actual),
+            "delta": delta,
+            "committed": True,
+        }
+
+    except HTTPException:
+        await session.rollback()
+        raise
+    except Exception:
+        await session.rollback()
+        raise

--- a/app/wms/inventory_adjustment/count/services/count_doc_service.py
+++ b/app/wms/inventory_adjustment/count/services/count_doc_service.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.wms.inventory_adjustment.count.contracts.count_doc import (
+    CountDocCreateIn,
+    CountDocDetailOut,
+    CountDocFreezeOut,
+    CountDocLinesUpdateIn,
+    CountDocLinesUpdateOut,
+    CountDocListOut,
+    CountDocOut,
+    CountDocPostOut,
+)
+from app.wms.inventory_adjustment.count.repos.count_doc_repo import CountDocRepo
+
+
+class CountDocService:
+    def __init__(self, *, repo: CountDocRepo | None = None) -> None:
+        self.repo = repo or CountDocRepo()
+
+    def _make_count_no(self, now: datetime | None = None) -> str:
+        ts = (now or datetime.now(timezone.utc)).strftime("%Y%m%d%H%M%S")
+        suffix = uuid4().hex[:8].upper()
+        return f"CTD-{ts}-{suffix}"
+
+    async def _require_doc(self, session: AsyncSession, *, doc_id: int):
+        doc = await self.repo.get_doc(session, doc_id=int(doc_id))
+        if doc is None:
+            raise LookupError(f"count_doc_not_found:{int(doc_id)}")
+        return doc
+
+    async def create_doc(
+        self,
+        session: AsyncSession,
+        *,
+        payload: CountDocCreateIn,
+        actor_user_id: int | None,
+    ) -> CountDocOut:
+        count_no = self._make_count_no(payload.snapshot_at)
+
+        doc = await self.repo.create_doc(
+            session,
+            count_no=count_no,
+            warehouse_id=int(payload.warehouse_id),
+            snapshot_at=payload.snapshot_at,
+            created_by=int(actor_user_id) if actor_user_id is not None else None,
+            remark=payload.remark,
+        )
+        await session.flush()
+        return CountDocOut.model_validate(doc)
+
+    async def get_doc_detail(
+        self,
+        session: AsyncSession,
+        *,
+        doc_id: int,
+    ) -> CountDocDetailOut:
+        doc = await self.repo.get_doc_detail(session, doc_id=int(doc_id))
+        if doc is None:
+            raise LookupError(f"count_doc_not_found:{int(doc_id)}")
+        return CountDocDetailOut.model_validate(doc)
+
+    async def list_docs(
+        self,
+        session: AsyncSession,
+        *,
+        warehouse_id: int | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> CountDocListOut:
+        total, docs = await self.repo.list_docs(
+            session,
+            warehouse_id=int(warehouse_id) if warehouse_id is not None else None,
+            limit=int(limit),
+            offset=int(offset),
+        )
+        return CountDocListOut(
+            total=int(total),
+            items=[CountDocOut.model_validate(x) for x in docs],
+        )
+
+    async def freeze_doc(
+        self,
+        session: AsyncSession,
+        *,
+        doc_id: int,
+    ) -> CountDocFreezeOut:
+        doc = await self._require_doc(session, doc_id=int(doc_id))
+
+        if str(doc.status) != "DRAFT":
+            raise ValueError(f"count_doc_freeze_requires_draft: current={doc.status}")
+
+        line_count, lot_snapshot_count = await self.repo.freeze_doc_lines_from_current_stock(
+            session,
+            doc_id=int(doc_id),
+        )
+
+        return CountDocFreezeOut(
+            doc_id=int(doc_id),
+            status="FROZEN",
+            snapshot_at=doc.snapshot_at,
+            line_count=int(line_count),
+            lot_snapshot_count=int(lot_snapshot_count),
+        )
+
+    async def update_doc_lines(
+        self,
+        session: AsyncSession,
+        *,
+        doc_id: int,
+        payload: CountDocLinesUpdateIn,
+    ) -> CountDocLinesUpdateOut:
+        doc = await self._require_doc(session, doc_id=int(doc_id))
+
+        if str(doc.status) not in {"FROZEN", "COUNTED"}:
+            raise ValueError(
+                f"count_doc_lines_update_requires_frozen_or_counted: current={doc.status}"
+            )
+
+        updated_count = await self.repo.update_line_counts(
+            session,
+            doc_id=int(doc_id),
+            lines=[
+                {
+                    "line_id": int(x.line_id),
+                    "counted_item_uom_id": int(x.counted_item_uom_id),
+                    "counted_qty_input": int(x.counted_qty_input),
+                    "reason_code": x.reason_code,
+                    "disposition": x.disposition,
+                    "remark": x.remark,
+                }
+                for x in payload.lines
+            ],
+        )
+
+        _ = await self.repo.try_mark_doc_counted(session, doc_id=int(doc_id))
+        detail = await self.repo.get_doc_detail(session, doc_id=int(doc_id))
+        if detail is None:
+            raise LookupError(f"count_doc_not_found_after_update:{int(doc_id)}")
+
+        return CountDocLinesUpdateOut(
+            doc_id=int(detail.id),
+            status=str(detail.status),  # type: ignore[arg-type]
+            updated_count=int(updated_count),
+            lines=[x for x in CountDocDetailOut.model_validate(detail).lines],
+        )
+
+    async def post_doc(
+        self,
+        session: AsyncSession,
+        *,
+        doc_id: int,
+    ) -> CountDocPostOut:
+        _ = session
+        _ = doc_id
+        raise RuntimeError(
+            "count_doc_post_not_ready: COUNT wms_events / ledger posting chain is not implemented yet."
+        )
+
+
+__all__ = [
+    "CountDocService",
+]

--- a/app/wms/inventory_adjustment/count/services/count_freeze_guard_service.py
+++ b/app/wms/inventory_adjustment/count/services/count_freeze_guard_service.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.wms.inventory_adjustment.count.repos.count_freeze_guard_repo import (
+    get_frozen_count_doc_brief,
+)
+
+
+async def ensure_warehouse_not_frozen(
+    session: AsyncSession,
+    *,
+    warehouse_id: int,
+) -> None:
+    frozen = await get_frozen_count_doc_brief(
+        session,
+        warehouse_id=int(warehouse_id),
+    )
+    if frozen is None:
+        return
+
+    raise HTTPException(
+        status_code=409,
+        detail={
+            "error_code": "count_doc_frozen_for_warehouse",
+            "warehouse_id": int(warehouse_id),
+            "count_doc_id": int(frozen["id"]),
+            "count_no": str(frozen["count_no"]),
+            "snapshot_at": frozen["snapshot_at"].isoformat()
+            if hasattr(frozen["snapshot_at"], "isoformat")
+            else str(frozen["snapshot_at"]),
+            "message": "该仓存在 FROZEN 状态盘点单，当前禁止任何会改库存的操作。",
+        },
+    )
+
+
+__all__ = [
+    "ensure_warehouse_not_frozen",
+]

--- a/app/wms/inventory_adjustment/count/services/count_service.py
+++ b/app/wms/inventory_adjustment/count/services/count_service.py
@@ -5,6 +5,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.enums import MovementType
 from app.wms.inventory_adjustment.count.contracts.count import CountRequest, CountResponse
 from app.wms.inventory_adjustment.count.repos.count_repo import CountRepo
+from app.wms.inventory_adjustment.count.services.count_freeze_guard_service import (
+    ensure_warehouse_not_frozen,
+)
 from app.wms.shared.services.lot_code_contract import validate_lot_code_contract
 from app.wms.stock.services.stock_service import StockService
 
@@ -25,6 +28,11 @@ class CountService:
         *,
         req: CountRequest,
     ) -> CountResponse:
+        await ensure_warehouse_not_frozen(
+            session,
+            warehouse_id=int(req.warehouse_id),
+        )
+
         expiry_policy_text = await self.repo.get_item_expiry_policy_text(
             session,
             item_id=int(req.item_id),

--- a/app/wms/inventory_adjustment/inbound_reversal/services/inbound_reversal_service.py
+++ b/app/wms/inventory_adjustment/inbound_reversal/services/inbound_reversal_service.py
@@ -8,6 +8,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.enums import MovementType
 from app.wms.inbound.models.inbound_event import InboundEventLine, WmsEvent
+from app.wms.inventory_adjustment.count.services.count_freeze_guard_service import (
+    ensure_warehouse_not_frozen,
+)
 from app.wms.inventory_adjustment.inbound_reversal.contracts.inbound_reversal import (
     InboundReversalIn,
     InboundReversalOut,
@@ -71,6 +74,11 @@ async def reverse_inbound_event(
     source_lines = await list_inbound_event_lines_for_reversal(
         session,
         event_id=int(original["event_id"]),
+    )
+
+    await ensure_warehouse_not_frozen(
+        session,
+        warehouse_id=int(original["warehouse_id"]),
     )
 
     occurred_at = payload.occurred_at

--- a/app/wms/inventory_adjustment/outbound_reversal/services/outbound_reversal_service.py
+++ b/app/wms/inventory_adjustment/outbound_reversal/services/outbound_reversal_service.py
@@ -8,6 +8,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.enums import MovementType
 from app.wms.inbound.models.inbound_event import WmsEvent
+from app.wms.inventory_adjustment.count.services.count_freeze_guard_service import (
+    ensure_warehouse_not_frozen,
+)
 from app.wms.inventory_adjustment.outbound_reversal.contracts.outbound_reversal import (
     OutboundReversalIn,
     OutboundReversalOut,
@@ -62,6 +65,11 @@ async def reverse_outbound_event(
     source_lines = await list_outbound_event_lines_for_reversal(
         session,
         event_id=int(original["event_id"]),
+    )
+
+    await ensure_warehouse_not_frozen(
+        session,
+        warehouse_id=int(original["warehouse_id"]),
     )
 
     occurred_at = payload.occurred_at

--- a/app/wms/inventory_adjustment/return_inbound/repos/inbound_operation_write_repo.py
+++ b/app/wms/inventory_adjustment/return_inbound/repos/inbound_operation_write_repo.py
@@ -9,6 +9,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.wms.inbound.repos.item_lookup_repo import get_item_policy_by_id
 from app.wms.inbound.repos.lot_resolve_repo import resolve_inbound_lot
+from app.wms.inventory_adjustment.count.services.count_freeze_guard_service import (
+    ensure_warehouse_not_frozen,
+)
 from app.wms.inventory_adjustment.return_inbound.contracts.operation_submit import (
     InboundOperationLineOut,
     InboundOperationSubmitIn,
@@ -165,6 +168,11 @@ async def submit_inbound_operation_repo(
             status_code=409,
             detail=f"inbound_task_not_released:{task['status']}",
         )
+
+    await ensure_warehouse_not_frozen(
+        session,
+        warehouse_id=int(task["warehouse_id"]),
+    )
 
     task_lines = (
         await session.execute(

--- a/app/wms/outbound/services/outbound_event_submit_service.py
+++ b/app/wms/outbound/services/outbound_event_submit_service.py
@@ -31,6 +31,9 @@ from app.wms.outbound.repos.outbound_event_repo import (
     load_stocks_lot_for_update,
     update_stocks_lot_qty,
 )
+from app.wms.inventory_adjustment.count.services.count_freeze_guard_service import (
+    ensure_warehouse_not_frozen,
+)
 
 UTC = timezone.utc
 
@@ -342,6 +345,11 @@ async def _write_event_and_ledger(
     ts = occurred_at or datetime.now(UTC)
     if ts.tzinfo is None:
         ts = ts.replace(tzinfo=UTC)
+
+    await ensure_warehouse_not_frozen(
+        session,
+        warehouse_id=int(warehouse_id),
+    )
 
     event = await insert_outbound_event(
         session,


### PR DESCRIPTION
## Summary
- build inventory-adjustment count-doc mainline
- add count_docs / count_doc_lines / count_doc_line_lot_snapshots migrations
- switch count lines from lot-anchor to item-anchor with lot snapshot children
- add count-doc contracts / models / repos / services / routers
- run count-doc flow through DRAFT -> FROZEN -> COUNTED
- add warehouse freeze guard to recount and formal stock-changing paths

## Scope
- count-doc schema and ORM
- count-doc repo/service/router
- freeze guard repo/service
- freeze guard integration for inbound / outbound / return inbound / inbound reversal / outbound reversal
- keep COUNT posted flow pending for next step

## Verified
- create count doc succeeds and persists
- freeze generates item-level lines and lot snapshot children
- count entry fills uom snapshot / ratio / counted base / diff base
- all lines counted auto-promotes doc to COUNTED
- frozen count doc blocks /stock/inventory/recount with 409
- frozen count doc blocks inbound reversal with 409
- frozen count doc blocks outbound reversal with 409
- python3 -m compileall passes
- make alembic-check passes