### PR TITLE
test(wms): migrate quick stock seeds to lot primitives

### DIFF
--- a/tests/quick/test_inbound_pick_count_v2.py
+++ b/tests/quick/test_inbound_pick_count_v2.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 
 import pytest
 from sqlalchemy import text
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.wms.shared.enums import MovementType
 from app.wms.stock.services.lots import ensure_internal_lot_singleton
-from app.wms.stock.services.stock_service import StockService
+from app.wms.stock.services.stock_adjust import adjust_lot_impl
 
 UTC = timezone.utc
 
@@ -45,7 +45,6 @@ async def _qty(session: AsyncSession, item_id: int, wh: int, lot_id: int) -> int
 
 @pytest.mark.asyncio
 async def test_receive_then_pick_then_count(session: AsyncSession):
-    svc = StockService()
     item_id = 1
     wh = 1
 
@@ -59,7 +58,7 @@ async def test_receive_then_pick_then_count(session: AsyncSession):
     lot_id = await _ensure_internal_lot(session, item_id=item_id, wh=wh, ref="UT-IPC-INTERNAL-RECEIPT-1")
     batch_code: str | None = None
 
-    await svc.adjust_lot(
+    await adjust_lot_impl(
         session=session,
         item_id=item_id,
         warehouse_id=wh,
@@ -69,12 +68,17 @@ async def test_receive_then_pick_then_count(session: AsyncSession):
         ref="Q-IPC-1",
         ref_line=1,
         occurred_at=datetime.now(UTC),
+        meta=None,
         batch_code=batch_code,
+        production_date=None,
+        expiry_date=None,
+        trace_id=None,
+        utc_now=lambda: datetime.now(UTC),
     )
     q1 = await _qty(session, item_id, wh, lot_id)
     assert q1 >= 2
 
-    await svc.adjust_lot(
+    await adjust_lot_impl(
         session=session,
         item_id=item_id,
         warehouse_id=wh,
@@ -84,7 +88,12 @@ async def test_receive_then_pick_then_count(session: AsyncSession):
         ref="Q-IPC-2",
         ref_line=1,
         occurred_at=datetime.now(UTC),
+        meta=None,
         batch_code=batch_code,
+        production_date=None,
+        expiry_date=None,
+        trace_id=None,
+        utc_now=lambda: datetime.now(UTC),
     )
     q2 = await _qty(session, item_id, wh, lot_id)
     assert q2 == q1 - 1
@@ -92,7 +101,7 @@ async def test_receive_then_pick_then_count(session: AsyncSession):
     remain = await _qty(session, item_id, wh, lot_id)
     delta = 1 - remain
     if delta != 0:
-        await svc.adjust_lot(
+        await adjust_lot_impl(
             session=session,
             item_id=item_id,
             warehouse_id=wh,
@@ -102,7 +111,12 @@ async def test_receive_then_pick_then_count(session: AsyncSession):
             ref="Q-IPC-3",
             ref_line=1,
             occurred_at=datetime.now(UTC),
+            meta=None,
             batch_code=batch_code,
+            production_date=None,
+            expiry_date=None,
+            trace_id=None,
+            utc_now=lambda: datetime.now(UTC),
         )
     q3 = await _qty(session, item_id, wh, lot_id)
     assert q3 == 1

--- a/tests/quick/test_inbound_reclassify_v2.py
+++ b/tests/quick/test_inbound_reclassify_v2.py
@@ -1,11 +1,12 @@
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 
 import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.wms.shared.enums import MovementType
-from app.wms.stock.services.stock_service import StockService
+from app.wms.stock.services.lots import ensure_internal_lot_singleton
+from app.wms.stock.services.stock_adjust import adjust_lot_impl
 
 UTC = timezone.utc
 
@@ -59,10 +60,49 @@ async def _qty(session: AsyncSession, item_id: int, wh: int, code: str | None) -
     return int(row.scalar_one_or_none() or 0)
 
 
+async def _ensure_internal_lot(session: AsyncSession, *, item_id: int, wh: int) -> int:
+    lot_id = await ensure_internal_lot_singleton(
+        session,
+        item_id=int(item_id),
+        warehouse_id=int(wh),
+        source_receipt_id=None,
+        source_line_no=None,
+    )
+    return int(lot_id)
+
+
+async def _write_delta(
+    session: AsyncSession,
+    *,
+    item_id: int,
+    wh: int,
+    lot_id: int,
+    delta: int,
+    reason: str,
+    ref: str,
+    ref_line: int,
+) -> None:
+    await adjust_lot_impl(
+        session=session,
+        item_id=int(item_id),
+        warehouse_id=int(wh),
+        lot_id=int(lot_id),
+        delta=int(delta),
+        reason=str(reason),
+        ref=str(ref),
+        ref_line=int(ref_line),
+        occurred_at=datetime.now(UTC),
+        meta=None,
+        batch_code=None,
+        production_date=None,
+        expiry_date=None,
+        trace_id=None,
+        utc_now=lambda: datetime.now(UTC),
+    )
+
+
 @pytest.mark.asyncio
 async def test_inbound_receive_and_reclassify_integrity(session: AsyncSession):
-    svc = StockService()
-
     item_id = 1
     wh_returns = await _ensure_wh(session, "RETURNS")
     wh_main = await _ensure_wh(session, "MAIN")
@@ -76,43 +116,41 @@ async def test_inbound_receive_and_reclassify_integrity(session: AsyncSession):
 
     batch_code: str | None = None
 
-    await svc.adjust(
-        session=session,
+    lot_returns = await _ensure_internal_lot(session, item_id=item_id, wh=wh_returns)
+    lot_main = await _ensure_internal_lot(session, item_id=item_id, wh=wh_main)
+
+    await _write_delta(
+        session,
         item_id=item_id,
-        warehouse_id=wh_returns,
+        wh=wh_returns,
+        lot_id=lot_returns,
         delta=+2,
         reason=MovementType.INBOUND,
         ref="PO-R1",
         ref_line=1,
-        occurred_at=datetime.now(UTC),
-        batch_code=batch_code,
-        production_date=date.today(),
     )
     r0 = await _qty(session, item_id, wh_returns, batch_code)
     assert r0 >= 2
 
-    await svc.adjust(
-        session=session,
+    await _write_delta(
+        session,
         item_id=item_id,
-        warehouse_id=wh_returns,
+        wh=wh_returns,
+        lot_id=lot_returns,
         delta=-1,
         reason="RETURN_RECLASSIFY",
         ref="X-MOVE-1",
         ref_line=1,
-        occurred_at=datetime.now(UTC),
-        batch_code=batch_code,
     )
-    await svc.adjust(
-        session=session,
+    await _write_delta(
+        session,
         item_id=item_id,
-        warehouse_id=wh_main,
+        wh=wh_main,
+        lot_id=lot_main,
         delta=+1,
         reason="RETURN_RECLASSIFY",
         ref="X-MOVE-1",
         ref_line=2,
-        occurred_at=datetime.now(UTC),
-        batch_code=batch_code,
-        production_date=date.today(),
     )
 
     r1 = await _qty(session, item_id, wh_returns, batch_code)

--- a/tests/quick/test_inbound_smoke_pg.py
+++ b/tests/quick/test_inbound_smoke_pg.py
@@ -1,11 +1,11 @@
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.wms.shared.enums import MovementType
-from app.wms.stock.services.stock_service import StockService
+from app.wms.stock.services.lots import ensure_lot_full
+from app.wms.stock.services.stock_adjust import adjust_lot_impl
 
 pytestmark = pytest.mark.asyncio
 
@@ -130,22 +130,35 @@ async def test_inbound_ledger_snapshot_smoke(session: AsyncSession):
     # 1) 确保最小域存在
     await _ensure_min_domain_v2(session, warehouse_id=WH, item_id=ITEM)
 
-    svc = StockService()
-
     before = await _qty_lot(session, warehouse_id=WH, item_id=ITEM, batch_code=BATCH)
 
-    # 2) 入库 +5（走 ledger 写入口）
-    await svc.adjust(
+    # 2) 入库 +5（走 lot-only ledger 写入口）
+    production_date = date.today()
+    expiry_date = production_date + timedelta(days=30)
+    lot_id = await ensure_lot_full(
+        session,
+        item_id=int(ITEM),
+        warehouse_id=int(WH),
+        lot_code=str(BATCH),
+        production_date=production_date,
+        expiry_date=expiry_date,
+    )
+    await adjust_lot_impl(
         session=session,
-        warehouse_id=WH,
-        item_id=ITEM,
+        warehouse_id=int(WH),
+        item_id=int(ITEM),
+        lot_id=int(lot_id),
         delta=5,
-        reason=MovementType.INBOUND,
+        reason="INBOUND",
         ref="SMOKE-INBOUND",
         ref_line=1,
         occurred_at=datetime.now(timezone.utc),
+        meta=None,
         batch_code=BATCH,
-        production_date=date.today(),
+        production_date=production_date,
+        expiry_date=expiry_date,
+        trace_id=None,
+        utc_now=lambda: datetime.now(timezone.utc),
     )
     await session.commit()
 

--- a/tests/quick/test_outbound_commit_v2.py
+++ b/tests/quick/test_outbound_commit_v2.py
@@ -5,9 +5,8 @@ from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.wms.shared.enums import MovementType
 from app.wms.outbound.services.outbound_commit_service import ship_commit
-from app.wms.stock.services.stock_service import StockService
+from tests.utils.ensure_minimal import set_stock_qty
 from tests.services._helpers import ensure_store
 
 
@@ -104,39 +103,17 @@ async def _ensure_stock_seed(session: AsyncSession, *, item_id: int, wh: int, co
     """
     强护栏下不要依赖 conftest 的隐式基线库存，测试必须显式 seed 目标槽位。
     """
-    svc = StockService()
     before = await _qty(session, item_id, wh, code)
     if before >= qty:
         return
 
-    need = qty - before
-    if code is None:
-        await svc.adjust(
-            session=session,
-            item_id=int(item_id),
-            warehouse_id=int(wh),
-            delta=int(need),
-            reason=MovementType.INBOUND,
-            ref=f"UT-SEED-QOUT-{item_id}-{wh}-NULL",
-            ref_line=1,
-            occurred_at=None,
-            batch_code=None,
-        )
-    else:
-        prod, exp = _required_dates_for_code(str(code))
-        await svc.adjust(
-            session=session,
-            item_id=int(item_id),
-            warehouse_id=int(wh),
-            delta=int(need),
-            reason=MovementType.INBOUND,
-            ref=f"UT-SEED-QOUT-{item_id}-{wh}-{code}",
-            ref_line=1,
-            occurred_at=None,
-            batch_code=str(code),
-            production_date=prod,
-            expiry_date=exp,
-        )
+    await set_stock_qty(
+        session,
+        item_id=int(item_id),
+        warehouse_id=int(wh),
+        batch_code=code,
+        qty=int(qty),
+    )
     await session.commit()
 
 

--- a/tests/quick/test_outbound_core_v2.py
+++ b/tests/quick/test_outbound_core_v2.py
@@ -1,12 +1,12 @@
 from datetime import date, datetime, timedelta, timezone
 
 import pytest
-from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.wms.shared.enums import MovementType
-from app.wms.stock.services.stock_service import StockService
+from app.wms.stock.services.lots import ensure_internal_lot_singleton, ensure_lot_full
+from app.wms.stock.services.stock_adjust import adjust_lot_impl
 
 UTC = timezone.utc
 
@@ -62,47 +62,86 @@ async def _qty(session: AsyncSession, item_id: int, wh: int, code: str | None) -
     return int(r.scalar_one_or_none() or 0)
 
 
+async def _lot_id_for_slot(session: AsyncSession, *, item_id: int, wh: int, code: str | None) -> int:
+    if code is None:
+        return int(
+            await ensure_internal_lot_singleton(
+                session,
+                item_id=int(item_id),
+                warehouse_id=int(wh),
+                source_receipt_id=None,
+                source_line_no=None,
+            )
+        )
+
+    prod = date.today()
+    exp = prod + timedelta(days=365)
+    return int(
+        await ensure_lot_full(
+            session,
+            item_id=int(item_id),
+            warehouse_id=int(wh),
+            lot_code=str(code),
+            production_date=prod,
+            expiry_date=exp,
+        )
+    )
+
+
+async def _write_delta(
+    session: AsyncSession,
+    *,
+    item_id: int,
+    wh: int,
+    code: str | None,
+    delta: int,
+    reason: MovementType | str,
+    ref: str,
+    ref_line: int,
+):
+    lot_id = await _lot_id_for_slot(session, item_id=int(item_id), wh=int(wh), code=code)
+    prod = date.today() if code is not None else None
+    exp = (prod + timedelta(days=365)) if prod is not None else None
+    return await adjust_lot_impl(
+        session=session,
+        item_id=int(item_id),
+        warehouse_id=int(wh),
+        lot_id=int(lot_id),
+        delta=int(delta),
+        reason=reason,
+        ref=str(ref),
+        ref_line=int(ref_line),
+        occurred_at=datetime.now(UTC),
+        meta=None,
+        batch_code=code,
+        production_date=prod,
+        expiry_date=exp,
+        trace_id=None,
+        utc_now=lambda: datetime.now(UTC),
+    )
+
+
 async def _ensure_stock_seed(session: AsyncSession, *, item_id: int, wh: int, code: str | None, qty: int) -> None:
-    svc = StockService()
     before = await _qty(session, item_id, wh, code)
     if before >= qty:
         return
 
     need = qty - before
-    if code is None:
-        await svc.adjust(
-            session=session,
-            item_id=int(item_id),
-            warehouse_id=int(wh),
-            delta=int(need),
-            reason=MovementType.INBOUND,
-            ref=f"UT-SEED-OUTCORE-{item_id}-{wh}-NULL",
-            ref_line=1,
-            occurred_at=datetime.now(UTC),
-            batch_code=None,
-        )
-    else:
-        prod = date.today()
-        exp = prod + timedelta(days=365)
-        await svc.adjust(
-            session=session,
-            item_id=int(item_id),
-            warehouse_id=int(wh),
-            delta=int(need),
-            reason=MovementType.INBOUND,
-            ref=f"UT-SEED-OUTCORE-{item_id}-{wh}-{code}",
-            ref_line=1,
-            occurred_at=datetime.now(UTC),
-            batch_code=str(code),
-            production_date=prod,
-            expiry_date=exp,
-        )
+    await _write_delta(
+        session,
+        item_id=int(item_id),
+        wh=int(wh),
+        code=code,
+        delta=int(need),
+        reason=MovementType.INBOUND,
+        ref=f"UT-SEED-OUTCORE-{item_id}-{wh}-{code or 'NULL'}",
+        ref_line=1,
+    )
     await session.commit()
 
 
 @pytest.mark.asyncio
 async def test_outbound_core_idem_and_insufficient(session: AsyncSession):
-    svc = StockService()
     item_id, wh = 3003, 1
     code = await _slot_code(session, item_id)
 
@@ -113,49 +152,44 @@ async def test_outbound_core_idem_and_insufficient(session: AsyncSession):
     assert before >= 1
 
     # 扣 1
-    await svc.adjust(
-        session=session,
+    await _write_delta(
+        session,
         item_id=item_id,
+        wh=wh,
+        code=code,
         delta=-1,
         reason=MovementType.OUTBOUND,
         ref="Q-OUTCORE-1",
         ref_line=1,
-        occurred_at=datetime.now(UTC),
-        batch_code=code,
-        warehouse_id=wh,
     )
     mid = await _qty(session, item_id, wh, code)
     assert mid == before - 1
 
     # 同 ref/ref_line 幂等
-    res = await svc.adjust(
-        session=session,
+    res = await _write_delta(
+        session,
         item_id=item_id,
+        wh=wh,
+        code=code,
         delta=-1,
         reason=MovementType.OUTBOUND,
         ref="Q-OUTCORE-1",
         ref_line=1,
-        occurred_at=datetime.now(UTC),
-        batch_code=code,
-        warehouse_id=wh,
     )
     assert res.get("idempotent") is True
 
     # 不足：新世界观为 409 + Problem（HTTPException）
     remain = await _qty(session, item_id, wh, code)
-    with pytest.raises(HTTPException) as exc:
-        await svc.adjust(
-            session=session,
+    with pytest.raises(ValueError) as exc:
+        await _write_delta(
+            session,
             item_id=item_id,
+            wh=wh,
+            code=code,
             delta=-(remain + 1),
             reason=MovementType.OUTBOUND,
             ref="Q-OUTCORE-2",
             ref_line=1,
-            occurred_at=datetime.now(UTC),
-            batch_code=code,
-            warehouse_id=wh,
         )
 
-    assert exc.value.status_code == 409
-    assert isinstance(exc.value.detail, dict)
-    assert exc.value.detail.get("error_code") == "insufficient_stock"
+    assert "insufficient stock" in str(exc.value).lower()

--- a/tests/quick/test_outbound_pg.py
+++ b/tests/quick/test_outbound_pg.py
@@ -1,14 +1,15 @@
 # tests/quick/test_outbound_pg.py — v2: warehouse + batch_code 口径
-from datetime import date, datetime, timedelta, timezone
+from datetime import datetime, timezone
+from uuid import uuid4
 
 import pytest
 from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.wms.shared.enums import MovementType
 from app.wms.outbound.services.outbound_commit_service import ship_commit
-from app.wms.stock.services.stock_service import StockService
+from app.wms.stock.services.lots import ensure_lot_full
+from tests.utils.ensure_minimal import set_stock_qty
 from tests.services._helpers import ensure_store
 
 UTC = timezone.utc
@@ -104,42 +105,17 @@ async def _ensure_stock_seed(session: AsyncSession, *, item_id: int, wh: int, co
     - code=None  => NULL 槽位（lot_id IS NULL）
     - code=str   => 批次槽位（lot_code 展示码），入库需日期
     """
-    svc = StockService()
-    now = datetime.now(UTC)
-
     before = await _qty(session, item_id, wh, code)
     if before >= qty:
         return
 
-    need = qty - before
-    if code is None:
-        await svc.adjust(
-            session=session,
-            item_id=int(item_id),
-            warehouse_id=int(wh),
-            delta=int(need),
-            reason=MovementType.INBOUND,
-            ref=f"UT-SEED-{item_id}-{wh}-NULL",
-            ref_line=1,
-            occurred_at=now,
-            batch_code=None,
-        )
-    else:
-        prod = date.today()
-        exp = prod + timedelta(days=365)
-        await svc.adjust(
-            session=session,
-            item_id=int(item_id),
-            warehouse_id=int(wh),
-            delta=int(need),
-            reason=MovementType.INBOUND,
-            ref=f"UT-SEED-{item_id}-{wh}-{code}",
-            ref_line=1,
-            occurred_at=now,
-            batch_code=str(code),
-            production_date=prod,
-            expiry_date=exp,
-        )
+    await set_stock_qty(
+        session,
+        item_id=int(item_id),
+        warehouse_id=int(wh),
+        batch_code=code,
+        qty=int(qty),
+    )
     await session.commit()
 
 
@@ -196,30 +172,20 @@ async def test_outbound_insufficient_stock(session: AsyncSession):
     """
     item_id = 1
     wh = 1
-    code = await _slot_code(session, item_id)
-
-    # 先确保槽位存在，再把 qty 清到 0
-    await _ensure_stock_seed(session, item_id=item_id, wh=wh, code=code, qty=1)
-
-    cur = await _qty(session, item_id, wh, code)
-    if cur != 0:
-        svc = StockService()
-        zero_prod = date.today() if code is not None else None
-        zero_exp = (zero_prod + timedelta(days=365)) if zero_prod is not None else None
-        await svc.adjust(
-            session=session,
-            item_id=int(item_id),
-            warehouse_id=int(wh),
-            delta=int(-cur),
-            reason=MovementType.COUNT,
-            ref=f"UT-ZERO-{item_id}-{wh}-{code or 'NULL'}",
-            ref_line=1,
-            occurred_at=datetime.now(UTC),
-            batch_code=code,
-            production_date=zero_prod,
-            expiry_date=zero_exp,
-        )
-        await session.commit()
+    # 使用唯一批次码，并只创建 lot 不造库存：
+    # 这样出库能命中既有 lot_id，然后稳定进入 insufficient_stock 分支。
+    code = f"UT-OUT-PG-INS-{uuid4().hex[:8].upper()}"
+    production_date = datetime.now(UTC).date()
+    expiry_date = production_date.replace(year=production_date.year + 1)
+    await ensure_lot_full(
+        session,
+        item_id=int(item_id),
+        warehouse_id=int(wh),
+        lot_code=str(code),
+        production_date=production_date,
+        expiry_date=expiry_date,
+    )
+    await session.commit()
 
     order_id = "UT:PH3:SO-INS-001"
     await _ensure_order_ref_exists(session, order_ref=order_id)


### PR DESCRIPTION
## Summary
- migrate quick WMS tests away from StockService.adjust seed/setup calls
- seed and mutate stock through set_stock_qty / ensure_lot_full / adjust_lot_impl
- keep outbound and inbound quick assertions focused on existing behavior
- leave StockService.adjust contract tests for final follow-up

## Validation
- python3 -m compileall app tests scripts
- make alembic-check
- make test TESTS="tests/quick/test_inbound_smoke_pg.py tests/quick/test_outbound_commit_v2.py tests/quick/test_inbound_pick_count_v2.py tests/quick/test_outbound_core_v2.py tests/quick/test_inbound_reclassify_v2.py tests/quick/test_outbound_pg.py tests/ci/test_ledger_idem_constraint.py"