### PR TITLE
feat(wms): anchor return tasks by lot id

### DIFF
--- a/alembic/versions/c896df82c17c_return_task_lines_add_lot_id.py
+++ b/alembic/versions/c896df82c17c_return_task_lines_add_lot_id.py
@@ -1,0 +1,161 @@
+"""return task lines add lot_id structural anchor
+
+Revision ID: c896df82c17c
+Revises: a2ceea372e0e
+Create Date: 2026-04-25 01:43:09.327580
+
+Contract:
+- return_task_lines.lot_id is the structural anchor for return-to-original-lot.
+- return_task_lines.batch_code remains a display snapshot from lots.lot_code.
+- Historical demo/UT rows that cannot be mapped back to current stock_ledger/lots are removed.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "c896df82c17c"
+down_revision = "a2ceea372e0e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1) Remove historical/orphan return tasks that cannot be linked to current ledger facts.
+    #
+    # Terminal lot-world rule:
+    #   return task creation must be driven by stock_ledger.ref and stock_ledger.lot_id.
+    #
+    # Any return_task without a matching stock_ledger.ref has no recoverable structural lot_id,
+    # so it cannot be migrated into the new return_task_lines.lot_id NOT NULL contract.
+    # This intentionally removes old demo/UT drift rows instead of introducing nullable fallback.
+    op.execute(
+        sa.text(
+            """
+            DELETE FROM return_tasks rt
+             WHERE NOT EXISTS (
+                     SELECT 1
+                       FROM stock_ledger sl
+                      WHERE sl.ref = rt.order_id
+                   )
+            """
+        )
+    )
+
+    # 2) Add nullable first, then backfill, then enforce NOT NULL.
+    op.add_column(
+        "return_task_lines",
+        sa.Column("lot_id", sa.Integer(), nullable=True),
+    )
+
+    # 3) Best-effort backfill for any real rows still present:
+    #    order_id -> stock_ledger.ref, item/warehouse match, batch_code snapshot == lots.lot_code.
+    #    Only unambiguous mappings are applied.
+    op.execute(
+        sa.text(
+            """
+            WITH mapped AS (
+                SELECT
+                    rtl.id AS return_task_line_id,
+                    MIN(sl.lot_id)::int AS lot_id,
+                    COUNT(DISTINCT sl.lot_id) AS lot_count
+                FROM return_task_lines rtl
+                JOIN return_tasks rt
+                  ON rt.id = rtl.task_id
+                JOIN stock_ledger sl
+                  ON sl.ref = rt.order_id
+                 AND sl.delta < 0
+                 AND sl.reason IN ('SHIPMENT', 'OUTBOUND_SHIP')
+                 AND sl.item_id = rtl.item_id
+                 AND sl.warehouse_id = rt.warehouse_id
+                JOIN lots lo
+                  ON lo.id = sl.lot_id
+                 AND lo.lot_code_source = 'SUPPLIER'
+                 AND lo.lot_code = rtl.batch_code
+                GROUP BY rtl.id
+                HAVING COUNT(DISTINCT sl.lot_id) = 1
+            )
+            UPDATE return_task_lines rtl
+               SET lot_id = mapped.lot_id
+              FROM mapped
+             WHERE rtl.id = mapped.return_task_line_id
+               AND rtl.lot_id IS NULL
+            """
+        )
+    )
+
+    # 4) Fail loudly if any non-demo row cannot be migrated.
+    op.execute(
+        sa.text(
+            """
+            DO $$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1
+                      FROM return_task_lines
+                     WHERE lot_id IS NULL
+                ) THEN
+                    RAISE EXCEPTION
+                        'return_task_lines.lot_id migration failed: NULL lot_id remains';
+                END IF;
+            END $$;
+            """
+        )
+    )
+
+    op.alter_column(
+        "return_task_lines",
+        "lot_id",
+        existing_type=sa.Integer(),
+        nullable=False,
+    )
+
+    op.create_index(
+        "ix_return_task_lines_lot_id",
+        "return_task_lines",
+        ["lot_id"],
+        unique=False,
+    )
+
+    op.create_foreign_key(
+        "fk_return_task_lines_lot",
+        "return_task_lines",
+        "lots",
+        ["lot_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+
+    op.execute(
+        sa.text(
+            """
+            COMMENT ON COLUMN return_task_lines.lot_id IS
+            '结构锚点：退货回原批次对应的 lots.id，来自原出库 stock_ledger.lot_id'
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            COMMENT ON COLUMN return_task_lines.batch_code IS
+            '展示快照：来自原出库 lot 的 lots.lot_code；不参与结构锚点'
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_return_task_lines_lot", "return_task_lines", type_="foreignkey")
+    op.drop_index("ix_return_task_lines_lot_id", table_name="return_task_lines")
+    op.drop_column("return_task_lines", "lot_id")
+
+    op.execute(
+        sa.text(
+            """
+            COMMENT ON COLUMN return_task_lines.batch_code IS
+            '批次编码（系统自动回原批次：来自订单出库台账，必填；不允许人工补录）'
+            """
+        )
+    )

--- a/app/wms/inventory_adjustment/return_inbound/contracts/return_task.py
+++ b/app/wms/inventory_adjustment/return_inbound/contracts/return_task.py
@@ -14,6 +14,7 @@ class ReturnTaskLineOut(BaseModel):
     order_line_id: Optional[int] = None
 
     item_id: int
+    lot_id: int
     item_name: Optional[str]
     batch_code: str
 

--- a/app/wms/inventory_adjustment/return_inbound/models/return_task.py
+++ b/app/wms/inventory_adjustment/return_inbound/models/return_task.py
@@ -83,14 +83,13 @@ class ReturnTaskLine(Base):
     """
     订单退货回仓任务行（Return Task Line）
 
-    一行代表一个 item（自动回原批次回仓）：
+    一行代表一个 item + lot（自动回原 lot 回仓）：
 
+    - lot_id: 回原批次的结构锚点，来自原出库 stock_ledger.lot_id；
+    - batch_code: 展示快照，来自 lots.lot_code，不参与结构身份；
     - expected_qty: 计划回仓数量（来自订单原出库数量）；
     - picked_qty: 已扫码/录入的回仓数量（累积）；
     - committed_qty: 最终确认入库数量（commit 时写入）。
-
-    核心约束：
-    - batch_code 必须由系统自动回原批次（来自出库台账），不允许人工补录。
     """
 
     __tablename__ = "return_task_lines"
@@ -118,6 +117,14 @@ class ReturnTaskLine(Base):
         comment="商品 ID",
     )
 
+    lot_id: Mapped[int] = mapped_column(
+        sa.Integer,
+        sa.ForeignKey("lots.id", name="fk_return_task_lines_lot", ondelete="RESTRICT"),
+        nullable=False,
+        index=True,
+        comment="结构锚点：退货回原批次对应的 lots.id，来自原出库 stock_ledger.lot_id",
+    )
+
     item_name: Mapped[Optional[str]] = mapped_column(
         sa.String(255),
         nullable=True,
@@ -127,7 +134,7 @@ class ReturnTaskLine(Base):
     batch_code: Mapped[str] = mapped_column(
         sa.String(64),
         nullable=False,
-        comment="批次编码（系统自动回原批次：来自订单出库台账，必填；不允许人工补录）",
+        comment="展示快照：来自原出库 lot 的 lots.lot_code；不参与结构锚点",
     )
 
     expected_qty: Mapped[Optional[int]] = mapped_column(
@@ -172,7 +179,7 @@ class ReturnTaskLine(Base):
     def __repr__(self) -> str:
         return (
             f"<ReturnTaskLine id={self.id} task_id={self.task_id} "
-            f"item_id={self.item_id} expected={self.expected_qty} "
-            f"picked={self.picked_qty} committed={self.committed_qty} "
-            f"status={self.status}>"
+            f"item_id={self.item_id} lot_id={self.lot_id} "
+            f"expected={self.expected_qty} picked={self.picked_qty} "
+            f"committed={self.committed_qty} status={self.status}>"
         )

--- a/app/wms/inventory_adjustment/return_inbound/services/return_task_service_impl.py
+++ b/app/wms/inventory_adjustment/return_inbound/services/return_task_service_impl.py
@@ -31,54 +31,39 @@ def _norm_bc(v: Any) -> Optional[str]:
     return s2
 
 
-def _norm_lot_code(v: str | None) -> str | None:
-    if v is None:
-        return None
-    s = str(v).strip()
-    if not s:
-        return None
-    return s
-
-
-async def _load_supplier_lot_snapshot_by_lot_code(
+async def _load_lot_snapshot_by_id(
     session: AsyncSession,
     *,
-    warehouse_id: int,
-    item_id: int,
-    lot_code: str | None,
+    lot_id: int,
 ) -> Optional[dict[str, Any]]:
-    if lot_code is None:
-        return None
-
-    code = _norm_lot_code(lot_code)
-    if not code:
-        return None
-
-    rows = (
+    row = (
         await session.execute(
             text(
                 """
-                SELECT id, production_date, expiry_date
-                  FROM lots
-                 WHERE warehouse_id = :w
-                   AND item_id      = :i
-                   AND lot_code_source = 'SUPPLIER'
-                   AND lot_code = :code
-                 LIMIT 2
+                SELECT
+                  id,
+                  warehouse_id,
+                  item_id,
+                  lot_code,
+                  production_date,
+                  expiry_date
+                FROM lots
+                WHERE id = :lot_id
+                LIMIT 1
                 """
             ),
-            {"w": int(warehouse_id), "i": int(item_id), "code": str(code)},
+            {"lot_id": int(lot_id)},
         )
-    ).mappings().all()
+    ).mappings().first()
 
-    if not rows:
-        return None
-    if len(rows) > 1:
+    if row is None:
         return None
 
-    row = rows[0]
     return {
         "id": int(row["id"]),
+        "warehouse_id": int(row["warehouse_id"]),
+        "item_id": int(row["item_id"]),
+        "lot_code": row.get("lot_code"),
         "production_date": row.get("production_date"),
         "expiry_date": row.get("expiry_date"),
     }
@@ -87,7 +72,11 @@ async def _load_supplier_lot_snapshot_by_lot_code(
 class ReturnTaskServiceImpl:
     """
     订单退货回仓任务服务（实现层）
-    （其余注释省略，保持原样）
+
+    终态口径：
+    - return_task_lines.lot_id 是回原批次结构锚点；
+    - return_task_lines.batch_code 只是 lots.lot_code 展示快照；
+    - commit 不再通过 batch_code 反查 lot_id。
     """
 
     SHIP_OUT_REASONS: Set[str] = {
@@ -197,13 +186,20 @@ class ReturnTaskServiceImpl:
 
         for x in shipped:
             item_id = int(x["item_id"])
+            lot_id = int(x["lot_id"])
             batch_code = _norm_bc(x.get("batch_code"))
+            if batch_code is None:
+                raise ValueError(
+                    f"return_task_batch_code_required_for_display:item_id={item_id}:lot_id={lot_id}"
+                )
+
             expected_qty = int(x["shipped_qty"])
 
             line = ReturnTaskLine(
                 task_id=task.id,
                 order_line_id=None,
                 item_id=item_id,
+                lot_id=lot_id,
                 batch_code=batch_code,
                 expected_qty=expected_qty,
                 picked_qty=0,
@@ -297,54 +293,57 @@ class ReturnTaskServiceImpl:
             ref_line = int(getattr(ln, "id", 1) or 1)
             bc = _norm_bc(ln.batch_code)
 
-            resolved_lot_id: Optional[int] = None
+            lot_id = int(getattr(ln, "lot_id", 0) or 0)
+            if lot_id <= 0:
+                raise ValueError(f"return_task_line_lot_id_required:line_id={getattr(ln, 'id', None)}")
 
-            if bc is not None:
-                lot_snapshot = await _load_supplier_lot_snapshot_by_lot_code(
-                    session,
-                    warehouse_id=int(task.warehouse_id),
-                    item_id=int(ln.item_id),
-                    lot_code=str(bc),
-                )
-                if lot_snapshot is None:
-                    raise ValueError("lot_not_found_for_batch_code")
+            lot_snapshot = await _load_lot_snapshot_by_id(session, lot_id=lot_id)
+            if lot_snapshot is None:
+                raise ValueError(f"return_task_line_lot_not_found:lot_id={lot_id}")
 
-                resolved_lot_id = int(lot_snapshot["id"])
-
-                # 已经解析到真实 lot_id 后，直接走 lot-only 原语入口，
-                # 不再让 RETURN 正增量再次走 batch_code -> 日期裁决。
-                res = await self.stock_svc.adjust_lot(
-                    session=session,
-                    item_id=int(ln.item_id),
-                    warehouse_id=int(task.warehouse_id),
-                    lot_id=int(resolved_lot_id),
-                    delta=+picked,
-                    reason=MovementType.RETURN,
-                    ref=str(task.order_id),
-                    ref_line=ref_line,
-                    occurred_at=ts,
-                    batch_code=None,
-                    production_date=lot_snapshot.get("production_date"),
-                    expiry_date=lot_snapshot.get("expiry_date"),
-                    trace_id=trace_id,
-                    meta={"sub_reason": "RETURN_RECEIPT"},
-                )
-            else:
-                res = await self.stock_svc.adjust(
-                    session=session,
-                    item_id=int(ln.item_id),
-                    delta=+picked,
-                    reason=MovementType.RETURN,
-                    ref=str(task.order_id),
-                    ref_line=ref_line,
-                    occurred_at=ts,
-                    batch_code=None,
-                    warehouse_id=int(task.warehouse_id),
-                    trace_id=trace_id,
-                    meta={"sub_reason": "RETURN_RECEIPT"},
+            if int(lot_snapshot["warehouse_id"]) != int(task.warehouse_id):
+                raise ValueError(
+                    f"return_task_line_lot_warehouse_mismatch:"
+                    f"line_id={getattr(ln, 'id', None)}:"
+                    f"task_warehouse_id={int(task.warehouse_id)}:"
+                    f"lot_warehouse_id={int(lot_snapshot['warehouse_id'])}"
                 )
 
-            applied_lot_id = int(res.get("lot_id") or (resolved_lot_id or 0) or 0)
+            if int(lot_snapshot["item_id"]) != int(ln.item_id):
+                raise ValueError(
+                    f"return_task_line_lot_item_mismatch:"
+                    f"line_id={getattr(ln, 'id', None)}:"
+                    f"line_item_id={int(ln.item_id)}:"
+                    f"lot_item_id={int(lot_snapshot['item_id'])}"
+                )
+
+            snapshot_batch_code = _norm_bc(lot_snapshot.get("lot_code"))
+            if bc != snapshot_batch_code:
+                raise ValueError(
+                    f"return_task_line_batch_code_snapshot_mismatch:"
+                    f"line_id={getattr(ln, 'id', None)}:"
+                    f"batch_code={bc}:"
+                    f"lot_code={snapshot_batch_code}"
+                )
+
+            res = await self.stock_svc.adjust_lot(
+                session=session,
+                item_id=int(ln.item_id),
+                warehouse_id=int(task.warehouse_id),
+                lot_id=int(lot_id),
+                delta=+picked,
+                reason=MovementType.RETURN,
+                ref=str(task.order_id),
+                ref_line=ref_line,
+                occurred_at=ts,
+                batch_code=None,
+                production_date=lot_snapshot.get("production_date"),
+                expiry_date=lot_snapshot.get("expiry_date"),
+                trace_id=trace_id,
+                meta={"sub_reason": "RETURN_RECEIPT"},
+            )
+
+            applied_lot_id = int(res.get("lot_id") or lot_id)
 
             effects.append(
                 {

--- a/tests/test_phase3_three_books_return_commit.py
+++ b/tests/test_phase3_three_books_return_commit.py
@@ -43,12 +43,10 @@ async def test_phase3_return_commit_three_books_strict(session: AsyncSession):
     Phase 3 合同测试（退货回仓 commit）：
 
     关键点：
-    - create_for_order 只认 ledger 出库事实：必须先写 OUTBOUND_SHIP delta<0
-    - return commit 用同一个 ref=order_ref，但 ref_line 不是 1（用 ReturnTaskLine.id）
-      因此校验必须用“真实落库 reason”，不能猜 MovementType.RETURN 的字符串值。
-
-    重要：
-    - order_ref 必须每次唯一，避免命中历史遗留未 COMMITTED 的 ReturnTask（跨测试污染）。
+    - create_for_order 只认 ledger 出库事实：必须先写 OUTBOUND_SHIP delta<0；
+    - return_task_lines.lot_id 必须来自原出库 stock_ledger.lot_id；
+    - return_task_lines.batch_code 仅是 lots.lot_code 展示快照；
+    - return commit 必须使用同一个 lot_id 回仓，而不是靠 batch_code 二次反查。
     """
     utc = timezone.utc
     now = datetime.now(utc)
@@ -82,7 +80,7 @@ async def test_phase3_return_commit_three_books_strict(session: AsyncSession):
         meta={"sub_reason": "UT_STOCK_IN"},
     )
 
-    # 2) 出库制造出库事实（ReturnTask 依据 ledger 反查 shipped）
+    # 2) 出库制造出库事实（ReturnTask 依据 ledger.lot_id 反查 shipped）
     order_ref = f"UT:PH3:RET:ORDER:{uniq}"
     shipped_qty = 4
 
@@ -100,11 +98,60 @@ async def test_phase3_return_commit_three_books_strict(session: AsyncSession):
         meta={"sub_reason": "ORDER_SHIP"},
     )
 
-    # 3) 创建回仓任务
+    shipped_lot_row = (
+        await session.execute(
+            text(
+                """
+                SELECT lot_id
+                  FROM stock_ledger
+                 WHERE warehouse_id = :w
+                   AND item_id = :i
+                   AND ref = :ref
+                   AND ref_line = 1
+                   AND delta < 0
+                 ORDER BY id DESC
+                 LIMIT 1
+                """
+            ),
+            {"w": wh_id, "i": item_id, "ref": order_ref},
+        )
+    ).first()
+    assert shipped_lot_row is not None, "missing shipped ledger row"
+    shipped_lot_id = int(shipped_lot_row[0])
+
+    # 3) 创建回仓任务：任务行必须固化原出库 lot_id
     task = await svc.create_for_order(session, order_id=order_ref)
     assert task.status != "COMMITTED"
     assert int(task.warehouse_id) == wh_id
     assert task.lines and len(task.lines) >= 1
+
+    task_line = None
+    for x in task.lines or []:
+        if int(x.item_id) == int(item_id):
+            task_line = x
+            break
+
+    assert task_line is not None
+    assert int(task_line.lot_id) == shipped_lot_id
+    assert str(task_line.batch_code) == batch_code
+
+    stored_task_line = (
+        await session.execute(
+            text(
+                """
+                SELECT rtl.lot_id, rtl.batch_code, lo.lot_code
+                  FROM return_task_lines rtl
+                  JOIN lots lo
+                    ON lo.id = rtl.lot_id
+                 WHERE rtl.id = :line_id
+                """
+            ),
+            {"line_id": int(task_line.id)},
+        )
+    ).first()
+    assert stored_task_line is not None
+    assert int(stored_task_line[0]) == shipped_lot_id
+    assert str(stored_task_line[1]) == str(stored_task_line[2]) == batch_code
 
     # 4) 录入回仓数量
     task = await svc.record_receive(session, task_id=int(task.id), item_id=item_id, qty=2)
@@ -114,6 +161,7 @@ async def test_phase3_return_commit_three_books_strict(session: AsyncSession):
             ln = x
             break
     assert ln is not None
+    assert int(ln.lot_id) == shipped_lot_id
     assert int(ln.picked_qty or 0) == 2
 
     # 5) commit：回仓入库（service 内 enforce_three_books）
@@ -132,6 +180,7 @@ async def test_phase3_return_commit_three_books_strict(session: AsyncSession):
             ln2 = x
             break
     assert ln2 is not None
+    assert int(ln2.lot_id) == shipped_lot_id
     ref_line = int(getattr(ln2, "id", 1) or 1)
 
     # ✅ 终态：stock_ledger 无 batch_code 列；用 (wh,item,ref,ref_line,delta>0) 定位回仓入库行
@@ -156,6 +205,7 @@ async def test_phase3_return_commit_three_books_strict(session: AsyncSession):
     assert row, "missing return-in ledger row"
     reason_val = str(row[1])
     lot_id_val = int(row[2])
+    assert lot_id_val == shipped_lot_id
 
     await run_snapshot(session)
     await verify_commit_three_books(
@@ -167,7 +217,7 @@ async def test_phase3_return_commit_three_books_strict(session: AsyncSession):
                 "warehouse_id": wh_id,
                 "item_id": item_id,
                 "lot_id": lot_id_val,
-                "batch_code": batch_code,  # 仅展示/兼容字段（不参与结构锚点）
+                "batch_code": batch_code,  # 仅展示快照（不参与结构锚点）
                 "qty": 2,
                 "ref": order_ref,
                 "ref_line": ref_line,


### PR DESCRIPTION
## Summary
- add return_task_lines.lot_id as the structural anchor for return-to-original-lot
- keep return_task_lines.batch_code as a display snapshot from lots.lot_code
- clean orphan historical return tasks that have no stock_ledger.ref during migration
- make return task creation persist lot_id from original outbound ledger facts
- make return task commit use lot_id directly instead of reverse resolving by batch_code
- strengthen return commit test to verify lot_id is preserved across shipped, task, and return ledger facts

## Validation
- python3 -m compileall app tests scripts
- make alembic-check
- make test TESTS="tests/test_phase3_three_books_return_commit.py tests/api/test_wms_receiving_batch_no_lot_code_contract_api.py tests/alembic/test_migration_contract.py tests/ci/test_ledger_idem_constraint.py"