### PR TITLE
chore(tms): move provider models to domain package

### DIFF
--- a/app/db/base.py
+++ b/app/db/base.py
@@ -145,6 +145,7 @@ def init_models(
         "app.oms.platforms.models",
         "app.oms.fsku.models",
         "app.tms.pricing.templates.models",
+        "app.tms.providers.models",
     ):
         for mod in _iter_model_modules_recursive(pkg_name):
             if mod in ex or mod in loaded:

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -24,10 +24,10 @@ MODEL_SPECS = [
     ("app.pms.suppliers.models.supplier_contact", "SupplierContact"),
     # ⚠️ 关键顺序：先加载 WarehouseShippingProvider
     # 再加载 ShippingProvider / Warehouse
-    ("app.models.warehouse_shipping_provider", "WarehouseShippingProvider"),
-    ("app.models.shipping_provider", "ShippingProvider"),
-    ("app.models.shipping_provider_contact", "ShippingProviderContact"),
-    ("app.models.electronic_waybill_config", "ElectronicWaybillConfig"),
+    ("app.tms.providers.models.warehouse_shipping_provider", "WarehouseShippingProvider"),
+    ("app.tms.providers.models.shipping_provider", "ShippingProvider"),
+    ("app.tms.providers.models.shipping_provider_contact", "ShippingProviderContact"),
+    ("app.tms.providers.models.electronic_waybill_config", "ElectronicWaybillConfig"),
     # ------------------------------------------------------------------
     # 仓库 / 基础库存模型
     # ------------------------------------------------------------------

--- a/app/tms/pricing/templates/repository.py
+++ b/app/tms/pricing/templates/repository.py
@@ -19,7 +19,7 @@ from app.tms.pricing.templates.models.shipping_provider_pricing_template_module_
 from app.tms.pricing.templates.models.shipping_provider_pricing_template_surcharge_config import (
     ShippingProviderPricingTemplateSurchargeConfig,
 )
-from app.models.warehouse_shipping_provider import WarehouseShippingProvider
+from app.tms.providers.models.warehouse_shipping_provider import WarehouseShippingProvider
 from app.tms.pricing.templates.contracts.template import TemplateOut
 
 

--- a/app/tms/pricing/templates/write/endpoints/create.py
+++ b/app/tms/pricing/templates/write/endpoints/create.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 
 from app.user.deps.auth import get_current_user
 from app.db.deps import get_db
-from app.models.shipping_provider import ShippingProvider
+from app.tms.providers.models.shipping_provider import ShippingProvider
 from app.tms.pricing.templates.models.shipping_provider_pricing_template import ShippingProviderPricingTemplate
 from app.tms.permissions import check_config_perm
 

--- a/app/tms/providers/models/__init__.py
+++ b/app/tms/providers/models/__init__.py
@@ -1,0 +1,14 @@
+# app/tms/providers/models/__init__.py
+# Domain-owned ORM models for TMS providers, waybill configs, and warehouse-provider bindings.
+
+from app.tms.providers.models.electronic_waybill_config import ElectronicWaybillConfig
+from app.tms.providers.models.shipping_provider import ShippingProvider
+from app.tms.providers.models.shipping_provider_contact import ShippingProviderContact
+from app.tms.providers.models.warehouse_shipping_provider import WarehouseShippingProvider
+
+__all__ = [
+    "ElectronicWaybillConfig",
+    "ShippingProvider",
+    "ShippingProviderContact",
+    "WarehouseShippingProvider",
+]

--- a/app/tms/providers/models/electronic_waybill_config.py
+++ b/app/tms/providers/models/electronic_waybill_config.py
@@ -1,4 +1,5 @@
-# app/models/electronic_waybill_config.py
+# app/tms/providers/models/electronic_waybill_config.py
+# Domain move: electronic waybill config ORM belongs to TMS providers.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/tms/providers/models/shipping_provider.py
+++ b/app/tms/providers/models/shipping_provider.py
@@ -1,4 +1,5 @@
-# app/models/shipping_provider.py
+# app/tms/providers/models/shipping_provider.py
+# Domain move: shipping provider ORM belongs to TMS providers.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/tms/providers/models/shipping_provider_contact.py
+++ b/app/tms/providers/models/shipping_provider_contact.py
@@ -1,4 +1,5 @@
-# app/models/shipping_provider_contact.py
+# app/tms/providers/models/shipping_provider_contact.py
+# Domain move: shipping provider contact ORM belongs to TMS providers.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/tms/providers/models/warehouse_shipping_provider.py
+++ b/app/tms/providers/models/warehouse_shipping_provider.py
@@ -1,4 +1,5 @@
-# app/models/warehouse_shipping_provider.py
+# app/tms/providers/models/warehouse_shipping_provider.py
+# Domain move: warehouse shipping provider binding ORM belongs to TMS providers.
 from __future__ import annotations
 
 from datetime import datetime


### PR DESCRIPTION
## Summary
- move TMS provider, provider contact, warehouse-provider binding, and electronic waybill ORM models to app/tms/providers/models
- update pricing template imports for provider models
- add app.tms.providers.models to ORM discovery

## Validation
- python3 -m compileall app tests
- make alembic-check
- make test TESTS="tests/api/test_shipping_providers_warehouse_contract.py tests/api/test_warehouse_shipping_providers_bulk_upsert_api.py tests/api/test_tms_pricing_bindings_runtime_api.py tests/api/test_tms_pricing_active_carriers_summary_api.py tests/api/test_pricing_template_update_contract.py tests/api/test_pricing_template_binding_runtime_guards.py tests/services/test_shipment_prepare_quotes.py tests/services/test_transport_shipments.py tests/api/test_v2_full_chain.py"