### PR TITLE
refactor(wms): make recount use lot adjust primitive

### DIFF
--- a/app/wms/inventory_adjustment/count/routers/stock_inventory_recount.py
+++ b/app/wms/inventory_adjustment/count/routers/stock_inventory_recount.py
@@ -14,6 +14,7 @@ from app.db.deps import get_async_session as get_session
 from app.wms.inventory_adjustment.count.services.count_freeze_guard_service import (
     ensure_warehouse_not_frozen,
 )
+from app.wms.stock.services.stock_contract_resolver import resolve_lot_for_stock_adjust
 
 router = APIRouter()
 
@@ -101,14 +102,28 @@ async def stock_recount(
         delta = int(req.actual) - on_hand
 
         if delta != 0:
-            await svc.adjust(
+            resolved_lot_id, resolved_lot_code = await resolve_lot_for_stock_adjust(
+                session,
+                lot_resolver=svc.lot_resolver,
+                item_id=int(req.item_id),
+                warehouse_id=int(req.warehouse_id),
+                batch_code=code,
+                lot_id=None,
+                ref=scan_ref,
+                occurred_at=occurred_at,
+                production_date=None,
+                expiry_date=None,
+            )
+
+            await svc.adjust_lot(
                 session=session,
                 item_id=int(req.item_id),
                 warehouse_id=int(req.warehouse_id),
+                lot_id=int(resolved_lot_id),
                 delta=delta,
                 reason="COUNT",
                 ref=scan_ref,
-                batch_code=code,
+                batch_code=resolved_lot_code,
             )
 
         ev_id = await _insert_event(


### PR DESCRIPTION
## Summary
- migrate /stock/inventory/recount from StockService.adjust(batch_code=...) to explicit lot resolution plus adjust_lot
- resolve lot_id before recount inventory writes
- keep /stock/inventory/recount public contract as lot_code-only
- leave StockService.adjust and other real callers unchanged for later migration

## Validation
- python3 -m compileall app tests scripts
- make alembic-check
- make test TESTS="tests/api/test_stock_inventory_recount_freeze_guard_api.py tests/test_phase3_three_books_count_contract.py tests/ci/test_ledger_idem_constraint.py"