### PR TITLE
chore(wms): move shared movement enums to domain package

### DIFF
--- a/app/devtools/routers/dev_seed_ledger.py
+++ b/app/devtools/routers/dev_seed_ledger.py
@@ -9,7 +9,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_session
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.stock.services.stock_service import StockService
 
 router = APIRouter(prefix="/dev", tags=["dev-seed"])

--- a/app/devtools/routers/dev_stock_adjust.py
+++ b/app/devtools/routers/dev_stock_adjust.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.deps import get_async_session as get_session
 from app.wms.shared.services.lot_code_contract import fetch_item_expiry_policy_map, validate_lot_code_contract
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.stock.services.stock_service import StockService
 
 router = APIRouter(prefix="/dev", tags=["dev-stock"])

--- a/app/diagnostics/services/inventory_autoheal_execute.py
+++ b/app/diagnostics/services/inventory_autoheal_execute.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.diagnostics.services.inventory_autoheal_service import InventoryAutoHealService
 from app.wms.stock.services.stock_service import StockService
 

--- a/app/oms/orders/models/order.py
+++ b/app/oms/orders/models/order.py
@@ -10,6 +10,9 @@ from sqlalchemy import BigInteger, DateTime, ForeignKey, Numeric, String, text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
+from app.oms.orders.models.order_item import OrderItem  # noqa: F401
+from app.oms.orders.models.order_logistics import OrderLogistics  # noqa: F401
+from app.oms.stores.models.store import Store  # noqa: F401
 
 if TYPE_CHECKING:
     from app.pms.items.models.item import Item

--- a/app/oms/stores/models/store.py
+++ b/app/oms/stores/models/store.py
@@ -19,6 +19,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import Mapped, backref, mapped_column, relationship
 
 from app.db.base import Base
+from app.wms.warehouses.models.warehouse import Warehouse  # noqa: F401
 
 if TYPE_CHECKING:
     from app.wms.warehouses.models.warehouse import Warehouse

--- a/app/pms/items/models/item.py
+++ b/app/pms/items/models/item.py
@@ -9,6 +9,10 @@ from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Integer, String, tex
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
+from app.oms.orders.models.order import Order  # noqa: F401
+from app.oms.orders.models.order_item import OrderItem  # noqa: F401
+from app.pms.items.models.item_uom import ItemUOM  # noqa: F401
+from app.pms.suppliers.models.supplier import Supplier  # noqa: F401
 
 if TYPE_CHECKING:
     from app.oms.orders.models.order import Order

--- a/app/tms/providers/models/warehouse_shipping_provider.py
+++ b/app/tms/providers/models/warehouse_shipping_provider.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
+from app.tms.pricing.templates.models.shipping_provider_pricing_template import ShippingProviderPricingTemplate  # noqa: F401
 
 
 class WarehouseShippingProvider(Base):

--- a/app/wms/inbound/repos/inbound_stock_write_repo.py
+++ b/app/wms/inbound/repos/inbound_stock_write_repo.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.inventory_adjustment.count.services.count_freeze_guard_service import (
     ensure_warehouse_not_frozen,
 )

--- a/app/wms/inventory_adjustment/count/services/count_doc_service.py
+++ b/app/wms/inventory_adjustment/count/services/count_doc_service.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.inventory_adjustment.count.contracts.count_doc import (
     CountDocCreateIn,
     CountDocFreezeOut,

--- a/app/wms/inventory_adjustment/count/services/count_service.py
+++ b/app/wms/inventory_adjustment/count/services/count_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.inventory_adjustment.count.contracts.count import CountRequest, CountResponse
 from app.wms.inventory_adjustment.count.repos.count_repo import CountRepo
 from app.wms.inventory_adjustment.count.services.count_freeze_guard_service import (

--- a/app/wms/inventory_adjustment/inbound_reversal/services/inbound_reversal_service.py
+++ b/app/wms/inventory_adjustment/inbound_reversal/services/inbound_reversal_service.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.inbound.models.inbound_event import InboundEventLine, WmsEvent
 from app.wms.inventory_adjustment.count.services.count_freeze_guard_service import (
     ensure_warehouse_not_frozen,

--- a/app/wms/inventory_adjustment/outbound_reversal/services/outbound_reversal_service.py
+++ b/app/wms/inventory_adjustment/outbound_reversal/services/outbound_reversal_service.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.inbound.models.inbound_event import WmsEvent
 from app.wms.inventory_adjustment.count.services.count_freeze_guard_service import (
     ensure_warehouse_not_frozen,

--- a/app/wms/inventory_adjustment/return_inbound/services/return_task_service_impl.py
+++ b/app/wms/inventory_adjustment/return_inbound/services/return_task_service_impl.py
@@ -8,7 +8,7 @@ from sqlalchemy import Select, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.inventory_adjustment.return_inbound.models.return_task import ReturnTask, ReturnTaskLine
 from app.wms.ledger.models.stock_ledger import StockLedger
 from app.wms.reconciliation.services.three_books_enforcer import enforce_three_books

--- a/app/wms/outbound/routers/orders_fulfillment_v2_routes_2_pick.py
+++ b/app/wms/outbound/routers/orders_fulfillment_v2_routes_2_pick.py
@@ -14,7 +14,7 @@ from app.wms.shared.services.lot_code_contract import (
     validate_lot_code_contract,
 )
 from app.wms.outbound.contracts.orders_fulfillment_v2 import PickRequest, PickResponse
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.outbound.services.pick_service import PickService
 from app.tms.shipment.router_helpers import get_order_ref_and_trace_id
 

--- a/app/wms/outbound/services/pick_service.py
+++ b/app/wms/outbound/services/pick_service.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional, Union
 from sqlalchemy import text as SA
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.stock.services.stock_service import StockService
 
 

--- a/app/wms/scan/services/pick_handler.py
+++ b/app/wms/scan/services/pick_handler.py
@@ -1,7 +1,7 @@
 # app/wms/scan/services/pick_handler.py
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.stock.services.stock_service import StockService
 
 

--- a/app/wms/shared/enums.py
+++ b/app/wms/shared/enums.py
@@ -1,4 +1,5 @@
-# app/models/enums.py
+# app/wms/shared/enums.py
+# Domain move: FlowType and MovementType belong to WMS shared.
 from __future__ import annotations
 
 try:

--- a/app/wms/shared/services/reconcile_service.py
+++ b/app/wms/shared/services/reconcile_service.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.snapshot.services.snapshot_run import run_snapshot
 from app.wms.stock.services.stock_service import StockService
 

--- a/app/wms/stock/contracts/stock.py
+++ b/app/wms/stock/contracts/stock.py
@@ -6,7 +6,7 @@ from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 
 class _Base(BaseModel):
     model_config = ConfigDict(from_attributes=True, extra="ignore")

--- a/app/wms/stock/models/stock_lot.py
+++ b/app/wms/stock/models/stock_lot.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
 from app.wms.stock.models.lot import Lot
+from app.wms.warehouses.models.warehouse import Warehouse  # noqa: F401
 
 
 class StockLot(Base):

--- a/app/wms/stock/services/stock_adjust/adjust_batch_impl.py
+++ b/app/wms/stock/services/stock_adjust/adjust_batch_impl.py
@@ -6,7 +6,7 @@ from typing import Any, Awaitable, Callable, Dict, Optional, Union
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.stock.services.lot_guard import assert_lot_belongs_to
 from app.wms.stock.services.stock_adjust.batch_keys import norm_batch_code
 from app.wms.stock.services.stock_adjust.date_rules import resolve_and_validate_dates_for_inbound

--- a/app/wms/stock/services/stock_adjust/adjust_lot_impl.py
+++ b/app/wms/stock/services/stock_adjust/adjust_lot_impl.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Dict, Optional, Union
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.stock.services.lot_guard import assert_lot_belongs_to
 from app.wms.stock.services.stock_adjust.batch_keys import norm_batch_code
 from app.wms.stock.services.stock_adjust.date_rules import resolve_and_validate_dates_for_inbound

--- a/app/wms/stock/services/stock_service.py
+++ b/app/wms/stock/services/stock_service.py
@@ -8,7 +8,7 @@ from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.problem import raise_problem
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.stock.services.stock_adjust import adjust_lot_impl
 from app.wms.stock.services.stock_ship_service import ship_commit_direct_lot_impl
 from app.wms.stock.services.lot_resolver import LotResolver

--- a/app/wms/stock/services/stock_ship_service.py
+++ b/app/wms/stock/services/stock_ship_service.py
@@ -8,7 +8,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.problem import raise_problem
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.outbound.services.invariant_guard_outbound import enforce_outbound_invariant_guard
 from app.wms.shared.services.lot_code_contract import fetch_item_expiry_policy_map
 

--- a/app/wms/warehouses/models/warehouse.py
+++ b/app/wms/warehouses/models/warehouse.py
@@ -8,6 +8,7 @@ from sqlalchemy import Boolean, Integer, String, text
 from sqlalchemy.orm import Mapped, mapped_column, relationship, validates
 
 from app.db.base import Base
+from app.tms.providers.models.warehouse_shipping_provider import WarehouseShippingProvider  # noqa: F401
 
 if TYPE_CHECKING:
     from app.tms.providers.models.warehouse_shipping_provider import WarehouseShippingProvider

--- a/tests/quick/test_inbound_pick_count_v2.py
+++ b/tests/quick/test_inbound_pick_count_v2.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.stock.services.lots import ensure_internal_lot_singleton
 from app.wms.stock.services.stock_service import StockService
 

--- a/tests/quick/test_inbound_reclassify_v2.py
+++ b/tests/quick/test_inbound_reclassify_v2.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.stock.services.stock_service import StockService
 
 UTC = timezone.utc

--- a/tests/quick/test_inbound_smoke_pg.py
+++ b/tests/quick/test_inbound_smoke_pg.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.stock.services.stock_service import StockService
 
 pytestmark = pytest.mark.asyncio

--- a/tests/quick/test_outbound_commit_v2.py
+++ b/tests/quick/test_outbound_commit_v2.py
@@ -5,7 +5,7 @@ from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.outbound.services.outbound_commit_service import ship_commit
 from app.wms.stock.services.stock_service import StockService
 from tests.services._helpers import ensure_store

--- a/tests/quick/test_outbound_core_v2.py
+++ b/tests/quick/test_outbound_core_v2.py
@@ -5,7 +5,7 @@ from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.stock.services.stock_service import StockService
 
 UTC = timezone.utc

--- a/tests/quick/test_outbound_pg.py
+++ b/tests/quick/test_outbound_pg.py
@@ -6,7 +6,7 @@ from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.outbound.services.outbound_commit_service import ship_commit
 from app.wms.stock.services.stock_service import StockService
 from tests.services._helpers import ensure_store

--- a/tests/services/test_inbound_service.py
+++ b/tests/services/test_inbound_service.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 # 测试辅助：按项目实际路径导入
 from tests.helpers.inventory import ensure_wh_loc_item, qty_by_code
 
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.stock.services.lots import ensure_lot_full
 from app.wms.stock.services.stock_service import StockService
 

--- a/tests/services/test_order_outbound_flow_v3.py
+++ b/tests/services/test_order_outbound_flow_v3.py
@@ -5,7 +5,7 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.oms.services.order_service import OrderService
 from app.wms.outbound.services.outbound_commit_service import OutboundService
 from app.wms.stock.services.stock_service import StockService

--- a/tests/services/test_order_rma_and_reconcile.py
+++ b/tests/services/test_order_rma_and_reconcile.py
@@ -8,7 +8,7 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.reconciliation.services.order_reconcile_service import OrderReconcileService
 from app.oms.services.order_service import OrderService
 from app.wms.stock.services.lots import ensure_internal_lot_singleton, ensure_lot_full

--- a/tests/test_phase3_three_books_receive_commit.py
+++ b/tests/test_phase3_three_books_receive_commit.py
@@ -8,7 +8,7 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.snapshot.services.snapshot_run import run_snapshot
 from app.wms.stock.services.lots import ensure_internal_lot_singleton, ensure_lot_full
 from app.wms.stock.services.stock_service import StockService

--- a/tests/unit/test_fefo_query_v2.py
+++ b/tests/unit/test_fefo_query_v2.py
@@ -6,7 +6,7 @@ from datetime import date, datetime, timedelta, timezone
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.shared.services.expiry_analytics_allocator import ExpiryAnalyticsAllocator
 from app.wms.stock.services.stock_service import StockService
 from tests.utils.ensure_minimal import ensure_item

--- a/tests/unit/test_stock_service_v2.py
+++ b/tests/unit/test_stock_service_v2.py
@@ -6,7 +6,7 @@ from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.enums import MovementType
+from app.wms.shared.enums import MovementType
 from app.wms.stock.services.lots import ensure_internal_lot_singleton, ensure_lot_full
 from app.wms.stock.services.stock_service import StockService
 


### PR DESCRIPTION
## Summary
- move FlowType and MovementType from app/models/enums.py to app/wms/shared/enums.py
- update WMS/devtools/tests imports to the new WMS shared enum path
- add runtime relationship imports needed after previous model domain moves

## Validation
- python3 -m compileall app tests
- make alembic-check
- make test TESTS="tests/unit/test_stock_service_v2.py tests/unit/test_fefo_query_v2.py tests/services/test_inbound_service.py tests/services/test_order_rma_and_reconcile.py tests/services/test_inbound_reversal_service.py tests/services/test_outbound_reversal_service.py tests/services/test_outbound_atomic_service.py tests/services/test_order_outbound_flow_v3.py tests/test_phase3_three_books_receive_commit.py tests/test_phase3_three_books_return_commit.py tests/test_phase3_three_books_count_contract.py"