### PR TITLE
refactor(wms): harden outbound submit lot id contract

### DIFF
--- a/app/wms/outbound/contracts/manual_submit.py
+++ b/app/wms/outbound/contracts/manual_submit.py
@@ -11,13 +11,12 @@ class ManualOutboundSubmitLineIn(BaseModel):
     """
     手动出库提交：单行实际出库事实
     """
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="forbid")
 
     manual_doc_line_id: int = Field(..., ge=1)
     item_id: int = Field(..., ge=1)
     qty_outbound: int = Field(..., gt=0)
     lot_id: int = Field(..., ge=1)
-    lot_code: Optional[str] = Field(default=None, min_length=1, max_length=64)
     remark: Optional[str] = Field(default=None, max_length=255)
 
 
@@ -25,7 +24,7 @@ class ManualOutboundSubmitIn(BaseModel):
     """
     手动出库提交：整单请求体
     """
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="forbid")
 
     remark: Optional[str] = Field(default=None, max_length=255)
     lines: List[ManualOutboundSubmitLineIn] = Field(default_factory=list)

--- a/app/wms/outbound/contracts/order_submit.py
+++ b/app/wms/outbound/contracts/order_submit.py
@@ -11,13 +11,12 @@ class OrderOutboundSubmitLineIn(BaseModel):
     """
     订单出库提交：单行实际出库事实
     """
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="forbid")
 
     order_line_id: int = Field(..., ge=1)
     item_id: int = Field(..., ge=1)
     qty_outbound: int = Field(..., gt=0)
     lot_id: int = Field(..., ge=1)
-    lot_code: Optional[str] = Field(default=None, min_length=1, max_length=64)
     remark: Optional[str] = Field(default=None, max_length=255)
 
 
@@ -25,7 +24,7 @@ class OrderOutboundSubmitIn(BaseModel):
     """
     订单出库提交：整单请求体
     """
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="forbid")
 
     warehouse_id: int = Field(..., ge=1)
     remark: Optional[str] = Field(default=None, max_length=255)

--- a/app/wms/outbound/repos/outbound_event_repo.py
+++ b/app/wms/outbound/repos/outbound_event_repo.py
@@ -150,7 +150,7 @@ async def insert_outbound_event_lines(
                         "item_id": int(ln["item_id"]),
                         "qty_outbound": int(ln["qty_outbound"]),
                         "lot_id": int(ln["lot_id"]),
-                        "lot_code_snapshot": ln.get("lot_code"),
+                        "lot_code_snapshot": ln.get("lot_code_snapshot"),
                         "order_line_id": ln.get("order_line_id"),
                         "manual_doc_line_id": ln.get("manual_doc_line_id"),
                         "item_name_snapshot": ln.get("item_name_snapshot"),

--- a/app/wms/outbound/services/outbound_event_submit_service.py
+++ b/app/wms/outbound/services/outbound_event_submit_service.py
@@ -45,6 +45,38 @@ def _clean_text(value: Any) -> str | None:
     return s or None
 
 
+
+async def load_lot_code_snapshot_map(
+    session: AsyncSession,
+    *,
+    lines: List[Dict[str, Any]],
+) -> Dict[int, str | None]:
+    lot_ids = sorted({int(line["lot_id"]) for line in lines})
+    if not lot_ids:
+        return {}
+
+    params = {f"lot_id_{idx}": lot_id for idx, lot_id in enumerate(lot_ids)}
+    placeholders = ", ".join(f":lot_id_{idx}" for idx in range(len(lot_ids)))
+
+    rows = (
+        (
+            await session.execute(
+                text(
+                    f"""
+                    SELECT id, lot_code
+                    FROM lots
+                    WHERE id IN ({placeholders})
+                    """
+                ),
+                params,
+            )
+        )
+        .mappings()
+        .all()
+    )
+    return {int(row["id"]): row["lot_code"] for row in rows}
+
+
 @dataclass(frozen=True)
 class OrderSubmitContext:
     order: Mapping[str, Any]
@@ -240,7 +272,6 @@ def normalize_order_submit_lines(
         item_id = int(raw["item_id"])
         qty_outbound = int(raw["qty_outbound"])
         lot_id = int(raw["lot_id"])
-        lot_code = _clean_text(raw.get("lot_code"))
         remark = _clean_text(raw.get("remark"))
 
         src = ctx.order_lines_by_id.get(order_line_id)
@@ -264,7 +295,6 @@ def normalize_order_submit_lines(
                 "item_id": item_id,
                 "qty_outbound": qty_outbound,
                 "lot_id": lot_id,
-                "lot_code": lot_code,
                 "item_name_snapshot": _clean_text(src.get("item_name")),
                 "item_sku_snapshot": _clean_text(src.get("item_sku")),
                 "item_spec_snapshot": _clean_text(src.get("item_spec")),
@@ -292,7 +322,6 @@ def normalize_manual_submit_lines(
         item_id = int(raw["item_id"])
         qty_outbound = int(raw["qty_outbound"])
         lot_id = int(raw["lot_id"])
-        lot_code = _clean_text(raw.get("lot_code"))
         remark = _clean_text(raw.get("remark"))
 
         src = ctx.doc_lines_by_id.get(manual_doc_line_id)
@@ -318,7 +347,6 @@ def normalize_manual_submit_lines(
                 "item_id": item_id,
                 "qty_outbound": qty_outbound,
                 "lot_id": lot_id,
-                "lot_code": lot_code,
                 "item_name_snapshot": _clean_text(src.get("item_name_snapshot")),
                 "item_sku_snapshot": _clean_text(src.get("item_sku_snapshot")),
                 "item_spec_snapshot": _clean_text(src.get("item_spec_snapshot")),
@@ -362,10 +390,22 @@ async def _write_event_and_ledger(
         remark=remark,
     )
 
+    lot_code_snapshot_map = await load_lot_code_snapshot_map(
+        session,
+        lines=normalized_lines,
+    )
+    lines_with_snapshots = [
+        {
+            **line,
+            "lot_code_snapshot": lot_code_snapshot_map.get(int(line["lot_id"])),
+        }
+        for line in normalized_lines
+    ]
+
     saved_lines = await insert_outbound_event_lines(
         session,
         event_id=int(event["id"]),
-        lines=normalized_lines,
+        lines=lines_with_snapshots,
     )
 
     for ln in saved_lines:

--- a/openapi/_current.json
+++ b/openapi/_current.json
@@ -29600,6 +29600,7 @@
             "title": "Lines"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "title": "ManualOutboundSubmitIn",
         "description": "手动出库提交：整单请求体"
@@ -29626,19 +29627,6 @@
             "minimum": 1.0,
             "title": "Lot Id"
           },
-          "lot_code": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 64,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Lot Code"
-          },
           "remark": {
             "anyOf": [
               {
@@ -29652,6 +29640,7 @@
             "title": "Remark"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": [
           "manual_doc_line_id",
@@ -30926,6 +30915,7 @@
             "title": "Lines"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": [
           "warehouse_id"
@@ -30955,19 +30945,6 @@
             "minimum": 1.0,
             "title": "Lot Id"
           },
-          "lot_code": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 64,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Lot Code"
-          },
           "remark": {
             "anyOf": [
               {
@@ -30981,6 +30958,7 @@
             "title": "Remark"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": [
           "order_line_id",

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -29600,6 +29600,7 @@
             "title": "Lines"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "title": "ManualOutboundSubmitIn",
         "description": "手动出库提交：整单请求体"
@@ -29626,19 +29627,6 @@
             "minimum": 1.0,
             "title": "Lot Id"
           },
-          "lot_code": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 64,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Lot Code"
-          },
           "remark": {
             "anyOf": [
               {
@@ -29652,6 +29640,7 @@
             "title": "Remark"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": [
           "manual_doc_line_id",
@@ -30926,6 +30915,7 @@
             "title": "Lines"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": [
           "warehouse_id"
@@ -30955,19 +30945,6 @@
             "minimum": 1.0,
             "title": "Lot Id"
           },
-          "lot_code": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 64,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Lot Code"
-          },
           "remark": {
             "anyOf": [
               {
@@ -30981,6 +30958,7 @@
             "title": "Remark"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": [
           "order_line_id",

--- a/tests/api/test_manual_outbound_submit_api.py
+++ b/tests/api/test_manual_outbound_submit_api.py
@@ -216,7 +216,6 @@ async def test_manual_outbound_submit_writes_event_and_ledger(
                     "item_id": item_id,
                     "qty_outbound": 2,
                     "lot_id": lot_id,
-                    "lot_code": None,
                     "remark": "line remark",
                 }
             ],
@@ -254,7 +253,7 @@ async def test_manual_outbound_submit_writes_event_and_ledger(
         await session.execute(
             text(
                 """
-                SELECT manual_doc_line_id, item_id, qty_outbound, lot_id
+                SELECT manual_doc_line_id, item_id, qty_outbound, lot_id, lot_code_snapshot
                 FROM outbound_event_lines
                 WHERE event_id = :event_id
                 ORDER BY ref_line ASC
@@ -269,6 +268,13 @@ async def test_manual_outbound_submit_writes_event_and_ledger(
     assert int(line[1]) == item_id
     assert int(line[2]) == 2
     assert int(line[3]) == lot_id
+    expected_lot_code = (
+        await session.execute(
+            text("SELECT lot_code FROM lots WHERE id = :lot_id"),
+            {"lot_id": int(lot_id)},
+        )
+    ).scalar_one()
+    assert line[4] == expected_lot_code
 
     led = (
         await session.execute(
@@ -346,7 +352,6 @@ async def test_manual_outbound_submit_keeps_doc_released_when_partially_submitte
                     "item_id": item_id,
                     "qty_outbound": 2,
                     "lot_id": lot_id,
-                    "lot_code": None,
                     "remark": "partial line remark",
                 }
             ],
@@ -374,3 +379,34 @@ async def test_manual_outbound_submit_keeps_doc_released_when_partially_submitte
         )
     ).scalar_one()
     assert str(doc_status) == "RELEASED"
+
+
+async def test_manual_outbound_submit_rejects_lot_code_and_batch_code_extras(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    doc_id, doc_line_id, _warehouse_id, lot_id, item_id = await _seed_manual_doc_and_stock(session)
+
+    resp = await client.post(
+        f"/wms/outbound/manual/{doc_id}/submit",
+        headers=headers,
+        json={
+            "remark": "UT manual outbound submit rejects extras",
+            "lines": [
+                {
+                    "manual_doc_line_id": doc_line_id,
+                    "item_id": item_id,
+                    "qty_outbound": 1,
+                    "lot_id": lot_id,
+                    "lot_code": "SHOULD-NOT-BE-ACCEPTED",
+                    "batch_code": "SHOULD-NOT-BE-ACCEPTED",
+                    "remark": "line remark",
+                }
+            ],
+        },
+    )
+
+    assert resp.status_code == 422, resp.text
+    body = resp.text
+    assert "Extra inputs are not permitted" in body

--- a/tests/api/test_order_outbound_submit_api.py
+++ b/tests/api/test_order_outbound_submit_api.py
@@ -203,7 +203,6 @@ async def test_order_outbound_submit_writes_event_and_ledger(
                     "item_id": item_id,
                     "qty_outbound": 2,
                     "lot_id": lot_id,
-                    "lot_code": None,
                     "remark": "line remark",
                 }
             ],
@@ -241,7 +240,7 @@ async def test_order_outbound_submit_writes_event_and_ledger(
         await session.execute(
             text(
                 """
-                SELECT order_line_id, item_id, qty_outbound, lot_id
+                SELECT order_line_id, item_id, qty_outbound, lot_id, lot_code_snapshot
                 FROM outbound_event_lines
                 WHERE event_id = :event_id
                 ORDER BY ref_line ASC
@@ -256,6 +255,13 @@ async def test_order_outbound_submit_writes_event_and_ledger(
     assert int(line[1]) == item_id
     assert int(line[2]) == 2
     assert int(line[3]) == lot_id
+    expected_lot_code = (
+        await session.execute(
+            text("SELECT lot_code FROM lots WHERE id = :lot_id"),
+            {"lot_id": int(lot_id)},
+        )
+    ).scalar_one()
+    assert line[4] == expected_lot_code
 
     led = (
         await session.execute(
@@ -323,7 +329,6 @@ async def test_order_outbound_submit_rejects_duplicate_submit_with_409(
                 "item_id": item_id,
                 "qty_outbound": 2,
                 "lot_id": lot_id,
-                "lot_code": None,
                 "remark": "line remark",
             }
         ],
@@ -344,3 +349,35 @@ async def test_order_outbound_submit_rejects_duplicate_submit_with_409(
     assert second.status_code == 409, second.text
     body = second.json()
     assert "order_line_already_completed" in str(body)
+
+
+async def test_order_outbound_submit_rejects_lot_code_and_batch_code_extras(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    order_id, order_line_id, warehouse_id, lot_id, item_id = await _seed_order_and_stock(session)
+
+    resp = await client.post(
+        f"/wms/outbound/orders/{order_id}/submit",
+        headers=headers,
+        json={
+            "warehouse_id": warehouse_id,
+            "remark": "UT order outbound submit rejects extras",
+            "lines": [
+                {
+                    "order_line_id": order_line_id,
+                    "item_id": item_id,
+                    "qty_outbound": 1,
+                    "lot_id": lot_id,
+                    "lot_code": "SHOULD-NOT-BE-ACCEPTED",
+                    "batch_code": "SHOULD-NOT-BE-ACCEPTED",
+                    "remark": "line remark",
+                }
+            ],
+        },
+    )
+
+    assert resp.status_code == 422, resp.text
+    body = resp.text
+    assert "Extra inputs are not permitted" in body


### PR DESCRIPTION
## Summary

- harden formal WMS outbound submit contracts to use `lot_id` as the only lot structure input
- remove client-provided `lot_code` from order/manual outbound submit payload contracts
- reject extra submit fields such as `lot_code` and `batch_code`
- generate `outbound_event_lines.lot_code_snapshot` on the backend from `lots.lot_code`
- keep `lot_code_snapshot` as read/display snapshot only
- regenerate OpenAPI

## Verification

- make openapi
- make test TESTS="tests/api/test_order_outbound_submit_api.py tests/api/test_manual_outbound_submit_api.py"

## Merge note

Merge the frontend PR first, because the current frontend still sends `lot_code` in outbound submit payloads.
