### PR TITLE
refactor(wms): retire count batch code alias

### DIFF
--- a/app/wms/inventory_adjustment/count/contracts/count.py
+++ b/app/wms/inventory_adjustment/count/contracts/count.py
@@ -11,19 +11,18 @@ class CountRequest(BaseModel):
     盘点校正请求（批次级）：
 
     - 必填：item_id, warehouse_id, qty(绝对量), ref
-    - lot_code 为正名字段；batch_code 保留兼容入参
+    - lot_code 为唯一批次展示码入参；batch_code alias 已退役
     - production_date / expiry_date：仅对批次受控商品要求至少其一
     """
 
-    model_config = ConfigDict(str_strip_whitespace=True)
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
 
     item_id: int = Field(..., description="商品ID")
     warehouse_id: int = Field(..., ge=1, description="仓库ID")
     qty: int = Field(..., ge=0, description="盘点后的实际数量（绝对量）")
     ref: str = Field(..., description="业务参考号（用于台账幂等）")
 
-    lot_code: Optional[str] = Field(None, description="Lot 展示码（优先使用；等价于 batch_code）")
-    batch_code: Optional[str] = Field(None, description="批次码（兼容字段；等价于 lot_code）")
+    lot_code: Optional[str] = Field(None, description="Lot 展示码")
 
     occurred_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
@@ -47,6 +46,4 @@ class CountResponse(BaseModel):
     warehouse_id: int
 
     lot_code: Optional[str] = None
-    batch_code: Optional[str] = None
-
     occurred_at: datetime

--- a/app/wms/inventory_adjustment/count/services/count_service.py
+++ b/app/wms/inventory_adjustment/count/services/count_service.py
@@ -39,10 +39,9 @@ class CountService:
         )
         requires_batch = expiry_policy_text.upper() == "REQUIRED"
 
-        lot_code_raw = req.lot_code or req.batch_code
         lot_code = validate_lot_code_contract(
             requires_batch=requires_batch,
-            lot_code=lot_code_raw,
+            lot_code=req.lot_code,
         )
 
         if requires_batch and req.production_date is None and req.expiry_date is None:
@@ -88,6 +87,5 @@ class CountService:
             item_id=req.item_id,
             warehouse_id=req.warehouse_id,
             lot_code=lot_code,
-            batch_code=lot_code,
             occurred_at=req.occurred_at,
         )

--- a/openapi/_current.json
+++ b/openapi/_current.json
@@ -21015,19 +21015,7 @@
               }
             ],
             "title": "Lot Code",
-            "description": "Lot 展示码（优先使用；等价于 batch_code）"
-          },
-          "batch_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Batch Code",
-            "description": "批次码（兼容字段；等价于 lot_code）"
+            "description": "Lot 展示码"
           },
           "occurred_at": {
             "type": "string",
@@ -21062,6 +21050,7 @@
             "description": "有效期（可选）"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": [
           "item_id",
@@ -21070,7 +21059,7 @@
           "ref"
         ],
         "title": "CountRequest",
-        "description": "盘点校正请求（批次级）：\n\n- 必填：item_id, warehouse_id, qty(绝对量), ref\n- lot_code 为正名字段；batch_code 保留兼容入参\n- production_date / expiry_date：仅对批次受控商品要求至少其一"
+        "description": "盘点校正请求（批次级）：\n\n- 必填：item_id, warehouse_id, qty(绝对量), ref\n- lot_code 为唯一批次展示码入参；batch_code alias 已退役\n- production_date / expiry_date：仅对批次受控商品要求至少其一"
       },
       "CountResponse": {
         "properties": {
@@ -21105,17 +21094,6 @@
               }
             ],
             "title": "Lot Code"
-          },
-          "batch_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Batch Code"
           },
           "occurred_at": {
             "type": "string",

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -21015,19 +21015,7 @@
               }
             ],
             "title": "Lot Code",
-            "description": "Lot 展示码（优先使用；等价于 batch_code）"
-          },
-          "batch_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Batch Code",
-            "description": "批次码（兼容字段；等价于 lot_code）"
+            "description": "Lot 展示码"
           },
           "occurred_at": {
             "type": "string",
@@ -21062,6 +21050,7 @@
             "description": "有效期（可选）"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": [
           "item_id",
@@ -21070,7 +21059,7 @@
           "ref"
         ],
         "title": "CountRequest",
-        "description": "盘点校正请求（批次级）：\n\n- 必填：item_id, warehouse_id, qty(绝对量), ref\n- lot_code 为正名字段；batch_code 保留兼容入参\n- production_date / expiry_date：仅对批次受控商品要求至少其一"
+        "description": "盘点校正请求（批次级）：\n\n- 必填：item_id, warehouse_id, qty(绝对量), ref\n- lot_code 为唯一批次展示码入参；batch_code alias 已退役\n- production_date / expiry_date：仅对批次受控商品要求至少其一"
       },
       "CountResponse": {
         "properties": {
@@ -21105,17 +21094,6 @@
               }
             ],
             "title": "Lot Code"
-          },
-          "batch_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Batch Code"
           },
           "occurred_at": {
             "type": "string",

--- a/tests/test_phase3_three_books_count_contract.py
+++ b/tests/test_phase3_three_books_count_contract.py
@@ -41,13 +41,58 @@ async def _pick_item(session: AsyncSession) -> tuple[int, bool]:
     return int(row2[0]), True
 
 
+async def _load_ledger_lot_id(
+    session: AsyncSession,
+    *,
+    warehouse_id: int,
+    item_id: int,
+    ref: str,
+    ref_line: int = 1,
+) -> int:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT lot_id
+                  FROM stock_ledger
+                 WHERE warehouse_id = :warehouse_id
+                   AND item_id = :item_id
+                   AND ref = :ref
+                   AND ref_line = :ref_line
+                 ORDER BY id DESC
+                 LIMIT 1
+                """
+            ),
+            {
+                "warehouse_id": int(warehouse_id),
+                "item_id": int(item_id),
+                "ref": str(ref),
+                "ref_line": int(ref_line),
+            },
+        )
+    ).first()
+
+    if not row or row[0] is None:
+        raise AssertionError(
+            {
+                "msg": "count ledger row must carry lot_id",
+                "warehouse_id": int(warehouse_id),
+                "item_id": int(item_id),
+                "ref": str(ref),
+                "ref_line": int(ref_line),
+            }
+        )
+
+    return int(row[0])
+
+
 def _build_count_request(
     *,
     item_id: int,
     warehouse_id: int,
     qty: int,
     ref: str,
-    batch_code: str,
+    lot_code: str,
     occurred_at: datetime,
     production_date: date | None,
     expiry_date: date | None,
@@ -58,7 +103,7 @@ def _build_count_request(
         "warehouse_id": warehouse_id,
         "qty": qty,
         "ref": ref,
-        "batch_code": batch_code,
+        "lot_code": lot_code,
         "occurred_at": occurred_at,
     }
     if requires_expiry:
@@ -108,7 +153,7 @@ async def test_phase3_count_confirm_delta_zero_records_ledger(session: AsyncSess
             warehouse_id=warehouse_id,
             qty=5,
             ref=ref,
-            batch_code=batch_code,
+            lot_code=batch_code,
             occurred_at=now,
             production_date=prod,
             expiry_date=exp,
@@ -119,7 +164,15 @@ async def test_phase3_count_confirm_delta_zero_records_ledger(session: AsyncSess
     assert int(payload.after) == 5
     assert payload.item_id == item_id
     assert payload.warehouse_id == warehouse_id
-    assert payload.batch_code == batch_code
+    assert payload.lot_code == batch_code
+
+    lot_id = await _load_ledger_lot_id(
+        session,
+        warehouse_id=warehouse_id,
+        item_id=item_id,
+        ref=ref,
+        ref_line=1,
+    )
 
     await run_snapshot(session)
     await verify_commit_three_books(
@@ -130,7 +183,8 @@ async def test_phase3_count_confirm_delta_zero_records_ledger(session: AsyncSess
             {
                 "warehouse_id": warehouse_id,
                 "item_id": item_id,
-                "batch_code": batch_code,
+                "lot_id": lot_id,
+                "lot_code": batch_code,
                 "qty": 0,
                 "ref": ref,
                 "ref_line": 1,
@@ -179,7 +233,7 @@ async def test_phase3_count_adjust_delta_nonzero_updates_stock(session: AsyncSes
             warehouse_id=warehouse_id,
             qty=7,
             ref=ref,
-            batch_code=batch_code,
+            lot_code=batch_code,
             occurred_at=now,
             production_date=prod,
             expiry_date=exp,
@@ -190,7 +244,15 @@ async def test_phase3_count_adjust_delta_nonzero_updates_stock(session: AsyncSes
     assert int(payload.after) == 7
     assert payload.item_id == item_id
     assert payload.warehouse_id == warehouse_id
-    assert payload.batch_code == batch_code
+    assert payload.lot_code == batch_code
+
+    lot_id = await _load_ledger_lot_id(
+        session,
+        warehouse_id=warehouse_id,
+        item_id=item_id,
+        ref=ref,
+        ref_line=1,
+    )
 
     await run_snapshot(session)
     await verify_commit_three_books(
@@ -201,7 +263,8 @@ async def test_phase3_count_adjust_delta_nonzero_updates_stock(session: AsyncSes
             {
                 "warehouse_id": warehouse_id,
                 "item_id": item_id,
-                "batch_code": batch_code,
+                "lot_id": lot_id,
+                "lot_code": batch_code,
                 "qty": 2,
                 "ref": ref,
                 "ref_line": 1,
@@ -209,3 +272,18 @@ async def test_phase3_count_adjust_delta_nonzero_updates_stock(session: AsyncSes
         ],
         at=now,
     )
+
+
+def test_count_request_rejects_retired_batch_code_alias() -> None:
+    try:
+        CountRequest(
+            item_id=910001,
+            warehouse_id=1,
+            qty=1,
+            ref="ut:count:retired-batch-code-alias",
+            batch_code="UT-COUNT-RETIRED-ALIAS",
+        )
+    except Exception as exc:
+        assert "batch_code" in str(exc)
+    else:
+        raise AssertionError("CountRequest must reject retired batch_code alias")


### PR DESCRIPTION
## Summary
- retire batch_code alias from /count request contract
- keep lot_code as the only public count lot display-code field
- remove batch_code from CountResponse
- forbid extra count request fields so retired aliases are rejected
- update count three-books test to pass lot_id under lot-only consistency checks
- update static OpenAPI after count contract cleanup

## Validation
- python3 -m compileall app tests scripts
- make alembic-check
- make test TESTS="tests/test_phase3_three_books_count_contract.py tests/api/test_stock_inventory_recount_freeze_guard_api.py tests/ci/test_ledger_idem_constraint.py"