### PR TITLE
chore(wms): move three-books tailgate services to shared

### DIFF
--- a/app/wms/inventory_adjustment/return_inbound/services/return_task_service_impl.py
+++ b/app/wms/inventory_adjustment/return_inbound/services/return_task_service_impl.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import selectinload
 from app.wms.shared.enums import MovementType
 from app.wms.inventory_adjustment.return_inbound.models.return_task import ReturnTask, ReturnTaskLine
 from app.wms.ledger.models.stock_ledger import StockLedger
-from app.wms.reconciliation.services.three_books_enforcer import enforce_three_books
+from app.wms.shared.services.three_books_enforcer import enforce_three_books
 from app.wms.stock.services.stock_service import StockService
 
 UTC = timezone.utc

--- a/app/wms/shared/services/three_books_consistency.py
+++ b/app/wms/shared/services/three_books_consistency.py
@@ -1,4 +1,4 @@
-# app/wms/reconciliation/services/three_books_consistency.py
+# app/wms/shared/services/three_books_consistency.py
 from __future__ import annotations
 
 from collections import defaultdict
@@ -265,21 +265,3 @@ async def verify_commit_three_books(
             "三账一致性失败：snapshot_total != stocks_lot_total（Phase 4C：按 item 总量对齐）"
             f" mismatches={mismatches} expected_delta_by_item={dict(expected_delta_by_item)}"
         )
-
-
-# 兼容旧名称
-async def verify_receive_commit_three_books(
-    session: AsyncSession,
-    *,
-    warehouse_id: int,
-    ref: str,
-    effects: List[Dict[str, Any]],
-    at: datetime,
-) -> None:
-    return await verify_commit_three_books(
-        session,
-        warehouse_id=warehouse_id,
-        ref=ref,
-        effects=effects,
-        at=at,
-    )

--- a/app/wms/shared/services/three_books_enforcer.py
+++ b/app/wms/shared/services/three_books_enforcer.py
@@ -1,4 +1,4 @@
-# app/wms/reconciliation/services/three_books_enforcer.py
+# app/wms/shared/services/three_books_enforcer.py
 from __future__ import annotations
 
 from collections import defaultdict
@@ -8,7 +8,7 @@ from typing import Any, Dict, List
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.wms.snapshot.services.snapshot_run import run_snapshot
-from app.wms.reconciliation.services.three_books_consistency import verify_commit_three_books
+from app.wms.shared.services.three_books_consistency import verify_commit_three_books
 
 
 async def enforce_three_books(

--- a/tests/api/test_inventory_adjustment_count_doc_mainline_api.py
+++ b/tests/api/test_inventory_adjustment_count_doc_mainline_api.py
@@ -8,7 +8,7 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.wms.reconciliation.services.three_books_consistency import verify_commit_three_books
+from app.wms.shared.services.three_books_consistency import verify_commit_three_books
 from app.wms.snapshot.services.snapshot_run import run_snapshot
 from app.wms.stock.services.stock_service import StockService
 

--- a/tests/test_phase3_three_books_count_contract.py
+++ b/tests/test_phase3_three_books_count_contract.py
@@ -11,7 +11,7 @@ from app.wms.inventory_adjustment.count.contracts.count import CountRequest
 from app.wms.inventory_adjustment.count.services.count_service import CountService
 from app.wms.snapshot.services.snapshot_run import run_snapshot
 from app.wms.stock.services.stock_service import StockService
-from app.wms.reconciliation.services.three_books_consistency import verify_commit_three_books
+from app.wms.shared.services.three_books_consistency import verify_commit_three_books
 
 
 def _date_to_utc_datetime(d: date) -> datetime:

--- a/tests/test_phase3_three_books_outbound_commit.py
+++ b/tests/test_phase3_three_books_outbound_commit.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.wms.outbound.services.outbound_commit_service import OutboundService
 from app.wms.snapshot.services.snapshot_run import run_snapshot
 from app.wms.stock.services.stock_service import StockService
-from app.wms.reconciliation.services.three_books_consistency import verify_receive_commit_three_books
+from app.wms.shared.services.three_books_consistency import verify_commit_three_books
 from tests.services._helpers import ensure_store
 
 
@@ -134,7 +134,7 @@ async def test_phase3_outbound_commit_three_books_strict(session: AsyncSession):
 
     # 双保险：再跑一次快照 + 三账校验（只对本次 touched key）
     await run_snapshot(session)
-    await verify_receive_commit_three_books(
+    await verify_commit_three_books(
         session,
         warehouse_id=warehouse_id,
         ref=str(order_id),

--- a/tests/test_phase3_three_books_receive_commit.py
+++ b/tests/test_phase3_three_books_receive_commit.py
@@ -12,7 +12,7 @@ from app.wms.shared.enums import MovementType
 from app.wms.snapshot.services.snapshot_run import run_snapshot
 from app.wms.stock.services.lots import ensure_internal_lot_singleton, ensure_lot_full
 from app.wms.stock.services.stock_service import StockService
-from app.wms.reconciliation.services.three_books_consistency import verify_receive_commit_three_books
+from app.wms.shared.services.three_books_consistency import verify_commit_three_books
 
 
 async def _pick_test_item(session: AsyncSession) -> tuple[int, bool]:
@@ -330,7 +330,7 @@ async def test_phase3_receive_commit_three_books_strict(session: AsyncSession):
     - 以 Receipt(RELEASED) 作为事实锚点（终态不再有旧执行层）
     - 以 StockService.adjust(INBOUND) 作为“入库落账动作”写入 ledger+stocks_lot
     - snapshot(today) == stocks_lot（至少对 touched keys）
-    - verify_receive_commit_three_books 对 touched effects 做三账一致性校验
+    - verify_commit_three_books 对 touched effects 做三账一致性校验
 
     Phase 1A 批次两态（真相源：items.expiry_policy）：
     - expiry_policy=NONE：batch_code=NULL 且 production/expiry=NULL；库存聚合到无批次槽位（INTERNAL lot_code NULL）
@@ -404,7 +404,7 @@ async def test_phase3_receive_commit_three_books_strict(session: AsyncSession):
     assert lot_id is not None, {"msg": "expected ledger row to provide lot_id", "ref": ref, "ref_line": 1, "item_id": item_id}
 
     await run_snapshot(session)
-    await verify_receive_commit_three_books(
+    await verify_commit_three_books(
         session,
         warehouse_id=1,
         ref=ref,

--- a/tests/test_phase3_three_books_return_commit.py
+++ b/tests/test_phase3_three_books_return_commit.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.wms.inventory_adjustment.return_inbound.services.return_task_service_impl import ReturnTaskServiceImpl
 from app.wms.snapshot.services.snapshot_run import run_snapshot
 from app.wms.stock.services.stock_service import StockService
-from app.wms.reconciliation.services.three_books_consistency import verify_commit_three_books
+from app.wms.shared.services.three_books_consistency import verify_commit_three_books
 
 
 async def _pick_item_for_stock_in(session: AsyncSession) -> tuple[int, bool]:


### PR DESCRIPTION
## Summary
- move WMS three-books tailgate services from reconciliation to shared services
- update all imports to app.wms.shared.services.three_books_*
- remove legacy verify_receive_commit_three_books alias
- keep order_reconcile_* under reconciliation because it is a separate order/RMA reconciliation concern

## Validation
- git diff --check
- python3 -m compileall app tests scripts
- make alembic-check
- make test TESTS="tests/test_phase3_three_books_receive_commit.py tests/test_phase3_three_books_outbound_commit.py tests/test_phase3_three_books_return_commit.py tests/test_phase3_three_books_count_contract.py tests/api/test_inventory_adjustment_count_doc_mainline_api.py tests/services/test_order_rma_and_reconcile.py"