### PR TITLE
refactor(wms): retire stock adjust compatibility entrypoint

### DIFF
--- a/app/wms/stock/services/lot_resolver.py
+++ b/app/wms/stock/services/lot_resolver.py
@@ -10,21 +10,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.wms.stock.services.lots import ensure_internal_lot_singleton, ensure_lot_full
 
 
-def _norm_lot_code(v: str | None) -> str | None:
-    if v is None:
-        return None
-    s = str(v).strip()
-    if not s:
-        return None
-    return s
-
-
 class LotResolver:
     """
     只负责“lot 决议 + lot 创建/复用”的纯服务：
     - supplier lot: ensure_lot_full
     - internal lot: ensure_internal_lot_singleton（(warehouse,item) 单例）
-    - 可用量估算：仅用于错误提示/诊断（不参与扣减决策）
 
     当前阶段：
     - REQUIRED lot 身份已切到 (warehouse_id, item_id, production_date)
@@ -81,60 +71,3 @@ class LotResolver:
             source_receipt_id=None,
             source_line_no=None,
         )
-
-    async def load_on_hand_qty(
-        self,
-        session: AsyncSession,
-        *,
-        warehouse_id: int,
-        item_id: int,
-        batch_code: Optional[str],
-    ) -> int:
-        """
-        只用于错误提示/诊断的“可用量”估算：
-        - batch_code 为空：聚合该 item 在该仓的总余额
-        - batch_code 非空：按展示码 lots.lot_code 聚合 SUPPLIER lot 的余额
-
-        注意：
-        - lot_code 不再是结构身份
-        - 这里按 lot_code 聚合只是为了提示用户，不参与扣减裁决
-        """
-        if batch_code is None:
-            row = (
-                await session.execute(
-                    SA(
-                        """
-                        SELECT COALESCE(SUM(s.qty), 0) AS qty
-                          FROM stocks_lot s
-                         WHERE s.warehouse_id = :w
-                           AND s.item_id      = :i
-                        """
-                    ),
-                    {"w": int(warehouse_id), "i": int(item_id)},
-                )
-            ).first()
-        else:
-            code = _norm_lot_code(batch_code) or ""
-            row = (
-                await session.execute(
-                    SA(
-                        """
-                        SELECT COALESCE(SUM(s.qty), 0) AS qty
-                          FROM stocks_lot s
-                          JOIN lots lo ON lo.id = s.lot_id
-                         WHERE s.warehouse_id = :w
-                           AND s.item_id      = :i
-                           AND lo.lot_code_source = 'SUPPLIER'
-                           AND lo.lot_code = :code
-                        """
-                    ),
-                    {"w": int(warehouse_id), "i": int(item_id), "code": str(code)},
-                )
-            ).first()
-
-        if not row:
-            return 0
-        try:
-            return int(row[0] or 0)
-        except Exception:
-            return 0

--- a/app/wms/stock/services/stock_service.py
+++ b/app/wms/stock/services/stock_service.py
@@ -4,339 +4,28 @@ from __future__ import annotations
 from datetime import date, datetime, timezone
 from typing import Any, Dict, Optional, Union
 
-from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.problem import raise_problem
 from app.wms.shared.enums import MovementType
+from app.wms.stock.services.lot_resolver import LotResolver
 from app.wms.stock.services.stock_adjust import adjust_lot_impl
 from app.wms.stock.services.stock_ship_service import ship_commit_direct_lot_impl
-from app.wms.stock.services.lot_resolver import LotResolver
-from app.wms.stock.services.stock_contract_resolver import resolve_lot_for_stock_adjust
 
 UTC = timezone.utc
 
 
 class StockService:
     """
-    v2 专业化库存内核（对外兼容 batch_code 入参，但内部以 lot-world 为主）。
+    v2 专业化库存内核（lot-world 终态）。
 
-    任务3 收口：
-    - adjust：合同入口（batch_code -> contract -> resolve lot_id -> write）
-      ❌ 禁止再传 lot_id（避免合同入口与 lot-only 原语混用）
-    - adjust_lot：lot-only 原语入口（调用方已解析 lot_id，直接写）
+    终态收口：
+    - adjust_lot：lot-only 原语入口，调用方必须先解析 lot_id；
+    - lot_resolver：保留给上层服务做合同裁决 + lot_id 解析；
+    - 旧 StockService.adjust(batch_code=...) 合同入口已退役。
     """
 
     def __init__(self, lot_resolver: Optional[LotResolver] = None) -> None:
         self.lot_resolver = lot_resolver or LotResolver()
-
-    def _classify_adjust_value_error(self, msg: str) -> str:
-        m = (msg or "").strip()
-        ml = m.lower()
-
-        if "insufficient stock" in ml:
-            return "insufficient_stock"
-        if "item_not_found" in ml:
-            return "item_not_found"
-        if "lot_not_found" in ml:
-            return "lot_not_found"
-        if "lot_mismatch" in ml:
-            return "lot_mismatch"
-        if "supplier_lot_code_ambiguous" in ml:
-            return "supplier_lot_code_ambiguous"
-
-        if "production_date_required_for_required_lot" in ml:
-            return "production_date_required_for_required_lot"
-        if "expiry_date_required_for_required_lot" in ml:
-            return "expiry_date_required_for_required_lot"
-
-        if ("production_date" in ml and "必须" in m) or ("生产日期" in m and "必须" in m):
-            return "production_date_required_for_required_lot"
-
-        if (
-            ("expiry_date" in ml and "必须" in m)
-            or ("到期日期" in m and "必须" in m)
-            or ("未提供到期日期" in m)
-            or ("canonical expiry_date" in ml)
-        ):
-            return "expiry_date_required_for_required_lot"
-
-        if ("batch_code" in ml) or ("批次" in m):
-            if ("必须" in m) or ("required" in ml):
-                return "batch_required"
-            return "stock_adjust_reject"
-
-        return "stock_adjust_reject"
-
-    async def _raise_problem_from_value_error(
-        self,
-        *,
-        session: AsyncSession,
-        msg: str,
-        kind: str,
-        ref: str,
-        ref_line: Optional[Union[int, str]],
-        warehouse_id: int,
-        item_id: int,
-        batch_code: Optional[str],
-        delta: int,
-        trace_id: Optional[str],
-        lot_id: Optional[int],
-    ) -> None:
-        bc_norm2 = (str(batch_code).strip() if batch_code is not None else None) or None
-        ctx = {
-            "ref": str(ref),
-            "ref_line": (str(ref_line) if ref_line is not None else None),
-            "warehouse_id": int(warehouse_id),
-            "item_id": int(item_id),
-            "batch_code": bc_norm2,
-            "delta": int(delta),
-            "trace_id": trace_id,
-            "lot_id": lot_id,
-            "raw_error": msg,
-        }
-
-        if kind == "item_not_found":
-            raise_problem(
-                status_code=422,
-                error_code="item_not_found",
-                message="商品不存在，写入被拒绝。",
-                context=ctx,
-                details=[{"type": "item", "path": "stock_adjust", "item_id": int(item_id), "reason": msg}],
-            )
-            return
-
-        if kind == "insufficient_stock":
-            if int(delta) < 0:
-                on_hand = await self.lot_resolver.load_on_hand_qty(
-                    session,
-                    warehouse_id=int(warehouse_id),
-                    item_id=int(item_id),
-                    batch_code=bc_norm2,
-                )
-                required_qty = int(-int(delta))
-                short_qty = max(0, int(required_qty) - int(on_hand))
-            else:
-                on_hand = await self.lot_resolver.load_on_hand_qty(
-                    session,
-                    warehouse_id=int(warehouse_id),
-                    item_id=int(item_id),
-                    batch_code=bc_norm2,
-                )
-                required_qty = int(delta)
-                short_qty = 0
-
-            raise_problem(
-                status_code=409,
-                error_code="insufficient_stock",
-                message="库存不足，扣减失败。",
-                context=ctx,
-                details=[
-                    {
-                        "type": "shortage",
-                        "path": "stock_adjust",
-                        "item_id": int(item_id),
-                        "batch_code": bc_norm2,
-                        "required_qty": int(required_qty),
-                        "available_qty": int(on_hand),
-                        "short_qty": int(short_qty),
-                        "reason": "insufficient_stock",
-                    }
-                ],
-            )
-            return
-
-        if kind == "production_date_required_for_required_lot":
-            raise_problem(
-                status_code=422,
-                error_code="production_date_required_for_required_lot",
-                message="批次受控商品必须提供 production_date，或提供可结合保质期反推出 production_date 的 expiry_date。",
-                context=ctx,
-                details=[
-                    {
-                        "type": "date",
-                        "path": "stock_adjust",
-                        "item_id": int(item_id),
-                        "batch_code": bc_norm2,
-                        "reason": msg,
-                    }
-                ],
-            )
-            return
-
-        if kind == "expiry_date_required_for_required_lot":
-            raise_problem(
-                status_code=422,
-                error_code="expiry_date_required_for_required_lot",
-                message="批次受控商品必须提供 expiry_date，或提供可结合保质期正推出 expiry_date 的 production_date。",
-                context=ctx,
-                details=[
-                    {
-                        "type": "date",
-                        "path": "stock_adjust",
-                        "item_id": int(item_id),
-                        "batch_code": bc_norm2,
-                        "reason": msg,
-                    }
-                ],
-            )
-            return
-
-        if kind == "batch_required":
-            raise_problem(
-                status_code=422,
-                error_code="batch_required",
-                message="批次受控商品必须提供批次。",
-                context=ctx,
-                details=[
-                    {
-                        "type": "batch",
-                        "path": "stock_adjust",
-                        "item_id": int(item_id),
-                        "batch_code": bc_norm2,
-                        "reason": msg,
-                    }
-                ],
-            )
-            return
-
-        if kind == "lot_not_found":
-            raise_problem(
-                status_code=404,
-                error_code="lot_not_found",
-                message="lot 不存在，写入被拒绝。",
-                context=ctx,
-                details=[
-                    {
-                        "type": "lot",
-                        "path": "stock_adjust",
-                        "warehouse_id": int(warehouse_id),
-                        "item_id": int(item_id),
-                        "lot_id": lot_id,
-                        "reason": "lot_not_found",
-                    }
-                ],
-            )
-            return
-
-        if kind == "lot_mismatch":
-            raise_problem(
-                status_code=409,
-                error_code="lot_mismatch",
-                message="lot 与 warehouse/item 不匹配，写入被拒绝。",
-                context=ctx,
-                details=[
-                    {
-                        "type": "lot",
-                        "path": "stock_adjust",
-                        "warehouse_id": int(warehouse_id),
-                        "item_id": int(item_id),
-                        "lot_id": lot_id,
-                        "reason": "lot_mismatch",
-                    }
-                ],
-            )
-            return
-
-        if kind == "supplier_lot_code_ambiguous":
-            raise_problem(
-                status_code=422,
-                error_code="supplier_lot_code_ambiguous",
-                message="同一展示批次码命中多个库存槽位，写入被拒绝。",
-                context=ctx,
-                details=[
-                    {
-                        "type": "lot",
-                        "path": "stock_adjust",
-                        "warehouse_id": int(warehouse_id),
-                        "item_id": int(item_id),
-                        "batch_code": bc_norm2,
-                        "reason": "supplier_lot_code_ambiguous",
-                    }
-                ],
-            )
-            return
-
-        raise_problem(
-            status_code=422,
-            error_code="stock_adjust_reject",
-            message="库存调整请求不合法。",
-            context=ctx,
-            details=[{"type": "validation", "path": "stock_adjust", "reason": msg}],
-        )
-
-    async def adjust(  # noqa: C901
-        self,
-        session: AsyncSession,
-        item_id: int,
-        delta: int,
-        reason: Union[str, MovementType],
-        ref: str,
-        ref_line: Optional[Union[int, str]] = None,
-        occurred_at: Optional[datetime] = None,
-        meta: Optional[Dict[str, Any]] = None,
-        batch_code: Optional[str] = None,
-        production_date: Optional[date] = None,
-        expiry_date: Optional[date] = None,
-        *,
-        warehouse_id: int,
-        trace_id: Optional[str] = None,
-        lot_id: Optional[int] = None,
-    ) -> Dict[str, Any]:
-        # ✅ 任务3 收口：合同入口禁止混用 lot_id
-        if lot_id is not None:
-            raise ValueError("use StockService.adjust_lot for lot_id calls (no mixed adjust+lot_id).")
-
-        try:
-            resolved_lot_id, bc_norm = await resolve_lot_for_stock_adjust(
-                session,
-                lot_resolver=self.lot_resolver,
-                item_id=int(item_id),
-                warehouse_id=int(warehouse_id),
-                batch_code=batch_code,
-                lot_id=None,
-                ref=str(ref),
-                occurred_at=occurred_at,
-                production_date=production_date,
-                expiry_date=expiry_date,
-            )
-
-            return await adjust_lot_impl(
-                session=session,
-                item_id=int(item_id),
-                warehouse_id=int(warehouse_id),
-                lot_id=int(resolved_lot_id),
-                delta=int(delta),
-                reason=reason,
-                ref=str(ref),
-                ref_line=ref_line,
-                occurred_at=occurred_at,
-                meta=meta,
-                batch_code=bc_norm,
-                production_date=production_date,
-                expiry_date=expiry_date,
-                trace_id=trace_id,
-                utc_now=lambda: datetime.now(UTC),
-            )
-        except HTTPException:
-            raise
-        except ValueError as e:
-            msg = str(e)
-            kind = self._classify_adjust_value_error(msg)
-            await self._raise_problem_from_value_error(
-                session=session,
-                msg=msg,
-                kind=kind,
-                ref=str(ref),
-                ref_line=ref_line,
-                warehouse_id=int(warehouse_id),
-                item_id=int(item_id),
-                batch_code=batch_code,
-                delta=int(delta),
-                trace_id=trace_id,
-                lot_id=None,
-            )
-            return {}
 
     async def adjust_lot(
         self,
@@ -358,8 +47,9 @@ class StockService:
     ) -> Dict[str, Any]:
         """
         lot-only 原语入口：
-        - 不做合同裁决（调用方应保证 lot_id 合法）
-        - 保留 ValueError 语义（单测依赖）
+        - 不做 batch_code 合同裁决；
+        - 调用方必须传入已解析且合法的 lot_id；
+        - 保留 ValueError 语义，供服务层/测试按 lot-only 终态处理。
         """
         return await adjust_lot_impl(
             session=session,


### PR DESCRIPTION
## Summary
- retire StockService.adjust(batch_code=...) compatibility entrypoint
- remove legacy stock adjust error-wrapper helpers
- remove LotResolver.load_on_hand_qty used only by the retired adjust wrapper
- keep StockService.adjust_lot as the lot-only write primitive
- keep stock_contract_resolver because count/recount/pick/outbound still use it for lot resolution

## Validation
- python3 -m compileall app tests scripts
- make alembic-check
- make test TESTS="tests/unit/test_stock_service_v2.py tests/quick/test_inbound_pick_count_v2.py tests/quick/test_outbound_core_v2.py tests/services/test_order_rma_and_reconcile.py tests/api/test_debug_trace_by_warehouse.py tests/api/test_v2_full_chain.py tests/ci/test_ledger_idem_constraint.py"