### PR TITLE
refactor(wms): retire ledger query batch_code alias

### DIFF
--- a/app/wms/analysis/routers/stock_ledger_routes_reconcile.py
+++ b/app/wms/analysis/routers/stock_ledger_routes_reconcile.py
@@ -23,9 +23,9 @@ def register(router: APIRouter) -> None:
         lot_filter = getattr(payload, "lot_id", None)
 
         fields_set = getattr(payload, "model_fields_set", set())
-        bc_filter = None
-        if "batch_code" in fields_set:
-            bc_filter = normalize_optional_lot_code(getattr(payload, "batch_code", None))
+        lot_code_filter = None
+        if "lot_code" in fields_set:
+            lot_code_filter = normalize_optional_lot_code(getattr(payload, "lot_code", None))
 
         sql = """
         WITH ledger_agg AS (
@@ -33,7 +33,7 @@ def register(router: APIRouter) -> None:
                 l.warehouse_id,
                 l.item_id,
                 l.lot_id,
-                lo.lot_code AS batch_code,
+                lo.lot_code AS lot_code,
                 SUM(l.delta) AS ledger_sum_delta
             FROM stock_ledger l
             JOIN lots lo ON lo.id = l.lot_id
@@ -42,7 +42,7 @@ def register(router: APIRouter) -> None:
               AND (:wh_id   IS NULL OR l.warehouse_id = :wh_id)
               AND (:item_id IS NULL OR l.item_id      = :item_id)
               AND (:lot_id  IS NULL OR l.lot_id       = :lot_id)
-              AND (:bc      IS NULL OR lo.lot_code IS NOT DISTINCT FROM :bc)
+              AND (:lot_code IS NULL OR lo.lot_code IS NOT DISTINCT FROM :lot_code)
             GROUP BY l.warehouse_id, l.item_id, l.lot_id, lo.lot_code
         ),
         stock_agg AS (
@@ -61,7 +61,7 @@ def register(router: APIRouter) -> None:
             l.warehouse_id,
             l.item_id,
             l.lot_id,
-            l.batch_code,
+            l.lot_code,
             l.ledger_sum_delta,
             COALESCE(a.stock_qty, 0) AS stock_qty
         FROM ledger_agg l
@@ -81,7 +81,7 @@ def register(router: APIRouter) -> None:
                 "wh_id": wh_filter,
                 "item_id": item_filter,
                 "lot_id": int(lot_filter) if lot_filter is not None else None,
-                "bc": bc_filter,
+                "lot_code": lot_code_filter,
             },
         )
 
@@ -90,7 +90,7 @@ def register(router: APIRouter) -> None:
             wh_id = int(row["warehouse_id"])
             item_id = int(row["item_id"])
             lot_id = int(row["lot_id"])
-            batch_code = row.get("batch_code")
+            lot_code = row.get("lot_code")
             ledger_sum = int(row["ledger_sum_delta"] or 0)
             stock_qty = int(row["stock_qty"] or 0)
             diff = ledger_sum - stock_qty
@@ -99,8 +99,7 @@ def register(router: APIRouter) -> None:
                 LedgerReconcileRow(
                     warehouse_id=wh_id,
                     item_id=item_id,
-                    batch_code=batch_code,
-                    lot_code=batch_code,
+                    lot_code=lot_code,
                     ledger_sum_delta=ledger_sum,
                     stock_qty=stock_qty,
                     diff=diff,

--- a/app/wms/analysis/routers/stock_ledger_routes_shadow_lot.py
+++ b/app/wms/analysis/routers/stock_ledger_routes_shadow_lot.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.wms.shared.services.lot_code_contract import normalize_optional_lot_code
 from app.db.session import get_session
 from app.wms.ledger.contracts.stock_ledger import LedgerQuery
 from app.wms.ledger.contracts.stock_ledger_lot_shadow import LotShadowReconcileOut
@@ -21,10 +20,6 @@ def register(router: APIRouter) -> None:
         if payload.warehouse_id is None or payload.item_id is None:
             raise HTTPException(status_code=400, detail="shadow-reconcile-lot 必须指定 warehouse_id + item_id。")
 
-        norm_bc = normalize_optional_lot_code(getattr(payload, "batch_code", None))
-        if getattr(payload, "batch_code", None) != norm_bc:
-            payload = payload.model_copy(update={"batch_code": norm_bc})
-
         time_from, time_to = normalize_time_range(payload)
 
         data = await LotShadowReconcileService.reconcile(
@@ -33,7 +28,7 @@ def register(router: APIRouter) -> None:
             item_id=int(payload.item_id),
             time_from=time_from,
             time_to=time_to,
-            batch_code=getattr(payload, "batch_code", None),
+            batch_code=getattr(payload, "lot_code", None),
             lot_id=getattr(payload, "lot_id", None),
         )
 

--- a/app/wms/ledger/contracts/stock_ledger.py
+++ b/app/wms/ledger/contracts/stock_ledger.py
@@ -12,7 +12,7 @@ class _Base(BaseModel):
     """
     通用基类：
     - from_attributes: 支持 SQLAlchemy ORM 自动序列化
-    - extra = ignore: 兼容老字段
+    - extra = ignore: 兼容 ORM / DB 多余属性
     - populate_by_name: 支持 alias
     """
 
@@ -49,17 +49,23 @@ class LedgerQuery(_Base):
     """
     库存台账查询条件（统一合同）
 
-    Phase M-4 governance：
-    - lot_code 为正名（展示码 lots.lot_code）
-    - batch_code 为历史兼容字段（与 lot_code 等价）
+    终态：
+    - lot_id 为结构事实维度；
+    - lot_code 为唯一批次展示码查询入参；
+    - batch_code 查询 alias 已退役，传入会被 extra=forbid 拒绝。
     """
+
+    model_config = ConfigDict(
+        from_attributes=True,
+        extra="forbid",
+        populate_by_name=True,
+    )
 
     item_id: Optional[int] = Field(default=None, description="商品 ID（精确）")
     item_keyword: Optional[str] = Field(default=None, description="商品关键词（模糊匹配 name / sku）")
     warehouse_id: Optional[int] = Field(default=None, description="仓库 ID")
 
-    lot_code: Optional[str] = Field(default=None, max_length=64, description="Lot 展示码（优先使用；等价于 batch_code）")
-    batch_code: Optional[str] = Field(default=None, max_length=64, description="批次编码（兼容字段；等价于 lot_code）")
+    lot_code: Optional[str] = Field(default=None, max_length=64, description="Lot 展示码")
 
     # Phase 4A-2a: lot 维度过滤（事实维度）
     lot_id: Optional[int] = Field(default=None, description="Lot ID（精确，影子事实维度过滤）")
@@ -91,7 +97,6 @@ class LedgerQuery(_Base):
     @field_validator(
         "item_keyword",
         "lot_code",
-        "batch_code",
         "reason",
         "ref",
         "trace_id",
@@ -128,9 +133,8 @@ class LedgerRow(_Base):
     base_item_uom_id: Optional[int] = None
     base_uom_name: Optional[str] = None
 
-    # ✅ 合同双轨：lot_code 正名 + batch_code 兼容
+    # 批次展示码：来自 lots.lot_code
     lot_code: Optional[str] = None
-    batch_code: Optional[str] = None
 
     # Phase 3+ : lot shadow dimension (Phase 4A-2a expose for query/history)
     lot_id: Optional[int] = None
@@ -168,15 +172,13 @@ class LedgerReconcileRow(_Base):
     warehouse_id: int
     item_id: int
 
-    # ✅ 合同双轨：lot_code 正名 + batch_code 兼容
+    # 批次展示码：来自 lots.lot_code
     lot_code: Optional[str] = None
-    batch_code: Optional[str] = None
 
     ledger_sum_delta: int
     stock_qty: int
     diff: int
 
-    # 如果调用方补齐 lot_id，则保留（extra=ignore 会兼容）
     lot_id: Optional[int] = None
 
 

--- a/app/wms/ledger/helpers/__init__.py
+++ b/app/wms/ledger/helpers/__init__.py
@@ -1,6 +1,7 @@
 # app/wms/ledger/helpers/__init__.py
 
 from app.wms.ledger.helpers.stock_ledger import (
+    ITEMS_TABLE,
     apply_common_filters_rows,
     build_base_ids_stmt,
     build_common_filters,
@@ -8,9 +9,11 @@ from app.wms.ledger.helpers.stock_ledger import (
     exec_rows,
     infer_movement_type,
     normalize_time_range,
+    resolve_ledger_lot_code_filter,
 )
 
 __all__ = [
+    "ITEMS_TABLE",
     "apply_common_filters_rows",
     "build_base_ids_stmt",
     "build_common_filters",
@@ -18,4 +21,5 @@ __all__ = [
     "exec_rows",
     "infer_movement_type",
     "normalize_time_range",
+    "resolve_ledger_lot_code_filter",
 ]

--- a/app/wms/ledger/helpers/stock_ledger.py
+++ b/app/wms/ledger/helpers/stock_ledger.py
@@ -92,67 +92,23 @@ def _to_str_or_none(v) -> str | None:
 
 def resolve_ledger_lot_code_filter(q: LedgerQuery) -> tuple[bool, str | None]:
     """
-    解析 ledger 查询中的 lot_code / batch_code 双轨入参。
+    解析 ledger 查询中的 lot_code 入参。
 
     规则：
-    - lot_code 是正名字段；
-    - batch_code 是历史兼容字段；
-    - 任一字段被调用方显式传入，都表示要按 lots.lot_code 过滤；
-    - 两个字段都传时，归一后必须完全一致；
+    - lot_code 是唯一批次展示码查询字段；
+    - batch_code alias 已从 LedgerQuery 退役；
+    - lot_code 被调用方显式传入时，表示要按 lots.lot_code 过滤；
     - "" / "None" 等伪空值由 normalize_optional_lot_code 归一为 None，
       且仍表示调用方显式要求过滤 INTERNAL lot_code NULL 口径。
     """
     fields_set = set(getattr(q, "model_fields_set", set()))
     has_lot_code = "lot_code" in fields_set
-    has_batch_code = "batch_code" in fields_set
 
-    if not has_lot_code and not has_batch_code:
+    if not has_lot_code:
         return False, None
 
-    lot_code = (
-        normalize_optional_lot_code(getattr(q, "lot_code", None))
-        if has_lot_code
-        else None
-    )
-    batch_code = (
-        normalize_optional_lot_code(getattr(q, "batch_code", None))
-        if has_batch_code
-        else None
-    )
-
-    if has_lot_code and has_batch_code and lot_code != batch_code:
-        raise HTTPException(
-            status_code=422,
-            detail={
-                "error_code": "lot_code_alias_conflict",
-                "message": "lot_code and batch_code must be identical when both provided.",
-                "lot_code": lot_code,
-                "batch_code": batch_code,
-            },
-        )
-
-    return True, lot_code if has_lot_code else batch_code
-
-
-def normalize_ledger_lot_code_aliases(q: LedgerQuery) -> LedgerQuery:
-    """
-    将 ledger 查询入参中的 lot_code / batch_code 归一为同一个展示码。
-
-    该函数只处理合同入参，不改变输出合同：
-    - 输出仍同时保留 lot_code + batch_code；
-    - 内部结构事实仍以 lot_id 为准；
-    - batch_code 不得重新成为 stock_ledger 的结构字段。
-    """
-    should_filter, lot_code = resolve_ledger_lot_code_filter(q)
-    if not should_filter:
-        return q
-
-    return q.model_copy(
-        update={
-            "lot_code": lot_code,
-            "batch_code": lot_code,
-        }
-    )
+    lot_code = normalize_optional_lot_code(getattr(q, "lot_code", None))
+    return True, lot_code
 
 
 def build_common_filters(q: LedgerQuery, time_from: datetime, time_to: datetime):
@@ -179,8 +135,8 @@ def build_common_filters(q: LedgerQuery, time_from: datetime, time_to: datetime)
     if getattr(q, "lot_id", None) is not None:
         conditions.append(StockLedger.lot_id == getattr(q, "lot_id"))
 
-    # ✅ lot-only：lot_code 为正名；batch_code 为兼容别名
-    # - 不传 lot_code/batch_code：不加过滤
+    # lot_code：唯一展示码查询入参
+    # - 不传 lot_code：不加过滤
     # - 传 "" / "None"：归一为 None -> lots.lot_code IS NULL（无批次标签槽位）
     # - 传 "B2026..."：lots.lot_code = 'B2026...'
     should_filter_lot_code, norm_lot_code = resolve_ledger_lot_code_filter(q)
@@ -276,7 +232,7 @@ def build_base_ids_stmt(q: LedgerQuery, time_from: datetime, time_to: datetime):
     """
     按查询条件构造基础 SQL（只选中符合条件的 id 列表）：
 
-    - 支持按 item_id / warehouse_id / lot_id / lot_code(batch_code 兼容别名) / reason / reason_canon / sub_reason / ref / trace_id / 时间过滤；
+    - 支持按 item_id / warehouse_id / lot_id / lot_code / reason / reason_canon / sub_reason / ref / trace_id / 时间过滤；
     - 支持按 item_keyword 模糊匹配 items.name / items.sku；
     - 不再依赖 stock_id / batch_id，完全对齐当前 StockLedger 模型。
     """

--- a/app/wms/ledger/routers/stock_ledger_routes_export.py
+++ b/app/wms/ledger/routers/stock_ledger_routes_export.py
@@ -10,7 +10,6 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.wms.shared.services.lot_code_contract import normalize_optional_lot_code
 from app.db.session import get_session
 from app.wms.stock.models.lot import Lot
 from app.wms.ledger.models.stock_ledger import StockLedger
@@ -40,7 +39,6 @@ def _build_export_csv_with_sub_reason(rows: list[StockLedger], lot_code_map: dic
             "item_id",
             "warehouse_id",
             "lot_code",
-            "batch_code",
             "lot_id",
             "trace_id",
         ]
@@ -48,7 +46,7 @@ def _build_export_csv_with_sub_reason(rows: list[StockLedger], lot_code_map: dic
 
     for r in rows:
         lot_id = getattr(r, "lot_id", None)
-        batch_code = lot_code_map.get(int(lot_id)) if lot_id is not None else None
+        lot_code = lot_code_map.get(int(lot_id)) if lot_id is not None else None
 
         writer.writerow(
             [
@@ -63,8 +61,7 @@ def _build_export_csv_with_sub_reason(rows: list[StockLedger], lot_code_map: dic
                 r.after_qty,
                 r.item_id,
                 r.warehouse_id,
-                batch_code,
-                batch_code,
+                lot_code,
                 lot_id,
                 r.trace_id or "",
             ]
@@ -82,10 +79,6 @@ def register(router: APIRouter) -> None:
         payload: LedgerQuery,
         session: AsyncSession = Depends(get_session),
     ):
-        norm_bc = normalize_optional_lot_code(getattr(payload, "batch_code", None))
-        if getattr(payload, "batch_code", None) != norm_bc:
-            payload = payload.model_copy(update={"batch_code": norm_bc})
-
         time_from, time_to = normalize_time_range(payload)
 
         rows_stmt = select(StockLedger)

--- a/app/wms/ledger/routers/stock_ledger_routes_query.py
+++ b/app/wms/ledger/routers/stock_ledger_routes_query.py
@@ -8,7 +8,6 @@ from fastapi import APIRouter, Depends
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.wms.shared.services.lot_code_contract import normalize_optional_lot_code
 from app.db.session import get_session
 from app.wms.stock.models.lot import Lot
 from app.wms.ledger.models.stock_ledger import StockLedger
@@ -50,13 +49,9 @@ def register(router: APIRouter) -> None:
         """
         普通查询（<=90 天限制由 normalize_time_range 控制）：
         - 默认按 occurred_at 降序 + id 降序排序；
-        - 支持 item_id/item_keyword/warehouse_id/batch_code(展示码)/lot_id/reason/reason_canon/sub_reason/ref/trace_id 过滤；
-        - 返回 item_name + batch_code(展示码) + base_uom_name（当前页批量补齐）。
+        - 支持 item_id/item_keyword/warehouse_id/lot_code/lot_id/reason/reason_canon/sub_reason/ref/trace_id 过滤；
+        - 返回 item_name + lot_code + base_uom_name（当前页批量补齐）。
         """
-        norm_bc = normalize_optional_lot_code(getattr(payload, "batch_code", None))
-        if getattr(payload, "batch_code", None) != norm_bc:
-            payload = payload.model_copy(update={"batch_code": norm_bc})
-
         time_from, time_to = normalize_time_range(payload)
 
         ids_stmt = build_base_ids_stmt(payload, time_from, time_to)
@@ -144,7 +139,6 @@ def register(router: APIRouter) -> None:
                         else None
                     ),
                     warehouse_id=r.warehouse_id,
-                    batch_code=lot_code_map.get(int(getattr(r, "lot_id"))) if getattr(r, "lot_id", None) is not None else None,
                     lot_code=lot_code_map.get(int(getattr(r, "lot_id"))) if getattr(r, "lot_id", None) is not None else None,
                     lot_id=getattr(r, "lot_id", None),
                     trace_id=r.trace_id,

--- a/app/wms/ledger/routers/stock_ledger_routes_query_history.py
+++ b/app/wms/ledger/routers/stock_ledger_routes_query_history.py
@@ -9,7 +9,6 @@ from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.wms.shared.services.lot_code_contract import normalize_optional_lot_code
 from app.db.session import get_session
 from app.wms.stock.models.lot import Lot
 from app.procurement.models.purchase_order import PurchaseOrder
@@ -233,10 +232,6 @@ def register(router: APIRouter) -> None:
         payload: LedgerQuery,
         session: AsyncSession = Depends(get_session),
     ) -> LedgerList:
-        norm_bc = normalize_optional_lot_code(getattr(payload, "batch_code", None))
-        if getattr(payload, "batch_code", None) != norm_bc:
-            payload = payload.model_copy(update={"batch_code": norm_bc})
-
         if not _has_anchor(payload):
             raise HTTPException(
                 status_code=400,
@@ -330,7 +325,6 @@ def register(router: APIRouter) -> None:
                         else None
                     ),
                     warehouse_id=r.warehouse_id,
-                    batch_code=lot_code_map.get(int(getattr(r, "lot_id"))) if getattr(r, "lot_id", None) is not None else None,
                     lot_code=lot_code_map.get(int(getattr(r, "lot_id"))) if getattr(r, "lot_id", None) is not None else None,
                     lot_id=getattr(r, "lot_id", None),
                     trace_id=r.trace_id,

--- a/app/wms/ledger/routers/stock_ledger_routes_summary.py
+++ b/app/wms/ledger/routers/stock_ledger_routes_summary.py
@@ -18,7 +18,6 @@ from app.wms.ledger.helpers.stock_ledger import (
     build_common_filters,
     normalize_time_range,
 )
-from app.wms.shared.services.lot_code_contract import normalize_optional_lot_code
 
 
 def register(router: APIRouter) -> None:
@@ -27,10 +26,6 @@ def register(router: APIRouter) -> None:
         payload: LedgerQuery,
         session: AsyncSession = Depends(get_session),
     ) -> LedgerSummary:
-        norm_bc = normalize_optional_lot_code(getattr(payload, "batch_code", None))
-        if getattr(payload, "batch_code", None) != norm_bc:
-            payload = payload.model_copy(update={"batch_code": norm_bc})
-
         time_from, time_to = normalize_time_range(payload)
         conditions = build_common_filters(payload, time_from, time_to)
 

--- a/tests/api/test_stock_ledger_lot_code_alias_api.py
+++ b/tests/api/test_stock_ledger_lot_code_alias_api.py
@@ -39,7 +39,7 @@ def _matched_seed_rows(
             continue
         if row.get("lot_code") != lot_code:
             continue
-        if row.get("batch_code") != lot_code:
+        if "batch_code" in row:
             continue
         matched.append(row)
 
@@ -47,24 +47,23 @@ def _matched_seed_rows(
 
 
 @pytest.mark.asyncio
-async def test_stock_ledger_query_accepts_lot_code_and_batch_code_aliases(
+async def test_stock_ledger_query_accepts_lot_code_only(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
     """
     /stock/ledger/query API 合同：
 
-    - lot_code 是正名查询字段；
-    - batch_code 是历史兼容查询字段；
-    - 两者查询同一个 lots.lot_code 时，必须命中同一批 ledger 行；
-    - 输出继续保留 lot_code + batch_code，且二者等价；
+    - lot_code 是唯一批次展示码查询字段；
+    - batch_code 查询 alias 已退役；
+    - 输出只保留 lot_code，不再输出 batch_code；
     - 结构事实仍由 lot_id 承载，不能依赖 stock_ledger.batch_code。
     """
     headers = await _login_admin_headers(client)
 
     warehouse_id = 1
     item_id = 930001
-    lot_code = f"UT-LEDGER-ALIAS-{uuid4().hex[:8].upper()}"
+    lot_code = f"UT-LEDGER-LOT-{uuid4().hex[:8].upper()}"
 
     await ensure_wh_loc_item(
         session,
@@ -82,66 +81,39 @@ async def test_stock_ledger_query_accepts_lot_code_and_batch_code_aliases(
     )
     await session.commit()
 
-    common_payload = {
-        "item_id": item_id,
-        "warehouse_id": warehouse_id,
-        "limit": 50,
-        "offset": 0,
-    }
-
-    by_lot_code = await client.post(
+    response = await client.post(
         "/stock/ledger/query",
         headers=headers,
         json={
-            **common_payload,
+            "item_id": item_id,
+            "warehouse_id": warehouse_id,
             "lot_code": lot_code,
+            "limit": 50,
+            "offset": 0,
         },
     )
-    assert by_lot_code.status_code == 200, by_lot_code.text
+    assert response.status_code == 200, response.text
 
-    by_batch_code = await client.post(
-        "/stock/ledger/query",
-        headers=headers,
-        json={
-            **common_payload,
-            "batch_code": lot_code,
-        },
-    )
-    assert by_batch_code.status_code == 200, by_batch_code.text
-
-    lot_body = by_lot_code.json()
-    batch_body = by_batch_code.json()
-
-    lot_rows = _matched_seed_rows(
-        lot_body,
-        item_id=item_id,
-        warehouse_id=warehouse_id,
-        lot_code=lot_code,
-    )
-    batch_rows = _matched_seed_rows(
-        batch_body,
+    body = response.json()
+    rows = _matched_seed_rows(
+        body,
         item_id=item_id,
         warehouse_id=warehouse_id,
         lot_code=lot_code,
     )
 
-    assert lot_rows, lot_body
-    assert batch_rows, batch_body
-
-    lot_row_ids = {int(row["id"]) for row in lot_rows}
-    batch_row_ids = {int(row["id"]) for row in batch_rows}
-
-    assert lot_row_ids == batch_row_ids
-    assert all(row.get("lot_id") is not None for row in lot_rows)
-    assert all(row.get("batch_code") == row.get("lot_code") == lot_code for row in lot_rows)
+    assert rows, body
+    assert all(row.get("lot_id") is not None for row in rows)
+    assert all(row.get("lot_code") == lot_code for row in rows)
+    assert all("batch_code" not in row for row in rows)
 
 
 @pytest.mark.asyncio
-async def test_stock_ledger_query_rejects_conflicting_lot_code_aliases(
+async def test_stock_ledger_query_rejects_retired_batch_code_alias(
     client: AsyncClient,
 ) -> None:
     """
-    lot_code 和 batch_code 同时传入时，归一后必须一致。
+    batch_code 已从 LedgerQuery 入参退役，传入应被 Pydantic extra=forbid 拒绝。
     """
     headers = await _login_admin_headers(client)
 
@@ -151,8 +123,7 @@ async def test_stock_ledger_query_rejects_conflicting_lot_code_aliases(
         json={
             "item_id": 930001,
             "warehouse_id": 1,
-            "lot_code": "UT-LEDGER-ALIAS-A",
-            "batch_code": "UT-LEDGER-ALIAS-B",
+            "batch_code": "UT-LEDGER-RETIRED-ALIAS",
             "limit": 50,
             "offset": 0,
         },
@@ -160,5 +131,5 @@ async def test_stock_ledger_query_rejects_conflicting_lot_code_aliases(
 
     assert response.status_code == 422, response.text
     body = response.json()
-    assert isinstance(body, dict)
-    assert body.get("error_code") == "lot_code_alias_conflict"
+    assert body.get("error_code") == "request_validation_error"
+    assert "Extra inputs are not permitted" in response.text

--- a/tests/unit/test_ledger_lot_code_aliases.py
+++ b/tests/unit/test_ledger_lot_code_aliases.py
@@ -1,79 +1,43 @@
 from __future__ import annotations
 
 import pytest
-from fastapi import HTTPException
+from pydantic import ValidationError
 
 from app.wms.ledger.contracts.stock_ledger import LedgerQuery
-from app.wms.ledger.helpers.stock_ledger import (
-    normalize_ledger_lot_code_aliases,
-    resolve_ledger_lot_code_filter,
-)
+from app.wms.ledger.helpers.stock_ledger import resolve_ledger_lot_code_filter
 
 
 def test_resolve_ledger_lot_code_filter_uses_lot_code_as_canonical_input() -> None:
     query = LedgerQuery(lot_code="  LOT-A  ")
 
     should_filter, value = resolve_ledger_lot_code_filter(query)
-    normalized = normalize_ledger_lot_code_aliases(query)
 
     assert should_filter is True
     assert value == "LOT-A"
-    assert normalized.lot_code == "LOT-A"
-    assert normalized.batch_code == "LOT-A"
+    assert query.lot_code == "LOT-A"
 
 
-def test_resolve_ledger_lot_code_filter_keeps_batch_code_compatibility() -> None:
-    query = LedgerQuery(batch_code="  LOT-B  ")
+def test_ledger_query_rejects_retired_batch_code_alias() -> None:
+    with pytest.raises(ValidationError) as exc:
+        LedgerQuery(batch_code="  LOT-B  ")
 
-    should_filter, value = resolve_ledger_lot_code_filter(query)
-    normalized = normalize_ledger_lot_code_aliases(query)
-
-    assert should_filter is True
-    assert value == "LOT-B"
-    assert normalized.lot_code == "LOT-B"
-    assert normalized.batch_code == "LOT-B"
-
-
-def test_resolve_ledger_lot_code_filter_accepts_matching_aliases() -> None:
-    query = LedgerQuery(lot_code="LOT-C", batch_code="  LOT-C  ")
-
-    should_filter, value = resolve_ledger_lot_code_filter(query)
-    normalized = normalize_ledger_lot_code_aliases(query)
-
-    assert should_filter is True
-    assert value == "LOT-C"
-    assert normalized.lot_code == "LOT-C"
-    assert normalized.batch_code == "LOT-C"
-
-
-def test_resolve_ledger_lot_code_filter_rejects_conflicting_aliases() -> None:
-    query = LedgerQuery(lot_code="LOT-D", batch_code="LOT-E")
-
-    with pytest.raises(HTTPException) as exc:
-        resolve_ledger_lot_code_filter(query)
-
-    assert exc.value.status_code == 422
-    assert exc.value.detail["error_code"] == "lot_code_alias_conflict"
+    assert "batch_code" in str(exc.value)
 
 
 def test_resolve_ledger_lot_code_filter_preserves_explicit_null_semantics() -> None:
     query = LedgerQuery(lot_code="")
 
     should_filter, value = resolve_ledger_lot_code_filter(query)
-    normalized = normalize_ledger_lot_code_aliases(query)
 
     assert should_filter is True
     assert value is None
-    assert normalized.lot_code is None
-    assert normalized.batch_code is None
+    assert query.lot_code == ""
 
 
-def test_resolve_ledger_lot_code_filter_ignores_absent_aliases() -> None:
+def test_resolve_ledger_lot_code_filter_ignores_absent_lot_code() -> None:
     query = LedgerQuery(item_id=1)
 
     should_filter, value = resolve_ledger_lot_code_filter(query)
-    normalized = normalize_ledger_lot_code_aliases(query)
 
     assert should_filter is False
     assert value is None
-    assert normalized is query


### PR DESCRIPTION
## Summary
- remove batch_code from LedgerQuery and reject it with extra=forbid
- switch ledger query/history/summary/export/reconcile/shadow read filters to lot_code
- remove batch_code from LedgerRow and LedgerReconcileRow responses
- keep lot_code as the only public ledger display-code field

## Verification
- python3 -m compileall on changed backend files
- make test TESTS="tests/unit/test_ledger_lot_code_aliases.py tests/api/test_stock_ledger_lot_code_alias_api.py"