### PR TITLE
chore(tms): move pricing template models to domain package

### DIFF
--- a/app/db/base.py
+++ b/app/db/base.py
@@ -144,6 +144,7 @@ def init_models(
         "app.tms.billing.models",
         "app.oms.platforms.models",
         "app.oms.fsku.models",
+        "app.tms.pricing.templates.models",
     ):
         for mod in _iter_model_modules_recursive(pkg_name):
             if mod in ex or mod in loaded:

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -127,31 +127,31 @@ MODEL_SPECS = [
     # 运价模板（新主线：template -> ranges/groups -> matrix + surcharge_config）
     # ------------------------------------------------------------------
     (
-        "app.models.shipping_provider_pricing_template_surcharge_config_city",
+        "app.tms.pricing.templates.models.shipping_provider_pricing_template_surcharge_config_city",
         "ShippingProviderPricingTemplateSurchargeConfigCity",
     ),
     (
-        "app.models.shipping_provider_pricing_template_surcharge_config",
+        "app.tms.pricing.templates.models.shipping_provider_pricing_template_surcharge_config",
         "ShippingProviderPricingTemplateSurchargeConfig",
     ),
-    ("app.models.shipping_provider_pricing_template", "ShippingProviderPricingTemplate"),
+    ("app.tms.pricing.templates.models.shipping_provider_pricing_template", "ShippingProviderPricingTemplate"),
     (
-        "app.models.shipping_provider_pricing_template_validation_record",
+        "app.tms.pricing.templates.models.shipping_provider_pricing_template_validation_record",
         "ShippingProviderPricingTemplateValidationRecord",
     ),
     (
-        "app.models.shipping_provider_pricing_template_module_range",
+        "app.tms.pricing.templates.models.shipping_provider_pricing_template_module_range",
         "ShippingProviderPricingTemplateModuleRange",
     ),
     (
-        "app.models.shipping_provider_pricing_template_destination_group",
+        "app.tms.pricing.templates.models.shipping_provider_pricing_template_destination_group",
         "ShippingProviderPricingTemplateDestinationGroup",
     ),
     (
-        "app.models.shipping_provider_pricing_template_destination_group_member",
+        "app.tms.pricing.templates.models.shipping_provider_pricing_template_destination_group_member",
         "ShippingProviderPricingTemplateDestinationGroupMember",
     ),
-    ("app.models.shipping_provider_pricing_template_matrix", "ShippingProviderPricingTemplateMatrix"),
+    ("app.tms.pricing.templates.models.shipping_provider_pricing_template_matrix", "ShippingProviderPricingTemplateMatrix"),
     # ------------------------------------------------------------------
     # 运价实例（终态主线：scheme -> ranges/groups -> pricing_matrix + surcharge_config）
     # ------------------------------------------------------------------

--- a/app/tms/pricing/templates/groups/routes.py
+++ b/app/tms/pricing/templates/groups/routes.py
@@ -7,10 +7,10 @@ from sqlalchemy.orm import Session
 
 from app.user.deps.auth import get_current_user
 from app.db.deps import get_db
-from app.models.shipping_provider_pricing_template_destination_group import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_destination_group import (
     ShippingProviderPricingTemplateDestinationGroup,
 )
-from app.models.shipping_provider_pricing_template_destination_group_member import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_destination_group_member import (
     ShippingProviderPricingTemplateDestinationGroupMember,
 )
 from app.tms.permissions import check_config_perm

--- a/app/tms/pricing/templates/matrix/routes.py
+++ b/app/tms/pricing/templates/matrix/routes.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 
 from app.user.deps.auth import get_current_user
 from app.db.deps import get_db
-from app.models.shipping_provider_pricing_template_matrix import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_matrix import (
     ShippingProviderPricingTemplateMatrix,
 )
 from app.tms.permissions import check_config_perm

--- a/app/tms/pricing/templates/models/__init__.py
+++ b/app/tms/pricing/templates/models/__init__.py
@@ -1,0 +1,38 @@
+# app/tms/pricing/templates/models/__init__.py
+# Domain-owned ORM models for TMS pricing templates.
+
+from app.tms.pricing.templates.models.shipping_provider_pricing_template import (
+    ShippingProviderPricingTemplate,
+)
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_destination_group import (
+    ShippingProviderPricingTemplateDestinationGroup,
+)
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_destination_group_member import (
+    ShippingProviderPricingTemplateDestinationGroupMember,
+)
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_matrix import (
+    ShippingProviderPricingTemplateMatrix,
+)
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_module_range import (
+    ShippingProviderPricingTemplateModuleRange,
+)
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_surcharge_config import (
+    ShippingProviderPricingTemplateSurchargeConfig,
+)
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_surcharge_config_city import (
+    ShippingProviderPricingTemplateSurchargeConfigCity,
+)
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_validation_record import (
+    ShippingProviderPricingTemplateValidationRecord,
+)
+
+__all__ = [
+    "ShippingProviderPricingTemplate",
+    "ShippingProviderPricingTemplateDestinationGroup",
+    "ShippingProviderPricingTemplateDestinationGroupMember",
+    "ShippingProviderPricingTemplateMatrix",
+    "ShippingProviderPricingTemplateModuleRange",
+    "ShippingProviderPricingTemplateSurchargeConfig",
+    "ShippingProviderPricingTemplateSurchargeConfigCity",
+    "ShippingProviderPricingTemplateValidationRecord",
+]

--- a/app/tms/pricing/templates/models/shipping_provider_pricing_template.py
+++ b/app/tms/pricing/templates/models/shipping_provider_pricing_template.py
@@ -1,4 +1,5 @@
-# app/models/shipping_provider_pricing_template.py
+# app/tms/pricing/templates/models/shipping_provider_pricing_template.py
+# Domain move: pricing template ORM belongs to TMS pricing templates.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/tms/pricing/templates/models/shipping_provider_pricing_template_destination_group.py
+++ b/app/tms/pricing/templates/models/shipping_provider_pricing_template_destination_group.py
@@ -1,4 +1,5 @@
-# app/models/shipping_provider_pricing_template_destination_group.py
+# app/tms/pricing/templates/models/shipping_provider_pricing_template_destination_group.py
+# Domain move: pricing template destination group ORM belongs to TMS pricing templates.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/tms/pricing/templates/models/shipping_provider_pricing_template_destination_group_member.py
+++ b/app/tms/pricing/templates/models/shipping_provider_pricing_template_destination_group_member.py
@@ -1,4 +1,5 @@
-# app/models/shipping_provider_pricing_template_destination_group_member.py
+# app/tms/pricing/templates/models/shipping_provider_pricing_template_destination_group_member.py
+# Domain move: pricing template destination group member ORM belongs to TMS pricing templates.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/tms/pricing/templates/models/shipping_provider_pricing_template_matrix.py
+++ b/app/tms/pricing/templates/models/shipping_provider_pricing_template_matrix.py
@@ -1,4 +1,5 @@
-# app/models/shipping_provider_pricing_template_matrix.py
+# app/tms/pricing/templates/models/shipping_provider_pricing_template_matrix.py
+# Domain move: pricing template matrix ORM belongs to TMS pricing templates.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/tms/pricing/templates/models/shipping_provider_pricing_template_module_range.py
+++ b/app/tms/pricing/templates/models/shipping_provider_pricing_template_module_range.py
@@ -1,4 +1,5 @@
-# app/models/shipping_provider_pricing_template_module_range.py
+# app/tms/pricing/templates/models/shipping_provider_pricing_template_module_range.py
+# Domain move: pricing template range ORM belongs to TMS pricing templates.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/tms/pricing/templates/models/shipping_provider_pricing_template_surcharge_config.py
+++ b/app/tms/pricing/templates/models/shipping_provider_pricing_template_surcharge_config.py
@@ -1,4 +1,5 @@
-# app/models/shipping_provider_pricing_template_surcharge_config.py
+# app/tms/pricing/templates/models/shipping_provider_pricing_template_surcharge_config.py
+# Domain move: pricing template surcharge config ORM belongs to TMS pricing templates.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/tms/pricing/templates/models/shipping_provider_pricing_template_surcharge_config_city.py
+++ b/app/tms/pricing/templates/models/shipping_provider_pricing_template_surcharge_config_city.py
@@ -1,4 +1,5 @@
-# app/models/shipping_provider_pricing_template_surcharge_config_city.py
+# app/tms/pricing/templates/models/shipping_provider_pricing_template_surcharge_config_city.py
+# Domain move: pricing template surcharge config city ORM belongs to TMS pricing templates.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/tms/pricing/templates/models/shipping_provider_pricing_template_validation_record.py
+++ b/app/tms/pricing/templates/models/shipping_provider_pricing_template_validation_record.py
@@ -1,4 +1,5 @@
-# app/models/shipping_provider_pricing_template_validation_record.py
+# app/tms/pricing/templates/models/shipping_provider_pricing_template_validation_record.py
+# Domain move: pricing template validation ORM belongs to TMS pricing templates.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/tms/pricing/templates/module_resources_shared.py
+++ b/app/tms/pricing/templates/module_resources_shared.py
@@ -6,17 +6,17 @@ from typing import Dict, Iterable, List, Optional, Tuple
 from fastapi import HTTPException
 from sqlalchemy.orm import Session, object_session, selectinload
 
-from app.models.shipping_provider_pricing_template import ShippingProviderPricingTemplate
-from app.models.shipping_provider_pricing_template_destination_group import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template import ShippingProviderPricingTemplate
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_destination_group import (
     ShippingProviderPricingTemplateDestinationGroup,
 )
-from app.models.shipping_provider_pricing_template_destination_group_member import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_destination_group_member import (
     ShippingProviderPricingTemplateDestinationGroupMember,
 )
-from app.models.shipping_provider_pricing_template_matrix import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_matrix import (
     ShippingProviderPricingTemplateMatrix,
 )
-from app.models.shipping_provider_pricing_template_module_range import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_module_range import (
     ShippingProviderPricingTemplateModuleRange,
 )
 from app.tms.pricing.templates.repository import (

--- a/app/tms/pricing/templates/ranges/routes.py
+++ b/app/tms/pricing/templates/ranges/routes.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 
 from app.user.deps.auth import get_current_user
 from app.db.deps import get_db
-from app.models.shipping_provider_pricing_template_module_range import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_module_range import (
     ShippingProviderPricingTemplateModuleRange,
 )
 from app.tms.permissions import check_config_perm

--- a/app/tms/pricing/templates/repository.py
+++ b/app/tms/pricing/templates/repository.py
@@ -6,17 +6,17 @@ from fastapi import HTTPException
 from sqlalchemy import func
 from sqlalchemy.orm import Session, selectinload
 
-from app.models.shipping_provider_pricing_template import ShippingProviderPricingTemplate
-from app.models.shipping_provider_pricing_template_destination_group import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template import ShippingProviderPricingTemplate
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_destination_group import (
     ShippingProviderPricingTemplateDestinationGroup,
 )
-from app.models.shipping_provider_pricing_template_matrix import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_matrix import (
     ShippingProviderPricingTemplateMatrix,
 )
-from app.models.shipping_provider_pricing_template_module_range import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_module_range import (
     ShippingProviderPricingTemplateModuleRange,
 )
-from app.models.shipping_provider_pricing_template_surcharge_config import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_surcharge_config import (
     ShippingProviderPricingTemplateSurchargeConfig,
 )
 from app.models.warehouse_shipping_provider import WarehouseShippingProvider

--- a/app/tms/pricing/templates/surcharge_configs/routes.py
+++ b/app/tms/pricing/templates/surcharge_configs/routes.py
@@ -7,11 +7,11 @@ from sqlalchemy.orm import Session, selectinload
 
 from app.user.deps.auth import get_current_user
 from app.db.deps import get_db
-from app.models.shipping_provider_pricing_template import ShippingProviderPricingTemplate
-from app.models.shipping_provider_pricing_template_surcharge_config import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template import ShippingProviderPricingTemplate
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_surcharge_config import (
     ShippingProviderPricingTemplateSurchargeConfig,
 )
-from app.models.shipping_provider_pricing_template_surcharge_config_city import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_surcharge_config_city import (
     ShippingProviderPricingTemplateSurchargeConfigCity,
 )
 from app.tms.permissions import check_config_perm

--- a/app/tms/pricing/templates/write/endpoints/clone.py
+++ b/app/tms/pricing/templates/write/endpoints/clone.py
@@ -5,23 +5,23 @@ from sqlalchemy.orm import Session, selectinload
 
 from app.user.deps.auth import get_current_user
 from app.db.deps import get_db
-from app.models.shipping_provider_pricing_template import ShippingProviderPricingTemplate
-from app.models.shipping_provider_pricing_template_destination_group import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template import ShippingProviderPricingTemplate
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_destination_group import (
     ShippingProviderPricingTemplateDestinationGroup,
 )
-from app.models.shipping_provider_pricing_template_destination_group_member import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_destination_group_member import (
     ShippingProviderPricingTemplateDestinationGroupMember,
 )
-from app.models.shipping_provider_pricing_template_matrix import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_matrix import (
     ShippingProviderPricingTemplateMatrix,
 )
-from app.models.shipping_provider_pricing_template_module_range import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_module_range import (
     ShippingProviderPricingTemplateModuleRange,
 )
-from app.models.shipping_provider_pricing_template_surcharge_config import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_surcharge_config import (
     ShippingProviderPricingTemplateSurchargeConfig,
 )
-from app.models.shipping_provider_pricing_template_surcharge_config_city import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_surcharge_config_city import (
     ShippingProviderPricingTemplateSurchargeConfigCity,
 )
 from app.tms.permissions import check_config_perm

--- a/app/tms/pricing/templates/write/endpoints/create.py
+++ b/app/tms/pricing/templates/write/endpoints/create.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from app.user.deps.auth import get_current_user
 from app.db.deps import get_db
 from app.models.shipping_provider import ShippingProvider
-from app.models.shipping_provider_pricing_template import ShippingProviderPricingTemplate
+from app.tms.pricing.templates.models.shipping_provider_pricing_template import ShippingProviderPricingTemplate
 from app.tms.permissions import check_config_perm
 
 from app.tms.pricing.templates.repository import build_template_stats, serialize_template_out

--- a/app/tms/pricing/templates/write/endpoints/submit_validation.py
+++ b/app/tms/pricing/templates/write/endpoints/submit_validation.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from app.user.deps.auth import get_current_user
 from app.db.deps import get_db
-from app.models.shipping_provider_pricing_template_validation_record import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_validation_record import (
     ShippingProviderPricingTemplateValidationRecord,
 )
 from app.tms.permissions import check_config_perm

--- a/app/tms/quote/context_from_template.py
+++ b/app/tms/quote/context_from_template.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 
 from sqlalchemy.orm import Session, selectinload
 
-from app.models.shipping_provider_pricing_template import ShippingProviderPricingTemplate
-from app.models.shipping_provider_pricing_template_destination_group import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template import ShippingProviderPricingTemplate
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_destination_group import (
     ShippingProviderPricingTemplateDestinationGroup,
 )
-from app.models.shipping_provider_pricing_template_matrix import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_matrix import (
     ShippingProviderPricingTemplateMatrix,
 )
-from app.models.shipping_provider_pricing_template_surcharge_config import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_surcharge_config import (
     ShippingProviderPricingTemplateSurchargeConfig,
 )
 

--- a/tests/unit/test_surcharge_city_wins_selection.py
+++ b/tests/unit/test_surcharge_city_wins_selection.py
@@ -1,10 +1,10 @@
 # tests/unit/test_surcharge_city_wins_selection.py
 from __future__ import annotations
 
-from app.models.shipping_provider_pricing_template_surcharge_config import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_surcharge_config import (
     ShippingProviderPricingTemplateSurchargeConfig,
 )
-from app.models.shipping_provider_pricing_template_surcharge_config_city import (
+from app.tms.pricing.templates.models.shipping_provider_pricing_template_surcharge_config_city import (
     ShippingProviderPricingTemplateSurchargeConfigCity,
 )
 from app.tms.quote.calc_quote_level3 import _select_surcharge_from_configs


### PR DESCRIPTION
## Summary
- move TMS pricing template ORM models to app/tms/pricing/templates/models
- update pricing template and quote imports
- add app.tms.pricing.templates.models to ORM discovery

## Validation
- python3 -m compileall app tests
- make alembic-check
- make test TESTS="tests/unit/test_surcharge_city_wins_selection.py tests/api/test_shipping_quote_calc_api.py tests/api/test_surcharge_config_invariants_audit.py tests/api/test_surcharge_upsert_mutual_exclusion_409.py tests/api/test_shipping_pricing_modules_api.py"
- make test TESTS="tests/unit/test_quote_snapshot_contract.py tests/api/test_v2_full_chain.py"