### PR TITLE
refactor(wms): retire batch param from stock idempotency

### DIFF
--- a/app/wms/stock/services/stock_adjust/adjust_lot_impl.py
+++ b/app/wms/stock/services/stock_adjust/adjust_lot_impl.py
@@ -11,7 +11,7 @@ from app.wms.stock.services.lot_guard import assert_lot_belongs_to
 from app.wms.stock.services.stock_adjust.batch_keys import norm_batch_code
 from app.wms.stock.services.stock_adjust.date_rules import resolve_and_validate_dates_for_inbound
 from app.wms.stock.services.stock_adjust.db_items import item_requires_batch
-from app.wms.stock.services.stock_adjust.idempotency import idem_hit_by_lot_and_batch_key
+from app.wms.stock.services.stock_adjust.idempotency import idem_hit_by_lot_key
 from app.wms.stock.services.stock_adjust.lot_code_repo import load_lot_code_for_lot_id
 from app.wms.stock.services.stock_adjust.meta import meta_bool, meta_str
 
@@ -97,11 +97,10 @@ async def adjust_lot_impl(
     )
 
     # 幂等：lot-only
-    if await idem_hit_by_lot_and_batch_key(
+    if await idem_hit_by_lot_key(
         session,
         warehouse_id=int(warehouse_id),
         item_id=int(item_id),
-        batch_code_norm=bc_norm,
         lot_id=int(lot_id),
         reason=reason_val,
         ref=str(ref),

--- a/app/wms/stock/services/stock_adjust/batch_keys.py
+++ b/app/wms/stock/services/stock_adjust/batch_keys.py
@@ -8,26 +8,6 @@ def norm_batch_code(batch_code: Optional[str]) -> Optional[str]:
     if batch_code is None:
         return None
     s = str(batch_code).strip()
-    # 防御：不允许空串；上游若传入 "None" 也归一为 None
     if not s or s.lower() == "none":
         return None
     return s
-
-
-def batch_key(batch_code_norm: Optional[str]) -> str:
-    """
-    Phase M-5:
-    - 禁止 "__NULL_BATCH__" sentinel。
-    - 仅用于内存聚合键：用空串 "" 表示 None 槽位（真实 batch_code 经 norm 后不会是空串）。
-    """
-    bc = norm_batch_code(batch_code_norm)
-    return bc if bc is not None else ""
-
-
-def lot_key(lot_id: Optional[int]) -> Optional[int]:
-    """
-    Phase M-5:
-    - 禁止 lot_id_key=0 sentinel。
-    - 内存键直接用 Optional[int]（None 就是 None）。
-    """
-    return int(lot_id) if lot_id is not None else None

--- a/app/wms/stock/services/stock_adjust/idempotency.py
+++ b/app/wms/stock/services/stock_adjust/idempotency.py
@@ -1,18 +1,15 @@
 # app/wms/stock/services/stock_adjust/idempotency.py
 from __future__ import annotations
 
-from typing import Optional
-
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
-async def idem_hit_by_lot_and_batch_key(
+async def idem_hit_by_lot_key(
     session: AsyncSession,
     *,
     warehouse_id: int,
     item_id: int,
-    batch_code_norm: Optional[str],
     lot_id: int,
     reason: str,
     ref: str,
@@ -24,12 +21,7 @@ async def idem_hit_by_lot_and_batch_key(
     - stock_ledger 不再存在 lot_id_key / batch_code_key
     - 幂等锚点与 DB 唯一约束保持 1:1：
       (warehouse_id, item_id, lot_id, reason, ref, ref_line)
-
-    说明：
-    - batch_code_norm 仅作为历史兼容入参（展示码），不参与幂等键
     """
-    _ = batch_code_norm  # 仅兼容签名，终态不参与幂等
-
     idem = await session.execute(
         text(
             """


### PR DESCRIPTION
## Summary
- rename stock idempotency helper to idem_hit_by_lot_key
- remove unused batch_code_norm compatibility parameter from idempotency check
- remove unused batch_key / lot_key helper functions
- keep norm_batch_code for current lot display-code normalization paths

## Validation
- python3 -m compileall app tests scripts
- make alembic-check
- make test TESTS="tests/unit/test_stock_service_v2.py tests/ci/test_ledger_idem_constraint.py tests/api/test_stock_inventory_recount_freeze_guard_api.py tests/test_phase3_three_books_count_contract.py"