### PR TITLE
chore: clean stale global path text references

### DIFF
--- a/app/oms/repos/platform_orders_fact.py
+++ b/app/oms/repos/platform_orders_fact.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 def line_key_from_inputs(*, filled_code: Optional[str], line_no: Optional[int]) -> Optional[str]:
     """
-    与 app/services/platform_order_fact_service._line_key 对齐（保持幂等键物理格式不变）：
+    与 app.oms.services.platform_order_fact_service._line_key 对齐（保持幂等键物理格式不变）：
 
     - 有填写码（filled_code 非空）：PSKU:{filled_code}
     - 无填写码（filled_code 为空）：NO_PSKU:{line_no}

--- a/app/wms/ledger/models/stock_ledger.py
+++ b/app/wms/ledger/models/stock_ledger.py
@@ -1,4 +1,4 @@
-# app/models/stock_ledger.py
+# app/wms/ledger/models/stock_ledger.py
 from __future__ import annotations
 
 from datetime import date

--- a/app/wms/ledger/services/stock_service_adjust.py
+++ b/app/wms/ledger/services/stock_service_adjust.py
@@ -22,7 +22,7 @@ from app.wms.ledger.services.ledger_writer import write_ledger as _write_ledger
 async def write_ledger_infra(**kwargs: Any) -> Any:
     """
     ✅ infra wrapper: 允许模块内直接 await write_ledger()
-    其他模块（例如 app/services/stock_adjust/*）必须调用本函数，而不能直接调用 write_ledger。
+    其他库存写入模块必须调用本函数，而不能直接调用 write_ledger。
     """
     return await _write_ledger(**kwargs)
 

--- a/app/wms/shared/services/barcode.py
+++ b/app/wms/shared/services/barcode.py
@@ -165,7 +165,7 @@ class BarcodeResolver:
         - 17 + 6 位 YYMMDD
         - 10 + 可变长批次号
 
-        这是原 app/utils/gs1.py 唯一仍被 /scan fallback 使用的能力。
+        这是从旧 GS1 工具收口到当前条码解析器后保留的紧凑 GS1 解析能力。
         """
         i = 0
         n = len(s)

--- a/app/wms/stock/models/lot.py
+++ b/app/wms/stock/models/lot.py
@@ -1,4 +1,4 @@
-# app/models/lot.py
+# app/wms/stock/models/lot.py
 from __future__ import annotations
 
 from datetime import date, datetime

--- a/app/wms/stock/models/stock_lot.py
+++ b/app/wms/stock/models/stock_lot.py
@@ -1,4 +1,4 @@
-# app/models/stock_lot.py
+# app/wms/stock/models/stock_lot.py
 from __future__ import annotations
 
 import sqlalchemy as sa

--- a/app/wms/stock/models/stock_snapshot.py
+++ b/app/wms/stock/models/stock_snapshot.py
@@ -1,4 +1,4 @@
-# app/models/stock_snapshot.py
+# app/wms/stock/models/stock_snapshot.py
 from __future__ import annotations
 
 from datetime import date

--- a/scripts/make/audit.mk
+++ b/scripts/make/audit.mk
@@ -60,7 +60,7 @@ audit-no-implicit-warehouse-id:
 	  if [ -z "$$hits" ]; then \
 	    echo "[audit-no-implicit-warehouse-id] OK (no hits)"; exit 0; \
 	  fi; \
-	  allow_re="app/services/order_fulfillment_manual_assign\\.py"; \
+	  allow_re="app/wms/outbound/services/order_fulfillment_manual_assign\\.py"; \
 	  bad="$$(printf "%s\n" "$$hits" | rg -v "$$allow_re" || true)"; \
 	  if [ -n "$$bad" ]; then \
 	    echo "$$bad"; \

--- a/tests/services/order_lifecycle_v2/seeders.py
+++ b/tests/services/order_lifecycle_v2/seeders.py
@@ -126,7 +126,7 @@ async def seed_full_lifecycle_case(session: AsyncSession) -> str:
     - 这里先 ensure SUPPLIER lot（lot_code='B-LIFE-1'）拿到 lot_id，再写 stock_ledger.lot_id
 
     ✅ 终态收口：禁止 tests 直接 INSERT INTO lots
-    -> 统一走 app/services/stock/lots.py: ensure_lot_full
+    -> 统一走 app.wms.stock.services.lots.ensure_lot_full
     """
     trace_id = "LIFE-UT-1"
     platform = "PDD"

--- a/tests/services/test_order_rma_and_reconcile.py
+++ b/tests/services/test_order_rma_and_reconcile.py
@@ -70,7 +70,7 @@ async def _ensure_supplier_lot(session: AsyncSession, *, warehouse_id: int, item
     - 必填快照从 items 取值
 
     ✅ 终态收口：禁止 tests 直接 INSERT INTO lots
-    -> 统一走 app/services/stock/lots.py: ensure_lot_full
+    -> 统一走 app.wms.stock.services.lots.ensure_lot_full
     """
     code_raw = str(code).strip()
     assert code_raw, {"msg": "empty lot_code", "warehouse_id": warehouse_id, "item_id": item_id}

--- a/tests/services/test_platform_order_line_key_format_contract.py
+++ b/tests/services/test_platform_order_line_key_format_contract.py
@@ -12,7 +12,7 @@ def test_line_key_format_contract_keeps_legacy_prefixes_and_matches_repo_helper(
     - filled_code 非空 -> 必须产出 "PSKU:{filled_code}"
     - filled_code 为空 -> 必须产出 "NO_PSKU:{line_no}"
 
-    同时保证 app/api 与 app/services 两处生成逻辑严格一致（防漂移）。
+    同时保证 OMS service 与 repo helper 两处生成逻辑严格一致（防漂移）。
     """
     # case 1: has filled_code
     filled_code = "SKU-INGEST-001"

--- a/tests/test_phase3_three_books_receive_commit.py
+++ b/tests/test_phase3_three_books_receive_commit.py
@@ -131,7 +131,7 @@ async def _ensure_supplier_lot(
     确保 SUPPLIER lot 存在，返回 lot_id。
 
     ✅ 终态收口：禁止 tests 直接 INSERT INTO lots
-    -> 统一走 app/services/stock/lots.py: ensure_lot_full
+    -> 统一走 app.wms.stock.services.lots.ensure_lot_full
 
     语义收口：
     - REQUIRED 商品：lot 身份已切到 (warehouse_id, item_id, production_date)
@@ -168,7 +168,7 @@ async def _ensure_internal_lot_for_receipt(
     INTERNAL lot：lot_code NULL。
 
     ✅ 终态收口：禁止 tests 直接 INSERT INTO lots
-    -> 统一走 app/services/stock/lots.py: ensure_internal_lot_singleton
+    -> 统一走 app.wms.stock.services.lots.ensure_internal_lot_singleton
 
     这里仍然把 receipt_id/line_no 作为 provenance 成对传入，满足成对可选规则。
     """

--- a/tests/utils/ensure_minimal.py
+++ b/tests/utils/ensure_minimal.py
@@ -157,7 +157,7 @@ async def ensure_supplier_lot(
     Phase M-5：创建/获取一个最小合法 SUPPLIER lot，并返回 lot_id。
 
     ✅ 工程收口：禁止 tests 里直接 INSERT INTO lots
-    -> 统一走 app.services.lot_service.ensure_lot_full
+    -> 统一走 app.wms.stock.services.lot_service.ensure_lot_full
 
     语义收口：
     - helper 名字就叫 ensure_supplier_lot，因此它必须保证商品策略至少提升到 REQUIRED


### PR DESCRIPTION
## Summary
- update stale comments that still referenced retired app/models, app/services, or app/utils paths
- update audit whitelist path to current WMS outbound service location
- keep intentional retired-path boundary tests and split-history notes unchanged

## Evidence
- app root cleanup has removed the old global directories
- remaining references are intentional retired-path boundary checks or split-history notes
- this PR does not move runtime code or change contracts

## Validation
- python3 -m compileall app tests scripts
- make alembic-check
- make test TESTS="tests/unit/test_tms_phase1_boundary.py tests/services/test_platform_order_line_key_format_contract.py tests/api/test_no_duplicate_routes.py tests/services/test_routing_metrics_emit.py"