### PR TITLE
chore(oms): move order models to domain package

### DIFF
--- a/app/db/base.py
+++ b/app/db/base.py
@@ -118,11 +118,11 @@ def init_models(
         "app.wms.stock.models.stock_snapshot",
         "app.wms.inbound.models.inbound_event",
         "app.wms.outbound.models.outbound_event",
-        "app.models.order",
-        "app.models.order_item",
-        "app.models.order_address",
-        "app.models.order_logistics",
-        "app.models.order_fulfillment",
+        "app.oms.orders.models.order",
+        "app.oms.orders.models.order_item",
+        "app.oms.orders.models.order_address",
+        "app.oms.orders.models.order_logistics",
+        "app.oms.orders.models.order_fulfillment",
         "app.models.store",
         "app.models.warehouse",
         "app.models.platform_shops",
@@ -147,6 +147,7 @@ def init_models(
         "app.tms.pricing.templates.models",
         "app.tms.providers.models",
         "app.tms.shipment.models",
+        "app.oms.orders.models",
     ):
         for mod in _iter_model_modules_recursive(pkg_name):
             if mod in ex or mod in loaded:

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -56,15 +56,15 @@ MODEL_SPECS = [
     # ------------------------------------------------------------------
     # 订单 & 出库
     # ------------------------------------------------------------------
-    ("app.models.order", "Order"),
-    ("app.models.order_item", "OrderItem"),
-    ("app.models.order_line", "OrderLine"),
-    ("app.models.order_logistics", "OrderLogistics"),
-    ("app.models.order_state_snapshot", "OrderStateSnapshot"),
+    ("app.oms.orders.models.order", "Order"),
+    ("app.oms.orders.models.order_item", "OrderItem"),
+    ("app.oms.orders.models.order_line", "OrderLine"),
+    ("app.oms.orders.models.order_logistics", "OrderLogistics"),
+    ("app.oms.orders.models.order_state_snapshot", "OrderStateSnapshot"),
     ("app.tms.shipment.models.order_shipment_prepare", "OrderShipmentPrepare"),
     ("app.tms.shipment.models.order_shipment_prepare_package", "OrderShipmentPreparePackage"),
     # ✅ Phase 5：执行域 authority（order_fulfillment）
-    ("app.models.order_fulfillment", "OrderFulfillment"),
+    ("app.oms.orders.models.order_fulfillment", "OrderFulfillment"),
     # 拣货任务
     # ------------------------------------------------------------------
     # 平台 & 事件

--- a/app/oms/orders/models/__init__.py
+++ b/app/oms/orders/models/__init__.py
@@ -1,0 +1,20 @@
+# app/oms/orders/models/__init__.py
+# Domain-owned ORM models for OMS orders.
+
+from app.oms.orders.models.order import Order
+from app.oms.orders.models.order_address import OrderAddress
+from app.oms.orders.models.order_fulfillment import OrderFulfillment
+from app.oms.orders.models.order_item import OrderItem
+from app.oms.orders.models.order_line import OrderLine
+from app.oms.orders.models.order_logistics import OrderLogistics
+from app.oms.orders.models.order_state_snapshot import OrderStateSnapshot
+
+__all__ = [
+    "Order",
+    "OrderAddress",
+    "OrderFulfillment",
+    "OrderItem",
+    "OrderLine",
+    "OrderLogistics",
+    "OrderStateSnapshot",
+]

--- a/app/oms/orders/models/order.py
+++ b/app/oms/orders/models/order.py
@@ -1,3 +1,5 @@
+# app/oms/orders/models/order.py
+# Domain move: order ORM belongs to OMS orders.
 from __future__ import annotations
 
 from datetime import datetime
@@ -11,9 +13,9 @@ from app.db.base import Base
 
 if TYPE_CHECKING:
     from app.pms.items.models.item import Item
-    from .order_item import OrderItem
-    from .order_logistics import OrderLogistics
-    from .store import Store
+    from app.oms.orders.models.order_item import OrderItem
+    from app.oms.orders.models.order_logistics import OrderLogistics
+    from app.models.store import Store
 
 
 class Order(Base):

--- a/app/oms/orders/models/order_address.py
+++ b/app/oms/orders/models/order_address.py
@@ -1,3 +1,5 @@
+# app/oms/orders/models/order_address.py
+# Domain move: order address ORM belongs to OMS orders.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/oms/orders/models/order_fulfillment.py
+++ b/app/oms/orders/models/order_fulfillment.py
@@ -1,4 +1,5 @@
-# app/models/order_fulfillment.py
+# app/oms/orders/models/order_fulfillment.py
+# Domain move: order fulfillment ORM belongs to OMS orders.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/oms/orders/models/order_item.py
+++ b/app/oms/orders/models/order_item.py
@@ -1,3 +1,5 @@
+# app/oms/orders/models/order_item.py
+# Domain move: order item ORM belongs to OMS orders.
 from __future__ import annotations
 
 from decimal import Decimal
@@ -11,7 +13,7 @@ from app.db.base import Base
 
 if TYPE_CHECKING:
     from app.pms.items.models.item import Item
-    from .order import Order
+    from app.oms.orders.models.order import Order
 
 
 class OrderItem(Base):

--- a/app/oms/orders/models/order_line.py
+++ b/app/oms/orders/models/order_line.py
@@ -1,3 +1,5 @@
+# app/oms/orders/models/order_line.py
+# Domain move: order line ORM belongs to OMS orders.
 from __future__ import annotations
 
 from sqlalchemy import BigInteger, ForeignKey, Index, Integer

--- a/app/oms/orders/models/order_logistics.py
+++ b/app/oms/orders/models/order_logistics.py
@@ -1,3 +1,5 @@
+# app/oms/orders/models/order_logistics.py
+# Domain move: order logistics ORM belongs to OMS orders.
 from __future__ import annotations
 
 from datetime import datetime
@@ -9,7 +11,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.db.base import Base
 
 if TYPE_CHECKING:
-    from .order import Order
+    from app.oms.orders.models.order import Order
 
 
 class OrderLogistics(Base):

--- a/app/oms/orders/models/order_state_snapshot.py
+++ b/app/oms/orders/models/order_state_snapshot.py
@@ -1,3 +1,5 @@
+# app/oms/orders/models/order_state_snapshot.py
+# Domain move: order state snapshot ORM belongs to OMS orders.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/oms/platforms/models/pdd_order_order_mapping.py
+++ b/app/oms/platforms/models/pdd_order_order_mapping.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.db.base import Base
 
 if TYPE_CHECKING:
-    from app.models.order import Order
+    from app.oms.orders.models.order import Order
     from app.oms.platforms.models.pdd_order import PddOrder
 
 

--- a/app/pms/items/models/item.py
+++ b/app/pms/items/models/item.py
@@ -11,8 +11,8 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.db.base import Base
 
 if TYPE_CHECKING:
-    from app.models.order import Order
-    from app.models.order_item import OrderItem
+    from app.oms.orders.models.order import Order
+    from app.oms.orders.models.order_item import OrderItem
     from app.pms.suppliers.models.supplier import Supplier
     from app.pms.items.models.item_uom import ItemUOM
 


### PR DESCRIPTION
## Summary
- move OMS order, order item, order line, order address, order logistics, order state snapshot, and order fulfillment ORM models to app/oms/orders/models
- update model registry and ORM discovery paths
- update cross-domain TYPE_CHECKING imports in PMS item and OMS platform order mapping

## Validation
- python3 -m compileall app tests
- make alembic-check
- make test TESTS="tests/api/test_orders_create_contract.py tests/api/test_order_outbound_view_api.py tests/api/test_order_outbound_submit_api.py tests/api/test_platform_orders_confirm_create_contract.py tests/api/test_platform_orders_replay_contract.py tests/api/test_platform_orders_ingest_next_actions_contract.py tests/services/test_order_rma_and_reconcile.py tests/services/test_outbound_ledger_consistency.py tests/services/test_trace_full_chain_order_reserve_outbound.py tests/db/test_vw_routing_metrics_daily.py"