### PR TITLE
chore(events,wms): move event audit and print models to domain packages

### DIFF
--- a/app/db/base.py
+++ b/app/db/base.py
@@ -151,6 +151,7 @@ def init_models(
         "app.wms.warehouses.models",
         "app.oms.stores.models",
         "app.user.models",
+        "app.events.models",
     ):
         for mod in _iter_model_modules_recursive(pkg_name):
             if mod in ex or mod in loaded:

--- a/app/events/models/__init__.py
+++ b/app/events/models/__init__.py
@@ -1,0 +1,16 @@
+# app/events/models/__init__.py
+# Domain-owned ORM models for shared events, audit, and platform event infrastructure.
+
+from app.events.models.audit_event import AuditEvent
+from app.events.models.event_error_log import EventErrorLog
+from app.events.models.event_log import EventLog
+from app.events.models.event_store import EventStore
+from app.events.models.platform_event import PlatformEvent
+
+__all__ = [
+    "AuditEvent",
+    "EventErrorLog",
+    "EventLog",
+    "EventStore",
+    "PlatformEvent",
+]

--- a/app/events/models/audit_event.py
+++ b/app/events/models/audit_event.py
@@ -1,3 +1,5 @@
+# app/events/models/audit_event.py
+# Domain move: AuditEvent ORM belongs to shared events/audit infrastructure.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/events/models/event_error_log.py
+++ b/app/events/models/event_error_log.py
@@ -1,3 +1,5 @@
+# app/events/models/event_error_log.py
+# Domain move: EventErrorLog ORM belongs to shared events infrastructure.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/events/models/event_log.py
+++ b/app/events/models/event_log.py
@@ -1,3 +1,5 @@
+# app/events/models/event_log.py
+# Domain move: EventLog ORM belongs to shared events infrastructure.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/events/models/event_store.py
+++ b/app/events/models/event_store.py
@@ -1,3 +1,5 @@
+# app/events/models/event_store.py
+# Domain move: EventStore ORM belongs to shared events infrastructure.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/events/models/platform_event.py
+++ b/app/events/models/platform_event.py
@@ -1,3 +1,5 @@
+# app/events/models/platform_event.py
+# Domain move: PlatformEvent ORM belongs to shared platform events infrastructure.
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -70,11 +70,11 @@ MODEL_SPECS = [
     # 平台 & 事件
     # ------------------------------------------------------------------
     ("app.oms.stores.models.platform_shops", "PlatformShop"),
-    ("app.models.platform_event", "PlatformEvent"),
-    ("app.models.event_store", "EventStore"),
-    ("app.models.event_log", "EventLog"),
-    ("app.models.event_error_log", "EventErrorLog"),
-    ("app.models.audit_event", "AuditEvent"),
+    ("app.events.models.platform_event", "PlatformEvent"),
+    ("app.events.models.event_store", "EventStore"),
+    ("app.events.models.event_log", "EventLog"),
+    ("app.events.models.event_error_log", "EventErrorLog"),
+    ("app.events.models.audit_event", "AuditEvent"),
     # ------------------------------------------------------------------
     # 门店 & 权限导航
     # ------------------------------------------------------------------

--- a/app/oms/services/platform_events_error_log.py
+++ b/app/oms/services/platform_events_error_log.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from sqlalchemy import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.event_error_log import EventErrorLog
+from app.events.models.event_error_log import EventErrorLog
 from app.oms.services.platform_events_extractors import extract_ref, extract_shop_id, extract_state
 
 

--- a/app/wms/outbound/models/__init__.py
+++ b/app/wms/outbound/models/__init__.py
@@ -1,4 +1,6 @@
 # app/wms/outbound/models/__init__.py
 from .outbound_event import OutboundEventLine
 
-__all__ = ["OutboundEventLine"]
+__all__ = ["OutboundEventLine", "PrintJob"]
+
+from app.wms.outbound.models.print_job import PrintJob

--- a/app/wms/outbound/models/print_job.py
+++ b/app/wms/outbound/models/print_job.py
@@ -1,4 +1,5 @@
-# app/models/print_job.py
+# app/wms/outbound/models/print_job.py
+# Domain move: PrintJob ORM belongs to WMS outbound print queue.
 from __future__ import annotations
 
 from datetime import datetime


### PR DESCRIPTION
## Summary
- move shared event/audit ORM models to app/events/models
- move PrintJob ORM to app/wms/outbound/models
- update model registry, ORM discovery, and EventErrorLog import
- keep print queue ownership under WMS outbound instead of global app/models

## Validation
- python3 -m compileall app tests
- make alembic-check
- make test TESTS="tests/services/test_audit_writer.py tests/services/test_audit_logger.py tests/contracts/test_event_to_ledger_contract.py tests/api/test_debug_trace_api.py tests/api/test_admin_users_audit_api.py tests/api/test_admin_user_permission_matrix_audit_api.py tests/api/test_admin_users_delete_audit_api.py tests/services/test_transport_shipment_service_audit.py tests/api/test_transport_shipment_service_commit_audit.py"