### PR TITLE
chore(wms): clean retired stock adjust wording

### DIFF
--- a/app/wms/analysis/services/rebuild_stocks_service.py
+++ b/app/wms/analysis/services/rebuild_stocks_service.py
@@ -23,7 +23,7 @@ class RebuildService:
 
         设计定位：
         - 用于 dev/test 环境的修复 / 回放 / 灾备演练
-        - 不属于业务执行路径（业务写入必须走 StockService.adjust）
+        - 不属于业务执行路径（业务写入必须走 lot-only 库存写入原语）
 
         安全护栏：
         - 默认拒绝执行，必须显式 allow_truncate=True

--- a/app/wms/stock/services/stock_adjust/stocks_lot_repo.py
+++ b/app/wms/stock/services/stock_adjust/stocks_lot_repo.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 # NOTE:
 # - 本模块属于 stock_adjust 执行器内部仓储层（repo）。
 # - 业务服务（Inbound/Outbound/Pick/Scan/Dev tools 等）不得直接调用这些函数，
-#   必须统一走 StockService.adjust -> adjust_lot_impl，避免绕过合同/幂等/台账。
+#   必须统一走 lot-only 库存写入原语，避免绕过合同/幂等/台账。
 # - 这里的 SQL 只做“slot 原语 + balance 写入”，不负责 batch/lot 合同裁决。
 
 

--- a/app/wms/stock/services/stock_service.py
+++ b/app/wms/stock/services/stock_service.py
@@ -21,7 +21,7 @@ class StockService:
     终态收口：
     - adjust_lot：lot-only 原语入口，调用方必须先解析 lot_id；
     - lot_resolver：保留给上层服务做合同裁决 + lot_id 解析；
-    - 旧 StockService.adjust(batch_code=...) 合同入口已退役。
+    - 旧 batch_code 合同写入口已退役。
     """
 
     def __init__(self, lot_resolver: Optional[LotResolver] = None) -> None:

--- a/tests/fixtures/base_seed.sql
+++ b/tests/fixtures/base_seed.sql
@@ -13,7 +13,7 @@
 --
 -- 库存/lot 事实必须在 tests 中显式通过统一入口构造：
 --   - ensure_lot_full / ensure_internal_lot_singleton
---   - adjust_lot_impl / StockService.adjust*
+--   - adjust_lot_impl / lot-only stock write primitives
 --   - tests/helpers/inventory.py: seed_batch_slot 等
 --
 -- Pricing Phase-3：

--- a/tests/quick/test_inbound_smoke_pg.py
+++ b/tests/quick/test_inbound_smoke_pg.py
@@ -117,7 +117,7 @@ async def test_inbound_ledger_snapshot_smoke(session: AsyncSession):
 
     场景：
     1. 确保最小维度存在；
-    2. 通过正式写入口（StockService.adjust）做入库 +5；
+    2. 通过 lot-only 写入口做入库 +5；
     3. 断言：
        - stocks_lot 的 qty 变化正确；
        - stock_ledger 中对应 ref/ref_line 的 after_qty 与余额一致。

--- a/tests/services/test_order_rma_and_reconcile.py
+++ b/tests/services/test_order_rma_and_reconcile.py
@@ -117,7 +117,7 @@ async def _ensure_stock_lot_for_adjust(
     expiry_date: Optional[date],
 ) -> int:
     """
-    测试造数专用：把原先 StockService.adjust(batch_code=...) 的 lot 解析提前显式化。
+    测试造数专用：把 lot 解析提前显式化。
     """
     if batch_code is not None:
         return await _ensure_supplier_lot(

--- a/tests/test_phase3_three_books_count_contract.py
+++ b/tests/test_phase3_three_books_count_contract.py
@@ -166,7 +166,7 @@ async def test_phase3_count_confirm_delta_zero_records_ledger(session: AsyncSess
     item_id, may_need_expiry = await _pick_item(session)
     batch_code = "B-PH3-CNT"
 
-    # 先造库存：+5。测试造数统一走 lot-only helper，不再调用 StockService.adjust。
+    # 先造库存：+5。测试造数统一走 lot-only helper。
     await set_stock_qty(
         session,
         item_id=item_id,
@@ -242,7 +242,7 @@ async def test_phase3_count_adjust_delta_nonzero_updates_stock(session: AsyncSes
     item_id, may_need_expiry = await _pick_item(session)
     batch_code = "B-PH3-CNT2"
 
-    # 先造库存：+5。测试造数统一走 lot-only helper，不再调用 StockService.adjust。
+    # 先造库存：+5。测试造数统一走 lot-only helper。
     await set_stock_qty(
         session,
         item_id=item_id,

--- a/tests/test_phase3_three_books_outbound_commit.py
+++ b/tests/test_phase3_three_books_outbound_commit.py
@@ -124,7 +124,7 @@ async def test_phase3_outbound_commit_three_books_strict(session: AsyncSession):
     item_id = await _pick_item_for_stock_in(session)
     batch_code = "B-PH3-OUT"
 
-    # 入库造数：给足库存，避免出库不足。测试造数统一走 lot-only helper，不再调用 StockService.adjust。
+    # 入库造数：给足库存，避免出库不足。测试造数统一走 lot-only helper。
     await set_stock_qty(
         session,
         item_id=item_id,

--- a/tests/test_phase3_three_books_receive_commit.py
+++ b/tests/test_phase3_three_books_receive_commit.py
@@ -372,7 +372,7 @@ async def test_phase3_receive_commit_three_books_strict(session: AsyncSession):
         expiry_date=exp,
     )
 
-    # 2) 写入入库动作（ledger+stocks_lot）。测试造数统一走 lot-only 原语，不再调用 StockService.adjust。
+    # 2) 写入入库动作（ledger+stocks_lot）。测试造数统一走 lot-only 原语。
     ref = "RCPT-PH3-UT"
     await adjust_lot_impl(
         session=session,

--- a/tests/test_phase3_three_books_return_commit.py
+++ b/tests/test_phase3_three_books_return_commit.py
@@ -94,7 +94,7 @@ async def test_phase3_return_commit_three_books_strict(session: AsyncSession):
         expiry_date=exp,
     )
 
-    # 1) 入库造库存：+10。测试造数统一走 lot-only 原语，不再调用 StockService.adjust。
+    # 1) 入库造库存：+10。测试造数统一走 lot-only 原语。
     await adjust_lot_impl(
         session=session,
         item_id=int(item_id),


### PR DESCRIPTION
## Summary
- clean stale comments that referenced the retired StockService.adjust entrypoint
- keep lot-only stock write wording consistent across app and tests
- avoid future grep noise around retired adjust compatibility

## Validation
- python3 -m compileall app tests scripts
- make alembic-check
- make test TESTS="tests/unit/test_stock_service_v2.py tests/ci/test_ledger_idem_constraint.py"