### PR TITLE
chore(cleanup): remove dev route comment residue

### DIFF
--- a/scripts/export_openapi.py
+++ b/scripts/export_openapi.py
@@ -19,7 +19,6 @@ def _build_app() -> Any:
     注意：
     - devtools 已退役；
     - 不再支持 --enable-dev-routes；
-    - 不再设置 WMS_ENABLE_DEV_ROUTES；
     - 把 cwd 切到 repo root，保证相对路径落在仓库内。
     """
     os.chdir(ROOT)


### PR DESCRIPTION
## Summary
- remove stale WMS_ENABLE_DEV_ROUTES comment after devtools retirement
- no runtime code changes

## Validation
- rg -n 'WMS_ENABLE_DEV_ROUTES|enable_dev_routes|DEV_ROUTES_ENABLED|app\.devtools|from app\.devtools|/dev/|fake-platform|fake_platform|openapi-export-dev|_current.dev|v1.dev' app tests scripts openapi .github || true
- git diff --check
- python3 -m compileall app tests scripts
- make alembic-check
- make test TESTS="tests/api/test_no_duplicate_routes.py"