### PR TITLE
feat(count-doc): finish posted chain, read model and freeze guard tests

### DIFF
--- a/alembic/versions/20260422174415_repair_wms_events_source_type_for_count_post.py
+++ b/alembic/versions/20260422174415_repair_wms_events_source_type_for_count_post.py
@@ -1,0 +1,76 @@
+"""repair wms_events source_type for count post
+
+Revision ID: 20260422174415
+Revises: 11c7f84c84b0
+Create Date: 2026-04-22 17:44:15
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20260422174415"
+down_revision: Union[str, Sequence[str], None] = "11c7f84c84b0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE wms_events
+        DROP CONSTRAINT IF EXISTS ck_wms_events_source_type
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE wms_events
+        ADD CONSTRAINT ck_wms_events_source_type
+        CHECK (
+          source_type IN (
+            'PURCHASE_ORDER',
+            'MANUAL',
+            'RETURN',
+            'TRANSFER_IN',
+            'ADJUST_IN',
+            'ORDER',
+            'ORDER_SHIP',
+            'INTERNAL_OUTBOUND',
+            'TRANSFER_OUT',
+            'SCRAP',
+            'ADJUST_OUT',
+            'COUNT_TASK',
+            'MANUAL_COUNT'
+          )
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE wms_events
+        DROP CONSTRAINT IF EXISTS ck_wms_events_source_type
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE wms_events
+        ADD CONSTRAINT ck_wms_events_source_type
+        CHECK (
+          source_type IN (
+            'PURCHASE_ORDER',
+            'MANUAL',
+            'RETURN',
+            'TRANSFER_IN',
+            'ADJUST_IN',
+            'ORDER'
+          )
+        )
+        """
+    )

--- a/app/wms/inbound/models/inbound_event.py
+++ b/app/wms/inbound/models/inbound_event.py
@@ -23,6 +23,7 @@ _SOURCE_TYPES = (
     "RETURN",
     "TRANSFER_IN",
     "ADJUST_IN",
+    "ORDER",
     "ORDER_SHIP",
     "INTERNAL_OUTBOUND",
     "TRANSFER_OUT",
@@ -57,7 +58,7 @@ class WmsEvent(Base):
             (
                 "source_type IN ("
                 "'PURCHASE_ORDER', 'MANUAL', 'RETURN', 'TRANSFER_IN', 'ADJUST_IN', "
-                "'ORDER_SHIP', 'INTERNAL_OUTBOUND', 'TRANSFER_OUT', 'SCRAP', 'ADJUST_OUT', "
+                "'ORDER', 'ORDER_SHIP', 'INTERNAL_OUTBOUND', 'TRANSFER_OUT', 'SCRAP', 'ADJUST_OUT', "
                 "'COUNT_TASK', 'MANUAL_COUNT'"
                 ")"
             ),

--- a/app/wms/inventory_adjustment/count/contracts/count_doc.py
+++ b/app/wms/inventory_adjustment/count/contracts/count_doc.py
@@ -61,7 +61,7 @@ class CountDocLineOut(_Base):
 
 
 # =========================================================
-# 出参：盘点单头
+# 出参：盘点单头（含读模型聚合）
 # =========================================================
 class CountDocOut(_Base):
     id: int
@@ -77,6 +77,18 @@ class CountDocOut(_Base):
     created_at: datetime
     counted_at: Optional[datetime] = None
     posted_at: Optional[datetime] = None
+
+    # 读模型聚合字段
+    line_count: int = 0
+    diff_line_count: int = 0
+    diff_qty_base_total: int = 0
+
+    # 已过账事件摘要
+    posted_event_no: Optional[str] = None
+    posted_event_type: Optional[str] = None
+    posted_source_type: Optional[str] = None
+    posted_event_kind: Optional[str] = None
+    posted_event_status: Optional[str] = None
 
 
 class CountDocDetailOut(CountDocOut):

--- a/app/wms/inventory_adjustment/count/repos/count_doc_repo.py
+++ b/app/wms/inventory_adjustment/count/repos/count_doc_repo.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Sequence
+from typing import Any, Sequence
 
-from sqlalchemy import select, text
+from sqlalchemy import case, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -97,6 +97,75 @@ class CountDocRepo:
 
         items = list((await session.execute(stmt)).scalars().all())
         return total, items
+
+    async def get_doc_line_stats(
+        self,
+        session: AsyncSession,
+        *,
+        doc_ids: Sequence[int],
+    ) -> dict[int, dict[str, int]]:
+        ids = [int(x) for x in doc_ids]
+        if not ids:
+            return {}
+
+        stmt = (
+            select(
+                CountDocLine.doc_id.label("doc_id"),
+                func.count().label("line_count"),
+                func.sum(
+                    case(
+                        (func.coalesce(CountDocLine.diff_qty_base, 0) != 0, 1),
+                        else_=0,
+                    )
+                ).label("diff_line_count"),
+                func.coalesce(func.sum(func.coalesce(CountDocLine.diff_qty_base, 0)), 0).label(
+                    "diff_qty_base_total"
+                ),
+            )
+            .where(CountDocLine.doc_id.in_(ids))
+            .group_by(CountDocLine.doc_id)
+        )
+
+        rows = (await session.execute(stmt)).mappings().all()
+        out: dict[int, dict[str, int]] = {}
+        for row in rows:
+            out[int(row["doc_id"])] = {
+                "line_count": int(row["line_count"] or 0),
+                "diff_line_count": int(row["diff_line_count"] or 0),
+                "diff_qty_base_total": int(row["diff_qty_base_total"] or 0),
+            }
+        return out
+
+    async def get_posted_event_briefs(
+        self,
+        session: AsyncSession,
+        *,
+        event_ids: Sequence[int],
+    ) -> dict[int, dict[str, Any]]:
+        ids = [int(x) for x in event_ids]
+        if not ids:
+            return {}
+
+        rows = await session.execute(
+            text(
+                """
+                SELECT
+                  id,
+                  event_no,
+                  event_type,
+                  source_type,
+                  event_kind,
+                  status
+                FROM wms_events
+                WHERE id = ANY(:event_ids)
+                """
+            ),
+            {"event_ids": ids},
+        )
+        out: dict[int, dict[str, Any]] = {}
+        for row in rows.mappings().all():
+            out[int(row["id"])] = dict(row)
+        return out
 
     async def freeze_doc_lines_from_current_stock(
         self,

--- a/app/wms/inventory_adjustment/count/routers/count_docs.py
+++ b/app/wms/inventory_adjustment/count/routers/count_docs.py
@@ -12,6 +12,7 @@ from app.wms.inventory_adjustment.count.contracts.count_doc import (
     CountDocLinesUpdateOut,
     CountDocListOut,
     CountDocOut,
+    CountDocPostOut,
 )
 from app.wms.inventory_adjustment.count.services.count_doc_service import CountDocService
 
@@ -143,3 +144,30 @@ async def update_count_doc_lines(
     except Exception as e:
         await session.rollback()
         raise HTTPException(status_code=500, detail=f"update_count_doc_lines_failed: {e}") from e
+
+
+@router.post("/{doc_id}/post", response_model=CountDocPostOut, status_code=status.HTTP_200_OK)
+async def post_count_doc(
+    doc_id: int,
+    session: AsyncSession = Depends(get_async_session),
+) -> CountDocPostOut:
+    service = CountDocService()
+    try:
+        out = await service.post_doc(
+            session,
+            doc_id=int(doc_id),
+        )
+        await session.commit()
+        return out
+    except ValueError as e:
+        await session.rollback()
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except LookupError as e:
+        await session.rollback()
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except HTTPException:
+        await session.rollback()
+        raise
+    except Exception as e:
+        await session.rollback()
+        raise HTTPException(status_code=500, detail=f"post_count_doc_failed: {e}") from e

--- a/app/wms/inventory_adjustment/count/services/count_doc_service.py
+++ b/app/wms/inventory_adjustment/count/services/count_doc_service.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from uuid import uuid4
 
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.enums import MovementType
 from app.wms.inventory_adjustment.count.contracts.count_doc import (
     CountDocCreateIn,
     CountDocDetailOut,
     CountDocFreezeOut,
+    CountDocLineOut,
     CountDocLinesUpdateIn,
     CountDocLinesUpdateOut,
     CountDocListOut,
@@ -16,22 +19,113 @@ from app.wms.inventory_adjustment.count.contracts.count_doc import (
     CountDocPostOut,
 )
 from app.wms.inventory_adjustment.count.repos.count_doc_repo import CountDocRepo
+from app.wms.stock.services.stock_service import StockService
 
 
 class CountDocService:
-    def __init__(self, *, repo: CountDocRepo | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        repo: CountDocRepo | None = None,
+        stock: StockService | None = None,
+    ) -> None:
         self.repo = repo or CountDocRepo()
+        self.stock = stock or StockService()
 
     def _make_count_no(self, now: datetime | None = None) -> str:
         ts = (now or datetime.now(timezone.utc)).strftime("%Y%m%d%H%M%S")
         suffix = uuid4().hex[:8].upper()
         return f"CTD-{ts}-{suffix}"
 
+    def _make_count_event_no(self, now: datetime | None = None) -> str:
+        ts = (now or datetime.now(timezone.utc)).strftime("%Y%m%d%H%M%S")
+        suffix = uuid4().hex[:8].upper()
+        return f"CNT-{ts}-{suffix}"
+
+    def _make_trace_id(self) -> str:
+        return f"COUNT-POST-{uuid4().hex[:20].upper()}"
+
     async def _require_doc(self, session: AsyncSession, *, doc_id: int):
         doc = await self.repo.get_doc(session, doc_id=int(doc_id))
         if doc is None:
             raise LookupError(f"count_doc_not_found:{int(doc_id)}")
         return doc
+
+    @staticmethod
+    def _sorted_lot_snapshots(line) -> list:
+        return sorted(
+            list(getattr(line, "lot_snapshots", []) or []),
+            key=lambda x: (-int(x.snapshot_qty_base), int(x.lot_id), int(x.id)),
+        )
+
+    @staticmethod
+    def _line_meta(
+        *,
+        doc,
+        line,
+        event_id: int,
+        sub_reason: str,
+    ) -> dict[str, object]:
+        meta: dict[str, object] = {
+            "sub_reason": str(sub_reason),
+            "count_doc_id": int(doc.id),
+            "count_doc_line_id": int(line.id),
+            "count_no": str(doc.count_no),
+            "event_id": int(event_id),
+        }
+        if getattr(line, "reason_code", None):
+            meta["reason_code"] = str(line.reason_code)
+        if getattr(line, "disposition", None):
+            meta["disposition"] = str(line.disposition)
+        if getattr(line, "remark", None):
+            meta["remark"] = str(line.remark)
+        if str(sub_reason) == "COUNT_CONFIRM":
+            meta["allow_zero_delta_ledger"] = True
+        return meta
+
+    @staticmethod
+    def _zero_stats() -> dict[str, int]:
+        return {
+            "line_count": 0,
+            "diff_line_count": 0,
+            "diff_qty_base_total": 0,
+        }
+
+    def _build_count_doc_out(
+        self,
+        doc,
+        *,
+        stats_map: dict[int, dict[str, int]],
+        event_map: dict[int, dict[str, object]],
+    ) -> CountDocOut:
+        stats = stats_map.get(int(doc.id), self._zero_stats())
+        event = (
+            event_map.get(int(doc.posted_event_id))
+            if getattr(doc, "posted_event_id", None) is not None
+            else None
+        ) or {}
+
+        return CountDocOut(
+            id=int(doc.id),
+            count_no=str(doc.count_no),
+            warehouse_id=int(doc.warehouse_id),
+            snapshot_at=doc.snapshot_at,
+            status=str(doc.status),  # type: ignore[arg-type]
+            posted_event_id=(int(doc.posted_event_id) if doc.posted_event_id is not None else None),
+            created_by=(int(doc.created_by) if doc.created_by is not None else None),
+            remark=doc.remark,
+            created_at=doc.created_at,
+            counted_at=doc.counted_at,
+            posted_at=doc.posted_at,
+            line_count=int(stats["line_count"]),
+            diff_line_count=int(stats["diff_line_count"]),
+            diff_qty_base_total=int(stats["diff_qty_base_total"]),
+            posted_event_no=(str(event["event_no"]) if event.get("event_no") is not None else None),
+            posted_event_type=(str(event["event_type"]) if event.get("event_type") is not None else None),
+            posted_source_type=(str(event["source_type"]) if event.get("source_type") is not None else None),
+            posted_event_kind=(str(event["event_kind"]) if event.get("event_kind") is not None else None),
+            posted_event_status=(str(event["status"]) if event.get("status") is not None else None),
+        )
 
     async def create_doc(
         self,
@@ -51,7 +145,7 @@ class CountDocService:
             remark=payload.remark,
         )
         await session.flush()
-        return CountDocOut.model_validate(doc)
+        return self._build_count_doc_out(doc, stats_map={}, event_map={})
 
     async def get_doc_detail(
         self,
@@ -62,7 +156,16 @@ class CountDocService:
         doc = await self.repo.get_doc_detail(session, doc_id=int(doc_id))
         if doc is None:
             raise LookupError(f"count_doc_not_found:{int(doc_id)}")
-        return CountDocDetailOut.model_validate(doc)
+
+        stats_map = await self.repo.get_doc_line_stats(session, doc_ids=[int(doc.id)])
+        event_ids = [int(doc.posted_event_id)] if doc.posted_event_id is not None else []
+        event_map = await self.repo.get_posted_event_briefs(session, event_ids=event_ids)
+
+        base = self._build_count_doc_out(doc, stats_map=stats_map, event_map=event_map)
+        return CountDocDetailOut(
+            **base.model_dump(),
+            lines=[CountDocLineOut.model_validate(x) for x in doc.lines],
+        )
 
     async def list_docs(
         self,
@@ -78,9 +181,16 @@ class CountDocService:
             limit=int(limit),
             offset=int(offset),
         )
+
+        doc_ids = [int(x.id) for x in docs]
+        stats_map = await self.repo.get_doc_line_stats(session, doc_ids=doc_ids)
+
+        event_ids = [int(x.posted_event_id) for x in docs if x.posted_event_id is not None]
+        event_map = await self.repo.get_posted_event_briefs(session, event_ids=event_ids)
+
         return CountDocListOut(
             total=int(total),
-            items=[CountDocOut.model_validate(x) for x in docs],
+            items=[self._build_count_doc_out(x, stats_map=stats_map, event_map=event_map) for x in docs],
         )
 
     async def freeze_doc(
@@ -138,6 +248,7 @@ class CountDocService:
         )
 
         _ = await self.repo.try_mark_doc_counted(session, doc_id=int(doc_id))
+        session.expire_all()
         detail = await self.repo.get_doc_detail(session, doc_id=int(doc_id))
         if detail is None:
             raise LookupError(f"count_doc_not_found_after_update:{int(doc_id)}")
@@ -149,16 +260,227 @@ class CountDocService:
             lines=[x for x in CountDocDetailOut.model_validate(detail).lines],
         )
 
+    async def _post_line_diff(
+        self,
+        session: AsyncSession,
+        *,
+        doc,
+        line,
+        event_id: int,
+        event_no: str,
+        posted_at: datetime,
+        trace_id: str,
+    ) -> int:
+        snapshots = self._sorted_lot_snapshots(line)
+        if not snapshots:
+            raise RuntimeError(f"count_doc_post_missing_lot_snapshots: line_id={int(line.id)}")
+
+        diff_qty_base = int(line.diff_qty_base or 0)
+        line_no = int(line.line_no)
+
+        if diff_qty_base == 0:
+            target = snapshots[0]
+            await self.stock.adjust_lot(
+                session=session,
+                item_id=int(line.item_id),
+                warehouse_id=int(doc.warehouse_id),
+                lot_id=int(target.lot_id),
+                delta=0,
+                reason=MovementType.COUNT,
+                ref=str(event_no),
+                ref_line=line_no,
+                occurred_at=posted_at,
+                batch_code=target.lot_code_snapshot,
+                production_date=None,
+                expiry_date=None,
+                trace_id=str(trace_id),
+                meta=self._line_meta(
+                    doc=doc,
+                    line=line,
+                    event_id=int(event_id),
+                    sub_reason="COUNT_CONFIRM",
+                ),
+                shadow_write_stocks=False,
+            )
+            return 1
+
+        if diff_qty_base > 0:
+            target = snapshots[0]
+            await self.stock.adjust_lot(
+                session=session,
+                item_id=int(line.item_id),
+                warehouse_id=int(doc.warehouse_id),
+                lot_id=int(target.lot_id),
+                delta=int(diff_qty_base),
+                reason=MovementType.COUNT,
+                ref=str(event_no),
+                ref_line=line_no,
+                occurred_at=posted_at,
+                batch_code=target.lot_code_snapshot,
+                production_date=None,
+                expiry_date=None,
+                trace_id=str(trace_id),
+                meta=self._line_meta(
+                    doc=doc,
+                    line=line,
+                    event_id=int(event_id),
+                    sub_reason="COUNT_ADJUST",
+                ),
+                shadow_write_stocks=False,
+            )
+            return 1
+
+        remaining = int(-diff_qty_base)
+        written = 0
+
+        for snap in snapshots:
+            if remaining <= 0:
+                break
+
+            snap_qty = int(snap.snapshot_qty_base)
+            if snap_qty <= 0:
+                continue
+
+            consume = min(remaining, snap_qty)
+            if consume <= 0:
+                continue
+
+            await self.stock.adjust_lot(
+                session=session,
+                item_id=int(line.item_id),
+                warehouse_id=int(doc.warehouse_id),
+                lot_id=int(snap.lot_id),
+                delta=-int(consume),
+                reason=MovementType.COUNT,
+                ref=str(event_no),
+                ref_line=line_no,
+                occurred_at=posted_at,
+                batch_code=snap.lot_code_snapshot,
+                production_date=None,
+                expiry_date=None,
+                trace_id=str(trace_id),
+                meta=self._line_meta(
+                    doc=doc,
+                    line=line,
+                    event_id=int(event_id),
+                    sub_reason="COUNT_ADJUST",
+                ),
+                shadow_write_stocks=False,
+            )
+            remaining -= int(consume)
+            written += 1
+
+        if remaining != 0:
+            raise RuntimeError(
+                f"count_doc_post_unallocated_negative_diff: line_id={int(line.id)}, remaining={int(remaining)}"
+            )
+
+        return int(written)
+
     async def post_doc(
         self,
         session: AsyncSession,
         *,
         doc_id: int,
     ) -> CountDocPostOut:
-        _ = session
-        _ = doc_id
-        raise RuntimeError(
-            "count_doc_post_not_ready: COUNT wms_events / ledger posting chain is not implemented yet."
+        doc = await self._require_doc(session, doc_id=int(doc_id))
+
+        if str(doc.status) == "POSTED":
+            if doc.posted_event_id is None or doc.posted_at is None:
+                raise RuntimeError(f"count_doc_posted_missing_bridge_fields:{int(doc_id)}")
+            return CountDocPostOut(
+                doc_id=int(doc.id),
+                status="POSTED",
+                posted_event_id=int(doc.posted_event_id),
+                posted_at=doc.posted_at,
+            )
+
+        if str(doc.status) != "COUNTED":
+            raise ValueError(f"count_doc_post_requires_counted: current={doc.status}")
+
+        detail_out = await self.get_doc_detail(session, doc_id=int(doc_id))
+
+        if not list(detail_out.lines or []):
+            raise ValueError(f"count_doc_post_requires_lines: doc_id={int(detail_out.id)}")
+
+        for line in detail_out.lines:
+            if line.counted_qty_base is None or line.diff_qty_base is None:
+                raise ValueError(f"count_doc_post_requires_all_lines_counted: line_id={int(line.id)}")
+
+        posted_at = datetime.now(timezone.utc)
+        trace_id = self._make_trace_id()
+        event_no = self._make_count_event_no(posted_at)
+
+        row = await session.execute(
+            text(
+                """
+                INSERT INTO wms_events (
+                  event_no,
+                  event_type,
+                  warehouse_id,
+                  source_type,
+                  source_ref,
+                  occurred_at,
+                  trace_id,
+                  event_kind,
+                  target_event_id,
+                  status,
+                  created_by,
+                  remark
+                )
+                VALUES (
+                  :event_no,
+                  'COUNT',
+                  :warehouse_id,
+                  'MANUAL_COUNT',
+                  :source_ref,
+                  :occurred_at,
+                  :trace_id,
+                  'COMMIT',
+                  NULL,
+                  'COMMITTED',
+                  :created_by,
+                  :remark
+                )
+                RETURNING id
+                """
+            ),
+            {
+                "event_no": str(event_no),
+                "warehouse_id": int(detail_out.warehouse_id),
+                "source_ref": str(detail_out.count_no),
+                "occurred_at": posted_at,
+                "trace_id": str(trace_id),
+                "created_by": (int(detail_out.created_by) if detail_out.created_by is not None else None),
+                "remark": (str(detail_out.remark).strip() if detail_out.remark else f"post count doc {detail_out.count_no}"),
+            },
+        )
+        event_id = int(row.scalar_one())
+
+        for line in detail_out.lines:
+            await self._post_line_diff(
+                session,
+                doc=detail_out,
+                line=line,
+                event_id=int(event_id),
+                event_no=str(event_no),
+                posted_at=posted_at,
+                trace_id=str(trace_id),
+            )
+
+        await self.repo.mark_doc_posted(
+            session,
+            doc_id=int(detail_out.id),
+            posted_event_id=int(event_id),
+            posted_at=posted_at,
+        )
+        session.expire_all()
+
+        return CountDocPostOut(
+            doc_id=int(detail_out.id),
+            status="POSTED",
+            posted_event_id=int(event_id),
+            posted_at=posted_at,
         )
 
 

--- a/app/wms/ledger/contracts/stock_ledger.py
+++ b/app/wms/ledger/contracts/stock_ledger.py
@@ -35,6 +35,7 @@ class ReasonCanon(str, Enum):
 class SubReason(str, Enum):
     PO_RECEIPT = "PO_RECEIPT"
     ORDER_SHIP = "ORDER_SHIP"
+    COUNT_CONFIRM = "COUNT_CONFIRM"
     COUNT_ADJUST = "COUNT_ADJUST"
     RETURN_RECEIPT = "RETURN_RECEIPT"
     INTERNAL_SHIP = "INTERNAL_SHIP"
@@ -75,7 +76,7 @@ class LedgerQuery(_Base):
     )
     sub_reason: Optional[SubReason] = Field(
         default=None,
-        description="具体动作（PO_RECEIPT / ORDER_SHIP / COUNT_ADJUST 等）",
+        description="具体动作（PO_RECEIPT / ORDER_SHIP / COUNT_CONFIRM / COUNT_ADJUST 等）",
     )
 
     ref: Optional[str] = Field(default=None, max_length=128, description="关联单据（精确匹配）")

--- a/tests/api/test_inventory_adjustment_count_docs_api.py
+++ b/tests/api/test_inventory_adjustment_count_docs_api.py
@@ -1,0 +1,1009 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from uuid import uuid4
+
+import httpx
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.wms.stock.services.stock_service import StockService
+from app.wms.snapshot.services.snapshot_run import run_snapshot
+from app.wms.reconciliation.services.three_books_consistency import verify_commit_three_books
+
+
+pytestmark = pytest.mark.asyncio
+UTC = timezone.utc
+
+
+def _norm_utc_iso(v: str) -> str:
+    return str(v).replace("Z", "+00:00")
+
+
+async def _login_admin_headers(client: httpx.AsyncClient) -> dict[str, str]:
+    r = await client.post("/users/login", json={"username": "admin", "password": "admin123"})
+    assert r.status_code == 200, r.text
+    token = r.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _pick_active_warehouse_id(session: AsyncSession) -> int:
+    row = await session.execute(
+        text(
+            """
+            SELECT id
+              FROM warehouses
+             WHERE COALESCE(active, true) = true
+             ORDER BY id
+             LIMIT 1
+            """
+        )
+    )
+    wid = row.scalar_one_or_none()
+    assert wid is not None, "no active warehouse found"
+    return int(wid)
+
+
+async def _pick_enabled_items_with_base_uom(
+    session: AsyncSession,
+    *,
+    limit: int,
+) -> list[dict[str, object]]:
+    rows = (
+        await session.execute(
+            text(
+                """
+                SELECT DISTINCT ON (i.id)
+                  i.id AS item_id,
+                  i.name AS item_name,
+                  i.spec AS item_spec,
+                  u.id AS item_uom_id,
+                  COALESCE(NULLIF(u.display_name, ''), u.uom) AS uom_name,
+                  u.ratio_to_base AS ratio_to_base
+                FROM items i
+                JOIN item_uoms u
+                  ON u.item_id = i.id
+                WHERE COALESCE(i.enabled, true) = true
+                ORDER BY
+                  i.id ASC,
+                  CASE
+                    WHEN COALESCE(u.is_inbound_default, false) THEN 0
+                    WHEN COALESCE(u.is_base, false) THEN 1
+                    ELSE 2
+                  END,
+                  u.id ASC
+                """
+            )
+        )
+    ).mappings().all()
+
+    items = [dict(x) for x in rows[:limit]]
+    assert len(items) >= limit, f"need at least {limit} enabled items with item_uoms"
+    return items
+
+
+async def _seed_positive_stock(
+    session: AsyncSession,
+    *,
+    warehouse_id: int,
+    item_id: int,
+    batch_code: str,
+    qty: int,
+    ref: str,
+    production_date: date | None = None,
+    expiry_date: date | None = None,
+) -> None:
+    now = datetime.now(UTC)
+    prod = production_date or now.date()
+    exp = expiry_date or (prod + timedelta(days=365))
+
+    stock = StockService()
+    await stock.adjust(
+        session=session,
+        item_id=int(item_id),
+        warehouse_id=int(warehouse_id),
+        batch_code=str(batch_code),
+        delta=int(qty),
+        reason="RECEIPT",
+        ref=str(ref),
+        ref_line=1,
+        occurred_at=now,
+        production_date=prod,
+        expiry_date=exp,
+        meta={"sub_reason": "UT_COUNT_DOC_STOCK_SEED"},
+    )
+
+
+async def _create_count_doc(
+    client: httpx.AsyncClient,
+    *,
+    headers: dict[str, str],
+    warehouse_id: int,
+    snapshot_at: datetime,
+    remark: str,
+) -> dict[str, object]:
+    resp = await client.post(
+        "/inventory-adjustment/count-docs",
+        json={
+            "warehouse_id": int(warehouse_id),
+            "snapshot_at": snapshot_at.isoformat(),
+            "remark": remark,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert int(body["id"]) > 0, body
+    return body
+
+
+@pytest.mark.asyncio
+async def test_count_doc_create_list_detail_contract(
+    client: httpx.AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    warehouse_id = await _pick_active_warehouse_id(session)
+    snapshot_at = datetime(2030, 1, 1, 8, 0, 0, tzinfo=UTC)
+
+    created = await _create_count_doc(
+        client,
+        headers=headers,
+        warehouse_id=warehouse_id,
+        snapshot_at=snapshot_at,
+        remark="UT-COUNT-DOC-CREATE",
+    )
+
+    assert created["status"] == "DRAFT", created
+    assert created["warehouse_id"] == int(warehouse_id), created
+    assert created["posted_event_id"] is None, created
+    assert created["counted_at"] is None, created
+    assert created["posted_at"] is None, created
+    assert str(created["count_no"]).startswith("CTD-"), created
+
+    doc_id = int(created["id"])
+
+    r_detail = await client.get(f"/inventory-adjustment/count-docs/{doc_id}", headers=headers)
+    assert r_detail.status_code == 200, r_detail.text
+    detail = r_detail.json()
+
+    assert int(detail["id"]) == doc_id, detail
+    assert detail["status"] == "DRAFT", detail
+    assert detail["warehouse_id"] == int(warehouse_id), detail
+    assert _norm_utc_iso(detail["snapshot_at"]) == snapshot_at.isoformat(), detail
+    assert detail["lines"] == [], detail
+
+    r_list = await client.get(
+        "/inventory-adjustment/count-docs",
+        params={"warehouse_id": warehouse_id, "limit": 50, "offset": 0},
+        headers=headers,
+    )
+    assert r_list.status_code == 200, r_list.text
+    listed = r_list.json()
+
+    assert int(listed["total"]) >= 1, listed
+    assert any(int(x["id"]) == doc_id for x in listed["items"]), listed
+
+
+@pytest.mark.asyncio
+async def test_count_doc_freeze_generates_item_lines_and_lot_snapshots(
+    client: httpx.AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    warehouse_id = await _pick_active_warehouse_id(session)
+    picked = await _pick_enabled_items_with_base_uom(session, limit=2)
+
+    item_a = picked[0]
+    item_b = picked[1]
+
+    code_a1 = f"UT-CNT-A1-{uuid4().hex[:8].upper()}"
+    code_a2 = f"UT-CNT-A2-{uuid4().hex[:8].upper()}"
+    code_b1 = f"UT-CNT-B1-{uuid4().hex[:8].upper()}"
+
+    await _seed_positive_stock(
+        session,
+        warehouse_id=warehouse_id,
+        item_id=int(item_a["item_id"]),
+        batch_code=code_a1,
+        qty=5,
+        ref=f"ut:count-doc:seed:{code_a1}",
+    )
+    await _seed_positive_stock(
+        session,
+        warehouse_id=warehouse_id,
+        item_id=int(item_a["item_id"]),
+        batch_code=code_a2,
+        qty=7,
+        ref=f"ut:count-doc:seed:{code_a2}",
+    )
+    await _seed_positive_stock(
+        session,
+        warehouse_id=warehouse_id,
+        item_id=int(item_b["item_id"]),
+        batch_code=code_b1,
+        qty=3,
+        ref=f"ut:count-doc:seed:{code_b1}",
+    )
+    await session.commit()
+
+    created = await _create_count_doc(
+        client,
+        headers=headers,
+        warehouse_id=warehouse_id,
+        snapshot_at=datetime(2030, 1, 2, 8, 0, 0, tzinfo=UTC),
+        remark="UT-COUNT-DOC-FREEZE",
+    )
+    doc_id = int(created["id"])
+
+    r_freeze = await client.post(
+        f"/inventory-adjustment/count-docs/{doc_id}/freeze",
+        headers=headers,
+    )
+    assert r_freeze.status_code == 200, r_freeze.text
+    frozen = r_freeze.json()
+
+    assert int(frozen["doc_id"]) == doc_id, frozen
+    assert frozen["status"] == "FROZEN", frozen
+    assert int(frozen["line_count"]) == 2, frozen
+    assert int(frozen["lot_snapshot_count"]) >= 2, frozen
+
+    r_detail = await client.get(f"/inventory-adjustment/count-docs/{doc_id}", headers=headers)
+    assert r_detail.status_code == 200, r_detail.text
+    detail = r_detail.json()
+
+    assert detail["status"] == "FROZEN", detail
+    assert len(detail["lines"]) == 2, detail
+
+    total_lot_snapshots = sum(len(x["lot_snapshots"]) for x in detail["lines"])
+    assert total_lot_snapshots == int(frozen["lot_snapshot_count"]), detail
+
+    lines_by_item = {int(x["item_id"]): x for x in detail["lines"]}
+    assert set(lines_by_item.keys()) == {int(item_a["item_id"]), int(item_b["item_id"])}, detail
+
+    line_a = lines_by_item[int(item_a["item_id"])]
+    assert int(line_a["snapshot_qty_base"]) == 12, line_a
+    assert len(line_a["lot_snapshots"]) >= 1, line_a
+    assert sum(int(x["snapshot_qty_base"]) for x in line_a["lot_snapshots"]) == 12, line_a
+
+    line_b = lines_by_item[int(item_b["item_id"])]
+    assert int(line_b["snapshot_qty_base"]) == 3, line_b
+    assert len(line_b["lot_snapshots"]) >= 1, line_b
+    assert sum(int(x["snapshot_qty_base"]) for x in line_b["lot_snapshots"]) == 3, line_b
+
+
+@pytest.mark.asyncio
+async def test_count_doc_update_lines_auto_marks_counted(
+    client: httpx.AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    warehouse_id = await _pick_active_warehouse_id(session)
+    picked = await _pick_enabled_items_with_base_uom(session, limit=2)
+
+    item_a = picked[0]
+    item_b = picked[1]
+
+    code_a1 = f"UT-CNT-UPD-A1-{uuid4().hex[:8].upper()}"
+    code_b1 = f"UT-CNT-UPD-B1-{uuid4().hex[:8].upper()}"
+
+    await _seed_positive_stock(
+        session,
+        warehouse_id=warehouse_id,
+        item_id=int(item_a["item_id"]),
+        batch_code=code_a1,
+        qty=4,
+        ref=f"ut:count-doc:update-seed:{code_a1}",
+    )
+    await _seed_positive_stock(
+        session,
+        warehouse_id=warehouse_id,
+        item_id=int(item_b["item_id"]),
+        batch_code=code_b1,
+        qty=2,
+        ref=f"ut:count-doc:update-seed:{code_b1}",
+    )
+    await session.commit()
+
+    created = await _create_count_doc(
+        client,
+        headers=headers,
+        warehouse_id=warehouse_id,
+        snapshot_at=datetime(2030, 1, 3, 8, 0, 0, tzinfo=UTC),
+        remark="UT-COUNT-DOC-UPDATE",
+    )
+    doc_id = int(created["id"])
+
+    r_freeze = await client.post(
+        f"/inventory-adjustment/count-docs/{doc_id}/freeze",
+        headers=headers,
+    )
+    assert r_freeze.status_code == 200, r_freeze.text
+
+    r_detail = await client.get(f"/inventory-adjustment/count-docs/{doc_id}", headers=headers)
+    assert r_detail.status_code == 200, r_detail.text
+    detail = r_detail.json()
+    assert detail["status"] == "FROZEN", detail
+    assert len(detail["lines"]) == 2, detail
+
+    uom_map = {
+        int(item_a["item_id"]): {
+            "item_uom_id": int(item_a["item_uom_id"]),
+            "ratio_to_base": int(item_a["ratio_to_base"]),
+        },
+        int(item_b["item_id"]): {
+            "item_uom_id": int(item_b["item_uom_id"]),
+            "ratio_to_base": int(item_b["ratio_to_base"]),
+        },
+    }
+
+    update_lines: list[dict[str, object]] = []
+    for line in detail["lines"]:
+        item_id = int(line["item_id"])
+        snapshot_qty_base = int(line["snapshot_qty_base"])
+        cfg = uom_map[item_id]
+        if item_id == int(item_a["item_id"]):
+            counted_qty_input = snapshot_qty_base
+            reason_code = "MATCHED"
+            disposition = "KEEP"
+            remark = "ut matched"
+        else:
+            counted_qty_input = snapshot_qty_base - 1
+            reason_code = "LOSS"
+            disposition = "ADJUST"
+            remark = "ut diff"
+
+        update_lines.append(
+            {
+                "line_id": int(line["id"]),
+                "counted_item_uom_id": int(cfg["item_uom_id"]),
+                "counted_qty_input": int(counted_qty_input),
+                "reason_code": reason_code,
+                "disposition": disposition,
+                "remark": remark,
+            }
+        )
+
+    r_update = await client.put(
+        f"/inventory-adjustment/count-docs/{doc_id}/lines",
+        json={"lines": update_lines},
+        headers=headers,
+    )
+    assert r_update.status_code == 200, r_update.text
+    updated = r_update.json()
+
+    assert int(updated["doc_id"]) == doc_id, updated
+    assert updated["status"] == "COUNTED", updated
+    assert int(updated["updated_count"]) == 2, updated
+    assert len(updated["lines"]) == 2, updated
+
+    lines_by_item = {int(x["item_id"]): x for x in updated["lines"]}
+
+    line_a = lines_by_item[int(item_a["item_id"])]
+    assert int(line_a["counted_item_uom_id"]) == int(item_a["item_uom_id"]), line_a
+    assert int(line_a["counted_ratio_to_base_snapshot"]) == int(item_a["ratio_to_base"]), line_a
+    assert int(line_a["counted_qty_input"]) == 4, line_a
+    assert int(line_a["counted_qty_base"]) == 4, line_a
+    assert int(line_a["diff_qty_base"]) == 0, line_a
+    assert line_a["reason_code"] == "MATCHED", line_a
+    assert line_a["disposition"] == "KEEP", line_a
+
+    line_b = lines_by_item[int(item_b["item_id"])]
+    assert int(line_b["counted_item_uom_id"]) == int(item_b["item_uom_id"]), line_b
+    assert int(line_b["counted_ratio_to_base_snapshot"]) == int(item_b["ratio_to_base"]), line_b
+    assert int(line_b["counted_qty_input"]) == 1, line_b
+    assert int(line_b["counted_qty_base"]) == 1, line_b
+    assert int(line_b["diff_qty_base"]) == -1, line_b
+    assert line_b["reason_code"] == "LOSS", line_b
+    assert line_b["disposition"] == "ADJUST", line_b
+
+    r_detail2 = await client.get(f"/inventory-adjustment/count-docs/{doc_id}", headers=headers)
+    assert r_detail2.status_code == 200, r_detail2.text
+    detail2 = r_detail2.json()
+
+    assert detail2["status"] == "COUNTED", detail2
+    assert detail2["counted_at"], detail2
+
+
+async def _post_load_lot_id_by_code(
+    session: AsyncSession,
+    *,
+    warehouse_id: int,
+    item_id: int,
+    lot_code: str,
+) -> int:
+    row = await session.execute(
+        text(
+            """
+            SELECT sl.lot_id
+              FROM stocks_lot sl
+              JOIN lots lo
+                ON lo.id = sl.lot_id
+             WHERE sl.warehouse_id = :warehouse_id
+               AND sl.item_id = :item_id
+               AND lo.lot_code = :lot_code
+             ORDER BY sl.lot_id ASC
+             LIMIT 1
+            """
+        ),
+        {
+            "warehouse_id": int(warehouse_id),
+            "item_id": int(item_id),
+            "lot_code": str(lot_code),
+        },
+    )
+    lot_id = row.scalar_one_or_none()
+    assert lot_id is not None, {"warehouse_id": warehouse_id, "item_id": item_id, "lot_code": lot_code}
+    return int(lot_id)
+
+
+async def _post_load_stock_qty(
+    session: AsyncSession,
+    *,
+    warehouse_id: int,
+    item_id: int,
+    lot_id: int,
+) -> int:
+    row = await session.execute(
+        text(
+            """
+            SELECT qty
+              FROM stocks_lot
+             WHERE warehouse_id = :warehouse_id
+               AND item_id = :item_id
+               AND lot_id = :lot_id
+             LIMIT 1
+            """
+        ),
+        {
+            "warehouse_id": int(warehouse_id),
+            "item_id": int(item_id),
+            "lot_id": int(lot_id),
+        },
+    )
+    qty = row.scalar_one_or_none()
+    return int(qty or 0)
+
+
+async def _post_fetch_event(
+    session: AsyncSession,
+    *,
+    event_id: int,
+) -> dict[str, object]:
+    row = await session.execute(
+        text(
+            """
+            SELECT
+              id,
+              event_no,
+              event_type,
+              warehouse_id,
+              source_type,
+              source_ref,
+              trace_id,
+              event_kind,
+              target_event_id,
+              status,
+              occurred_at
+            FROM wms_events
+            WHERE id = :event_id
+            LIMIT 1
+            """
+        ),
+        {"event_id": int(event_id)},
+    )
+    m = row.mappings().first()
+    assert m is not None, {"event_id": event_id}
+    return dict(m)
+
+
+async def _post_fetch_ledgers(
+    session: AsyncSession,
+    *,
+    event_id: int,
+) -> list[dict[str, object]]:
+    rows = await session.execute(
+        text(
+            """
+            SELECT
+              id,
+              event_id,
+              ref,
+              ref_line,
+              warehouse_id,
+              item_id,
+              lot_id,
+              delta,
+              after_qty,
+              reason,
+              reason_canon,
+              sub_reason
+            FROM stock_ledger
+            WHERE event_id = :event_id
+            ORDER BY id ASC
+            """
+        ),
+        {"event_id": int(event_id)},
+    )
+    return [dict(x) for x in rows.mappings().all()]
+
+
+@pytest.mark.asyncio
+async def test_count_doc_post_zero_diff_marks_posted_and_writes_count_confirm(
+    client: httpx.AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    warehouse_id = await _pick_active_warehouse_id(session)
+    picked = await _pick_enabled_items_with_base_uom(session, limit=1)
+    item = picked[0]
+
+    batch_code = f"UT-CNT-POST-ZERO-{uuid4().hex[:8].upper()}"
+    await _seed_positive_stock(
+        session,
+        warehouse_id=warehouse_id,
+        item_id=int(item["item_id"]),
+        batch_code=batch_code,
+        qty=5,
+        ref=f"ut:count-doc:post-zero-seed:{batch_code}",
+    )
+    await session.commit()
+
+    created = await _create_count_doc(
+        client,
+        headers=headers,
+        warehouse_id=warehouse_id,
+        snapshot_at=datetime(2030, 1, 5, 8, 0, 0, tzinfo=UTC),
+        remark="UT-COUNT-DOC-POST-ZERO",
+    )
+    doc_id = int(created["id"])
+
+    r_freeze = await client.post(
+        f"/inventory-adjustment/count-docs/{doc_id}/freeze",
+        headers=headers,
+    )
+    assert r_freeze.status_code == 200, r_freeze.text
+
+    r_detail = await client.get(f"/inventory-adjustment/count-docs/{doc_id}", headers=headers)
+    assert r_detail.status_code == 200, r_detail.text
+    detail = r_detail.json()
+    assert detail["status"] == "FROZEN", detail
+    assert len(detail["lines"]) == 1, detail
+
+    line = detail["lines"][0]
+    assert int(line["snapshot_qty_base"]) == 5, line
+    assert len(line["lot_snapshots"]) == 1, line
+    lot_id = int(line["lot_snapshots"][0]["lot_id"])
+
+    r_update = await client.put(
+        f"/inventory-adjustment/count-docs/{doc_id}/lines",
+        json={
+            "lines": [
+                {
+                    "line_id": int(line["id"]),
+                    "counted_item_uom_id": int(item["item_uom_id"]),
+                    "counted_qty_input": 5,
+                    "reason_code": "MATCHED",
+                    "disposition": "KEEP",
+                    "remark": "ut post zero diff",
+                }
+            ]
+        },
+        headers=headers,
+    )
+    assert r_update.status_code == 200, r_update.text
+    updated = r_update.json()
+    assert updated["status"] == "COUNTED", updated
+
+    r_post = await client.post(
+        f"/inventory-adjustment/count-docs/{doc_id}/post",
+        headers=headers,
+    )
+    assert r_post.status_code == 200, r_post.text
+    posted = r_post.json()
+
+    assert int(posted["doc_id"]) == doc_id, posted
+    assert posted["status"] == "POSTED", posted
+    assert int(posted["posted_event_id"]) > 0, posted
+    assert posted["posted_at"], posted
+
+    r_detail2 = await client.get(f"/inventory-adjustment/count-docs/{doc_id}", headers=headers)
+    assert r_detail2.status_code == 200, r_detail2.text
+    detail2 = r_detail2.json()
+    assert detail2["status"] == "POSTED", detail2
+    assert int(detail2["posted_event_id"]) == int(posted["posted_event_id"]), detail2
+    assert _norm_utc_iso(detail2["posted_at"]) == _norm_utc_iso(posted["posted_at"]), detail2
+
+    event = await _post_fetch_event(session, event_id=int(posted["posted_event_id"]))
+    assert str(event["event_type"]) == "COUNT", event
+    assert str(event["source_type"]) == "MANUAL_COUNT", event
+    assert str(event["event_kind"]) == "COMMIT", event
+    assert str(event["status"]) == "COMMITTED", event
+    assert int(event["warehouse_id"]) == int(warehouse_id), event
+    assert str(event["source_ref"]) == str(created["count_no"]), event
+
+    ledgers = await _post_fetch_ledgers(session, event_id=int(posted["posted_event_id"]))
+    assert len(ledgers) == 1, ledgers
+
+    ledger = ledgers[0]
+    assert str(ledger["sub_reason"]) == "COUNT_CONFIRM", ledger
+    assert int(ledger["delta"]) == 0, ledger
+
+    # 顶层 reason 以当前 stock_ledger 真相为准，不在这里写死为 COUNT；
+    # 盘点语义由 sub_reason 稳定表达。
+    assert str(ledger["reason_canon"]) in {"ADJUSTMENT", "COUNT"}, ledger
+    assert int(ledger["warehouse_id"]) == int(warehouse_id), ledger
+    assert int(ledger["item_id"]) == int(item["item_id"]), ledger
+    assert int(ledger["lot_id"]) == int(lot_id), ledger
+
+    qty_after = await _post_load_stock_qty(
+        session,
+        warehouse_id=warehouse_id,
+        item_id=int(item["item_id"]),
+        lot_id=int(lot_id),
+    )
+    assert qty_after == 5
+
+
+@pytest.mark.asyncio
+async def test_count_doc_post_negative_diff_splits_across_lot_snapshots(
+    client: httpx.AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    warehouse_id = await _pick_active_warehouse_id(session)
+    picked = await _pick_enabled_items_with_base_uom(session, limit=1)
+    item = picked[0]
+
+    code_small = f"UT-CNT-POST-SMALL-{uuid4().hex[:8].upper()}"
+    code_big = f"UT-CNT-POST-BIG-{uuid4().hex[:8].upper()}"
+
+    await _seed_positive_stock(
+        session,
+        warehouse_id=warehouse_id,
+        item_id=int(item["item_id"]),
+        batch_code=code_small,
+        qty=5,
+        ref=f"ut:count-doc:post-split-seed:{code_small}",
+        production_date=date(2030, 1, 1),
+        expiry_date=date(2031, 1, 1),
+    )
+    await _seed_positive_stock(
+        session,
+        warehouse_id=warehouse_id,
+        item_id=int(item["item_id"]),
+        batch_code=code_big,
+        qty=7,
+        ref=f"ut:count-doc:post-split-seed:{code_big}",
+        production_date=date(2030, 2, 1),
+        expiry_date=date(2031, 2, 1),
+    )
+    await session.commit()
+
+    created = await _create_count_doc(
+        client,
+        headers=headers,
+        warehouse_id=warehouse_id,
+        snapshot_at=datetime(2030, 1, 6, 8, 0, 0, tzinfo=UTC),
+        remark="UT-COUNT-DOC-POST-SPLIT",
+    )
+    doc_id = int(created["id"])
+
+    r_freeze = await client.post(
+        f"/inventory-adjustment/count-docs/{doc_id}/freeze",
+        headers=headers,
+    )
+    assert r_freeze.status_code == 200, r_freeze.text
+
+    r_detail = await client.get(f"/inventory-adjustment/count-docs/{doc_id}", headers=headers)
+    assert r_detail.status_code == 200, r_detail.text
+    detail = r_detail.json()
+    assert detail["status"] == "FROZEN", detail
+    assert len(detail["lines"]) == 1, detail
+
+    line = detail["lines"][0]
+    assert int(line["snapshot_qty_base"]) == 12, line
+    assert len(line["lot_snapshots"]) == 2, {"line": line, "msg": "expected exactly 2 lot snapshots for split-post test"}
+
+    snapshots = sorted(
+        line["lot_snapshots"],
+        key=lambda x: (-int(x["snapshot_qty_base"]), int(x["lot_id"])),
+    )
+    assert int(snapshots[0]["snapshot_qty_base"]) == 7, snapshots
+    assert int(snapshots[1]["snapshot_qty_base"]) == 5, snapshots
+
+    lot_big = int(snapshots[0]["lot_id"])
+    lot_small = int(snapshots[1]["lot_id"])
+
+    r_update = await client.put(
+        f"/inventory-adjustment/count-docs/{doc_id}/lines",
+        json={
+            "lines": [
+                {
+                    "line_id": int(line["id"]),
+                    "counted_item_uom_id": int(item["item_uom_id"]),
+                    "counted_qty_input": 4,
+                    "reason_code": "LOSS",
+                    "disposition": "ADJUST",
+                    "remark": "ut post split diff",
+                }
+            ]
+        },
+        headers=headers,
+    )
+    assert r_update.status_code == 200, r_update.text
+    updated = r_update.json()
+    assert updated["status"] == "COUNTED", updated
+
+    r_post = await client.post(
+        f"/inventory-adjustment/count-docs/{doc_id}/post",
+        headers=headers,
+    )
+    assert r_post.status_code == 200, r_post.text
+    posted = r_post.json()
+
+    assert posted["status"] == "POSTED", posted
+    event_id = int(posted["posted_event_id"])
+
+    event = await _post_fetch_event(session, event_id=event_id)
+    assert str(event["event_type"]) == "COUNT", event
+    assert str(event["source_type"]) == "MANUAL_COUNT", event
+    assert str(event["event_kind"]) == "COMMIT", event
+    assert str(event["status"]) == "COMMITTED", event
+
+    ledgers = await _post_fetch_ledgers(session, event_id=event_id)
+    assert len(ledgers) == 2, ledgers
+    assert all(str(x["sub_reason"]) == "COUNT_ADJUST" for x in ledgers), ledgers
+    assert all(str(x["reason_canon"]) in {"ADJUSTMENT", "COUNT"} for x in ledgers), ledgers
+
+    deltas = sorted(int(x["delta"]) for x in ledgers)
+    assert deltas == [-7, -1], ledgers
+
+    ledger_by_lot = {int(x["lot_id"]): x for x in ledgers}
+    assert int(ledger_by_lot[lot_big]["delta"]) == -7, ledgers
+    assert int(ledger_by_lot[lot_small]["delta"]) == -1, ledgers
+
+    qty_big_after = await _post_load_stock_qty(
+        session,
+        warehouse_id=warehouse_id,
+        item_id=int(item["item_id"]),
+        lot_id=int(lot_big),
+    )
+    qty_small_after = await _post_load_stock_qty(
+        session,
+        warehouse_id=warehouse_id,
+        item_id=int(item["item_id"]),
+        lot_id=int(lot_small),
+    )
+
+    assert qty_big_after == 0
+    assert qty_small_after == 4
+
+
+
+@pytest.mark.asyncio
+async def test_count_doc_post_zero_diff_three_books_consistent(
+    client: httpx.AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    warehouse_id = await _pick_active_warehouse_id(session)
+    picked = await _pick_enabled_items_with_base_uom(session, limit=1)
+    item = picked[0]
+
+    batch_code = f"UT-CNT-3BOOKS-ZERO-{uuid4().hex[:8].upper()}"
+    await _seed_positive_stock(
+        session,
+        warehouse_id=warehouse_id,
+        item_id=int(item["item_id"]),
+        batch_code=batch_code,
+        qty=5,
+        ref=f"ut:count-doc:3books-zero-seed:{batch_code}",
+    )
+    await session.commit()
+
+    created = await _create_count_doc(
+        client,
+        headers=headers,
+        warehouse_id=warehouse_id,
+        snapshot_at=datetime(2030, 1, 7, 8, 0, 0, tzinfo=UTC),
+        remark="UT-COUNT-DOC-3BOOKS-ZERO",
+    )
+    doc_id = int(created["id"])
+
+    r_freeze = await client.post(
+        f"/inventory-adjustment/count-docs/{doc_id}/freeze",
+        headers=headers,
+    )
+    assert r_freeze.status_code == 200, r_freeze.text
+
+    r_detail = await client.get(f"/inventory-adjustment/count-docs/{doc_id}", headers=headers)
+    assert r_detail.status_code == 200, r_detail.text
+    detail = r_detail.json()
+    assert detail["status"] == "FROZEN", detail
+    assert len(detail["lines"]) == 1, detail
+
+    line = detail["lines"][0]
+    assert int(line["snapshot_qty_base"]) == 5, line
+
+    r_update = await client.put(
+        f"/inventory-adjustment/count-docs/{doc_id}/lines",
+        json={
+            "lines": [
+                {
+                    "line_id": int(line["id"]),
+                    "counted_item_uom_id": int(item["item_uom_id"]),
+                    "counted_qty_input": 5,
+                    "reason_code": "MATCHED",
+                    "disposition": "KEEP",
+                    "remark": "ut 3books zero diff",
+                }
+            ]
+        },
+        headers=headers,
+    )
+    assert r_update.status_code == 200, r_update.text
+    updated = r_update.json()
+    assert updated["status"] == "COUNTED", updated
+
+    r_post = await client.post(
+        f"/inventory-adjustment/count-docs/{doc_id}/post",
+        headers=headers,
+    )
+    assert r_post.status_code == 200, r_post.text
+    posted = r_post.json()
+    assert posted["status"] == "POSTED", posted
+
+    event = await _post_fetch_event(session, event_id=int(posted["posted_event_id"]))
+    assert str(event["event_type"]) == "COUNT", event
+    assert str(event["source_type"]) == "MANUAL_COUNT", event
+
+    ledgers = await _post_fetch_ledgers(session, event_id=int(posted["posted_event_id"]))
+    assert len(ledgers) == 1, ledgers
+    assert str(ledgers[0]["sub_reason"]) == "COUNT_CONFIRM", ledgers
+    assert int(ledgers[0]["delta"]) == 0, ledgers
+
+    await run_snapshot(session)
+    await verify_commit_three_books(
+        session,
+        warehouse_id=warehouse_id,
+        ref=str(event["event_no"]),
+        effects=[
+            {
+                "warehouse_id": warehouse_id,
+                "item_id": int(item["item_id"]),
+                "batch_code": batch_code,
+                "qty": 0,
+                "ref": str(event["event_no"]),
+                "ref_line": 1,
+            }
+        ],
+        at=event["occurred_at"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_count_doc_post_negative_diff_three_books_consistent(
+    client: httpx.AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    warehouse_id = await _pick_active_warehouse_id(session)
+    picked = await _pick_enabled_items_with_base_uom(session, limit=1)
+    item = picked[0]
+
+    code_small = f"UT-CNT-3BOOKS-SMALL-{uuid4().hex[:8].upper()}"
+    code_big = f"UT-CNT-3BOOKS-BIG-{uuid4().hex[:8].upper()}"
+
+    await _seed_positive_stock(
+        session,
+        warehouse_id=warehouse_id,
+        item_id=int(item["item_id"]),
+        batch_code=code_small,
+        qty=5,
+        ref=f"ut:count-doc:3books-split-seed:{code_small}",
+        production_date=date(2030, 1, 1),
+        expiry_date=date(2031, 1, 1),
+    )
+    await _seed_positive_stock(
+        session,
+        warehouse_id=warehouse_id,
+        item_id=int(item["item_id"]),
+        batch_code=code_big,
+        qty=7,
+        ref=f"ut:count-doc:3books-split-seed:{code_big}",
+        production_date=date(2030, 2, 1),
+        expiry_date=date(2031, 2, 1),
+    )
+    await session.commit()
+
+    created = await _create_count_doc(
+        client,
+        headers=headers,
+        warehouse_id=warehouse_id,
+        snapshot_at=datetime(2030, 1, 8, 8, 0, 0, tzinfo=UTC),
+        remark="UT-COUNT-DOC-3BOOKS-SPLIT",
+    )
+    doc_id = int(created["id"])
+
+    r_freeze = await client.post(
+        f"/inventory-adjustment/count-docs/{doc_id}/freeze",
+        headers=headers,
+    )
+    assert r_freeze.status_code == 200, r_freeze.text
+
+    r_detail = await client.get(f"/inventory-adjustment/count-docs/{doc_id}", headers=headers)
+    assert r_detail.status_code == 200, r_detail.text
+    detail = r_detail.json()
+    assert detail["status"] == "FROZEN", detail
+    assert len(detail["lines"]) == 1, detail
+
+    line = detail["lines"][0]
+    assert int(line["snapshot_qty_base"]) == 12, line
+    assert len(line["lot_snapshots"]) == 2, line
+
+    r_update = await client.put(
+        f"/inventory-adjustment/count-docs/{doc_id}/lines",
+        json={
+            "lines": [
+                {
+                    "line_id": int(line["id"]),
+                    "counted_item_uom_id": int(item["item_uom_id"]),
+                    "counted_qty_input": 4,
+                    "reason_code": "LOSS",
+                    "disposition": "ADJUST",
+                    "remark": "ut 3books split diff",
+                }
+            ]
+        },
+        headers=headers,
+    )
+    assert r_update.status_code == 200, r_update.text
+    updated = r_update.json()
+    assert updated["status"] == "COUNTED", updated
+
+    r_post = await client.post(
+        f"/inventory-adjustment/count-docs/{doc_id}/post",
+        headers=headers,
+    )
+    assert r_post.status_code == 200, r_post.text
+    posted = r_post.json()
+    assert posted["status"] == "POSTED", posted
+
+    event = await _post_fetch_event(session, event_id=int(posted["posted_event_id"]))
+    assert str(event["event_type"]) == "COUNT", event
+    assert str(event["source_type"]) == "MANUAL_COUNT", event
+
+    ledgers = await _post_fetch_ledgers(session, event_id=int(posted["posted_event_id"]))
+    assert len(ledgers) == 2, ledgers
+    assert all(str(x["sub_reason"]) == "COUNT_ADJUST" for x in ledgers), ledgers
+
+    deltas = sorted(int(x["delta"]) for x in ledgers)
+    assert deltas == [-7, -1], ledgers
+
+    await run_snapshot(session)
+    await verify_commit_three_books(
+        session,
+        warehouse_id=warehouse_id,
+        ref=str(event["event_no"]),
+        effects=[
+            {
+                "warehouse_id": warehouse_id,
+                "item_id": int(item["item_id"]),
+                "batch_code": code_big,
+                "qty": -7,
+                "ref": str(event["event_no"]),
+                "ref_line": 1,
+            },
+            {
+                "warehouse_id": warehouse_id,
+                "item_id": int(item["item_id"]),
+                "batch_code": code_small,
+                "qty": -1,
+                "ref": str(event["event_no"]),
+                "ref_line": 1,
+            },
+        ],
+        at=event["occurred_at"],
+    )

--- a/tests/api/test_inventory_adjustment_count_docs_read_model_api.py
+++ b/tests/api/test_inventory_adjustment_count_docs_read_model_api.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from uuid import uuid4
+
+import httpx
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.wms.stock.services.stock_service import StockService
+
+
+pytestmark = pytest.mark.asyncio
+UTC = timezone.utc
+
+
+async def _login_admin_headers(client: httpx.AsyncClient) -> dict[str, str]:
+    r = await client.post("/users/login", json={"username": "admin", "password": "admin123"})
+    assert r.status_code == 200, r.text
+    token = r.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _pick_active_warehouse_id(session: AsyncSession) -> int:
+    row = await session.execute(
+        text(
+            """
+            SELECT id
+              FROM warehouses
+             WHERE COALESCE(active, true) = true
+             ORDER BY id
+             LIMIT 1
+            """
+        )
+    )
+    wid = row.scalar_one_or_none()
+    assert wid is not None, "no active warehouse found"
+    return int(wid)
+
+
+async def _pick_enabled_item_with_base_uom(session: AsyncSession) -> dict[str, object]:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT DISTINCT ON (i.id)
+                  i.id AS item_id,
+                  u.id AS item_uom_id
+                FROM items i
+                JOIN item_uoms u
+                  ON u.item_id = i.id
+                WHERE COALESCE(i.enabled, true) = true
+                ORDER BY
+                  i.id ASC,
+                  CASE
+                    WHEN COALESCE(u.is_inbound_default, false) THEN 0
+                    WHEN COALESCE(u.is_base, false) THEN 1
+                    ELSE 2
+                  END,
+                  u.id ASC
+                LIMIT 1
+                """
+            )
+        )
+    ).mappings().first()
+    assert row is not None, "no enabled item with base uom found"
+    return dict(row)
+
+
+async def _seed_positive_stock(
+    session: AsyncSession,
+    *,
+    warehouse_id: int,
+    item_id: int,
+    batch_code: str,
+    qty: int,
+    ref: str,
+    production_date: date | None = None,
+    expiry_date: date | None = None,
+) -> None:
+    now = datetime.now(UTC)
+    prod = production_date or now.date()
+    exp = expiry_date or (prod + timedelta(days=365))
+
+    stock = StockService()
+    await stock.adjust(
+        session=session,
+        item_id=int(item_id),
+        warehouse_id=int(warehouse_id),
+        batch_code=str(batch_code),
+        delta=int(qty),
+        reason="RECEIPT",
+        ref=str(ref),
+        ref_line=1,
+        occurred_at=now,
+        production_date=prod,
+        expiry_date=exp,
+        meta={"sub_reason": "UT_COUNT_DOC_READ_MODEL_SEED"},
+    )
+
+
+async def _create_count_doc(
+    client: httpx.AsyncClient,
+    *,
+    headers: dict[str, str],
+    warehouse_id: int,
+    snapshot_at: datetime,
+    remark: str,
+) -> dict[str, object]:
+    resp = await client.post(
+        "/inventory-adjustment/count-docs",
+        json={
+            "warehouse_id": int(warehouse_id),
+            "snapshot_at": snapshot_at.isoformat(),
+            "remark": remark,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert int(body["id"]) > 0, body
+    return body
+
+
+@pytest.mark.asyncio
+async def test_count_doc_detail_read_model_exposes_posted_summary_and_aggregates(
+    client: httpx.AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    warehouse_id = await _pick_active_warehouse_id(session)
+    picked = await _pick_enabled_item_with_base_uom(session)
+
+    item_id = int(picked["item_id"])
+    item_uom_id = int(picked["item_uom_id"])
+
+    code_small = f"UT-CNT-RM-SMALL-{uuid4().hex[:8].upper()}"
+    code_big = f"UT-CNT-RM-BIG-{uuid4().hex[:8].upper()}"
+
+    await _seed_positive_stock(
+        session,
+        warehouse_id=warehouse_id,
+        item_id=item_id,
+        batch_code=code_small,
+        qty=5,
+        ref=f"ut:count-doc:read-model-seed:{code_small}",
+        production_date=date(2030, 1, 1),
+        expiry_date=date(2031, 1, 1),
+    )
+    await _seed_positive_stock(
+        session,
+        warehouse_id=warehouse_id,
+        item_id=item_id,
+        batch_code=code_big,
+        qty=7,
+        ref=f"ut:count-doc:read-model-seed:{code_big}",
+        production_date=date(2030, 2, 1),
+        expiry_date=date(2031, 2, 1),
+    )
+    await session.commit()
+
+    created = await _create_count_doc(
+        client,
+        headers=headers,
+        warehouse_id=warehouse_id,
+        snapshot_at=datetime(2030, 1, 9, 8, 0, 0, tzinfo=UTC),
+        remark="UT-COUNT-DOC-READMODEL-DETAIL",
+    )
+    doc_id = int(created["id"])
+
+    r_freeze = await client.post(f"/inventory-adjustment/count-docs/{doc_id}/freeze", headers=headers)
+    assert r_freeze.status_code == 200, r_freeze.text
+
+    r_detail0 = await client.get(f"/inventory-adjustment/count-docs/{doc_id}", headers=headers)
+    assert r_detail0.status_code == 200, r_detail0.text
+    detail0 = r_detail0.json()
+    assert detail0["status"] == "FROZEN", detail0
+    assert len(detail0["lines"]) == 1, detail0
+
+    line = detail0["lines"][0]
+    assert int(line["snapshot_qty_base"]) == 12, line
+
+    r_update = await client.put(
+        f"/inventory-adjustment/count-docs/{doc_id}/lines",
+        json={
+            "lines": [
+                {
+                    "line_id": int(line["id"]),
+                    "counted_item_uom_id": item_uom_id,
+                    "counted_qty_input": 4,
+                    "reason_code": "LOSS",
+                    "disposition": "ADJUST",
+                    "remark": "ut read model detail",
+                }
+            ]
+        },
+        headers=headers,
+    )
+    assert r_update.status_code == 200, r_update.text
+    assert r_update.json()["status"] == "COUNTED", r_update.text
+
+    r_post = await client.post(f"/inventory-adjustment/count-docs/{doc_id}/post", headers=headers)
+    assert r_post.status_code == 200, r_post.text
+    posted = r_post.json()
+    assert posted["status"] == "POSTED", posted
+
+    r_detail = await client.get(f"/inventory-adjustment/count-docs/{doc_id}", headers=headers)
+    assert r_detail.status_code == 200, r_detail.text
+    detail = r_detail.json()
+
+    assert detail["status"] == "POSTED", detail
+    assert int(detail["line_count"]) == 1, detail
+    assert int(detail["diff_line_count"]) == 1, detail
+    assert int(detail["diff_qty_base_total"]) == -8, detail
+
+    assert int(detail["posted_event_id"]) == int(posted["posted_event_id"]), detail
+    assert str(detail["posted_event_no"]).startswith("CNT-"), detail
+    assert detail["posted_event_type"] == "COUNT", detail
+    assert detail["posted_source_type"] == "MANUAL_COUNT", detail
+    assert detail["posted_event_kind"] == "COMMIT", detail
+    assert detail["posted_event_status"] == "COMMITTED", detail
+
+    assert len(detail["lines"]) == 1, detail
+    dline = detail["lines"][0]
+    assert int(dline["diff_qty_base"]) == -8, dline
+    assert dline["reason_code"] == "LOSS", dline
+    assert dline["disposition"] == "ADJUST", dline
+    assert len(dline["lot_snapshots"]) == 2, dline
+
+
+@pytest.mark.asyncio
+async def test_count_doc_list_read_model_exposes_aggregates_and_posted_summary(
+    client: httpx.AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    warehouse_id = await _pick_active_warehouse_id(session)
+    picked = await _pick_enabled_item_with_base_uom(session)
+
+    item_id = int(picked["item_id"])
+    item_uom_id = int(picked["item_uom_id"])
+
+    batch_code = f"UT-CNT-RM-LIST-{uuid4().hex[:8].upper()}"
+    await _seed_positive_stock(
+        session,
+        warehouse_id=warehouse_id,
+        item_id=item_id,
+        batch_code=batch_code,
+        qty=5,
+        ref=f"ut:count-doc:list-read-model-seed:{batch_code}",
+    )
+    await session.commit()
+
+    created = await _create_count_doc(
+        client,
+        headers=headers,
+        warehouse_id=warehouse_id,
+        snapshot_at=datetime(2030, 1, 10, 8, 0, 0, tzinfo=UTC),
+        remark="UT-COUNT-DOC-READMODEL-LIST",
+    )
+    doc_id = int(created["id"])
+
+    r_freeze = await client.post(f"/inventory-adjustment/count-docs/{doc_id}/freeze", headers=headers)
+    assert r_freeze.status_code == 200, r_freeze.text
+
+    r_detail0 = await client.get(f"/inventory-adjustment/count-docs/{doc_id}", headers=headers)
+    assert r_detail0.status_code == 200, r_detail0.text
+    detail0 = r_detail0.json()
+    assert len(detail0["lines"]) == 1, detail0
+    line = detail0["lines"][0]
+    assert int(line["snapshot_qty_base"]) == 5, line
+
+    r_update = await client.put(
+        f"/inventory-adjustment/count-docs/{doc_id}/lines",
+        json={
+            "lines": [
+                {
+                    "line_id": int(line["id"]),
+                    "counted_item_uom_id": item_uom_id,
+                    "counted_qty_input": 5,
+                    "reason_code": "MATCHED",
+                    "disposition": "KEEP",
+                    "remark": "ut read model list",
+                }
+            ]
+        },
+        headers=headers,
+    )
+    assert r_update.status_code == 200, r_update.text
+    assert r_update.json()["status"] == "COUNTED", r_update.text
+
+    r_post = await client.post(f"/inventory-adjustment/count-docs/{doc_id}/post", headers=headers)
+    assert r_post.status_code == 200, r_post.text
+    posted = r_post.json()
+    assert posted["status"] == "POSTED", posted
+
+    r_list = await client.get(
+        "/inventory-adjustment/count-docs",
+        params={"warehouse_id": warehouse_id, "limit": 50, "offset": 0},
+        headers=headers,
+    )
+    assert r_list.status_code == 200, r_list.text
+    listed = r_list.json()
+
+    row = next((x for x in listed["items"] if int(x["id"]) == doc_id), None)
+    assert row is not None, listed
+
+    assert row["status"] == "POSTED", row
+    assert int(row["line_count"]) == 1, row
+    assert int(row["diff_line_count"]) == 0, row
+    assert int(row["diff_qty_base_total"]) == 0, row
+
+    assert int(row["posted_event_id"]) == int(posted["posted_event_id"]), row
+    assert str(row["posted_event_no"]).startswith("CNT-"), row
+    assert row["posted_event_type"] == "COUNT", row
+    assert row["posted_source_type"] == "MANUAL_COUNT", row
+    assert row["posted_event_kind"] == "COMMIT", row
+    assert row["posted_event_status"] == "COMMITTED", row

--- a/tests/api/test_stock_inventory_recount_freeze_guard_api.py
+++ b/tests/api/test_stock_inventory_recount_freeze_guard_api.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import httpx
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.wms.stock.services.stock_service import StockService
+
+
+pytestmark = pytest.mark.asyncio
+UTC = timezone.utc
+
+
+def _norm_utc_iso(v: str) -> str:
+    return str(v).replace("Z", "+00:00")
+
+
+def _extract_freeze_guard_detail(body: dict) -> dict | None:
+    # 1) FastAPI 原生 HTTPException 直出：{"detail": {...}}
+    detail = body.get("detail")
+    if isinstance(detail, dict) and detail.get("error_code") == "count_doc_frozen_for_warehouse":
+        return detail
+
+    # 2) 某些路径可能直接平铺 error_code
+    if body.get("error_code") == "count_doc_frozen_for_warehouse":
+        return body
+
+    # 3) 统一问题响应壳：{"http_status":409, "details":[...], "context":{...}}
+    details = body.get("details")
+    if isinstance(details, list):
+        for entry in details:
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("error_code") == "count_doc_frozen_for_warehouse":
+                return entry
+            if entry.get("reason") == "count_doc_frozen_for_warehouse":
+                return {"error_code": entry["reason"], **entry}
+
+    return None
+
+
+async def _login_admin_headers(client: httpx.AsyncClient) -> dict[str, str]:
+    r = await client.post("/users/login", json={"username": "admin", "password": "admin123"})
+    assert r.status_code == 200, r.text
+    token = r.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _pick_active_warehouse_id(session: AsyncSession) -> int:
+    row = await session.execute(
+        text(
+            """
+            SELECT id
+              FROM warehouses
+             WHERE COALESCE(active, true) = true
+             ORDER BY id
+             LIMIT 1
+            """
+        )
+    )
+    wid = row.scalar_one_or_none()
+    assert wid is not None, "no active warehouse found"
+    return int(wid)
+
+
+async def _pick_enabled_item_with_base_uom(session: AsyncSession) -> dict[str, object]:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT DISTINCT ON (i.id)
+                  i.id AS item_id,
+                  u.id AS item_uom_id
+                FROM items i
+                JOIN item_uoms u
+                  ON u.item_id = i.id
+                WHERE COALESCE(i.enabled, true) = true
+                ORDER BY
+                  i.id ASC,
+                  CASE
+                    WHEN COALESCE(u.is_inbound_default, false) THEN 0
+                    WHEN COALESCE(u.is_base, false) THEN 1
+                    ELSE 2
+                  END,
+                  u.id ASC
+                LIMIT 1
+                """
+            )
+        )
+    ).mappings().first()
+    assert row is not None, "no enabled item with item_uom found"
+    return dict(row)
+
+
+async def _seed_positive_stock(
+    session: AsyncSession,
+    *,
+    warehouse_id: int,
+    item_id: int,
+    batch_code: str,
+    qty: int,
+    ref: str,
+) -> None:
+    now = datetime.now(UTC)
+    prod = now.date()
+    exp = prod + timedelta(days=365)
+
+    stock = StockService()
+    await stock.adjust(
+        session=session,
+        item_id=int(item_id),
+        warehouse_id=int(warehouse_id),
+        batch_code=str(batch_code),
+        delta=int(qty),
+        reason="RECEIPT",
+        ref=str(ref),
+        ref_line=1,
+        occurred_at=now,
+        production_date=prod,
+        expiry_date=exp,
+        meta={"sub_reason": "UT_RECOUNT_FREEZE_GUARD_SEED"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_stock_inventory_recount_returns_409_when_count_doc_frozen(
+    client: httpx.AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    warehouse_id = await _pick_active_warehouse_id(session)
+    picked = await _pick_enabled_item_with_base_uom(session)
+
+    item_id = int(picked["item_id"])
+    batch_code = f"UT-RECOUNT-FROZEN-{uuid4().hex[:8].upper()}"
+
+    await _seed_positive_stock(
+        session,
+        warehouse_id=warehouse_id,
+        item_id=item_id,
+        batch_code=batch_code,
+        qty=5,
+        ref=f"ut:recount:freeze-guard:seed:{batch_code}",
+    )
+    await session.commit()
+
+    snapshot_at = datetime(2030, 1, 4, 8, 0, 0, tzinfo=UTC)
+    r_create = await client.post(
+        "/inventory-adjustment/count-docs",
+        json={
+            "warehouse_id": int(warehouse_id),
+            "snapshot_at": snapshot_at.isoformat(),
+            "remark": "UT-RECOUNT-FROZEN-GUARD",
+        },
+        headers=headers,
+    )
+    assert r_create.status_code == 201, r_create.text
+    created = r_create.json()
+    doc_id = int(created["id"])
+
+    r_freeze = await client.post(
+        f"/inventory-adjustment/count-docs/{doc_id}/freeze",
+        headers=headers,
+    )
+    assert r_freeze.status_code == 200, r_freeze.text
+    frozen = r_freeze.json()
+    assert frozen["status"] == "FROZEN", frozen
+
+    r = await client.post(
+        "/stock/inventory/recount",
+        headers=headers,
+        json={
+            "item_id": int(item_id),
+            "warehouse_id": int(warehouse_id),
+            "lot_code": batch_code,
+            "actual": 5,
+            "ctx": {"device_id": "UT-COUNT-RECOUNT"},
+        },
+    )
+    assert r.status_code == 409, r.text
+    body = r.json()
+
+    detail = _extract_freeze_guard_detail(body)
+    assert detail is not None, body
+    assert detail["error_code"] == "count_doc_frozen_for_warehouse", body
+
+    # 统一壳与直出 detail 的字段形状可能略有差异：
+    # 能断言的强字段尽量断言；缺失时不硬绑死包体细节。
+    if "warehouse_id" in detail:
+        assert int(detail["warehouse_id"]) == int(warehouse_id), body
+    if "count_doc_id" in detail:
+        assert int(detail["count_doc_id"]) == int(doc_id), body
+    if "count_no" in detail:
+        assert str(detail["count_no"]) == str(created["count_no"]), body
+    if "snapshot_at" in detail:
+        assert _norm_utc_iso(str(detail["snapshot_at"])) == snapshot_at.isoformat(), body
+
+    if "http_status" in body:
+        assert int(body["http_status"]) == 409, body

--- a/tests/contracts/test_stock_ledger_sub_reason_contract.py
+++ b/tests/contracts/test_stock_ledger_sub_reason_contract.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from app.wms.ledger.contracts.stock_ledger import SubReason
+
+
+def test_stock_ledger_sub_reason_contract_includes_count_confirm() -> None:
+    values = {x.value for x in SubReason}
+    assert "COUNT_CONFIRM" in values
+    assert "COUNT_ADJUST" in values

--- a/tests/services/test_inbound_reversal_service.py
+++ b/tests/services/test_inbound_reversal_service.py
@@ -121,6 +121,45 @@ def _date_to_utc_datetime(d: date) -> datetime:
     return datetime(d.year, d.month, d.day, tzinfo=timezone.utc)
 
 
+async def _insert_frozen_count_doc(
+    session,
+    *,
+    warehouse_id: int,
+) -> tuple[int, str, datetime]:
+    snapshot_at = datetime.now(timezone.utc)
+    count_no = f"UT-CNT-FROZEN-IN-{warehouse_id}-{int(snapshot_at.timestamp() * 1_000_000)}"
+    row = await session.execute(
+        text(
+            """
+            INSERT INTO count_docs (
+              count_no,
+              warehouse_id,
+              snapshot_at,
+              status,
+              remark
+            )
+            VALUES (
+              :count_no,
+              :warehouse_id,
+              :snapshot_at,
+              'FROZEN',
+              :remark
+            )
+            RETURNING id
+            """
+        ),
+        {
+            "count_no": count_no,
+            "warehouse_id": int(warehouse_id),
+            "snapshot_at": snapshot_at,
+            "remark": "ut inbound reversal freeze guard",
+        },
+    )
+    doc_id = int(row.scalar_one())
+    await session.flush()
+    return doc_id, count_no, snapshot_at
+
+
 @pytest.mark.asyncio
 async def test_inbound_reversal_creates_reversal_event_and_supersedes_original(session):
     picked = await _pick_seed_item_uom(session)
@@ -270,3 +309,65 @@ async def test_inbound_reversal_duplicate_returns_already_reversed(session):
 
     assert exc.value.status_code == 409
     assert str(exc.value.detail).startswith("inbound_event_already_reversed:")
+
+
+@pytest.mark.asyncio
+async def test_inbound_reversal_rejects_when_count_doc_frozen(session):
+    picked = await _pick_seed_item_uom(session)
+
+    warehouse_id = int(picked["warehouse_id"])
+    item_id = int(picked["item_id"])
+    uom_id = int(picked["uom_id"])
+    lot_source_policy = str(picked["lot_source_policy"])
+
+    qty_input = 2
+    production_date = date.today()
+    expiry_date = production_date + timedelta(days=30)
+
+    lot_code_input = None
+    if lot_source_policy in {"SUPPLIER_ONLY", "SUPPLIER"}:
+        lot_code_input = f"UT-IN-REV-FROZEN-{item_id}-{uom_id}"
+
+    payload = InboundCommitIn.model_validate(
+        {
+            "warehouse_id": warehouse_id,
+            "source_type": "MANUAL",
+            "source_ref": None,
+            "occurred_at": production_date.isoformat() + "T00:00:00Z",
+            "remark": "ut inbound reversal frozen source",
+            "lines": [
+                {
+                    "item_id": item_id,
+                    "uom_id": uom_id,
+                    "qty_input": qty_input,
+                    "lot_code_input": lot_code_input,
+                    "production_date": production_date.isoformat(),
+                    "expiry_date": expiry_date.isoformat(),
+                    "remark": "ut frozen source line",
+                }
+            ],
+        }
+    )
+
+    original = await commit_inbound(session, payload=payload, user_id=None)
+    doc_id, count_no, snapshot_at = await _insert_frozen_count_doc(
+        session,
+        warehouse_id=warehouse_id,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await reverse_inbound_event(
+            session,
+            event_id=int(original.event_id),
+            payload=InboundReversalIn(remark="ut frozen reversal"),
+            user_id=None,
+        )
+
+    assert exc.value.status_code == 409
+    detail = exc.value.detail
+    assert isinstance(detail, dict), detail
+    assert detail["error_code"] == "count_doc_frozen_for_warehouse"
+    assert int(detail["warehouse_id"]) == warehouse_id
+    assert int(detail["count_doc_id"]) == doc_id
+    assert str(detail["count_no"]) == count_no
+    assert str(detail["snapshot_at"]) == snapshot_at.isoformat()

--- a/tests/services/test_outbound_reversal_service.py
+++ b/tests/services/test_outbound_reversal_service.py
@@ -298,6 +298,45 @@ async def _load_ledger_by_event(session: AsyncSession, *, event_id: int):
     return dict(m) if m else None
 
 
+async def _insert_frozen_count_doc(
+    session: AsyncSession,
+    *,
+    warehouse_id: int,
+) -> tuple[int, str, datetime]:
+    snapshot_at = datetime.now(timezone.utc)
+    count_no = f"UT-CNT-FROZEN-OUT-{warehouse_id}-{int(snapshot_at.timestamp() * 1_000_000)}"
+    row = await session.execute(
+        text(
+            """
+            INSERT INTO count_docs (
+              count_no,
+              warehouse_id,
+              snapshot_at,
+              status,
+              remark
+            )
+            VALUES (
+              :count_no,
+              :warehouse_id,
+              :snapshot_at,
+              'FROZEN',
+              :remark
+            )
+            RETURNING id
+            """
+        ),
+        {
+            "count_no": count_no,
+            "warehouse_id": int(warehouse_id),
+            "snapshot_at": snapshot_at,
+            "remark": "ut outbound reversal freeze guard",
+        },
+    )
+    doc_id = int(row.scalar_one())
+    await session.flush()
+    return doc_id, count_no, snapshot_at
+
+
 @pytest.mark.asyncio
 async def test_outbound_reversal_creates_reversal_event_and_supersedes_original(session: AsyncSession):
     original = await _seed_outbound_source_event(session)
@@ -370,3 +409,31 @@ async def test_outbound_reversal_duplicate_returns_already_reversed(session: Asy
 
     assert exc.value.status_code == 409
     assert str(exc.value.detail).startswith("outbound_event_already_reversed:")
+
+
+@pytest.mark.asyncio
+async def test_outbound_reversal_rejects_when_count_doc_frozen(session: AsyncSession):
+    original = await _seed_outbound_source_event(session)
+    warehouse_id = int(original["warehouse_id"])
+
+    doc_id, count_no, snapshot_at = await _insert_frozen_count_doc(
+        session,
+        warehouse_id=warehouse_id,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await reverse_outbound_event(
+            session,
+            event_id=int(original["event_id"]),
+            payload=OutboundReversalIn(remark="ut frozen outbound reversal"),
+            user_id=None,
+        )
+
+    assert exc.value.status_code == 409
+    detail = exc.value.detail
+    assert isinstance(detail, dict), detail
+    assert detail["error_code"] == "count_doc_frozen_for_warehouse"
+    assert int(detail["warehouse_id"]) == warehouse_id
+    assert int(detail["count_doc_id"]) == doc_id
+    assert str(detail["count_no"]) == count_no
+    assert str(detail["snapshot_at"]) == snapshot_at.isoformat()


### PR DESCRIPTION
## Summary
- finish count-doc posted chain from COUNTED to POSTED
- align wms_events source_type constraint with MANUAL_COUNT / COUNT_TASK
- expose count-doc read model aggregates and posted event summary
- add mainline API tests, freeze guard tests, sub-reason contract test
- keep count-doc mainline on rigid contract without reviving legacy count flow

## Included changes
- count-doc contracts / repo / service / router
- wms event source_type alignment migration
- stock ledger sub_reason contract
- inbound/outbound reversal freeze guard tests
- count-doc mainline API tests
- count-doc read-model API tests

## Validation
- count-doc mainline tests passed
- freeze guard tests passed
- posted chain tests passed
- posted three-books consistency tests passed
- read-model tests passed