### PR TITLE
test(wms): migrate formal stock seeds to lot primitives

### DIFF
--- a/tests/services/test_order_rma_and_reconcile.py
+++ b/tests/services/test_order_rma_and_reconcile.py
@@ -12,7 +12,7 @@ from app.wms.shared.enums import MovementType
 from app.oms.orders.services.order_reconcile_service import OrderReconcileService
 from app.oms.services.order_service import OrderService
 from app.wms.stock.services.lots import ensure_internal_lot_singleton, ensure_lot_full
-from app.wms.stock.services.stock_service import StockService
+from app.wms.stock.services.stock_adjust import adjust_lot_impl
 
 UTC = timezone.utc
 
@@ -104,6 +104,79 @@ async def _ensure_internal_lot_for_receipt(session: AsyncSession, *, warehouse_i
         warehouse_id=int(warehouse_id),
         source_receipt_id=int(receipt_id),
         source_line_no=1,
+    )
+
+
+async def _ensure_stock_lot_for_adjust(
+    session: AsyncSession,
+    *,
+    warehouse_id: int,
+    item_id: int,
+    batch_code: Optional[str],
+    production_date: Optional[date],
+    expiry_date: Optional[date],
+) -> int:
+    """
+    测试造数专用：把原先 StockService.adjust(batch_code=...) 的 lot 解析提前显式化。
+    """
+    if batch_code is not None:
+        return await _ensure_supplier_lot(
+            session,
+            warehouse_id=int(warehouse_id),
+            item_id=int(item_id),
+            code=str(batch_code),
+        )
+
+    return int(
+        await ensure_internal_lot_singleton(
+            session,
+            item_id=int(item_id),
+            warehouse_id=int(warehouse_id),
+            source_receipt_id=None,
+            source_line_no=None,
+        )
+    )
+
+
+async def _write_stock_delta_for_test(
+    session: AsyncSession,
+    *,
+    warehouse_id: int,
+    item_id: int,
+    batch_code: Optional[str],
+    delta: int,
+    reason: MovementType,
+    ref: str,
+    ref_line: int,
+    occurred_at: datetime,
+    production_date: Optional[date],
+    expiry_date: Optional[date],
+) -> None:
+    lot_id = await _ensure_stock_lot_for_adjust(
+        session,
+        warehouse_id=int(warehouse_id),
+        item_id=int(item_id),
+        batch_code=batch_code,
+        production_date=production_date,
+        expiry_date=expiry_date,
+    )
+
+    await adjust_lot_impl(
+        session=session,
+        item_id=int(item_id),
+        warehouse_id=int(warehouse_id),
+        lot_id=int(lot_id),
+        delta=int(delta),
+        reason=reason,
+        ref=str(ref),
+        ref_line=int(ref_line),
+        occurred_at=occurred_at,
+        meta=None,
+        batch_code=batch_code,
+        production_date=production_date,
+        expiry_date=expiry_date,
+        trace_id=None,
+        utc_now=lambda: datetime.now(UTC),
     )
 
 
@@ -392,11 +465,9 @@ async def test_rma_cannot_exceed_shipped(session: AsyncSession) -> None:
     order_id = int(result["id"])
     order_ref = result["ref"]  # 形如 ORD:PDD:SHOP:EXT
 
-    stock_svc = StockService()
-
     # 2) 先做一笔入库，保证库存足够
-    await stock_svc.adjust(
-        session=session,
+    await _write_stock_delta_for_test(
+        session,
         item_id=item_id,
         warehouse_id=1,
         delta=2,
@@ -410,8 +481,8 @@ async def test_rma_cannot_exceed_shipped(session: AsyncSession) -> None:
     )
 
     # 3) 模拟发货 shipped=2（只统计负数 delta，用于 shipped 计算）
-    await stock_svc.adjust(
-        session=session,
+    await _write_stock_delta_for_test(
+        session,
         item_id=item_id,
         warehouse_id=1,
         delta=-2,
@@ -528,11 +599,9 @@ async def test_rma_receipt_updates_counters_and_status(session: AsyncSession) ->
     order_id = int(result["id"])
     order_ref = result["ref"]
 
-    stock_svc = StockService()
-
     # 2) 入库 + 发货 shipped=2
-    await stock_svc.adjust(
-        session=session,
+    await _write_stock_delta_for_test(
+        session,
         item_id=item_id,
         warehouse_id=1,
         delta=2,
@@ -544,8 +613,8 @@ async def test_rma_receipt_updates_counters_and_status(session: AsyncSession) ->
         production_date=pd,
         expiry_date=ed,
     )
-    await stock_svc.adjust(
-        session=session,
+    await _write_stock_delta_for_test(
+        session,
         item_id=item_id,
         warehouse_id=1,
         delta=-2,

--- a/tests/unit/test_fefo_query_v2.py
+++ b/tests/unit/test_fefo_query_v2.py
@@ -8,7 +8,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.wms.shared.enums import MovementType
 from app.wms.shared.services.expiry_analytics_allocator import ExpiryAnalyticsAllocator
-from app.wms.stock.services.stock_service import StockService
+from app.wms.stock.services.lots import ensure_lot_full
+from app.wms.stock.services.stock_adjust import adjust_lot_impl
 from tests.utils.ensure_minimal import ensure_item
 
 UTC = timezone.utc
@@ -37,40 +38,64 @@ async def test_expiry_analytics_query_returns_sorted_not_enforcing(session: Asyn
     """
     await ensure_item(session, id=3003, sku="SKU-3003", name="ITEM-3003", expiry_required=True)
 
-    svc = StockService()
     now = datetime.now(UTC)
     prod = date.today()
 
     exp_near = prod + timedelta(days=1)
     exp_far = prod + timedelta(days=10)
 
-    # 用正路写入：RECEIPT 路径写 lot canonical snapshot + RECEIPT ledger snapshot
+    lot_near = await ensure_lot_full(
+        session,
+        item_id=3003,
+        warehouse_id=1,
+        lot_code="A_NEAR",
+        production_date=prod,
+        expiry_date=exp_near,
+    )
+    lot_far = await ensure_lot_full(
+        session,
+        item_id=3003,
+        warehouse_id=1,
+        lot_code="B_FAR",
+        production_date=prod,
+        expiry_date=exp_far,
+    )
+
+    # 用 lot-only 原语写入：RECEIPT 路径写 lot canonical snapshot + RECEIPT ledger snapshot
     # ref 必须不同，避免 ledger 唯一键冲突
-    await svc.adjust(
+    await adjust_lot_impl(
         session=session,
         warehouse_id=1,
         item_id=3003,
+        lot_id=int(lot_near),
         delta=3,
         reason=MovementType.RECEIPT,
         ref="UT-EXP-NEAR",
         ref_line=1,
         occurred_at=now,
+        meta=None,
         batch_code="A_NEAR",
         production_date=prod,
         expiry_date=exp_near,
+        trace_id=None,
+        utc_now=lambda: datetime.now(UTC),
     )
-    await svc.adjust(
+    await adjust_lot_impl(
         session=session,
         warehouse_id=1,
         item_id=3003,
+        lot_id=int(lot_far),
         delta=3,
         reason=MovementType.RECEIPT,
         ref="UT-EXP-FAR",
         ref_line=1,
         occurred_at=now,
+        meta=None,
         batch_code="B_FAR",
         production_date=prod,
         expiry_date=exp_far,
+        trace_id=None,
+        utc_now=lambda: datetime.now(UTC),
     )
     await session.commit()
 


### PR DESCRIPTION
## Summary
- migrate remaining formal WMS tests away from StockService.adjust seed setup
- seed FEFO lots through ensure_lot_full plus adjust_lot_impl
- seed RMA/reconcile stock movements through explicit lot resolution plus adjust_lot_impl
- leave quick tests and StockService.adjust contract tests for separate follow-up

## Validation
- python3 -m compileall app tests scripts
- make alembic-check
- make test TESTS="tests/unit/test_fefo_query_v2.py tests/services/test_order_rma_and_reconcile.py tests/ci/test_ledger_idem_constraint.py"