### PR TITLE
chore(wms): fix return inbound stale file headers

### DIFF
--- a/app/wms/inventory_adjustment/return_inbound/contracts/return_task.py
+++ b/app/wms/inventory_adjustment/return_inbound/contracts/return_task.py
@@ -1,4 +1,4 @@
-# app/wms/outbound/contracts/return_task.py
+# app/wms/inventory_adjustment/return_inbound/contracts/return_task.py
 from __future__ import annotations
 
 from datetime import datetime

--- a/app/wms/inventory_adjustment/return_inbound/models/inbound_operation.py
+++ b/app/wms/inventory_adjustment/return_inbound/models/inbound_operation.py
@@ -1,4 +1,4 @@
-# app/wms/receiving/models/inbound_operation.py
+# app/wms/inventory_adjustment/return_inbound/models/inbound_operation.py
 # 拆分说明：
 # 本文件承接“WMS 收货操作事实层”ORM 模型，只负责
 # wms_inbound_operations / wms_inbound_operation_lines。

--- a/app/wms/inventory_adjustment/return_inbound/models/inbound_receipt.py
+++ b/app/wms/inventory_adjustment/return_inbound/models/inbound_receipt.py
@@ -1,4 +1,4 @@
-# app/inbound_receipts/models/inbound_receipt.py
+# app/wms/inventory_adjustment/return_inbound/models/inbound_receipt.py
 # 拆分说明：
 # 本文件承接“入库任务层”ORM 模型，只负责 inbound_receipts / inbound_receipt_lines。
 # 它位于 procurement 与 WMS 之间的独立模块，不再沿用旧 app/wms/inbound/models/inbound_receipt.py 的混合语义。

--- a/app/wms/inventory_adjustment/return_inbound/routers/_common.py
+++ b/app/wms/inventory_adjustment/return_inbound/routers/_common.py
@@ -1,4 +1,4 @@
-# app/wms/outbound/routers/return_tasks/_common.py
+# app/wms/inventory_adjustment/return_inbound/routers/_common.py
 from __future__ import annotations
 
 import json

--- a/app/wms/inventory_adjustment/return_inbound/routers/order_refs.py
+++ b/app/wms/inventory_adjustment/return_inbound/routers/order_refs.py
@@ -1,4 +1,4 @@
-# app/wms/outbound/routers/return_tasks/order_refs.py
+# app/wms/inventory_adjustment/return_inbound/routers/order_refs.py
 from __future__ import annotations
 
 from typing import List, Optional

--- a/app/wms/inventory_adjustment/return_inbound/routers/tasks.py
+++ b/app/wms/inventory_adjustment/return_inbound/routers/tasks.py
@@ -1,4 +1,4 @@
-# app/wms/outbound/routers/return_tasks/tasks.py
+# app/wms/inventory_adjustment/return_inbound/routers/tasks.py
 from __future__ import annotations
 
 from typing import List, Optional

--- a/app/wms/inventory_adjustment/return_inbound/services/return_task_service_impl.py
+++ b/app/wms/inventory_adjustment/return_inbound/services/return_task_service_impl.py
@@ -1,4 +1,4 @@
-# app/wms/outbound/services/return_task_service_impl.py
+# app/wms/inventory_adjustment/return_inbound/services/return_task_service_impl.py
 from __future__ import annotations
 
 from datetime import datetime, timezone


### PR DESCRIPTION
## Summary
- fix stale file header comments under WMS inventory_adjustment return_inbound
- align headers with current module ownership
- no behavior, route, contract, schema, or test logic changes

## Validation
- git diff --check
- python3 -m compileall app tests scripts
- make alembic-check
- make test TESTS="tests/test_phase3_three_books_return_commit.py tests/services/test_order_rma_and_reconcile.py tests/api/test_inbound_receipts_manual_api.py"