### PR TITLE
chore(oms): move platform models to domain package

### DIFF
--- a/app/db/base.py
+++ b/app/db/base.py
@@ -142,6 +142,7 @@ def init_models(
         "app.wms.outbound.models",
         "app.tms.records.models",
         "app.tms.billing.models",
+        "app.oms.platforms.models",
     ):
         for mod in _iter_model_modules_recursive(pkg_name):
             if mod in ex or mod in loaded:

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -86,18 +86,18 @@ MODEL_SPECS = [
     # ------------------------------------------------------------------
     # 店铺 × 平台接入（OMS 淘宝 / 拼多多 / 京东）
     # ------------------------------------------------------------------
-    ("app.models.taobao_app_config", "TaobaoAppConfig"),
-    ("app.models.pdd_app_config", "PddAppConfig"),
-    ("app.models.jd_app_config", "JdAppConfig"),
-    ("app.models.store_platform_credential", "StorePlatformCredential"),
-    ("app.models.store_platform_connection", "StorePlatformConnection"),
-    ("app.models.taobao_order", "TaobaoOrder"),
-    ("app.models.taobao_order", "TaobaoOrderItem"),
-    ("app.models.pdd_order", "PddOrder"),
-    ("app.models.pdd_order", "PddOrderItem"),
-    ("app.models.jd_order", "JdOrder"),
-    ("app.models.jd_order", "JdOrderItem"),
-    ("app.models.pdd_order_order_mapping", "PddOrderOrderMapping"),
+    ("app.oms.platforms.models.taobao_app_config", "TaobaoAppConfig"),
+    ("app.oms.platforms.models.pdd_app_config", "PddAppConfig"),
+    ("app.oms.platforms.models.jd_app_config", "JdAppConfig"),
+    ("app.oms.platforms.models.store_platform_credential", "StorePlatformCredential"),
+    ("app.oms.platforms.models.store_platform_connection", "StorePlatformConnection"),
+    ("app.oms.platforms.models.taobao_order", "TaobaoOrder"),
+    ("app.oms.platforms.models.taobao_order", "TaobaoOrderItem"),
+    ("app.oms.platforms.models.pdd_order", "PddOrder"),
+    ("app.oms.platforms.models.pdd_order", "PddOrderItem"),
+    ("app.oms.platforms.models.jd_order", "JdOrder"),
+    ("app.oms.platforms.models.jd_order", "JdOrderItem"),
+    ("app.oms.platforms.models.pdd_order_order_mapping", "PddOrderOrderMapping"),
     # ------------------------------------------------------------------
     # 采购系统
     # ------------------------------------------------------------------

--- a/app/oms/platforms/jd/repo_orders.py
+++ b/app/oms/platforms/jd/repo_orders.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.models.jd_order import JdOrder
+from app.oms.platforms.models.jd_order import JdOrder
 
 
 async def list_jd_orders(

--- a/app/oms/platforms/jd/repository.py
+++ b/app/oms/platforms/jd/repository.py
@@ -8,9 +8,9 @@ from typing import Optional
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.jd_app_config import JdAppConfig
-from app.models.store_platform_connection import StorePlatformConnection
-from app.models.store_platform_credential import StorePlatformCredential
+from app.oms.platforms.models.jd_app_config import JdAppConfig
+from app.oms.platforms.models.store_platform_connection import StorePlatformConnection
+from app.oms.platforms.models.store_platform_credential import StorePlatformCredential
 
 
 def _norm_platform(platform: str) -> str:

--- a/app/oms/platforms/jd/service_ledger.py
+++ b/app/oms/platforms/jd/service_ledger.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import List
 
-from app.models.jd_order import JdOrder, JdOrderItem
+from app.oms.platforms.models.jd_order import JdOrder, JdOrderItem
 from app.oms.platforms.jd.contracts_ledger import (
     JdOrderLedgerDetailOut,
     JdOrderLedgerItemOut,

--- a/app/oms/platforms/jd/settings.py
+++ b/app/oms/platforms/jd/settings.py
@@ -5,7 +5,7 @@ import os
 from dataclasses import dataclass
 from typing import Mapping, Optional
 
-from app.models.jd_app_config import JdAppConfig
+from app.oms.platforms.models.jd_app_config import JdAppConfig
 
 from .errors import JdJosConfigError
 

--- a/app/oms/platforms/models/__init__.py
+++ b/app/oms/platforms/models/__init__.py
@@ -1,0 +1,29 @@
+# app/oms/platforms/models/__init__.py
+# Domain-owned ORM models for OMS platform access and platform order facts.
+
+from app.oms.platforms.models.jd_app_config import JdAppConfig
+from app.oms.platforms.models.jd_order import JdOrder, JdOrderItem
+from app.oms.platforms.models.pdd_app_config import PddAppConfig
+from app.oms.platforms.models.pdd_order import PddOrder, PddOrderItem
+from app.oms.platforms.models.pdd_order_order_mapping import PddOrderOrderMapping
+from app.oms.platforms.models.store_platform_connection import StorePlatformConnection
+from app.oms.platforms.models.store_platform_credential import StorePlatformCredential
+from app.oms.platforms.models.store_token import StoreToken
+from app.oms.platforms.models.taobao_app_config import TaobaoAppConfig
+from app.oms.platforms.models.taobao_order import TaobaoOrder, TaobaoOrderItem
+
+__all__ = [
+    "JdAppConfig",
+    "JdOrder",
+    "JdOrderItem",
+    "PddAppConfig",
+    "PddOrder",
+    "PddOrderItem",
+    "PddOrderOrderMapping",
+    "StorePlatformConnection",
+    "StorePlatformCredential",
+    "StoreToken",
+    "TaobaoAppConfig",
+    "TaobaoOrder",
+    "TaobaoOrderItem",
+]

--- a/app/oms/platforms/models/jd_app_config.py
+++ b/app/oms/platforms/models/jd_app_config.py
@@ -1,4 +1,5 @@
-# app/models/pdd_app_config.py
+# app/oms/platforms/models/jd_app_config.py
+# Domain move: JD app config ORM belongs to OMS platform access.
 from __future__ import annotations
 
 from datetime import datetime
@@ -9,26 +10,21 @@ from sqlalchemy.orm import Mapped, mapped_column
 from app.db.base import Base
 
 
-class PddAppConfig(Base):
+class JdAppConfig(Base):
     """
-    拼多多开放平台系统级应用配置表。
+    京东平台系统级接入配置（当前态）。
 
     职责：
-    - 保存 OMS 系统接入拼多多开放平台所需的应用配置
-    - 保存 client_id / client_secret / redirect_uri / api_base_url / sign_method
-    - 保存当前是否启用的配置记录
-
-    不负责：
-    - 店铺授权材料（access_token / refresh_token）
-    - 店铺接入状态裁决
-    - 店铺 identity
+    - 保存 JD OAuth / JOS 所需系统级配置
+    - 不保存店铺级 access_token / refresh_token
+    - 不承载 OMS connection / pull_ready 等业务状态
     """
 
-    __tablename__ = "pdd_app_configs"
+    __tablename__ = "jd_app_configs"
 
     __table_args__ = (
         sa.Index(
-            "ix_pdd_app_configs_is_enabled",
+            "ix_jd_app_configs_is_enabled",
             "is_enabled",
         ),
     )
@@ -49,19 +45,19 @@ class PddAppConfig(Base):
         nullable=False,
     )
 
-    redirect_uri: Mapped[str] = mapped_column(
+    callback_url: Mapped[str] = mapped_column(
         sa.String(512),
         nullable=False,
     )
 
-    api_base_url: Mapped[str] = mapped_column(
-        sa.String(255),
+    gateway_url: Mapped[str] = mapped_column(
+        sa.String(512),
         nullable=False,
-        server_default=sa.text("'https://gw-api.pinduoduo.com/api/router'"),
+        server_default=sa.text("'https://api.jd.com/routerjson'"),
     )
 
     sign_method: Mapped[str] = mapped_column(
-        sa.String(16),
+        sa.String(32),
         nullable=False,
         server_default=sa.text("'md5'"),
     )
@@ -69,7 +65,7 @@ class PddAppConfig(Base):
     is_enabled: Mapped[bool] = mapped_column(
         sa.Boolean,
         nullable=False,
-        server_default=sa.false(),
+        server_default=sa.true(),
     )
 
     created_at: Mapped[datetime] = mapped_column(

--- a/app/oms/platforms/models/jd_order.py
+++ b/app/oms/platforms/models/jd_order.py
@@ -1,3 +1,5 @@
+# app/oms/platforms/models/jd_order.py
+# Domain move: JD order fact ORM belongs to OMS platform order ledger.
 from __future__ import annotations
 
 from datetime import datetime
@@ -11,43 +13,43 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.db.base import Base
 
 
-class TaobaoOrder(Base):
+class JdOrder(Base):
     """
-    淘宝平台订单头事实表（taobao_orders）。
+    京东平台订单头事实表（jd_orders）。
 
     职责：
-    - 保存淘宝平台订单头原生事实字段
+    - 保存 JD 平台订单头原生事实字段
     - 保存收件信息快照
-    - 保存淘宝摘要 / 详情原始 payload
+    - 保存 JD 摘要 / 详情原始 payload
 
     不负责：
     - 保存内部桥接 / 匹配 / 准入 / 建单状态
     - 替代内部 orders 主表
     """
 
-    __tablename__ = "taobao_orders"
+    __tablename__ = "jd_orders"
 
     __table_args__ = (
         sa.UniqueConstraint(
             "store_id",
-            "tid",
-            name="uq_taobao_orders_store_tid",
+            "order_id",
+            name="uq_jd_orders_store_order_id",
         ),
         sa.Index(
-            "ix_taobao_orders_store_id",
+            "ix_jd_orders_store_id",
             "store_id",
         ),
         sa.Index(
-            "ix_taobao_orders_status",
-            "status",
+            "ix_jd_orders_order_state",
+            "order_state",
         ),
         sa.Index(
-            "ix_taobao_orders_created",
-            "created",
+            "ix_jd_orders_order_start_time",
+            "order_start_time",
         ),
         sa.Index(
-            "ix_taobao_orders_pay_time",
-            "pay_time",
+            "ix_jd_orders_modified",
+            "modified",
         ),
     )
 
@@ -64,148 +66,130 @@ class TaobaoOrder(Base):
         comment="OMS 店铺 id（stores.id）",
     )
 
-    tid: Mapped[str] = mapped_column(
+    order_id: Mapped[str] = mapped_column(
         sa.String(64),
         nullable=False,
-        comment="淘宝主订单号 tid",
+        comment="京东主订单号 order_id",
     )
 
-    status: Mapped[str | None] = mapped_column(
+    vender_id: Mapped[str | None] = mapped_column(
         sa.String(64),
         nullable=True,
-        comment="淘宝原始交易状态",
+        comment="京东商家 id / vender_id",
     )
 
-    type: Mapped[str | None] = mapped_column(
+    order_type: Mapped[str | None] = mapped_column(
         sa.String(64),
         nullable=True,
-        comment="淘宝原始交易类型",
+        comment="京东原始订单类型",
     )
 
-    buyer_nick: Mapped[str | None] = mapped_column(
+    order_state: Mapped[str | None] = mapped_column(
+        sa.String(64),
+        nullable=True,
+        comment="京东原始订单状态",
+    )
+
+    buyer_pin: Mapped[str | None] = mapped_column(
         sa.String(128),
         nullable=True,
-        comment="买家昵称",
+        comment="买家标识 buyer_pin",
     )
 
-    buyer_open_uid: Mapped[str | None] = mapped_column(
-        sa.String(128),
-        nullable=True,
-        comment="买家 OpenUID",
-    )
-
-    receiver_name: Mapped[str | None] = mapped_column(
+    consignee_name: Mapped[str | None] = mapped_column(
         sa.String(128),
         nullable=True,
         comment="收件人姓名",
     )
 
-    receiver_mobile: Mapped[str | None] = mapped_column(
+    consignee_mobile: Mapped[str | None] = mapped_column(
         sa.String(64),
         nullable=True,
         comment="收件人手机号",
     )
 
-    receiver_phone: Mapped[str | None] = mapped_column(
+    consignee_phone: Mapped[str | None] = mapped_column(
         sa.String(64),
         nullable=True,
         comment="收件人电话",
     )
 
-    receiver_state: Mapped[str | None] = mapped_column(
+    consignee_province: Mapped[str | None] = mapped_column(
         sa.String(64),
         nullable=True,
         comment="收件省",
     )
 
-    receiver_city: Mapped[str | None] = mapped_column(
+    consignee_city: Mapped[str | None] = mapped_column(
         sa.String(64),
         nullable=True,
         comment="收件市",
     )
 
-    receiver_district: Mapped[str | None] = mapped_column(
+    consignee_county: Mapped[str | None] = mapped_column(
         sa.String(64),
         nullable=True,
         comment="收件区/县",
     )
 
-    receiver_town: Mapped[str | None] = mapped_column(
+    consignee_town: Mapped[str | None] = mapped_column(
         sa.String(64),
         nullable=True,
         comment="收件街道/镇",
     )
 
-    receiver_address: Mapped[str | None] = mapped_column(
+    consignee_address: Mapped[str | None] = mapped_column(
         sa.String(512),
         nullable=True,
         comment="收件详细地址",
     )
 
-    receiver_zip: Mapped[str | None] = mapped_column(
-        sa.String(32),
-        nullable=True,
-        comment="收件邮编",
-    )
-
-    buyer_memo: Mapped[str | None] = mapped_column(
+    order_remark: Mapped[str | None] = mapped_column(
         sa.Text,
         nullable=True,
-        comment="买家备注",
+        comment="订单备注 / 买家备注",
     )
 
-    buyer_message: Mapped[str | None] = mapped_column(
-        sa.Text,
-        nullable=True,
-        comment="买家留言/附言",
-    )
-
-    seller_memo: Mapped[str | None] = mapped_column(
+    seller_remark: Mapped[str | None] = mapped_column(
         sa.Text,
         nullable=True,
         comment="卖家备注",
     )
 
-    seller_flag: Mapped[int | None] = mapped_column(
-        sa.Integer,
-        nullable=True,
-        comment="卖家备注旗帜",
-    )
-
-    payment: Mapped[Decimal | None] = mapped_column(
+    order_total_price: Mapped[Decimal | None] = mapped_column(
         sa.Numeric(14, 2),
         nullable=True,
-        comment="实付金额（元）",
+        comment="订单总金额（元）",
     )
 
-    total_fee: Mapped[Decimal | None] = mapped_column(
+    order_seller_price: Mapped[Decimal | None] = mapped_column(
         sa.Numeric(14, 2),
         nullable=True,
-        comment="应付金额（元）",
+        comment="商家应收金额（元）",
     )
 
-    post_fee: Mapped[Decimal | None] = mapped_column(
+    freight_price: Mapped[Decimal | None] = mapped_column(
         sa.Numeric(14, 2),
         nullable=True,
-        comment="邮费（元）",
+        comment="运费金额（元）",
     )
 
-    coupon_fee: Mapped[Decimal | None] = mapped_column(
-        sa.Numeric(14, 2),
+    payment_confirm: Mapped[str | None] = mapped_column(
+        sa.String(32),
         nullable=True,
-        comment="优惠券金额（元）",
+        comment="付款确认状态",
     )
 
-    created: Mapped[datetime | None] = mapped_column(
+    order_start_time: Mapped[datetime | None] = mapped_column(
         sa.DateTime(timezone=True),
         nullable=True,
-        comment="交易创建时间",
+        comment="下单时间 / 订单开始时间",
     )
 
-    pay_time: Mapped[datetime | None] = mapped_column(
+    order_end_time: Mapped[datetime | None] = mapped_column(
         sa.DateTime(timezone=True),
         nullable=True,
-        comment="付款时间",
+        comment="订单结束时间",
     )
 
     modified: Mapped[datetime | None] = mapped_column(
@@ -217,13 +201,13 @@ class TaobaoOrder(Base):
     raw_summary_payload: Mapped[dict | None] = mapped_column(
         JSONB,
         nullable=True,
-        comment="淘宝摘要接口原始 payload",
+        comment="JD 摘要接口原始 payload",
     )
 
     raw_detail_payload: Mapped[dict | None] = mapped_column(
         JSONB,
         nullable=True,
-        comment="淘宝详情接口原始 payload",
+        comment="JD 详情接口原始 payload",
     )
 
     pulled_at: Mapped[datetime] = mapped_column(
@@ -255,8 +239,8 @@ class TaobaoOrder(Base):
         comment="记录更新时间",
     )
 
-    items: Mapped[List["TaobaoOrderItem"]] = relationship(
-        "TaobaoOrderItem",
+    items: Mapped[List["JdOrderItem"]] = relationship(
+        "JdOrderItem",
         back_populates="order",
         lazy="selectin",
         cascade="all, delete-orphan",
@@ -264,46 +248,39 @@ class TaobaoOrder(Base):
 
     def __repr__(self) -> str:
         return (
-            f"<TaobaoOrder id={self.id} store_id={self.store_id} "
-            f"tid={self.tid} status={self.status}>"
+            f"<JdOrder id={self.id} store_id={self.store_id} "
+            f"order_id={self.order_id} state={self.order_state}>"
         )
 
 
-class TaobaoOrderItem(Base):
+class JdOrderItem(Base):
     """
-    淘宝平台子订单事实表（taobao_order_items）。
+    京东平台订单行事实表（jd_order_items）。
 
     职责：
-    - 保存淘宝子订单原生商品行字段
-    - 保存子订单原始 payload
+    - 保存 JD 平台原始商品行字段
+    - 保存 JD 订单行原始 payload
     """
 
-    __tablename__ = "taobao_order_items"
+    __tablename__ = "jd_order_items"
 
     __table_args__ = (
         sa.UniqueConstraint(
-            "taobao_order_id",
-            "oid",
-            name="uq_taobao_order_items_order_oid",
+            "jd_order_id",
+            "sku_id",
+            "ware_id",
+            name="uq_jd_order_items_order_sku_ware",
         ),
         sa.Index(
-            "ix_taobao_order_items_taobao_order_id",
-            "taobao_order_id",
+            "ix_jd_order_items_jd_order_id",
+            "jd_order_id",
         ),
         sa.Index(
-            "ix_taobao_order_items_tid",
-            "tid",
+            "ix_jd_order_items_order_id",
+            "order_id",
         ),
         sa.Index(
-            "ix_taobao_order_items_oid",
-            "oid",
-        ),
-        sa.Index(
-            "ix_taobao_order_items_outer_iid",
-            "outer_iid",
-        ),
-        sa.Index(
-            "ix_taobao_order_items_outer_sku_id",
+            "ix_jd_order_items_outer_sku_id",
             "outer_sku_id",
         ),
     )
@@ -314,41 +291,23 @@ class TaobaoOrderItem(Base):
         autoincrement=True,
     )
 
-    taobao_order_id: Mapped[int] = mapped_column(
+    jd_order_id: Mapped[int] = mapped_column(
         sa.BigInteger,
-        sa.ForeignKey("taobao_orders.id", ondelete="CASCADE"),
+        sa.ForeignKey("jd_orders.id", ondelete="CASCADE"),
         nullable=False,
-        comment="所属淘宝订单头 id",
+        comment="所属 JD 订单头 id",
     )
 
-    tid: Mapped[str] = mapped_column(
+    order_id: Mapped[str] = mapped_column(
         sa.String(64),
         nullable=False,
-        comment="淘宝主订单号 tid（冗余保存）",
-    )
-
-    oid: Mapped[str] = mapped_column(
-        sa.String(64),
-        nullable=False,
-        comment="淘宝子订单号 oid",
-    )
-
-    num_iid: Mapped[str | None] = mapped_column(
-        sa.String(64),
-        nullable=True,
-        comment="商品数字 ID",
+        comment="京东主订单号（冗余保存）",
     )
 
     sku_id: Mapped[str | None] = mapped_column(
         sa.String(64),
         nullable=True,
-        comment="SKU ID",
-    )
-
-    outer_iid: Mapped[str | None] = mapped_column(
-        sa.String(128),
-        nullable=True,
-        comment="商家外部商品编码",
+        comment="京东 sku_id",
     )
 
     outer_sku_id: Mapped[str | None] = mapped_column(
@@ -357,47 +316,47 @@ class TaobaoOrderItem(Base):
         comment="商家外部 SKU 编码",
     )
 
-    title: Mapped[str | None] = mapped_column(
+    ware_id: Mapped[str | None] = mapped_column(
+        sa.String(64),
+        nullable=True,
+        comment="京东商品 ware_id",
+    )
+
+    item_name: Mapped[str | None] = mapped_column(
         sa.String(255),
         nullable=True,
-        comment="商品标题",
+        comment="商品名称",
     )
 
-    price: Mapped[Decimal | None] = mapped_column(
-        sa.Numeric(14, 2),
-        nullable=True,
-        comment="单价（元）",
-    )
-
-    num: Mapped[int] = mapped_column(
+    item_total: Mapped[int] = mapped_column(
         sa.Integer,
         nullable=False,
         server_default="0",
         comment="购买数量",
     )
 
-    payment: Mapped[Decimal | None] = mapped_column(
+    item_price: Mapped[Decimal | None] = mapped_column(
         sa.Numeric(14, 2),
         nullable=True,
-        comment="子订单实付金额（元）",
+        comment="单价（元）",
     )
 
-    total_fee: Mapped[Decimal | None] = mapped_column(
-        sa.Numeric(14, 2),
-        nullable=True,
-        comment="子订单应付金额（元）",
-    )
-
-    sku_properties_name: Mapped[str | None] = mapped_column(
+    sku_name: Mapped[str | None] = mapped_column(
         sa.Text,
         nullable=True,
-        comment="SKU 属性名串",
+        comment="SKU 规格描述",
+    )
+
+    gift_point: Mapped[int | None] = mapped_column(
+        sa.Integer,
+        nullable=True,
+        comment="是否赠品标识 / gift_point",
     )
 
     raw_item_payload: Mapped[dict | None] = mapped_column(
         JSONB,
         nullable=True,
-        comment="淘宝子订单原始 payload",
+        comment="JD 行原始 payload",
     )
 
     created_at: Mapped[datetime] = mapped_column(
@@ -415,14 +374,14 @@ class TaobaoOrderItem(Base):
         comment="记录更新时间",
     )
 
-    order: Mapped["TaobaoOrder"] = relationship(
-        "TaobaoOrder",
+    order: Mapped["JdOrder"] = relationship(
+        "JdOrder",
         back_populates="items",
         lazy="selectin",
     )
 
     def __repr__(self) -> str:
         return (
-            f"<TaobaoOrderItem id={self.id} taobao_order_id={self.taobao_order_id} "
-            f"oid={self.oid} qty={self.num}>"
+            f"<JdOrderItem id={self.id} jd_order_id={self.jd_order_id} "
+            f"sku_id={self.sku_id} qty={self.item_total}>"
         )

--- a/app/oms/platforms/models/pdd_app_config.py
+++ b/app/oms/platforms/models/pdd_app_config.py
@@ -1,4 +1,5 @@
-# app/models/taobao_app_config.py
+# app/oms/platforms/models/pdd_app_config.py
+# Domain move: PDD app config ORM belongs to OMS platform access.
 from __future__ import annotations
 
 from datetime import datetime
@@ -9,13 +10,13 @@ from sqlalchemy.orm import Mapped, mapped_column
 from app.db.base import Base
 
 
-class TaobaoAppConfig(Base):
+class PddAppConfig(Base):
     """
-    淘宝开放平台系统级应用配置表。
+    拼多多开放平台系统级应用配置表。
 
     职责：
-    - 保存 OMS 系统接入淘宝开放平台所需的应用配置
-    - 保存 app_key / app_secret / callback_url / api_base_url / sign_method
+    - 保存 OMS 系统接入拼多多开放平台所需的应用配置
+    - 保存 client_id / client_secret / redirect_uri / api_base_url / sign_method
     - 保存当前是否启用的配置记录
 
     不负责：
@@ -24,11 +25,11 @@ class TaobaoAppConfig(Base):
     - 店铺 identity
     """
 
-    __tablename__ = "taobao_app_configs"
+    __tablename__ = "pdd_app_configs"
 
     __table_args__ = (
         sa.Index(
-            "ix_taobao_app_configs_is_enabled",
+            "ix_pdd_app_configs_is_enabled",
             "is_enabled",
         ),
     )
@@ -39,17 +40,17 @@ class TaobaoAppConfig(Base):
         autoincrement=True,
     )
 
-    app_key: Mapped[str] = mapped_column(
+    client_id: Mapped[str] = mapped_column(
         sa.String(128),
         nullable=False,
     )
 
-    app_secret: Mapped[str] = mapped_column(
+    client_secret: Mapped[str] = mapped_column(
         sa.Text,
         nullable=False,
     )
 
-    callback_url: Mapped[str] = mapped_column(
+    redirect_uri: Mapped[str] = mapped_column(
         sa.String(512),
         nullable=False,
     )
@@ -57,7 +58,7 @@ class TaobaoAppConfig(Base):
     api_base_url: Mapped[str] = mapped_column(
         sa.String(255),
         nullable=False,
-        server_default=sa.text("'https://eco.taobao.com/router/rest'"),
+        server_default=sa.text("'https://gw-api.pinduoduo.com/api/router'"),
     )
 
     sign_method: Mapped[str] = mapped_column(

--- a/app/oms/platforms/models/pdd_order.py
+++ b/app/oms/platforms/models/pdd_order.py
@@ -1,3 +1,5 @@
+# app/oms/platforms/models/pdd_order.py
+# Domain move: PDD order fact ORM belongs to OMS platform order ledger.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/oms/platforms/models/pdd_order_order_mapping.py
+++ b/app/oms/platforms/models/pdd_order_order_mapping.py
@@ -1,3 +1,5 @@
+# app/oms/platforms/models/pdd_order_order_mapping.py
+# Domain move: PDD order mapping ORM belongs to OMS platform order ledger.
 from __future__ import annotations
 
 from datetime import datetime
@@ -9,8 +11,8 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.db.base import Base
 
 if TYPE_CHECKING:
-    from .order import Order
-    from .pdd_order import PddOrder
+    from app.models.order import Order
+    from app.oms.platforms.models.pdd_order import PddOrder
 
 
 class PddOrderOrderMapping(Base):

--- a/app/oms/platforms/models/store_platform_connection.py
+++ b/app/oms/platforms/models/store_platform_connection.py
@@ -1,4 +1,5 @@
-# app/models/store_platform_connection.py
+# app/oms/platforms/models/store_platform_connection.py
+# Domain move: store platform connection ORM belongs to OMS platform access.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/oms/platforms/models/store_platform_credential.py
+++ b/app/oms/platforms/models/store_platform_credential.py
@@ -1,4 +1,5 @@
-# app/models/store_platform_credential.py
+# app/oms/platforms/models/store_platform_credential.py
+# Domain move: store platform credential ORM belongs to OMS platform access.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/oms/platforms/models/store_token.py
+++ b/app/oms/platforms/models/store_token.py
@@ -1,4 +1,5 @@
-# app/models/store_token.py
+# app/oms/platforms/models/store_token.py
+# Domain move: store token ORM belongs to OMS platform access.
 from __future__ import annotations
 
 from datetime import datetime, timezone

--- a/app/oms/platforms/models/taobao_app_config.py
+++ b/app/oms/platforms/models/taobao_app_config.py
@@ -1,4 +1,5 @@
-# app/models/jd_app_config.py
+# app/oms/platforms/models/taobao_app_config.py
+# Domain move: Taobao app config ORM belongs to OMS platform access.
 from __future__ import annotations
 
 from datetime import datetime
@@ -9,21 +10,26 @@ from sqlalchemy.orm import Mapped, mapped_column
 from app.db.base import Base
 
 
-class JdAppConfig(Base):
+class TaobaoAppConfig(Base):
     """
-    京东平台系统级接入配置（当前态）。
+    淘宝开放平台系统级应用配置表。
 
     职责：
-    - 保存 JD OAuth / JOS 所需系统级配置
-    - 不保存店铺级 access_token / refresh_token
-    - 不承载 OMS connection / pull_ready 等业务状态
+    - 保存 OMS 系统接入淘宝开放平台所需的应用配置
+    - 保存 app_key / app_secret / callback_url / api_base_url / sign_method
+    - 保存当前是否启用的配置记录
+
+    不负责：
+    - 店铺授权材料（access_token / refresh_token）
+    - 店铺接入状态裁决
+    - 店铺 identity
     """
 
-    __tablename__ = "jd_app_configs"
+    __tablename__ = "taobao_app_configs"
 
     __table_args__ = (
         sa.Index(
-            "ix_jd_app_configs_is_enabled",
+            "ix_taobao_app_configs_is_enabled",
             "is_enabled",
         ),
     )
@@ -34,12 +40,12 @@ class JdAppConfig(Base):
         autoincrement=True,
     )
 
-    client_id: Mapped[str] = mapped_column(
+    app_key: Mapped[str] = mapped_column(
         sa.String(128),
         nullable=False,
     )
 
-    client_secret: Mapped[str] = mapped_column(
+    app_secret: Mapped[str] = mapped_column(
         sa.Text,
         nullable=False,
     )
@@ -49,14 +55,14 @@ class JdAppConfig(Base):
         nullable=False,
     )
 
-    gateway_url: Mapped[str] = mapped_column(
-        sa.String(512),
+    api_base_url: Mapped[str] = mapped_column(
+        sa.String(255),
         nullable=False,
-        server_default=sa.text("'https://api.jd.com/routerjson'"),
+        server_default=sa.text("'https://eco.taobao.com/router/rest'"),
     )
 
     sign_method: Mapped[str] = mapped_column(
-        sa.String(32),
+        sa.String(16),
         nullable=False,
         server_default=sa.text("'md5'"),
     )
@@ -64,7 +70,7 @@ class JdAppConfig(Base):
     is_enabled: Mapped[bool] = mapped_column(
         sa.Boolean,
         nullable=False,
-        server_default=sa.true(),
+        server_default=sa.false(),
     )
 
     created_at: Mapped[datetime] = mapped_column(

--- a/app/oms/platforms/models/taobao_order.py
+++ b/app/oms/platforms/models/taobao_order.py
@@ -1,3 +1,5 @@
+# app/oms/platforms/models/taobao_order.py
+# Domain move: Taobao order fact ORM belongs to OMS platform order ledger.
 from __future__ import annotations
 
 from datetime import datetime
@@ -11,43 +13,43 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.db.base import Base
 
 
-class JdOrder(Base):
+class TaobaoOrder(Base):
     """
-    京东平台订单头事实表（jd_orders）。
+    淘宝平台订单头事实表（taobao_orders）。
 
     职责：
-    - 保存 JD 平台订单头原生事实字段
+    - 保存淘宝平台订单头原生事实字段
     - 保存收件信息快照
-    - 保存 JD 摘要 / 详情原始 payload
+    - 保存淘宝摘要 / 详情原始 payload
 
     不负责：
     - 保存内部桥接 / 匹配 / 准入 / 建单状态
     - 替代内部 orders 主表
     """
 
-    __tablename__ = "jd_orders"
+    __tablename__ = "taobao_orders"
 
     __table_args__ = (
         sa.UniqueConstraint(
             "store_id",
-            "order_id",
-            name="uq_jd_orders_store_order_id",
+            "tid",
+            name="uq_taobao_orders_store_tid",
         ),
         sa.Index(
-            "ix_jd_orders_store_id",
+            "ix_taobao_orders_store_id",
             "store_id",
         ),
         sa.Index(
-            "ix_jd_orders_order_state",
-            "order_state",
+            "ix_taobao_orders_status",
+            "status",
         ),
         sa.Index(
-            "ix_jd_orders_order_start_time",
-            "order_start_time",
+            "ix_taobao_orders_created",
+            "created",
         ),
         sa.Index(
-            "ix_jd_orders_modified",
-            "modified",
+            "ix_taobao_orders_pay_time",
+            "pay_time",
         ),
     )
 
@@ -64,130 +66,148 @@ class JdOrder(Base):
         comment="OMS 店铺 id（stores.id）",
     )
 
-    order_id: Mapped[str] = mapped_column(
+    tid: Mapped[str] = mapped_column(
         sa.String(64),
         nullable=False,
-        comment="京东主订单号 order_id",
+        comment="淘宝主订单号 tid",
     )
 
-    vender_id: Mapped[str | None] = mapped_column(
+    status: Mapped[str | None] = mapped_column(
         sa.String(64),
         nullable=True,
-        comment="京东商家 id / vender_id",
+        comment="淘宝原始交易状态",
     )
 
-    order_type: Mapped[str | None] = mapped_column(
+    type: Mapped[str | None] = mapped_column(
         sa.String(64),
         nullable=True,
-        comment="京东原始订单类型",
+        comment="淘宝原始交易类型",
     )
 
-    order_state: Mapped[str | None] = mapped_column(
-        sa.String(64),
-        nullable=True,
-        comment="京东原始订单状态",
-    )
-
-    buyer_pin: Mapped[str | None] = mapped_column(
+    buyer_nick: Mapped[str | None] = mapped_column(
         sa.String(128),
         nullable=True,
-        comment="买家标识 buyer_pin",
+        comment="买家昵称",
     )
 
-    consignee_name: Mapped[str | None] = mapped_column(
+    buyer_open_uid: Mapped[str | None] = mapped_column(
+        sa.String(128),
+        nullable=True,
+        comment="买家 OpenUID",
+    )
+
+    receiver_name: Mapped[str | None] = mapped_column(
         sa.String(128),
         nullable=True,
         comment="收件人姓名",
     )
 
-    consignee_mobile: Mapped[str | None] = mapped_column(
+    receiver_mobile: Mapped[str | None] = mapped_column(
         sa.String(64),
         nullable=True,
         comment="收件人手机号",
     )
 
-    consignee_phone: Mapped[str | None] = mapped_column(
+    receiver_phone: Mapped[str | None] = mapped_column(
         sa.String(64),
         nullable=True,
         comment="收件人电话",
     )
 
-    consignee_province: Mapped[str | None] = mapped_column(
+    receiver_state: Mapped[str | None] = mapped_column(
         sa.String(64),
         nullable=True,
         comment="收件省",
     )
 
-    consignee_city: Mapped[str | None] = mapped_column(
+    receiver_city: Mapped[str | None] = mapped_column(
         sa.String(64),
         nullable=True,
         comment="收件市",
     )
 
-    consignee_county: Mapped[str | None] = mapped_column(
+    receiver_district: Mapped[str | None] = mapped_column(
         sa.String(64),
         nullable=True,
         comment="收件区/县",
     )
 
-    consignee_town: Mapped[str | None] = mapped_column(
+    receiver_town: Mapped[str | None] = mapped_column(
         sa.String(64),
         nullable=True,
         comment="收件街道/镇",
     )
 
-    consignee_address: Mapped[str | None] = mapped_column(
+    receiver_address: Mapped[str | None] = mapped_column(
         sa.String(512),
         nullable=True,
         comment="收件详细地址",
     )
 
-    order_remark: Mapped[str | None] = mapped_column(
-        sa.Text,
+    receiver_zip: Mapped[str | None] = mapped_column(
+        sa.String(32),
         nullable=True,
-        comment="订单备注 / 买家备注",
+        comment="收件邮编",
     )
 
-    seller_remark: Mapped[str | None] = mapped_column(
+    buyer_memo: Mapped[str | None] = mapped_column(
+        sa.Text,
+        nullable=True,
+        comment="买家备注",
+    )
+
+    buyer_message: Mapped[str | None] = mapped_column(
+        sa.Text,
+        nullable=True,
+        comment="买家留言/附言",
+    )
+
+    seller_memo: Mapped[str | None] = mapped_column(
         sa.Text,
         nullable=True,
         comment="卖家备注",
     )
 
-    order_total_price: Mapped[Decimal | None] = mapped_column(
+    seller_flag: Mapped[int | None] = mapped_column(
+        sa.Integer,
+        nullable=True,
+        comment="卖家备注旗帜",
+    )
+
+    payment: Mapped[Decimal | None] = mapped_column(
         sa.Numeric(14, 2),
         nullable=True,
-        comment="订单总金额（元）",
+        comment="实付金额（元）",
     )
 
-    order_seller_price: Mapped[Decimal | None] = mapped_column(
+    total_fee: Mapped[Decimal | None] = mapped_column(
         sa.Numeric(14, 2),
         nullable=True,
-        comment="商家应收金额（元）",
+        comment="应付金额（元）",
     )
 
-    freight_price: Mapped[Decimal | None] = mapped_column(
+    post_fee: Mapped[Decimal | None] = mapped_column(
         sa.Numeric(14, 2),
         nullable=True,
-        comment="运费金额（元）",
+        comment="邮费（元）",
     )
 
-    payment_confirm: Mapped[str | None] = mapped_column(
-        sa.String(32),
+    coupon_fee: Mapped[Decimal | None] = mapped_column(
+        sa.Numeric(14, 2),
         nullable=True,
-        comment="付款确认状态",
+        comment="优惠券金额（元）",
     )
 
-    order_start_time: Mapped[datetime | None] = mapped_column(
+    created: Mapped[datetime | None] = mapped_column(
         sa.DateTime(timezone=True),
         nullable=True,
-        comment="下单时间 / 订单开始时间",
+        comment="交易创建时间",
     )
 
-    order_end_time: Mapped[datetime | None] = mapped_column(
+    pay_time: Mapped[datetime | None] = mapped_column(
         sa.DateTime(timezone=True),
         nullable=True,
-        comment="订单结束时间",
+        comment="付款时间",
     )
 
     modified: Mapped[datetime | None] = mapped_column(
@@ -199,13 +219,13 @@ class JdOrder(Base):
     raw_summary_payload: Mapped[dict | None] = mapped_column(
         JSONB,
         nullable=True,
-        comment="JD 摘要接口原始 payload",
+        comment="淘宝摘要接口原始 payload",
     )
 
     raw_detail_payload: Mapped[dict | None] = mapped_column(
         JSONB,
         nullable=True,
-        comment="JD 详情接口原始 payload",
+        comment="淘宝详情接口原始 payload",
     )
 
     pulled_at: Mapped[datetime] = mapped_column(
@@ -237,8 +257,8 @@ class JdOrder(Base):
         comment="记录更新时间",
     )
 
-    items: Mapped[List["JdOrderItem"]] = relationship(
-        "JdOrderItem",
+    items: Mapped[List["TaobaoOrderItem"]] = relationship(
+        "TaobaoOrderItem",
         back_populates="order",
         lazy="selectin",
         cascade="all, delete-orphan",
@@ -246,39 +266,46 @@ class JdOrder(Base):
 
     def __repr__(self) -> str:
         return (
-            f"<JdOrder id={self.id} store_id={self.store_id} "
-            f"order_id={self.order_id} state={self.order_state}>"
+            f"<TaobaoOrder id={self.id} store_id={self.store_id} "
+            f"tid={self.tid} status={self.status}>"
         )
 
 
-class JdOrderItem(Base):
+class TaobaoOrderItem(Base):
     """
-    京东平台订单行事实表（jd_order_items）。
+    淘宝平台子订单事实表（taobao_order_items）。
 
     职责：
-    - 保存 JD 平台原始商品行字段
-    - 保存 JD 订单行原始 payload
+    - 保存淘宝子订单原生商品行字段
+    - 保存子订单原始 payload
     """
 
-    __tablename__ = "jd_order_items"
+    __tablename__ = "taobao_order_items"
 
     __table_args__ = (
         sa.UniqueConstraint(
-            "jd_order_id",
-            "sku_id",
-            "ware_id",
-            name="uq_jd_order_items_order_sku_ware",
+            "taobao_order_id",
+            "oid",
+            name="uq_taobao_order_items_order_oid",
         ),
         sa.Index(
-            "ix_jd_order_items_jd_order_id",
-            "jd_order_id",
+            "ix_taobao_order_items_taobao_order_id",
+            "taobao_order_id",
         ),
         sa.Index(
-            "ix_jd_order_items_order_id",
-            "order_id",
+            "ix_taobao_order_items_tid",
+            "tid",
         ),
         sa.Index(
-            "ix_jd_order_items_outer_sku_id",
+            "ix_taobao_order_items_oid",
+            "oid",
+        ),
+        sa.Index(
+            "ix_taobao_order_items_outer_iid",
+            "outer_iid",
+        ),
+        sa.Index(
+            "ix_taobao_order_items_outer_sku_id",
             "outer_sku_id",
         ),
     )
@@ -289,23 +316,41 @@ class JdOrderItem(Base):
         autoincrement=True,
     )
 
-    jd_order_id: Mapped[int] = mapped_column(
+    taobao_order_id: Mapped[int] = mapped_column(
         sa.BigInteger,
-        sa.ForeignKey("jd_orders.id", ondelete="CASCADE"),
+        sa.ForeignKey("taobao_orders.id", ondelete="CASCADE"),
         nullable=False,
-        comment="所属 JD 订单头 id",
+        comment="所属淘宝订单头 id",
     )
 
-    order_id: Mapped[str] = mapped_column(
+    tid: Mapped[str] = mapped_column(
         sa.String(64),
         nullable=False,
-        comment="京东主订单号（冗余保存）",
+        comment="淘宝主订单号 tid（冗余保存）",
+    )
+
+    oid: Mapped[str] = mapped_column(
+        sa.String(64),
+        nullable=False,
+        comment="淘宝子订单号 oid",
+    )
+
+    num_iid: Mapped[str | None] = mapped_column(
+        sa.String(64),
+        nullable=True,
+        comment="商品数字 ID",
     )
 
     sku_id: Mapped[str | None] = mapped_column(
         sa.String(64),
         nullable=True,
-        comment="京东 sku_id",
+        comment="SKU ID",
+    )
+
+    outer_iid: Mapped[str | None] = mapped_column(
+        sa.String(128),
+        nullable=True,
+        comment="商家外部商品编码",
     )
 
     outer_sku_id: Mapped[str | None] = mapped_column(
@@ -314,47 +359,47 @@ class JdOrderItem(Base):
         comment="商家外部 SKU 编码",
     )
 
-    ware_id: Mapped[str | None] = mapped_column(
-        sa.String(64),
-        nullable=True,
-        comment="京东商品 ware_id",
-    )
-
-    item_name: Mapped[str | None] = mapped_column(
+    title: Mapped[str | None] = mapped_column(
         sa.String(255),
         nullable=True,
-        comment="商品名称",
+        comment="商品标题",
     )
 
-    item_total: Mapped[int] = mapped_column(
+    price: Mapped[Decimal | None] = mapped_column(
+        sa.Numeric(14, 2),
+        nullable=True,
+        comment="单价（元）",
+    )
+
+    num: Mapped[int] = mapped_column(
         sa.Integer,
         nullable=False,
         server_default="0",
         comment="购买数量",
     )
 
-    item_price: Mapped[Decimal | None] = mapped_column(
+    payment: Mapped[Decimal | None] = mapped_column(
         sa.Numeric(14, 2),
         nullable=True,
-        comment="单价（元）",
+        comment="子订单实付金额（元）",
     )
 
-    sku_name: Mapped[str | None] = mapped_column(
+    total_fee: Mapped[Decimal | None] = mapped_column(
+        sa.Numeric(14, 2),
+        nullable=True,
+        comment="子订单应付金额（元）",
+    )
+
+    sku_properties_name: Mapped[str | None] = mapped_column(
         sa.Text,
         nullable=True,
-        comment="SKU 规格描述",
-    )
-
-    gift_point: Mapped[int | None] = mapped_column(
-        sa.Integer,
-        nullable=True,
-        comment="是否赠品标识 / gift_point",
+        comment="SKU 属性名串",
     )
 
     raw_item_payload: Mapped[dict | None] = mapped_column(
         JSONB,
         nullable=True,
-        comment="JD 行原始 payload",
+        comment="淘宝子订单原始 payload",
     )
 
     created_at: Mapped[datetime] = mapped_column(
@@ -372,14 +417,14 @@ class JdOrderItem(Base):
         comment="记录更新时间",
     )
 
-    order: Mapped["JdOrder"] = relationship(
-        "JdOrder",
+    order: Mapped["TaobaoOrder"] = relationship(
+        "TaobaoOrder",
         back_populates="items",
         lazy="selectin",
     )
 
     def __repr__(self) -> str:
         return (
-            f"<JdOrderItem id={self.id} jd_order_id={self.jd_order_id} "
-            f"sku_id={self.sku_id} qty={self.item_total}>"
+            f"<TaobaoOrderItem id={self.id} taobao_order_id={self.taobao_order_id} "
+            f"oid={self.oid} qty={self.num}>"
         )

--- a/app/oms/platforms/pdd/access_repository.py
+++ b/app/oms/platforms/pdd/access_repository.py
@@ -8,8 +8,8 @@ from typing import Optional
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.store_platform_connection import StorePlatformConnection
-from app.models.store_platform_credential import StorePlatformCredential
+from app.oms.platforms.models.store_platform_connection import StorePlatformConnection
+from app.oms.platforms.models.store_platform_credential import StorePlatformCredential
 
 
 def _norm_platform(platform: str) -> str:

--- a/app/oms/platforms/pdd/repo_orders.py
+++ b/app/oms/platforms/pdd/repo_orders.py
@@ -7,8 +7,8 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.models.pdd_order import PddOrder, PddOrderItem
-from app.models.pdd_order_order_mapping import PddOrderOrderMapping
+from app.oms.platforms.models.pdd_order import PddOrder, PddOrderItem
+from app.oms.platforms.models.pdd_order_order_mapping import PddOrderOrderMapping
 from app.oms.platforms.pdd.contracts import PddOrderDetail
 
 

--- a/app/oms/platforms/pdd/repository.py
+++ b/app/oms/platforms/pdd/repository.py
@@ -7,7 +7,7 @@ from typing import Optional
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.pdd_app_config import PddAppConfig
+from app.oms.platforms.models.pdd_app_config import PddAppConfig
 
 from .settings import DEFAULT_PDD_API_BASE_URL, DEFAULT_PDD_SIGN_METHOD
 

--- a/app/oms/platforms/pdd/service_ingest.py
+++ b/app/oms/platforms/pdd/service_ingest.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.pdd_order import PddOrder
+from app.oms.platforms.models.pdd_order import PddOrder
 from app.oms.platforms.pdd.contracts import PddOrderSummary
 from app.oms.platforms.pdd.repo_orders import (
     load_shop_id_by_store_id_for_pdd,

--- a/app/oms/platforms/pdd/service_ledger.py
+++ b/app/oms/platforms/pdd/service_ledger.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import List
 
-from app.models.pdd_order import PddOrder, PddOrderItem
+from app.oms.platforms.models.pdd_order import PddOrder, PddOrderItem
 from app.oms.platforms.pdd.contracts_ledger import (
     PddOrderLedgerDetailOut,
     PddOrderLedgerItemOut,

--- a/app/oms/platforms/pdd/service_mock.py
+++ b/app/oms/platforms/pdd/service_mock.py
@@ -9,9 +9,9 @@ from uuid import uuid4
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.pdd_order import PddOrder, PddOrderItem
-from app.models.store_platform_connection import StorePlatformConnection
-from app.models.store_platform_credential import StorePlatformCredential
+from app.oms.platforms.models.pdd_order import PddOrder, PddOrderItem
+from app.oms.platforms.models.store_platform_connection import StorePlatformConnection
+from app.oms.platforms.models.store_platform_credential import StorePlatformCredential
 
 from .access_repository import (
     ConnectionUpsertInput,

--- a/app/oms/platforms/pdd/services/pdd_auth_service.py
+++ b/app/oms/platforms/pdd/services/pdd_auth_service.py
@@ -10,7 +10,7 @@ import httpx
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.store_token import StoreToken
+from app.oms.platforms.models.store_token import StoreToken
 
 # ===== 配置：先用环境变量，后面你可以接到自己的 settings 体系 =====
 PDD_CLIENT_ID = os.getenv("PDD_CLIENT_ID", "")

--- a/app/oms/platforms/pdd/settings.py
+++ b/app/oms/platforms/pdd/settings.py
@@ -5,7 +5,7 @@ import os
 from dataclasses import dataclass
 from typing import Mapping, Optional
 
-from app.models.pdd_app_config import PddAppConfig
+from app.oms.platforms.models.pdd_app_config import PddAppConfig
 
 
 DEFAULT_PDD_API_BASE_URL = "https://gw-api.pinduoduo.com/api/router"

--- a/app/oms/platforms/taobao/repo_orders.py
+++ b/app/oms/platforms/taobao/repo_orders.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.models.taobao_order import TaobaoOrder
+from app.oms.platforms.models.taobao_order import TaobaoOrder
 
 
 async def list_taobao_orders(

--- a/app/oms/platforms/taobao/repository.py
+++ b/app/oms/platforms/taobao/repository.py
@@ -8,9 +8,9 @@ from typing import Optional
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.store_platform_connection import StorePlatformConnection
-from app.models.store_platform_credential import StorePlatformCredential
-from app.models.taobao_app_config import TaobaoAppConfig
+from app.oms.platforms.models.store_platform_connection import StorePlatformConnection
+from app.oms.platforms.models.store_platform_credential import StorePlatformCredential
+from app.oms.platforms.models.taobao_app_config import TaobaoAppConfig
 
 
 def _norm_platform(platform: str) -> str:

--- a/app/oms/platforms/taobao/service_ledger.py
+++ b/app/oms/platforms/taobao/service_ledger.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import List
 
-from app.models.taobao_order import TaobaoOrder, TaobaoOrderItem
+from app.oms.platforms.models.taobao_order import TaobaoOrder, TaobaoOrderItem
 from app.oms.platforms.taobao.contracts_ledger import (
     TaobaoOrderLedgerDetailOut,
     TaobaoOrderLedgerItemOut,

--- a/app/oms/platforms/taobao/settings.py
+++ b/app/oms/platforms/taobao/settings.py
@@ -5,7 +5,7 @@ import os
 from dataclasses import dataclass
 from typing import Mapping, Optional
 
-from app.models.taobao_app_config import TaobaoAppConfig
+from app.oms.platforms.models.taobao_app_config import TaobaoAppConfig
 
 from .errors import TaobaoTopConfigError
 

--- a/tests/api/test_jd_connection_contract.py
+++ b/tests/api/test_jd_connection_contract.py
@@ -5,8 +5,8 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from sqlalchemy import text
 
-from app.models.store_platform_connection import StorePlatformConnection
-from app.models.store_platform_credential import StorePlatformCredential
+from app.oms.platforms.models.store_platform_connection import StorePlatformConnection
+from app.oms.platforms.models.store_platform_credential import StorePlatformCredential
 
 
 pytestmark = pytest.mark.asyncio

--- a/tests/api/test_jd_orders_contract.py
+++ b/tests/api/test_jd_orders_contract.py
@@ -8,7 +8,7 @@ from sqlalchemy import text
 
 from app.user.deps.auth import get_current_user
 from app.main import app
-from app.models.jd_order import JdOrder, JdOrderItem
+from app.oms.platforms.models.jd_order import JdOrder, JdOrderItem
 import app.oms.platforms.jd.router_orders as jd_router_orders
 
 

--- a/tests/api/test_pdd_connection_and_pull_contract.py
+++ b/tests/api/test_pdd_connection_and_pull_contract.py
@@ -7,9 +7,9 @@ from sqlalchemy import text
 
 from app.user.deps.auth import get_current_user
 from app.main import app
-from app.models.pdd_app_config import PddAppConfig
-from app.models.store_platform_connection import StorePlatformConnection
-from app.models.store_platform_credential import StorePlatformCredential
+from app.oms.platforms.models.pdd_app_config import PddAppConfig
+from app.oms.platforms.models.store_platform_connection import StorePlatformConnection
+from app.oms.platforms.models.store_platform_credential import StorePlatformCredential
 
 
 class _TestUser:

--- a/tests/unit/test_jd_ledger_service.py
+++ b/tests/unit/test_jd_ledger_service.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 import pytest
 
-from app.models.jd_order import JdOrder, JdOrderItem
+from app.oms.platforms.models.jd_order import JdOrder, JdOrderItem
 from app.oms.platforms.jd import service_ledger as jd_ledger_module
 
 

--- a/tests/unit/test_jd_pull_service.py
+++ b/tests/unit/test_jd_pull_service.py
@@ -5,8 +5,8 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from sqlalchemy import text
 
-from app.models.jd_app_config import JdAppConfig
-from app.models.store_platform_credential import StorePlatformCredential
+from app.oms.platforms.models.jd_app_config import JdAppConfig
+from app.oms.platforms.models.store_platform_credential import StorePlatformCredential
 from app.oms.platforms.jd import service_pull as jd_pull_module
 from app.oms.platforms.jd.service_order_detail import (
     JdOrderDetail,

--- a/tests/unit/test_pdd_pull_service.py
+++ b/tests/unit/test_pdd_pull_service.py
@@ -5,9 +5,9 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from sqlalchemy import text
 
-from app.models.pdd_app_config import PddAppConfig
-from app.models.store_platform_connection import StorePlatformConnection
-from app.models.store_platform_credential import StorePlatformCredential
+from app.oms.platforms.models.pdd_app_config import PddAppConfig
+from app.oms.platforms.models.store_platform_connection import StorePlatformConnection
+from app.oms.platforms.models.store_platform_credential import StorePlatformCredential
 from app.oms.platforms.pdd.service_pull import PddPullService
 
 

--- a/tests/unit/test_pdd_settings_resolution.py
+++ b/tests/unit/test_pdd_settings_resolution.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 
 import pytest
 
-from app.models.pdd_app_config import PddAppConfig
+from app.oms.platforms.models.pdd_app_config import PddAppConfig
 from app.oms.platforms.pdd.repository import get_enabled_pdd_app_config
 from app.oms.platforms.pdd.settings import (
     PddOpenConfigError,

--- a/tests/unit/test_taobao_settings_resolution.py
+++ b/tests/unit/test_taobao_settings_resolution.py
@@ -3,14 +3,24 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 import pytest
+from sqlalchemy import text
 
-from app.models.taobao_app_config import TaobaoAppConfig
+from app.oms.platforms.models.taobao_app_config import TaobaoAppConfig
 from app.oms.platforms.taobao.errors import TaobaoTopConfigError
 from app.oms.platforms.taobao.repository import get_enabled_taobao_app_config
 from app.oms.platforms.taobao.settings import (
     build_taobao_callback_url_from_model,
     build_taobao_top_config_from_model,
 )
+
+
+@pytest.fixture(autouse=True)
+async def _clean_taobao_app_configs(session):
+    await session.execute(text("DELETE FROM taobao_app_configs"))
+    await session.commit()
+    yield
+    await session.execute(text("DELETE FROM taobao_app_configs"))
+    await session.commit()
 
 
 def _row(


### PR DESCRIPTION
## Summary
- move OMS platform app config, credential, connection, token, and platform order ORM models to app/oms/platforms/models
- update OMS platform imports and model registry paths
- add app.oms.platforms.models to ORM discovery
- fix Taobao settings unit test isolation for taobao_app_configs

## Validation
- python3 -m compileall app tests
- make alembic-check
- make test TESTS="tests/unit/test_pdd_pull_service.py tests/unit/test_jd_pull_service.py tests/unit/test_taobao_settings_resolution.py tests/unit/test_pdd_settings_resolution.py tests/api/test_pdd_connection_and_pull_contract.py tests/api/test_jd_connection_contract.py tests/api/test_jd_orders_contract.py tests/api/test_pdd_app_config_contract.py tests/api/test_jd_app_config_contract.py tests/api/test_taobao_app_config_contract.py tests/api/test_pdd_oauth_contract.py tests/api/test_jd_oauth_start_contract.py"