### PR TITLE
test(wms): seed stock through lot primitives

### DIFF
--- a/tests/api/test_debug_trace_by_warehouse.py
+++ b/tests/api/test_debug_trace_by_warehouse.py
@@ -107,30 +107,36 @@ async def test_debug_trace_filter_by_warehouse(client, session: AsyncSession):
     )
 
     # 在 WH1 写一条 ledger 负账
-    await stock_svc.adjust(
+    await stock_svc.adjust_lot(
         session=session,
         item_id=item_id,
         warehouse_id=wh1,
+        lot_id=int(lot1),
         delta=-2,
         reason="UNIT_TEST_WH1",
         ref="REF-WH1",
         ref_line=1,
         occurred_at=now,
         batch_code=batch1,
+        production_date=None,
+        expiry_date=None,
         trace_id=trace_id,
     )
 
     # 在 WH2 写一条 ledger 负账
-    await stock_svc.adjust(
+    await stock_svc.adjust_lot(
         session=session,
         item_id=item_id,
         warehouse_id=wh2,
+        lot_id=int(lot2),
         delta=-3,
         reason="UNIT_TEST_WH2",
         ref="REF-WH2",
         ref_line=1,
         occurred_at=now + timedelta(seconds=1),
         batch_code=batch2,
+        production_date=None,
+        expiry_date=None,
         trace_id=trace_id,
     )
 

--- a/tests/api/test_inventory_adjustment_count_doc_execution_api.py
+++ b/tests/api/test_inventory_adjustment_count_doc_execution_api.py
@@ -8,7 +8,7 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.wms.stock.services.stock_service import StockService
+from tests.utils.ensure_minimal import set_stock_qty
 
 pytestmark = pytest.mark.asyncio
 UTC = timezone.utc
@@ -69,21 +69,13 @@ async def _seed_positive_stock(
     qty: int,
     ref: str,
 ) -> None:
-    stock = StockService()
-    now = datetime.now(UTC)
-    await stock.adjust(
-        session=session,
+    _ = ref
+    await set_stock_qty(
+        session,
         item_id=int(item_id),
         warehouse_id=int(warehouse_id),
         batch_code=str(batch_code),
-        delta=int(qty),
-        reason="RECEIPT",
-        ref=str(ref),
-        ref_line=1,
-        occurred_at=now,
-        production_date=now.date(),
-        expiry_date=now.date().replace(year=now.date().year + 1),
-        meta={"sub_reason": "UT_COUNT_DOC_EXECUTION_SEED"},
+        qty=int(qty),
     )
 
 

--- a/tests/api/test_inventory_adjustment_count_doc_mainline_api.py
+++ b/tests/api/test_inventory_adjustment_count_doc_mainline_api.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timezone
 from uuid import uuid4
 
 import httpx
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.wms.shared.services.three_books_consistency import verify_commit_three_books
 from app.wms.snapshot.services.snapshot_run import run_snapshot
-from app.wms.stock.services.stock_service import StockService
+from tests.utils.ensure_minimal import set_stock_qty
 
 pytestmark = pytest.mark.asyncio
 UTC = timezone.utc
@@ -83,24 +83,15 @@ async def _seed_positive_stock(
     production_date: date | None = None,
     expiry_date: date | None = None,
 ) -> None:
-    now = datetime.now(UTC)
-    prod = production_date or now.date()
-    exp = expiry_date or (prod + timedelta(days=365))
-
-    stock = StockService()
-    await stock.adjust(
-        session=session,
+    _ = ref
+    _ = production_date
+    _ = expiry_date
+    await set_stock_qty(
+        session,
         item_id=int(item_id),
         warehouse_id=int(warehouse_id),
         batch_code=str(batch_code),
-        delta=int(qty),
-        reason="RECEIPT",
-        ref=str(ref),
-        ref_line=1,
-        occurred_at=now,
-        production_date=prod,
-        expiry_date=exp,
-        meta={"sub_reason": "UT_COUNT_DOC_MAINLINE_SEED"},
+        qty=int(qty),
     )
 
 

--- a/tests/api/test_stock_inventory_recount_freeze_guard_api.py
+++ b/tests/api/test_stock_inventory_recount_freeze_guard_api.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from uuid import uuid4
 
 import httpx
@@ -8,7 +8,7 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.wms.stock.services.stock_service import StockService
+from tests.utils.ensure_minimal import set_stock_qty
 
 
 pytestmark = pytest.mark.asyncio
@@ -105,24 +105,13 @@ async def _seed_positive_stock(
     qty: int,
     ref: str,
 ) -> None:
-    now = datetime.now(UTC)
-    prod = now.date()
-    exp = prod + timedelta(days=365)
-
-    stock = StockService()
-    await stock.adjust(
-        session=session,
+    _ = ref
+    await set_stock_qty(
+        session,
         item_id=int(item_id),
         warehouse_id=int(warehouse_id),
         batch_code=str(batch_code),
-        delta=int(qty),
-        reason="RECEIPT",
-        ref=str(ref),
-        ref_line=1,
-        occurred_at=now,
-        production_date=prod,
-        expiry_date=exp,
-        meta={"sub_reason": "UT_RECOUNT_FREEZE_GUARD_SEED"},
+        qty=int(qty),
     )
 
 

--- a/tests/services/test_order_outbound_flow_v3.py
+++ b/tests/services/test_order_outbound_flow_v3.py
@@ -5,10 +5,9 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.wms.shared.enums import MovementType
 from app.oms.services.order_service import OrderService
 from app.wms.outbound.services.outbound_commit_service import OutboundService
-from app.wms.stock.services.stock_service import StockService
+from tests.utils.ensure_minimal import set_stock_qty
 
 pytestmark = pytest.mark.asyncio
 
@@ -138,22 +137,16 @@ async def _ensure_seed_to_10(session: AsyncSession) -> None:
     )
     await session.commit()
 
-    svc = StockService()
     before = await _read_qty_lot(session)
     if before >= 10:
         return
 
-    need = 10 - before
-    await svc.adjust(
-        session=session,
-        item_id=ITEM_ID,
-        warehouse_id=WAREHOUSE_ID,
-        delta=int(need),
-        reason=MovementType.INBOUND,
-        ref=f"UT-SEED-OUTFLOW-{ITEM_ID}-{WAREHOUSE_ID}-NULL",
-        ref_line=1,
-        occurred_at=datetime.now(timezone.utc),
+    await set_stock_qty(
+        session,
+        item_id=int(ITEM_ID),
+        warehouse_id=int(WAREHOUSE_ID),
         batch_code=None,
+        qty=10,
     )
     await session.commit()
 

--- a/tests/services/test_outbound_idempotency.py
+++ b/tests/services/test_outbound_idempotency.py
@@ -4,7 +4,7 @@
 """
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 import pytest
 import sqlalchemy as sa
@@ -12,9 +12,8 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.wms.outbound.services.outbound_commit_service import OutboundService
-from app.wms.stock.services.stock_service import StockService
 from tests.services._helpers import ensure_store
-from tests.utils.ensure_minimal import ensure_item
+from tests.utils.ensure_minimal import ensure_item, set_stock_qty
 
 UTC = timezone.utc
 
@@ -51,23 +50,12 @@ async def _seed_stock(
 ) -> None:
     await _ensure_item_row(session, item_id=item_id)
 
-    svc = StockService()
-    ts = datetime.now(UTC)
-    prod = date.today()
-    exp = prod + timedelta(days=365)
-
-    await svc.adjust(
-        session=session,
-        item_id=item_id,
-        delta=qty,
-        reason="INBOUND_SEED",
-        ref="SEED-STOCK-IDEM",
-        ref_line=1,
-        occurred_at=ts,
-        warehouse_id=warehouse_id,
-        batch_code=batch_code,
-        production_date=prod,
-        expiry_date=exp,
+    await set_stock_qty(
+        session,
+        item_id=int(item_id),
+        warehouse_id=int(warehouse_id),
+        batch_code=str(batch_code),
+        qty=int(qty),
     )
     await session.commit()
 

--- a/tests/services/test_stock_adjust_trace_id.py
+++ b/tests/services/test_stock_adjust_trace_id.py
@@ -4,7 +4,8 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.wms.stock.services.stock_service import StockService
+from app.wms.stock.services.lots import ensure_lot_full
+from app.wms.stock.services.stock_adjust import adjust_lot_impl
 
 pytestmark = pytest.mark.asyncio
 UTC = timezone.utc
@@ -12,20 +13,20 @@ UTC = timezone.utc
 
 async def test_stock_adjust_writes_trace_id(session: AsyncSession):
     """
-    验证 StockService.adjust 会把 trace_id 落在 stock_ledger.trace_id 上。
+    验证 lot-only 写入原语会把 trace_id 落在 stock_ledger.trace_id 上。
 
     说明：
       - 这是“技术链路锚点”测试，不是“业务事件锚点”测试。
-      - 当前 StockService.adjust 这条原语入口并不要求一定创建 wms_events 头，
+      - 当前 stock adjust 原语入口并不要求一定创建 wms_events 头，
         因此这里不对 stock_ledger.event_id 做强断言，只确认 trace_id 可追踪。
 
     步骤：
       1) 从 items 表拿一条现有 item_id；
-      2) 调用 adjust 做一次入库（delta>0），带上 trace_id='TR-UNIT-1'；
-      3) 在同一个测试中查询 stock_ledger，按 ref='UT-ADJUST-1' 过滤；
-      4) 断言存在一条记录，且 trace_id='TR-UNIT-1'。
+      2) 创建/复用 SUPPLIER lot；
+      3) 调用 adjust_lot_impl 做一次入库（delta>0），带上 trace_id='TR-UNIT-1'；
+      4) 在同一个测试中查询 stock_ledger，按 ref='UT-ADJUST-1' 过滤；
+      5) 断言存在一条记录，且 trace_id='TR-UNIT-1'。
     """
-    svc = StockService()
     now = datetime.now(UTC)
 
     # 1) 取一个已经存在的 item_id，避免触发 items 外键错误（Phase 4E：批次主档已迁移到 lots）
@@ -33,23 +34,37 @@ async def test_stock_adjust_writes_trace_id(session: AsyncSession):
     item_id = row.scalar_one()
     assert item_id is not None
 
-    # 2) 入库：让 adjust 写入 lot-world：lots + stocks_lot + ledger
+    # 2) 入库：让 lot-only primitive 写入 lot-world：lots + stocks_lot + ledger
     ref = "UT-ADJUST-1"
     trace_id = "TR-UNIT-1"
+    production_date = date.today()
+    expiry_date = production_date + timedelta(days=365)
 
-    await svc.adjust(
+    lot_id = await ensure_lot_full(
+        session,
+        item_id=int(item_id),
+        warehouse_id=1,
+        lot_code="B-UT-1",
+        production_date=production_date,
+        expiry_date=expiry_date,
+    )
+
+    await adjust_lot_impl(
         session=session,
         item_id=int(item_id),
         warehouse_id=1,
+        lot_id=int(lot_id),
         delta=5,
         reason="UNIT_INBOUND",
         ref=ref,
         ref_line=1,
         occurred_at=now,
+        meta=None,
         batch_code="B-UT-1",
-        production_date=date.today(),
-        expiry_date=date.today() + timedelta(days=365),
+        production_date=production_date,
+        expiry_date=expiry_date,
         trace_id=trace_id,
+        utc_now=lambda: datetime.now(UTC),
     )
 
     # 3) 查询 ledger，确认 trace_id 已经写入

--- a/tests/services/test_trace_full_chain_order_reserve_outbound.py
+++ b/tests/services/test_trace_full_chain_order_reserve_outbound.py
@@ -6,7 +6,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.oms.services.order_service import OrderService
 from app.wms.outbound.services.outbound_commit_service import OutboundService
-from app.wms.stock.services.stock_service import StockService
+from app.wms.stock.services.lots import ensure_lot_full
+from app.wms.stock.services.stock_adjust import adjust_lot_impl
 from app.diagnostics.services.trace_service import TraceService
 
 pytestmark = pytest.mark.asyncio
@@ -48,24 +49,36 @@ async def test_full_trace_order_outbound(session: AsyncSession):
     row = await session.execute(text("SELECT id FROM warehouses ORDER BY id ASC LIMIT 1"))
     wh_id = int(row.scalar_one())
 
-    stock_svc = StockService()
     now = datetime.now(UTC)
     batch_code = "B-TRACE-E2E-1"
 
     # === 1) 预先做一次入库：给这个 item/仓/批次准备库存 ===
-    await stock_svc.adjust(
+    production_date = date.today()
+    expiry_date = production_date + timedelta(days=365)
+    lot_id = await ensure_lot_full(
+        session,
+        item_id=int(item_id),
+        warehouse_id=int(wh_id),
+        lot_code=str(batch_code),
+        production_date=production_date,
+        expiry_date=expiry_date,
+    )
+    await adjust_lot_impl(
         session=session,
         item_id=int(item_id),
-        warehouse_id=wh_id,
+        warehouse_id=int(wh_id),
+        lot_id=int(lot_id),
         delta=10,
         reason="UT_TRACE_SEED_INBOUND",
         ref="UT-TRACE-SEED",
         ref_line=1,
         occurred_at=now,
+        meta=None,
         batch_code=batch_code,
-        production_date=date.today(),
-        expiry_date=date.today() + timedelta(days=365),
+        production_date=production_date,
+        expiry_date=expiry_date,
         trace_id=trace_id,
+        utc_now=lambda: datetime.now(UTC),
     )
 
     # === 2) 建订单 ===
@@ -141,7 +154,7 @@ async def test_full_trace_order_outbound(session: AsyncSession):
     )
 
     # === 3) 出库（OutboundService.commit）→ ledger.trace_id ===
-    outbound_svc = OutboundService(stock_svc)
+    outbound_svc = OutboundService()
 
     r_outbound = await outbound_svc.commit(
         session=session,


### PR DESCRIPTION
## Summary
- migrate selected WMS tests away from StockService.adjust seed setup
- seed stock through existing lot-only helpers / adjust_lot_impl
- keep business assertions unchanged
- leave quick tests and StockService.adjust contract tests for separate follow-up

## Validation
- python3 -m compileall app tests scripts
- make alembic-check
- make test TESTS="tests/services/test_stock_adjust_trace_id.py tests/api/test_stock_inventory_recount_freeze_guard_api.py tests/api/test_inventory_adjustment_count_doc_execution_api.py tests/api/test_inventory_adjustment_count_doc_mainline_api.py tests/services/test_outbound_idempotency.py tests/services/test_order_outbound_flow_v3.py tests/services/test_trace_full_chain_order_reserve_outbound.py tests/api/test_debug_trace_by_warehouse.py tests/ci/test_ledger_idem_constraint.py"