### PR TITLE
chore(oms): move fsku models to domain package

### DIFF
--- a/app/db/base.py
+++ b/app/db/base.py
@@ -143,6 +143,7 @@ def init_models(
         "app.tms.records.models",
         "app.tms.billing.models",
         "app.oms.platforms.models",
+        "app.oms.fsku.models",
     ):
         for mod in _iter_model_modules_recursive(pkg_name):
             if mod in ex or mod in loaded:

--- a/app/oms/fsku/models/__init__.py
+++ b/app/oms/fsku/models/__init__.py
@@ -1,0 +1,11 @@
+# app/oms/fsku/models/__init__.py
+# Domain-owned ORM models for OMS FSKU.
+
+from app.oms.fsku.models.fsku import Fsku, FskuComponent
+from app.oms.fsku.models.merchant_code_fsku_binding import MerchantCodeFskuBinding
+
+__all__ = [
+    "Fsku",
+    "FskuComponent",
+    "MerchantCodeFskuBinding",
+]

--- a/app/oms/fsku/models/fsku.py
+++ b/app/oms/fsku/models/fsku.py
@@ -1,4 +1,5 @@
-# app/models/fsku.py
+# app/oms/fsku/models/fsku.py
+# Domain move: FSKU ORM belongs to OMS FSKU.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/oms/fsku/models/merchant_code_fsku_binding.py
+++ b/app/oms/fsku/models/merchant_code_fsku_binding.py
@@ -1,4 +1,5 @@
-# app/models/merchant_code_fsku_binding.py
+# app/oms/fsku/models/merchant_code_fsku_binding.py
+# Domain move: merchant code binding ORM belongs to OMS FSKU.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/oms/fsku/router_merchant_code_bindings.py
+++ b/app/oms/fsku/router_merchant_code_bindings.py
@@ -17,8 +17,8 @@ from app.oms.fsku.contracts.merchant_code_bindings import (
     MerchantCodeBindingRowOut,
     StoreLiteOut,
 )
-from app.models.fsku import Fsku
-from app.models.merchant_code_fsku_binding import MerchantCodeFskuBinding
+from app.oms.fsku.models.fsku import Fsku
+from app.oms.fsku.models.merchant_code_fsku_binding import MerchantCodeFskuBinding
 from app.models.store import Store
 from app.oms.fsku.services.merchant_code_binding_service import MerchantCodeBindingService
 from app.oms.services.platform_order_resolve_service import norm_platform, norm_shop_id

--- a/app/oms/fsku/services/fsku_service_mapper.py
+++ b/app/oms/fsku/services/fsku_service_mapper.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from app.oms.fsku.contracts.fsku import FskuComponentOut, FskuDetailOut
-from app.models.fsku import Fsku, FskuComponent
+from app.oms.fsku.models.fsku import Fsku, FskuComponent
 
 
 def to_detail(f: Fsku, components: list[FskuComponent]) -> FskuDetailOut:

--- a/app/oms/fsku/services/fsku_service_read.py
+++ b/app/oms/fsku/services/fsku_service_read.py
@@ -7,7 +7,7 @@ from sqlalchemy import select, text
 from sqlalchemy.orm import Session
 
 from app.oms.fsku.contracts.fsku import FskuDetailOut, FskuListItem, FskuListOut
-from app.models.fsku import Fsku, FskuComponent
+from app.oms.fsku.models.fsku import Fsku, FskuComponent
 from app.oms.fsku.services.fsku_service_mapper import to_detail
 
 

--- a/app/oms/fsku/services/fsku_service_write.py
+++ b/app/oms/fsku/services/fsku_service_write.py
@@ -9,7 +9,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.oms.fsku.contracts.fsku import FskuComponentIn, FskuDetailOut
-from app.models.fsku import Fsku, FskuComponent
+from app.oms.fsku.models.fsku import Fsku, FskuComponent
 from app.oms.fsku.services.fsku_service_errors import FskuBadInput, FskuConflict, FskuNotFound
 from app.oms.fsku.services.fsku_service_mapper import to_detail
 from app.oms.fsku.services.fsku_service_utils import normalize_code, normalize_shape, utc_now

--- a/app/oms/fsku/services/merchant_code_binding_service.py
+++ b/app/oms/fsku/services/merchant_code_binding_service.py
@@ -8,8 +8,8 @@ from typing import Optional
 from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.fsku import Fsku
-from app.models.merchant_code_fsku_binding import MerchantCodeFskuBinding
+from app.oms.fsku.models.fsku import Fsku
+from app.oms.fsku.models.merchant_code_fsku_binding import MerchantCodeFskuBinding
 
 
 def _utc_now() -> datetime:


### PR DESCRIPTION
## Summary
- move FSKU and merchant-code binding ORM models to app/oms/fsku/models
- update OMS FSKU imports
- add app.oms.fsku.models to ORM discovery

## Validation
- python3 -m compileall app tests
- make alembic-check
- make test TESTS="tests/api/test_fskus_contract.py tests/api/test_merchant_code_bindings_contract.py tests/services/test_platform_order_line_key_format_contract.py tests/api/test_platform_orders_replay_contract.py tests/api/test_platform_orders_ingest_next_actions_contract.py"