### PR TITLE
chore(oms,pms): move store and test set models to domain packages

### DIFF
--- a/app/db/base.py
+++ b/app/db/base.py
@@ -123,9 +123,9 @@ def init_models(
         "app.oms.orders.models.order_address",
         "app.oms.orders.models.order_logistics",
         "app.oms.orders.models.order_fulfillment",
-        "app.models.store",
+        "app.oms.stores.models.store",
         "app.wms.warehouses.models.warehouse",
-        "app.models.platform_shops",
+        "app.oms.stores.models.platform_shops",
     ]
     for mod in [m for m in explicit_chain if m and m not in ex]:
         if _safe_import(mod):
@@ -149,6 +149,7 @@ def init_models(
         "app.tms.shipment.models",
         "app.oms.orders.models",
         "app.wms.warehouses.models",
+        "app.oms.stores.models",
     ):
         for mod in _iter_model_modules_recursive(pkg_name):
             if mod in ex or mod in loaded:

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -36,8 +36,8 @@ MODEL_SPECS = [
     ("app.pms.items.models.item", "Item"),
     # ✅ Phase M-2：多包装/多单位结构化
     ("app.pms.items.models.item_uom", "ItemUOM"),
-    ("app.models.item_test_set", "ItemTestSet"),
-    ("app.models.item_test_set_item", "ItemTestSetItem"),
+    ("app.pms.items.models.item_test_set", "ItemTestSet"),
+    ("app.pms.items.models.item_test_set_item", "ItemTestSetItem"),
     ("app.wms.stock.models.lot", "Lot"),
     # ✅ Phase 5：lot-world 成为唯一库存余额真相（stocks_lot + lots）
     ("app.wms.stock.models.stock_lot", "StockLot"),
@@ -69,7 +69,7 @@ MODEL_SPECS = [
     # ------------------------------------------------------------------
     # 平台 & 事件
     # ------------------------------------------------------------------
-    ("app.models.platform_shops", "PlatformShop"),
+    ("app.oms.stores.models.platform_shops", "PlatformShop"),
     ("app.models.platform_event", "PlatformEvent"),
     ("app.models.event_store", "EventStore"),
     ("app.models.event_log", "EventLog"),
@@ -78,7 +78,7 @@ MODEL_SPECS = [
     # ------------------------------------------------------------------
     # 门店 & 权限导航
     # ------------------------------------------------------------------
-    ("app.models.store", "Store"),
+    ("app.oms.stores.models.store", "Store"),
     ("app.models.user", "User"),
     ("app.models.permission", "Permission"),
     ("app.models.page_registry", "PageRegistry"),

--- a/app/oms/fsku/router_merchant_code_bindings.py
+++ b/app/oms/fsku/router_merchant_code_bindings.py
@@ -19,7 +19,7 @@ from app.oms.fsku.contracts.merchant_code_bindings import (
 )
 from app.oms.fsku.models.fsku import Fsku
 from app.oms.fsku.models.merchant_code_fsku_binding import MerchantCodeFskuBinding
-from app.models.store import Store
+from app.oms.stores.models.store import Store
 from app.oms.fsku.services.merchant_code_binding_service import MerchantCodeBindingService
 from app.oms.services.platform_order_resolve_service import norm_platform, norm_shop_id
 from app.oms.services.test_shop_testset_guard_service import TestShopTestSetGuardService

--- a/app/oms/orders/models/order.py
+++ b/app/oms/orders/models/order.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from app.pms.items.models.item import Item
     from app.oms.orders.models.order_item import OrderItem
     from app.oms.orders.models.order_logistics import OrderLogistics
-    from app.models.store import Store
+    from app.oms.stores.models.store import Store
 
 
 class Order(Base):

--- a/app/oms/stores/models/__init__.py
+++ b/app/oms/stores/models/__init__.py
@@ -1,0 +1,11 @@
+# app/oms/stores/models/__init__.py
+# Domain-owned ORM models for OMS stores.
+
+from app.oms.stores.models.platform_shops import PlatformShop
+from app.oms.stores.models.store import Store, StoreWarehouse
+
+__all__ = [
+    "PlatformShop",
+    "Store",
+    "StoreWarehouse",
+]

--- a/app/oms/stores/models/platform_shops.py
+++ b/app/oms/stores/models/platform_shops.py
@@ -1,3 +1,5 @@
+# app/oms/stores/models/platform_shops.py
+# Domain move: PlatformShop ORM belongs to OMS stores.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/oms/stores/models/store.py
+++ b/app/oms/stores/models/store.py
@@ -1,3 +1,5 @@
+# app/oms/stores/models/store.py
+# Domain move: Store and StoreWarehouse ORM belong to OMS stores.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/pms/items/models/item_test_set.py
+++ b/app/pms/items/models/item_test_set.py
@@ -1,4 +1,5 @@
-# app/models/item_test_set.py
+# app/pms/items/models/item_test_set.py
+# Domain move: ItemTestSet ORM belongs to PMS item test sets.
 from __future__ import annotations
 
 from datetime import datetime
@@ -11,7 +12,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.db.base import Base
 
 if TYPE_CHECKING:
-    from app.models.item_test_set_item import ItemTestSetItem
+    from app.pms.items.models.item_test_set_item import ItemTestSetItem
 
 
 class ItemTestSet(Base):

--- a/app/pms/items/models/item_test_set_item.py
+++ b/app/pms/items/models/item_test_set_item.py
@@ -1,4 +1,5 @@
-# app/models/item_test_set_item.py
+# app/pms/items/models/item_test_set_item.py
+# Domain move: ItemTestSetItem ORM belongs to PMS item test sets.
 from __future__ import annotations
 
 from datetime import datetime
@@ -11,7 +12,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.db.base import Base
 
 if TYPE_CHECKING:
-    from app.models.item_test_set import ItemTestSet
+    from app.pms.items.models.item_test_set import ItemTestSet
 
 
 class ItemTestSetItem(Base):

--- a/app/wms/ledger/routers/stock_ledger_routes_summary.py
+++ b/app/wms/ledger/routers/stock_ledger_routes_summary.py
@@ -9,8 +9,8 @@ from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_session
-from app.models.item_test_set import ItemTestSet
-from app.models.item_test_set_item import ItemTestSetItem
+from app.pms.items.models.item_test_set import ItemTestSet
+from app.pms.items.models.item_test_set_item import ItemTestSetItem
 from app.wms.ledger.models.stock_ledger import StockLedger
 from app.wms.ledger.contracts.stock_ledger import LedgerQuery, LedgerReasonStat, LedgerSummary
 from app.wms.ledger.helpers.stock_ledger import (


### PR DESCRIPTION
## Summary
- move Store, StoreWarehouse, and PlatformShop ORM models to app/oms/stores/models
- move ItemTestSet and ItemTestSetItem ORM models to app/pms/items/models
- update model registry, ORM discovery, and direct imports
- keep OMS as consumer of PMS item test-set ownership rather than owning those models

## Validation
- python3 -m compileall app tests
- make alembic-check
- make test TESTS="tests/api/test_stores_routes_contract.py tests/services/test_store_binding_contract.py tests/services/test_store_service.py tests/api/test_stores_order_sim_filled_code_options_contract.py tests/api/test_platform_orders_ingest_next_actions_contract.py tests/api/test_platform_orders_replay_contract.py tests/api/test_user_navigation_api.py"