### PR TITLE
chore(tms): move shipment models to domain package

### DIFF
--- a/app/db/base.py
+++ b/app/db/base.py
@@ -146,6 +146,7 @@ def init_models(
         "app.oms.fsku.models",
         "app.tms.pricing.templates.models",
         "app.tms.providers.models",
+        "app.tms.shipment.models",
     ):
         for mod in _iter_model_modules_recursive(pkg_name):
             if mod in ex or mod in loaded:

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -61,8 +61,8 @@ MODEL_SPECS = [
     ("app.models.order_line", "OrderLine"),
     ("app.models.order_logistics", "OrderLogistics"),
     ("app.models.order_state_snapshot", "OrderStateSnapshot"),
-    ("app.models.order_shipment_prepare", "OrderShipmentPrepare"),
-    ("app.models.order_shipment_prepare_package", "OrderShipmentPreparePackage"),
+    ("app.tms.shipment.models.order_shipment_prepare", "OrderShipmentPrepare"),
+    ("app.tms.shipment.models.order_shipment_prepare_package", "OrderShipmentPreparePackage"),
     # ✅ Phase 5：执行域 authority（order_fulfillment）
     ("app.models.order_fulfillment", "OrderFulfillment"),
     # 拣货任务
@@ -119,7 +119,7 @@ MODEL_SPECS = [
     # ------------------------------------------------------------------
     # 运输执行 / 账本（Phase-2：Shipment 主实体 + Record 投影）
     # ------------------------------------------------------------------
-    ("app.models.transport_shipment", "TransportShipment"),
+    ("app.tms.shipment.models.transport_shipment", "TransportShipment"),
     ("app.tms.records.models.shipping_record", "ShippingRecord"),
     ("app.tms.billing.models.carrier_bill_item", "CarrierBillItem"),
     ("app.tms.billing.models.shipping_record_reconciliation", "ShippingRecordReconciliation"),

--- a/app/tms/shipment/models/__init__.py
+++ b/app/tms/shipment/models/__init__.py
@@ -1,0 +1,12 @@
+# app/tms/shipment/models/__init__.py
+# Domain-owned ORM models for TMS shipment and shipment preparation.
+
+from app.tms.shipment.models.order_shipment_prepare import OrderShipmentPrepare
+from app.tms.shipment.models.order_shipment_prepare_package import OrderShipmentPreparePackage
+from app.tms.shipment.models.transport_shipment import TransportShipment
+
+__all__ = [
+    "OrderShipmentPrepare",
+    "OrderShipmentPreparePackage",
+    "TransportShipment",
+]

--- a/app/tms/shipment/models/order_shipment_prepare.py
+++ b/app/tms/shipment/models/order_shipment_prepare.py
@@ -1,3 +1,5 @@
+# app/tms/shipment/models/order_shipment_prepare.py
+# Domain move: order shipment prepare ORM belongs to TMS shipment.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/tms/shipment/models/order_shipment_prepare_package.py
+++ b/app/tms/shipment/models/order_shipment_prepare_package.py
@@ -1,3 +1,5 @@
+# app/tms/shipment/models/order_shipment_prepare_package.py
+# Domain move: order shipment prepare package ORM belongs to TMS shipment.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/tms/shipment/models/transport_shipment.py
+++ b/app/tms/shipment/models/transport_shipment.py
@@ -1,4 +1,5 @@
-# app/models/transport_shipment.py
+# app/tms/shipment/models/transport_shipment.py
+# Domain move: transport shipment ORM belongs to TMS shipment.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/tms/shipment/service.py
+++ b/app/tms/shipment/service.py
@@ -18,8 +18,8 @@ from typing import Any
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.order_shipment_prepare import OrderShipmentPrepare
-from app.models.order_shipment_prepare_package import OrderShipmentPreparePackage
+from app.tms.shipment.models.order_shipment_prepare import OrderShipmentPrepare
+from app.tms.shipment.models.order_shipment_prepare_package import OrderShipmentPreparePackage
 from app.tms.quote_snapshot import (
     extract_cost_estimated,
     extract_freight_estimated,

--- a/app/tms/shipment/service_prepare_orders.py
+++ b/app/tms/shipment/service_prepare_orders.py
@@ -16,7 +16,7 @@ from fastapi import HTTPException, status
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.order_shipment_prepare import OrderShipmentPrepare
+from app.tms.shipment.models.order_shipment_prepare import OrderShipmentPrepare
 
 from .contracts_prepare_orders import (
     ShipPrepareImportResponse,

--- a/app/tms/shipment/service_prepare_packages.py
+++ b/app/tms/shipment/service_prepare_packages.py
@@ -19,7 +19,7 @@ from fastapi import HTTPException, status
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.order_shipment_prepare_package import OrderShipmentPreparePackage
+from app.tms.shipment.models.order_shipment_prepare_package import OrderShipmentPreparePackage
 
 from .contracts_prepare_packages import ShipPreparePackageOut
 

--- a/app/tms/shipment/service_prepare_quotes.py
+++ b/app/tms/shipment/service_prepare_quotes.py
@@ -17,8 +17,8 @@ from fastapi import HTTPException, status
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.order_shipment_prepare import OrderShipmentPrepare
-from app.models.order_shipment_prepare_package import OrderShipmentPreparePackage
+from app.tms.shipment.models.order_shipment_prepare import OrderShipmentPrepare
+from app.tms.shipment.models.order_shipment_prepare_package import OrderShipmentPreparePackage
 from app.tms.quote.recommend import recommend_quotes
 from app.tms.quote.types import Dest
 from app.tms.quote_snapshot import build_quote_snapshot


### PR DESCRIPTION
## Summary
- move transport shipment and shipment prepare ORM models to app/tms/shipment/models
- update TMS shipment imports and model registry paths
- add app.tms.shipment.models to ORM discovery

## Validation
- python3 -m compileall app tests
- make alembic-check
- make test TESTS="tests/services/test_transport_shipments.py tests/services/test_shipment_prepare_service.py tests/services/test_shipment_prepare_packages.py tests/services/test_shipment_prepare_quotes.py tests/api/test_transport_shipment_service_commit_audit.py tests/services/test_transport_shipment_service_audit.py"