### PR TITLE
refactor(wms): use lot_code in ledger explain and shadow filters

### DIFF
--- a/app/wms/analysis/routers/stock_ledger_routes_shadow_lot.py
+++ b/app/wms/analysis/routers/stock_ledger_routes_shadow_lot.py
@@ -28,7 +28,7 @@ def register(router: APIRouter) -> None:
             item_id=int(payload.item_id),
             time_from=time_from,
             time_to=time_to,
-            batch_code=getattr(payload, "lot_code", None),
+            lot_code=getattr(payload, "lot_code", None),
             lot_id=getattr(payload, "lot_id", None),
         )
 

--- a/app/wms/analysis/services/lot_shadow_reconcile_service.py
+++ b/app/wms/analysis/services/lot_shadow_reconcile_service.py
@@ -14,7 +14,7 @@ class LotShadowReconcileService:
     """
     Phase 3（结构收口后的 ledger-only 影子对账）：
 
-    - 只读 stock_ledger（lots 不再承载日期字段；batch_code_key 语义已退场）
+    - 只读 stock_ledger（lots 不再承载日期字段；历史 batch key 语义已退场）
     - 给出：
       1) lot 覆盖率（整体 + receipt 口径）
       2) 按 lot 聚合的 sum(delta)（影子余额）
@@ -29,7 +29,7 @@ class LotShadowReconcileService:
         item_id: int,
         time_from: datetime,
         time_to: datetime,
-        batch_code: Optional[str] = None,
+        lot_code: Optional[str] = None,
         lot_id: Optional[int] = None,
         violation_limit: int = 50,
     ) -> Dict[str, Any]:
@@ -46,11 +46,11 @@ class LotShadowReconcileService:
             cond.append("l.lot_id=:lot")
             params["lot"] = int(lot_id)
 
-        # batch_code 视为展示码 lots.lot_code（支持 NULL 语义）
-        if batch_code is not None:
-            norm_bc = normalize_optional_lot_code(batch_code)
-            cond.append("lo.lot_code IS NOT DISTINCT FROM :bc")
-            params["bc"] = norm_bc
+        # lot_code 为展示码 lots.lot_code（支持 NULL 语义）
+        if lot_code is not None:
+            norm_lot_code = normalize_optional_lot_code(lot_code)
+            cond.append("lo.lot_code IS NOT DISTINCT FROM :lot_code")
+            params["lot_code"] = norm_lot_code
 
         join_lots = "JOIN lots lo ON lo.id = l.lot_id"
 

--- a/app/wms/ledger/contracts/stock_ledger_explain.py
+++ b/app/wms/ledger/contracts/stock_ledger_explain.py
@@ -44,7 +44,7 @@ class ExplainReceiptLine(BaseModel):
     category: Optional[str] = None
     spec_text: Optional[str] = None
 
-    batch_code: str
+    lot_code: Optional[str] = None
     production_date: Optional[date] = None
     expiry_date: Optional[date] = None
 
@@ -103,7 +103,7 @@ class ExplainLedgerRow(BaseModel):
     id: int
     warehouse_id: int
     item_id: int
-    batch_code: str
+    lot_code: Optional[str] = None
 
     reason: str
     reason_canon: Optional[str] = None

--- a/app/wms/ledger/routers/stock_ledger_routes_query_history.py
+++ b/app/wms/ledger/routers/stock_ledger_routes_query_history.py
@@ -139,7 +139,7 @@ async def _load_receipt_line_rows(
             pol.item_sku AS item_sku,
             NULL::varchar AS category,
             pol.spec_text AS spec_text,
-            COALESCE(lo.lot_code, rl.lot_code_input, '') AS batch_code,
+            COALESCE(lo.lot_code, rl.lot_code_input, '') AS lot_code,
             rl.production_date,
             rl.expiry_date,
             COALESCE(rl.qty_base, 0) AS qty_received,
@@ -159,6 +159,47 @@ async def _load_receipt_line_rows(
     )
     rows = await session.execute(sql, {"receipt_id": int(receipt_id)})
     return [dict(r) for r in rows.mappings().all()]
+
+
+async def _load_lot_code_map(
+    session: AsyncSession,
+    *,
+    ledger_rows: list[StockLedger],
+) -> dict[int, str | None]:
+    lot_ids = sorted(
+        {
+            int(getattr(row, "lot_id"))
+            for row in ledger_rows
+            if getattr(row, "lot_id", None) is not None
+        }
+    )
+    if not lot_ids:
+        return {}
+
+    res = await session.execute(select(Lot.id, Lot.lot_code).where(Lot.id.in_(lot_ids)))
+    return {int(lot_id): lot_code for lot_id, lot_code in res.all()}
+
+
+def _explain_ledger_row(row: StockLedger, lot_code_map: dict[int, str | None]) -> ExplainLedgerRow:
+    lot_id = getattr(row, "lot_id", None)
+    return ExplainLedgerRow(
+        id=int(row.id),
+        warehouse_id=int(row.warehouse_id),
+        item_id=int(row.item_id),
+        lot_code=lot_code_map.get(int(lot_id)) if lot_id is not None else None,
+        reason=str(row.reason),
+        reason_canon=getattr(row, "reason_canon", None),
+        sub_reason=getattr(row, "sub_reason", None),
+        ref=str(row.ref),
+        ref_line=int(row.ref_line),
+        delta=int(row.delta),
+        after_qty=int(row.after_qty),
+        occurred_at=row.occurred_at,
+        created_at=row.created_at,
+        trace_id=getattr(row, "trace_id", None),
+        production_date=getattr(row, "production_date", None),
+        expiry_date=getattr(row, "expiry_date", None),
+    )
 
 
 def register(router: APIRouter) -> None:
@@ -196,6 +237,7 @@ def register(router: APIRouter) -> None:
             .limit(limit)
         )
         ledger_rows = (await session.execute(ledger_stmt)).scalars().all()
+        lot_code_map = await _load_lot_code_map(session, ledger_rows=ledger_rows)
 
         po_obj: Optional[PurchaseOrder] = None
         if str(receipt_row.get("source_type") or "") == "PO" and receipt_row.get("source_id") is not None:
@@ -203,7 +245,7 @@ def register(router: APIRouter) -> None:
 
         return LedgerExplainOut(
             anchor=ExplainAnchor(ref=ref, trace_id=normalized_trace_id),
-            ledger=[ExplainLedgerRow.model_validate(r) for r in ledger_rows],
+            ledger=[_explain_ledger_row(r, lot_code_map) for r in ledger_rows],
             receipt=ExplainReceipt.model_validate(receipt_row),
             receipt_lines=[ExplainReceiptLine.model_validate(ln) for ln in receipt_lines],
             purchase_order=(


### PR DESCRIPTION
## Summary
- rename ledger explain receipt-line and ledger-row display field from batch_code to lot_code
- construct explain ledger rows from stock_ledger plus lots.lot_code
- rename LotShadowReconcileService filter parameter from batch_code to lot_code
- keep lot_id as structural fact and lots.lot_code as display code

## Verification
- python3 -m compileall on changed files
- make test TESTS="tests/unit/test_ledger_lot_code_aliases.py tests/api/test_stock_ledger_lot_code_alias_api.py"
- make test TESTS="tests/api/test_stock_ledger_lot_code_alias_api.py tests/unit/test_ledger_lot_code_aliases.py tests/api/test_stock_inventory_read_api.py"