### PR TITLE
chore(tms): move records and billing models to domain packages

### DIFF
--- a/app/db/base.py
+++ b/app/db/base.py
@@ -140,6 +140,8 @@ def init_models(
         "app.wms.inventory_adjustment.count.models",
         "app.wms.inbound.models",
         "app.wms.outbound.models",
+        "app.tms.records.models",
+        "app.tms.billing.models",
     ):
         for mod in _iter_model_modules_recursive(pkg_name):
             if mod in ex or mod in loaded:

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -120,9 +120,9 @@ MODEL_SPECS = [
     # 运输执行 / 账本（Phase-2：Shipment 主实体 + Record 投影）
     # ------------------------------------------------------------------
     ("app.models.transport_shipment", "TransportShipment"),
-    ("app.models.shipping_record", "ShippingRecord"),
-    ("app.models.carrier_bill_item", "CarrierBillItem"),
-    ("app.models.shipping_record_reconciliation", "ShippingRecordReconciliation"),
+    ("app.tms.records.models.shipping_record", "ShippingRecord"),
+    ("app.tms.billing.models.carrier_bill_item", "CarrierBillItem"),
+    ("app.tms.billing.models.shipping_record_reconciliation", "ShippingRecordReconciliation"),
     # ------------------------------------------------------------------
     # 运价模板（新主线：template -> ranges/groups -> matrix + surcharge_config）
     # ------------------------------------------------------------------

--- a/app/tms/billing/models/__init__.py
+++ b/app/tms/billing/models/__init__.py
@@ -1,0 +1,16 @@
+# app/tms/billing/models/__init__.py
+# Domain-owned ORM models for TMS billing.
+
+from app.tms.billing.models.carrier_bill_item import CarrierBillItem
+from app.tms.billing.models.shipping_bill_reconciliation_history import (
+    ShippingBillReconciliationHistory,
+)
+from app.tms.billing.models.shipping_record_reconciliation import (
+    ShippingRecordReconciliation,
+)
+
+__all__ = [
+    "CarrierBillItem",
+    "ShippingBillReconciliationHistory",
+    "ShippingRecordReconciliation",
+]

--- a/app/tms/billing/models/carrier_bill_item.py
+++ b/app/tms/billing/models/carrier_bill_item.py
@@ -1,4 +1,5 @@
-# app/models/carrier_bill_item.py
+# app/tms/billing/models/carrier_bill_item.py
+# Domain move: carrier bill item ORM belongs to TMS billing.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/tms/billing/models/shipping_bill_reconciliation_history.py
+++ b/app/tms/billing/models/shipping_bill_reconciliation_history.py
@@ -1,4 +1,5 @@
-# app/models/shipping_bill_reconciliation_history.py
+# app/tms/billing/models/shipping_bill_reconciliation_history.py
+# Domain move: reconciliation history ORM belongs to TMS billing.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/tms/billing/models/shipping_record_reconciliation.py
+++ b/app/tms/billing/models/shipping_record_reconciliation.py
@@ -1,4 +1,5 @@
-# app/models/shipping_record_reconciliation.py
+# app/tms/billing/models/shipping_record_reconciliation.py
+# Domain move: shipping record reconciliation ORM belongs to TMS billing.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/tms/records/models/__init__.py
+++ b/app/tms/records/models/__init__.py
@@ -1,0 +1,8 @@
+# app/tms/records/models/__init__.py
+# Domain-owned ORM models for TMS records / logistics ledger.
+
+from app.tms.records.models.shipping_record import ShippingRecord
+
+__all__ = [
+    "ShippingRecord",
+]

--- a/app/tms/records/models/shipping_record.py
+++ b/app/tms/records/models/shipping_record.py
@@ -1,4 +1,5 @@
-# app/models/shipping_record.py
+# app/tms/records/models/shipping_record.py
+# Domain move: shipping record ORM belongs to TMS records as the logistics ledger.
 from __future__ import annotations
 
 from datetime import datetime


### PR DESCRIPTION
## Summary
- move ShippingRecord ORM to app/tms/records/models
- move CarrierBillItem and reconciliation ORM models to app/tms/billing/models
- update model registry paths in app/models/__init__.py
- add TMS records/billing model packages to ORM model discovery

## Validation
- python3 -m compileall app tests
- make alembic-check
- make test TESTS="tests/api/test_tms_billing_reconciliations.py tests/services/test_transport_shipments.py tests/unit/test_tms_phase1_boundary.py"