### PR TITLE
test(wms): seed outbound commit via lot helper

### DIFF
--- a/tests/test_phase3_three_books_outbound_commit.py
+++ b/tests/test_phase3_three_books_outbound_commit.py
@@ -1,7 +1,7 @@
 # tests/test_phase3_three_books_outbound_commit.py
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 import pytest
 from sqlalchemy import text
@@ -9,36 +9,27 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.wms.outbound.services.outbound_commit_service import OutboundService
 from app.wms.snapshot.services.snapshot_run import run_snapshot
-from app.wms.stock.services.stock_service import StockService
 from app.wms.shared.services.three_books_consistency import verify_commit_three_books
 from tests.services._helpers import ensure_store
+from tests.utils.ensure_minimal import set_stock_qty
 
 
-async def _pick_item_for_stock_in(session: AsyncSession) -> tuple[int, bool]:
-    """
-    尽量挑 expiry_policy=NONE 的 item，避免入库日期推导依赖 shelf_life 参数。
-    若找不到，就退回任意 item，并在入库时显式填 expiry_date。
-    """
+async def _pick_item_for_stock_in(session: AsyncSession) -> int:
     row = (
         await session.execute(
             text(
                 """
                 SELECT id
                   FROM items
-                 WHERE COALESCE(expiry_policy::text, 'NONE') <> 'REQUIRED'
                  ORDER BY id ASC
                  LIMIT 1
                 """
             )
         )
     ).first()
-    if row:
-        return int(row[0]), False
-
-    row2 = (await session.execute(text("SELECT id FROM items ORDER BY id ASC LIMIT 1"))).first()
-    if not row2:
+    if not row:
         raise RuntimeError("测试库没有 items 种子数据，无法运行 Phase 3 出库合同测试")
-    return int(row2[0]), True
+    return int(row[0])
 
 
 async def _ensure_order_ref_exists(session: AsyncSession, *, order_ref: str) -> None:
@@ -71,43 +62,75 @@ async def _ensure_order_ref_exists(session: AsyncSession, *, order_ref: str) -> 
     await session.commit()
 
 
+async def _load_ledger_lot_id(
+    session: AsyncSession,
+    *,
+    warehouse_id: int,
+    item_id: int,
+    ref: str,
+    ref_line: int = 1,
+) -> int:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT lot_id
+                  FROM stock_ledger
+                 WHERE warehouse_id = :warehouse_id
+                   AND item_id = :item_id
+                   AND ref = :ref
+                   AND ref_line = :ref_line
+                 ORDER BY id DESC
+                 LIMIT 1
+                """
+            ),
+            {
+                "warehouse_id": int(warehouse_id),
+                "item_id": int(item_id),
+                "ref": str(ref),
+                "ref_line": int(ref_line),
+            },
+        )
+    ).first()
+
+    if not row or row[0] is None:
+        raise AssertionError(
+            {
+                "msg": "outbound commit ledger row must carry lot_id",
+                "warehouse_id": int(warehouse_id),
+                "item_id": int(item_id),
+                "ref": str(ref),
+                "ref_line": int(ref_line),
+            }
+        )
+
+    return int(row[0])
+
+
 @pytest.mark.asyncio
 async def test_phase3_outbound_commit_three_books_strict(session: AsyncSession):
     """
     Phase 3 合同测试（出库链路）：
-    - 先用 StockService.adjust(delta>0) 造库存（写 ledger + stocks_lot）
+    - 先用 lot-only 测试 helper 造库存（写 ledger + stocks_lot）
     - 再用 OutboundService.commit 出库（写 ledger + stocks_lot + snapshot 尾门）
     - 最后用三账校验器兜底复验：ledger(ref/ref_line) + stocks_lot + snapshot(today) 一致
     """
     utc = timezone.utc
     now = datetime.now(utc)
 
-    stock_svc = StockService()
-    outbound_svc = OutboundService(stock_svc=stock_svc)
+    outbound_svc = OutboundService()
 
     warehouse_id = 1
-    item_id, may_need_expiry = await _pick_item_for_stock_in(session)
+    item_id = await _pick_item_for_stock_in(session)
     batch_code = "B-PH3-OUT"
 
-    # 入库造数：给足库存，避免出库不足
-    prod = now.date()
-    exp = (prod + timedelta(days=30)) if may_need_expiry else None
-
-    ref_in = "UT:PH3:IN"
-    await stock_svc.adjust(
-        session=session,
+    # 入库造数：给足库存，避免出库不足。测试造数统一走 lot-only helper，不再调用 StockService.adjust。
+    await set_stock_qty(
+        session,
         item_id=item_id,
-        delta=10,  # 入库 +10
-        reason="RECEIPT",
-        ref=ref_in,
-        ref_line=1,
-        occurred_at=now,
         warehouse_id=warehouse_id,
         batch_code=batch_code,
-        production_date=prod,
-        expiry_date=exp,
-        trace_id="PH3-UT-TRACE-OUT",
-        meta={"sub_reason": "UT_STOCK_IN"},
+        qty=10,
     )
 
     # 出库：扣 3
@@ -132,6 +155,14 @@ async def test_phase3_outbound_commit_three_books_strict(session: AsyncSession):
 
     assert res["status"] == "OK"
 
+    lot_id = await _load_ledger_lot_id(
+        session,
+        warehouse_id=warehouse_id,
+        item_id=item_id,
+        ref=str(order_id),
+        ref_line=1,
+    )
+
     # 双保险：再跑一次快照 + 三账校验（只对本次 touched key）
     await run_snapshot(session)
     await verify_commit_three_books(
@@ -142,7 +173,8 @@ async def test_phase3_outbound_commit_three_books_strict(session: AsyncSession):
             {
                 "warehouse_id": warehouse_id,
                 "item_id": item_id,
-                "batch_code": batch_code,
+                "lot_id": lot_id,
+                "lot_code": batch_code,
                 "qty": -ship_qty,  # 出库 delta 为负
                 "ref": str(order_id),
                 "ref_line": 1,


### PR DESCRIPTION
## Summary
- migrate outbound commit three-books test away from StockService.adjust seed setup
- seed stock through existing lot-only set_stock_qty helper
- pass lot_id into three-books consistency effects under lot-only world

## Validation
- python3 -m compileall app tests scripts
- make alembic-check
- make test TESTS="tests/test_phase3_three_books_outbound_commit.py tests/ci/test_ledger_idem_constraint.py"