### PR TITLE
chore(pms): retire item barcode primary compat endpoint

### DIFF
--- a/app/pms/items/routers/item_barcodes.py
+++ b/app/pms/items/routers/item_barcodes.py
@@ -233,12 +233,6 @@ def set_primary(id: int, db: Session = Depends(get_db)):
     return bc
 
 
-@router.post("/{id}/primary", status_code=status.HTTP_204_NO_CONTENT)
-def set_primary_compat(id: int, db: Session = Depends(get_db)):
-    _ = set_primary(id, db)
-    return None
-
-
 @router.patch("/{id}", response_model=ItemBarcodeOut)
 def update_barcode(id: int, body: ItemBarcodeUpdate, db: Session = Depends(get_db)):
     bc = get_item_barcode_by_id(db, int(id))

--- a/openapi/_current.json
+++ b/openapi/_current.json
@@ -23363,41 +23363,6 @@
         ]
       }
     },
-    "/item-barcodes/{id}/primary": {
-      "post": {
-        "operationId": "set_primary_compat_item_barcodes__id__primary_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "title": "Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Set Primary Compat",
-        "tags": [
-          "item-barcodes"
-        ]
-      }
-    },
     "/item-barcodes/{id}/set-primary": {
       "post": {
         "operationId": "set_primary_item_barcodes__id__set_primary_post",

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -23363,41 +23363,6 @@
         ]
       }
     },
-    "/item-barcodes/{id}/primary": {
-      "post": {
-        "operationId": "set_primary_compat_item_barcodes__id__primary_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "title": "Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Set Primary Compat",
-        "tags": [
-          "item-barcodes"
-        ]
-      }
-    },
     "/item-barcodes/{id}/set-primary": {
       "post": {
         "operationId": "set_primary_item_barcodes__id__set_primary_post",


### PR DESCRIPTION
## Summary
- remove legacy /item-barcodes/{id}/primary compat endpoint
- keep /item-barcodes/{id}/set-primary as the only primary barcode endpoint
- remove retired path from OpenAPI
- no DB, Alembic, or frontend changes

## Validation
- rg -n 'set_primary_compat|"/item-barcodes/\{id\}/primary"|/item-barcodes/\{id\}/primary|item-barcodes/.*/primary' app tests scripts openapi ../wms-fe/src 2>/dev/null || true
- rg -n '"/item-barcodes/\{id\}/set-primary"|set_primary_item_barcodes|/item-barcodes/\$\{id\}/set-primary|setPrimaryBarcode' app tests scripts openapi ../wms-fe/src 2>/dev/null || true
- git diff --check
- python3 -m compileall app tests scripts
- make alembic-check
- make test TESTS="tests/api/test_item_owner_aggregate_api.py tests/services/test_pms_public_item_read_service.py tests/api/test_user_navigation_api.py tests/api/test_no_duplicate_routes.py"