### PR TITLE
chore(wms): move warehouse model to domain package

### DIFF
--- a/app/db/base.py
+++ b/app/db/base.py
@@ -124,7 +124,7 @@ def init_models(
         "app.oms.orders.models.order_logistics",
         "app.oms.orders.models.order_fulfillment",
         "app.models.store",
-        "app.models.warehouse",
+        "app.wms.warehouses.models.warehouse",
         "app.models.platform_shops",
     ]
     for mod in [m for m in explicit_chain if m and m not in ex]:
@@ -148,6 +148,7 @@ def init_models(
         "app.tms.providers.models",
         "app.tms.shipment.models",
         "app.oms.orders.models",
+        "app.wms.warehouses.models",
     ):
         for mod in _iter_model_modules_recursive(pkg_name):
             if mod in ex or mod in loaded:

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -31,7 +31,7 @@ MODEL_SPECS = [
     # ------------------------------------------------------------------
     # 仓库 / 基础库存模型
     # ------------------------------------------------------------------
-    ("app.models.warehouse", "Warehouse"),
+    ("app.wms.warehouses.models.warehouse", "Warehouse"),
     # ✅ 旧“库位维度”已从主线移除（库存主链路仅使用 warehouse_id）
     ("app.pms.items.models.item", "Item"),
     # ✅ Phase M-2：多包装/多单位结构化

--- a/app/models/store.py
+++ b/app/models/store.py
@@ -19,7 +19,7 @@ from sqlalchemy.orm import Mapped, backref, mapped_column, relationship
 from app.db.base import Base
 
 if TYPE_CHECKING:
-    from app.models.warehouse import Warehouse
+    from app.wms.warehouses.models.warehouse import Warehouse
 
 
 class Store(Base):

--- a/app/oms/services/platform_events_actions.py
+++ b/app/oms/services/platform_events_actions.py
@@ -11,12 +11,7 @@ from app.wms.outbound.services.outbound_commit_service import OutboundService
 
 from app.oms.services.platform_events_ship import build_ship_lines_for_commit
 
-try:
-    from app.models.warehouse import WarehouseCode
-except Exception:
-
-    class WarehouseCode:  # type: ignore
-        MAIN = "MAIN"
+from app.wms.warehouses.models.warehouse import WarehouseCode
 
 
 def _build_lines_for_pick_or_cancel(task: Dict[str, Any]) -> List[Dict[str, Any]]:

--- a/app/wms/shared/services/rma_service.py
+++ b/app/wms/shared/services/rma_service.py
@@ -7,7 +7,7 @@ from typing import Optional
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.warehouse import WarehouseCode
+from app.wms.warehouses.models.warehouse import WarehouseCode
 from app.wms.stock.services.stock_service import StockService
 
 

--- a/app/wms/warehouses/models/__init__.py
+++ b/app/wms/warehouses/models/__init__.py
@@ -1,0 +1,9 @@
+# app/wms/warehouses/models/__init__.py
+# Domain-owned ORM models for WMS warehouses.
+
+from app.wms.warehouses.models.warehouse import Warehouse, WarehouseCode
+
+__all__ = [
+    "Warehouse",
+    "WarehouseCode",
+]

--- a/app/wms/warehouses/models/warehouse.py
+++ b/app/wms/warehouses/models/warehouse.py
@@ -1,12 +1,16 @@
-# app/models/warehouse.py
+# app/wms/warehouses/models/warehouse.py
+# Domain move: Warehouse ORM belongs to WMS warehouses.
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from sqlalchemy import Boolean, Integer, String, text
 from sqlalchemy.orm import Mapped, mapped_column, relationship, validates
 
 from app.db.base import Base
+
+if TYPE_CHECKING:
+    from app.tms.providers.models.warehouse_shipping_provider import WarehouseShippingProvider
 
 
 class WarehouseCode:


### PR DESCRIPTION
## Summary
- move Warehouse and WarehouseCode to app/wms/warehouses/models
- update model registry and ORM discovery paths
- update Store TYPE_CHECKING and WMS/OMS WarehouseCode imports
- remove legacy WarehouseCode import fallback
- add TYPE_CHECKING import for WarehouseShippingProvider after the domain move

## Validation
- python3 -m compileall app tests
- make alembic-check
- make test TESTS="tests/api/test_stores_routes_contract.py tests/services/test_store_binding_contract.py tests/api/test_shipping_providers_warehouse_contract.py tests/api/test_user_navigation_api.py tests/api/test_stock_inventory_read_api.py tests/services/test_warehouse_router.py"