### PR TITLE
chore(wms): use OMS order ref resolver in outbound commit

### DIFF
--- a/app/wms/outbound/services/outbound_commit_service.py
+++ b/app/wms/outbound/services/outbound_commit_service.py
@@ -13,7 +13,7 @@ from app.wms.shared.services.lot_code_contract import fetch_item_expiry_policy_m
 from app.core.problem import raise_problem
 from app.wms.outbound.services.invariant_guard_outbound import enforce_outbound_invariant_guard
 from app.wms.outbound.services.order_fulfillment_service import OrderFulfillmentService
-from app.oms.services.order_ref_helper import parse_order_ref
+from app.oms.services.order_ref_resolver import resolve_order_id
 from app.wms.outbound.contracts.outbound_commit_models import (
     ShipLine,
     coerce_line,
@@ -30,86 +30,7 @@ async def _load_existing_order_id(session: AsyncSession, *, order_ref: str) -> i
     if not s:
         raise ValueError("order_id/order_ref cannot be empty")
 
-    if s.isdigit():
-        row = (
-            await session.execute(
-                sa.text("SELECT id FROM orders WHERE id = :id LIMIT 1"),
-                {"id": int(s)},
-            )
-        ).first()
-        if row:
-            return int(row[0])
-        raise_problem(
-            status_code=404,
-            error_code="order_not_found",
-            message="订单不存在（按 orders.id 查询）。",
-            context={"order_ref": s, "order_id": int(s)},
-            details=[],
-            next_actions=[],
-        )
-        return 0
-
-    parsed = parse_order_ref(s)
-    if parsed is None:
-        parts = s.split(":", 2)
-        if len(parts) == 3:
-            plat, sid, ext = parts
-            plat = str(plat or "").upper().strip()
-            sid = str(sid or "").strip()
-            ext = str(ext or "").strip()
-            if plat and sid and ext:
-                class _CompatParsed:
-                    platform = plat
-                    shop_id = sid
-                    ext_order_no = ext
-                parsed = _CompatParsed()
-        if parsed is None:
-            raise_problem(
-                status_code=422,
-                error_code="invalid_order_ref",
-                message="订单引用格式不合法，必须传 orders.id、ORD:PLAT:SHOP:EXT 或 PLAT:SHOP:EXT。",
-                context={"order_ref": s},
-                details=[],
-                next_actions=[],
-            )
-            return 0
-
-    row = (
-        await session.execute(
-            sa.text(
-                """
-                SELECT id
-                  FROM orders
-                 WHERE platform = :p
-                   AND shop_id = :sid
-                   AND ext_order_no = :ext
-                 LIMIT 1
-                """
-            ),
-            {
-                "p": str(parsed.platform),
-                "sid": str(parsed.shop_id),
-                "ext": str(parsed.ext_order_no),
-            },
-        )
-    ).first()
-    if row:
-        return int(row[0])
-
-    raise_problem(
-        status_code=404,
-        error_code="order_not_found",
-        message="订单不存在，禁止在出库阶段自动补订单头。",
-        context={
-            "order_ref": s,
-            "platform": str(parsed.platform),
-            "shop_id": str(parsed.shop_id),
-            "ext_order_no": str(parsed.ext_order_no),
-        },
-        details=[],
-        next_actions=[],
-    )
-    return 0
+    return int(await resolve_order_id(session, order_ref=s))
 
 
 def _norm_lot_code(v: str | None) -> str | None:


### PR DESCRIPTION
## Summary
- remove local _CompatParsed order-ref parsing shell from outbound commit
- delegate order_id / ORD:PLAT:SHOP:EXT / PLAT:SHOP:EXT resolution to OMS order_ref_resolver
- keep existing supported input formats unchanged
- no DB, Alembic, OpenAPI, or frontend changes

## Validation
- rg -n '_CompatParsed|class _CompatParsed|invalid_order_ref|ORD:PLAT:SHOP:EXT 或 PLAT:SHOP:EXT' app/wms/outbound/services/outbound_commit_service.py app tests scripts || true
- git diff --check
- python3 -m compileall app tests scripts
- make alembic-check
- make test TESTS="tests/test_phase3_three_books_outbound_commit.py tests/services/test_outbound_ledger_consistency.py tests/services/test_outbound_idempotency.py tests/api/test_order_outbound_submit_api.py tests/api/test_v2_full_chain.py"