### PR TITLE
refactor(wms): retire recount batch code alias

### DIFF
--- a/app/wms/inventory_adjustment/count/routers/stock_inventory_recount.py
+++ b/app/wms/inventory_adjustment/count/routers/stock_inventory_recount.py
@@ -6,7 +6,7 @@ import json
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -26,10 +26,11 @@ def _make_scan_ref(device_id: Optional[str], occurred_at: datetime, warehouse_id
 
 
 class StockRecountRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     item_id: int = Field(..., description="物料ID")
     warehouse_id: int = Field(..., ge=1, description="仓库ID")
-    lot_code: Optional[str] = Field(None, description="Lot 展示码（优先使用；等价于 batch_code）")
-    batch_code: Optional[str] = Field(None, description="批次（无批次槽位传 null）")
+    lot_code: Optional[str] = Field(None, description="Lot 展示码")
     actual: int = Field(..., ge=0, description="实际数量")
     ctx: Dict[str, Any] | None = None
 
@@ -55,19 +56,19 @@ async def stock_recount(
     session: AsyncSession = Depends(get_session),
 ) -> Dict[str, Any]:
     """
-    运维盘点：把 item@warehouse@batch_code 的 qty 校正为 actual。
+    运维盘点：把 item@warehouse@lot_code 的 qty 校正为 actual。
 
     Phase 4E 真收口：
     - 禁止读取 legacy stocks
     - current 余额统一来自 stocks_lot
-    - batch_code 为展示码（lots.lot_code），按 NULL 语义用 IS NOT DISTINCT FROM
+    - lot_code 为展示码（lots.lot_code），按 NULL 语义用 IS NOT DISTINCT FROM
     """
     device_id = (req.ctx or {}).get("device_id") if isinstance(req.ctx, dict) else None
     occurred_at = datetime.now(timezone.utc)
     scan_ref = _make_scan_ref(device_id, occurred_at, req.warehouse_id)
 
-    # Phase M-4 governance：lot_code 正名；batch_code 兼容字段
-    code = getattr(req, "lot_code", None) or req.batch_code
+    # Phase M-4 governance：lot_code 为唯一公开入参；batch_code alias 已退役
+    code = req.lot_code
 
     try:
         from app.wms.stock.services.stock_service import StockService  # type: ignore

--- a/openapi/_current.json
+++ b/openapi/_current.json
@@ -595,7 +595,7 @@
     "/stock/inventory/recount": {
       "post": {
         "summary": "Stock Recount",
-        "description": "运维盘点：把 item@warehouse@batch_code 的 qty 校正为 actual。\n\nPhase 4E 真收口：\n- 禁止读取 legacy stocks\n- current 余额统一来自 stocks_lot\n- batch_code 为展示码（lots.lot_code），按 NULL 语义用 IS NOT DISTINCT FROM",
+        "description": "运维盘点：把 item@warehouse@lot_code 的 qty 校正为 actual。\n\nPhase 4E 真收口：\n- 禁止读取 legacy stocks\n- current 余额统一来自 stocks_lot\n- lot_code 为展示码（lots.lot_code），按 NULL 语义用 IS NOT DISTINCT FROM",
         "operationId": "stock_recount_stock_inventory_recount_post",
         "requestBody": {
           "content": {
@@ -42402,19 +42402,7 @@
               }
             ],
             "title": "Lot Code",
-            "description": "Lot 展示码（优先使用；等价于 batch_code）"
-          },
-          "batch_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Batch Code",
-            "description": "批次（无批次槽位传 null）"
+            "description": "Lot 展示码"
           },
           "actual": {
             "type": "integer",
@@ -42435,6 +42423,7 @@
             "title": "Ctx"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": [
           "item_id",

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -595,7 +595,7 @@
     "/stock/inventory/recount": {
       "post": {
         "summary": "Stock Recount",
-        "description": "运维盘点：把 item@warehouse@batch_code 的 qty 校正为 actual。\n\nPhase 4E 真收口：\n- 禁止读取 legacy stocks\n- current 余额统一来自 stocks_lot\n- batch_code 为展示码（lots.lot_code），按 NULL 语义用 IS NOT DISTINCT FROM",
+        "description": "运维盘点：把 item@warehouse@lot_code 的 qty 校正为 actual。\n\nPhase 4E 真收口：\n- 禁止读取 legacy stocks\n- current 余额统一来自 stocks_lot\n- lot_code 为展示码（lots.lot_code），按 NULL 语义用 IS NOT DISTINCT FROM",
         "operationId": "stock_recount_stock_inventory_recount_post",
         "requestBody": {
           "content": {
@@ -42402,19 +42402,7 @@
               }
             ],
             "title": "Lot Code",
-            "description": "Lot 展示码（优先使用；等价于 batch_code）"
-          },
-          "batch_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Batch Code",
-            "description": "批次（无批次槽位传 null）"
+            "description": "Lot 展示码"
           },
           "actual": {
             "type": "integer",
@@ -42435,6 +42423,7 @@
             "title": "Ctx"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": [
           "item_id",

--- a/tests/api/test_stock_inventory_recount_freeze_guard_api.py
+++ b/tests/api/test_stock_inventory_recount_freeze_guard_api.py
@@ -201,3 +201,19 @@ async def test_stock_inventory_recount_returns_409_when_count_doc_frozen(
 
     if "http_status" in body:
         assert int(body["http_status"]) == 409, body
+
+@pytest.mark.asyncio
+async def test_stock_inventory_recount_rejects_retired_batch_code_alias(
+    client: httpx.AsyncClient,
+) -> None:
+    response = await client.post(
+        "/stock/inventory/recount",
+        json={
+            "item_id": 910001,
+            "warehouse_id": 1,
+            "batch_code": "UT-RECOUNT-RETIRED-ALIAS",
+            "actual": 1,
+        },
+    )
+
+    assert response.status_code == 422, response.text


### PR DESCRIPTION
## Summary
- retire batch_code alias from /stock/inventory/recount request contract
- keep lot_code as the only public recount lot display-code field
- forbid extra recount request fields so retired aliases return 422
- update static OpenAPI after recount contract cleanup

## Validation
- python3 -m compileall app tests scripts
- make alembic-check
- make test TESTS="tests/api/test_stock_inventory_recount_freeze_guard_api.py tests/test_phase3_three_books_count_contract.py tests/ci/test_ledger_idem_constraint.py"