### PR TITLE
chore(wms): retire return task pick compat endpoint

### DIFF
--- a/app/wms/inventory_adjustment/return_inbound/routers/tasks.py
+++ b/app/wms/inventory_adjustment/return_inbound/routers/tasks.py
@@ -112,17 +112,6 @@ def register_tasks(router: APIRouter) -> None:
             await session.rollback()
             raise HTTPException(status_code=400, detail=str(e))
 
-    # =========================================================
-    # Pick（旧路径兼容，内部转发到 receive）
-    # =========================================================
-    @router.post("/{task_id}/pick", response_model=ReturnTaskOut)
-    async def pick_return_task_compat(
-        task_id: int,
-        payload: ReturnTaskReceiveIn,
-        session: AsyncSession = Depends(get_session),
-    ) -> ReturnTaskOut:
-        return await receive_return_task(task_id, payload, session)
-
     # -----------------------------
     # Commit
     # -----------------------------

--- a/openapi/_current.json
+++ b/openapi/_current.json
@@ -29971,58 +29971,6 @@
         ]
       }
     },
-    "/return-tasks/{task_id}/pick": {
-      "post": {
-        "operationId": "pick_return_task_compat_return_tasks__task_id__pick_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "task_id",
-            "required": true,
-            "schema": {
-              "title": "Task Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ReturnTaskReceiveIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ReturnTaskOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Pick Return Task Compat",
-        "tags": [
-          "return-tasks"
-        ]
-      }
-    },
     "/return-tasks/{task_id}/receive": {
       "post": {
         "operationId": "receive_return_task_return_tasks__task_id__receive_post",

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -29971,58 +29971,6 @@
         ]
       }
     },
-    "/return-tasks/{task_id}/pick": {
-      "post": {
-        "operationId": "pick_return_task_compat_return_tasks__task_id__pick_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "task_id",
-            "required": true,
-            "schema": {
-              "title": "Task Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ReturnTaskReceiveIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ReturnTaskOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Pick Return Task Compat",
-        "tags": [
-          "return-tasks"
-        ]
-      }
-    },
     "/return-tasks/{task_id}/receive": {
       "post": {
         "operationId": "receive_return_task_return_tasks__task_id__receive_post",


### PR DESCRIPTION
## Summary
- remove legacy /return-tasks/{task_id}/pick compat endpoint
- keep /return-tasks/{task_id}/receive as the only return receive endpoint
- remove the retired path from OpenAPI
- no DB, Alembic, or frontend changes

## Validation
- rg -n 'pick_return_task_compat|/return-tasks/\{task_id\}/pick|return-tasks/.*/pick' app tests scripts openapi ../wms-fe/src 2>/dev/null || true
- git diff --check
- python3 -m compileall app tests scripts
- make alembic-check
- make test TESTS="tests/test_phase3_three_books_return_commit.py tests/api/test_no_duplicate_routes.py tests/api/test_inbound_receipts_manual_api.py"