### PR TITLE
refactor(wms): rename return task lot display snapshot

### DIFF
--- a/alembic/versions/36ee63805894_wms_return_task_lines_rename_batch_code_.py
+++ b/alembic/versions/36ee63805894_wms_return_task_lines_rename_batch_code_.py
@@ -1,0 +1,48 @@
+"""wms_return_task_lines_rename_batch_code_to_lot_code_snapshot
+
+Revision ID: 36ee63805894
+Revises: c896df82c17c
+Create Date: 2026-04-25
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "36ee63805894"
+down_revision: Union[str, Sequence[str], None] = "c896df82c17c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Rename return task lot display snapshot to lot_code_snapshot."""
+
+    op.alter_column(
+        "return_task_lines",
+        "batch_code",
+        new_column_name="lot_code_snapshot",
+        existing_type=sa.String(length=64),
+        existing_nullable=False,
+        existing_comment="展示快照：来自原出库 lot 的 lots.lot_code；不参与结构锚点",
+        comment="展示快照：来自原出库 lot 的 lots.lot_code；不参与结构锚点",
+    )
+
+
+def downgrade() -> None:
+    """Restore previous return task display snapshot column name."""
+
+    op.alter_column(
+        "return_task_lines",
+        "lot_code_snapshot",
+        new_column_name="batch_code",
+        existing_type=sa.String(length=64),
+        existing_nullable=False,
+        existing_comment="展示快照：来自原出库 lot 的 lots.lot_code；不参与结构锚点",
+        comment="展示快照：来自原出库 lot 的 lots.lot_code；不参与结构锚点",
+    )

--- a/app/wms/inventory_adjustment/return_inbound/contracts/return_task.py
+++ b/app/wms/inventory_adjustment/return_inbound/contracts/return_task.py
@@ -16,7 +16,7 @@ class ReturnTaskLineOut(BaseModel):
     item_id: int
     lot_id: int
     item_name: Optional[str]
-    batch_code: str
+    lot_code_snapshot: str
 
     expected_qty: Optional[int]
     picked_qty: int
@@ -85,7 +85,7 @@ class ReturnOrderRefSummaryLine(BaseModel):
     warehouse_id: int
     item_id: int
     item_name: Optional[str] = None  # ✅ 新增：用于详情展示（作业人员视角）
-    batch_code: str
+    lot_code_snapshot: str
     shipped_qty: int
 
 

--- a/app/wms/inventory_adjustment/return_inbound/models/return_task.py
+++ b/app/wms/inventory_adjustment/return_inbound/models/return_task.py
@@ -86,7 +86,7 @@ class ReturnTaskLine(Base):
     一行代表一个 item + lot（自动回原 lot 回仓）：
 
     - lot_id: 回原批次的结构锚点，来自原出库 stock_ledger.lot_id；
-    - batch_code: 展示快照，来自 lots.lot_code，不参与结构身份；
+    - lot_code_snapshot: 展示快照，来自 lots.lot_code，不参与结构身份；
     - expected_qty: 计划回仓数量（来自订单原出库数量）；
     - picked_qty: 已扫码/录入的回仓数量（累积）；
     - committed_qty: 最终确认入库数量（commit 时写入）。
@@ -131,7 +131,7 @@ class ReturnTaskLine(Base):
         comment="商品名称快照（可选）",
     )
 
-    batch_code: Mapped[str] = mapped_column(
+    lot_code_snapshot: Mapped[str] = mapped_column(
         sa.String(64),
         nullable=False,
         comment="展示快照：来自原出库 lot 的 lots.lot_code；不参与结构锚点",

--- a/app/wms/inventory_adjustment/return_inbound/routers/order_refs.py
+++ b/app/wms/inventory_adjustment/return_inbound/routers/order_refs.py
@@ -118,16 +118,17 @@ def register_order_refs(router: APIRouter) -> None:
             wh_cond = "AND l.warehouse_id = :wid"
             params["wid"] = int(warehouse_id)
 
-        # 维度封板：GROUP BY lot_id；batch_code 仅展示（用 MAX 聚合）
+        # 维度封板：GROUP BY lot_id；lot_code_snapshot 仅展示，来自 lots.lot_code
         sql = f"""
         SELECT l.warehouse_id,
                l.item_id,
                i.name AS item_name,
                l.lot_id,
-               MAX(l.batch_code) AS batch_code,
+               MAX(lo.lot_code) AS lot_code_snapshot,
                COALESCE(SUM(-l.delta), 0)::int AS shipped_qty
           FROM stock_ledger l
           LEFT JOIN items i ON i.id = l.item_id
+          LEFT JOIN lots lo ON lo.id = l.lot_id
          WHERE l.ref = :ref
            AND l.delta < 0
            AND l.reason = ANY(:reasons)

--- a/app/wms/inventory_adjustment/return_inbound/services/return_task_service_impl.py
+++ b/app/wms/inventory_adjustment/return_inbound/services/return_task_service_impl.py
@@ -17,7 +17,7 @@ from app.wms.stock.services.stock_service import StockService
 UTC = timezone.utc
 
 
-def _norm_bc(v: Any) -> Optional[str]:
+def _norm_lot_code_snapshot(v: Any) -> Optional[str]:
     if v is None:
         return None
     if isinstance(v, str):
@@ -75,8 +75,8 @@ class ReturnTaskServiceImpl:
 
     终态口径：
     - return_task_lines.lot_id 是回原批次结构锚点；
-    - return_task_lines.batch_code 只是 lots.lot_code 展示快照；
-    - commit 不再通过 batch_code 反查 lot_id。
+    - return_task_lines.lot_code_snapshot 只是 lots.lot_code 展示快照；
+    - commit 不再通过 lot_code_snapshot 反查 lot_id。
     """
 
     SHIP_OUT_REASONS: Set[str] = {
@@ -128,7 +128,7 @@ class ReturnTaskServiceImpl:
                     "item_id": item_id,
                     "warehouse_id": wh_id,
                     "lot_id": lot_id,
-                    "batch_code": lot_code_map.get(lot_id),
+                    "lot_code_snapshot": lot_code_map.get(lot_id),
                     "shipped_qty": shipped_qty,
                 }
             )
@@ -187,10 +187,10 @@ class ReturnTaskServiceImpl:
         for x in shipped:
             item_id = int(x["item_id"])
             lot_id = int(x["lot_id"])
-            batch_code = _norm_bc(x.get("batch_code"))
-            if batch_code is None:
+            lot_code_snapshot = _norm_lot_code_snapshot(x.get("lot_code_snapshot"))
+            if lot_code_snapshot is None:
                 raise ValueError(
-                    f"return_task_batch_code_required_for_display:item_id={item_id}:lot_id={lot_id}"
+                    f"return_task_lot_code_snapshot_required_for_display:item_id={item_id}:lot_id={lot_id}"
                 )
 
             expected_qty = int(x["shipped_qty"])
@@ -200,7 +200,7 @@ class ReturnTaskServiceImpl:
                 order_line_id=None,
                 item_id=item_id,
                 lot_id=lot_id,
-                batch_code=batch_code,
+                lot_code_snapshot=lot_code_snapshot,
                 expected_qty=expected_qty,
                 picked_qty=0,
                 committed_qty=0,
@@ -291,7 +291,7 @@ class ReturnTaskServiceImpl:
                 continue
 
             ref_line = int(getattr(ln, "id", 1) or 1)
-            bc = _norm_bc(ln.batch_code)
+            lot_code_snapshot = _norm_lot_code_snapshot(ln.lot_code_snapshot)
 
             lot_id = int(getattr(ln, "lot_id", 0) or 0)
             if lot_id <= 0:
@@ -317,13 +317,13 @@ class ReturnTaskServiceImpl:
                     f"lot_item_id={int(lot_snapshot['item_id'])}"
                 )
 
-            snapshot_batch_code = _norm_bc(lot_snapshot.get("lot_code"))
-            if bc != snapshot_batch_code:
+            snapshot_lot_code = _norm_lot_code_snapshot(lot_snapshot.get("lot_code"))
+            if lot_code_snapshot != snapshot_lot_code:
                 raise ValueError(
-                    f"return_task_line_batch_code_snapshot_mismatch:"
+                    f"return_task_line_lot_code_snapshot_mismatch:"
                     f"line_id={getattr(ln, 'id', None)}:"
-                    f"batch_code={bc}:"
-                    f"lot_code={snapshot_batch_code}"
+                    f"lot_code_snapshot={lot_code_snapshot}:"
+                    f"lot_code={snapshot_lot_code}"
                 )
 
             res = await self.stock_svc.adjust_lot(
@@ -350,7 +350,7 @@ class ReturnTaskServiceImpl:
                     "warehouse_id": int(task.warehouse_id),
                     "item_id": int(ln.item_id),
                     "lot_id": int(applied_lot_id),
-                    "batch_code": bc,
+                    "lot_code": lot_code_snapshot,
                     "qty": int(picked),
                     "ref": str(task.order_id),
                     "ref_line": ref_line,

--- a/tests/test_phase3_three_books_return_commit.py
+++ b/tests/test_phase3_three_books_return_commit.py
@@ -69,8 +69,8 @@ async def test_phase3_return_commit_three_books_strict(session: AsyncSession):
     关键点：
     - create_for_order 只认 ledger 出库事实：必须先写 OUTBOUND_SHIP delta<0；
     - return_task_lines.lot_id 必须来自原出库 stock_ledger.lot_id；
-    - return_task_lines.batch_code 仅是 lots.lot_code 展示快照；
-    - return commit 必须使用同一个 lot_id 回仓，而不是靠 batch_code 二次反查。
+    - return_task_lines.lot_code_snapshot 仅是 lots.lot_code 展示快照；
+    - return commit 必须使用同一个 lot_id 回仓，而不是靠 lot_code_snapshot 二次反查。
     """
     now = datetime.now(UTC)
 
@@ -78,7 +78,7 @@ async def test_phase3_return_commit_three_books_strict(session: AsyncSession):
 
     wh_id = 1
     item_id, may_need_expiry = await _pick_item_for_stock_in(session)
-    batch_code = "B-PH3-RET"
+    lot_code_snapshot = "B-PH3-RET"
     prod = now.date()
     exp = (prod + timedelta(days=30)) if may_need_expiry else None
 
@@ -89,7 +89,7 @@ async def test_phase3_return_commit_three_books_strict(session: AsyncSession):
         session,
         warehouse_id=wh_id,
         item_id=item_id,
-        lot_code=batch_code,
+        lot_code=lot_code_snapshot,
         production_date=prod,
         expiry_date=exp,
     )
@@ -106,7 +106,7 @@ async def test_phase3_return_commit_three_books_strict(session: AsyncSession):
         ref_line=1,
         occurred_at=now,
         meta={"sub_reason": "UT_STOCK_IN"},
-        batch_code=batch_code,
+        batch_code=lot_code_snapshot,
         production_date=prod,
         expiry_date=exp,
         trace_id=trace_id,
@@ -128,7 +128,7 @@ async def test_phase3_return_commit_three_books_strict(session: AsyncSession):
         ref_line=1,
         occurred_at=now,
         meta={"sub_reason": "ORDER_SHIP"},
-        batch_code=batch_code,
+        batch_code=lot_code_snapshot,
         production_date=None,
         expiry_date=None,
         trace_id=trace_id,
@@ -171,13 +171,13 @@ async def test_phase3_return_commit_three_books_strict(session: AsyncSession):
 
     assert task_line is not None
     assert int(task_line.lot_id) == shipped_lot_id
-    assert str(task_line.batch_code) == batch_code
+    assert str(task_line.lot_code_snapshot) == lot_code_snapshot
 
     stored_task_line = (
         await session.execute(
             text(
                 """
-                SELECT rtl.lot_id, rtl.batch_code, lo.lot_code
+                SELECT rtl.lot_id, rtl.lot_code_snapshot, lo.lot_code
                   FROM return_task_lines rtl
                   JOIN lots lo
                     ON lo.id = rtl.lot_id
@@ -189,7 +189,7 @@ async def test_phase3_return_commit_three_books_strict(session: AsyncSession):
     ).first()
     assert stored_task_line is not None
     assert int(stored_task_line[0]) == shipped_lot_id
-    assert str(stored_task_line[1]) == str(stored_task_line[2]) == batch_code
+    assert str(stored_task_line[1]) == str(stored_task_line[2]) == lot_code_snapshot
 
     # 4) 录入回仓数量
     task = await svc.record_receive(session, task_id=int(task.id), item_id=item_id, qty=2)
@@ -255,7 +255,7 @@ async def test_phase3_return_commit_three_books_strict(session: AsyncSession):
                 "warehouse_id": wh_id,
                 "item_id": item_id,
                 "lot_id": lot_id_val,
-                "lot_code": batch_code,
+                "lot_code": lot_code_snapshot,
                 "qty": 2,
                 "ref": order_ref,
                 "ref_line": ref_line,


### PR DESCRIPTION
## Summary
- rename return_task_lines.batch_code to lot_code_snapshot
- update ReturnTaskLine and return order summary contracts to expose lot_code_snapshot
- update return order summary to join lots.lot_code instead of reading stock_ledger.batch_code
- keep lot_id as the structural anchor for return inbound

## Verification
- python3 -m compileall on changed files
- make alembic-check
- make test TESTS="tests/test_phase3_three_books_return_commit.py"