### PR TITLE
chore(wms): retire audit service wrapper

### DIFF
--- a/app/wms/shared/services/audit_writer.py
+++ b/app/wms/shared/services/audit_writer.py
@@ -86,35 +86,3 @@ class AuditEventWriter:
                 ref,
                 json.dumps(payload, ensure_ascii=False),
             )
-
-
-class AuditService:
-    """
-    兼容用审计服务（薄封装）：
-
-    - 新代码请直接用 AuditEventWriter.write；
-    - 旧代码如依赖 AuditService，可以逐步迁移。
-    """
-
-    def __init__(self, session: AsyncSession) -> None:
-        self.session = session
-
-    async def log_event(
-        self,
-        *,
-        flow: str,
-        event: str,
-        ref: str,
-        trace_id: Optional[str] = None,
-        meta: Optional[Dict[str, Any]] = None,
-        auto_commit: bool = False,
-    ) -> None:
-        await AuditEventWriter.write(
-            self.session,
-            flow=flow,
-            event=event,
-            ref=ref,
-            trace_id=trace_id,
-            meta=meta,
-            auto_commit=auto_commit,
-        )


### PR DESCRIPTION
## Summary
- remove unused AuditService compatibility wrapper
- keep AuditEventWriter as the async audit writer
- keep SyncAuditEventWriter unchanged for sync Session flows
- no DB, Alembic, OpenAPI, or frontend changes

## Validation
- rg -n 'AuditService|\.log_event\(' app tests scripts || true
- git diff --check
- python3 -m compileall app tests scripts
- make alembic-check
- make test TESTS="tests/services/test_audit_writer.py tests/api/test_v2_full_chain.py tests/api/test_phase3x_diagnostics_seed_scenario.py"