### PR TITLE
chore(wms): clean retired pick route wording

### DIFF
--- a/app/wms/scan/services/scan_orchestrator_ingest.py
+++ b/app/wms/scan/services/scan_orchestrator_ingest.py
@@ -175,7 +175,7 @@ async def ingest(scan: Dict[str, Any], session: Optional[AsyncSession]) -> Dict[
                 "event_id": ev,
                 "source": "scan_feature_disabled",
                 "evidence": [{"source": "scan_feature_disabled", "db": True}],
-                "errors": [{"stage": "ingest", "error": "FEATURE_DISABLED: scan_is_probe_only_use_/orders/{platform}/{shop_id}/{ext_order_no}/pick"}],
+                "errors": [{"stage": "ingest", "error": "FEATURE_DISABLED: scan_is_probe_only_use_formal_outbound_submit"}],
                 "item_id": item_id,
                 "item_uom_id": item_uom_id,
                 "ratio_to_base": ratio_to_base,

--- a/app/wms/scan/services/scan_orchestrator_ingest_pick.py
+++ b/app/wms/scan/services/scan_orchestrator_ingest_pick.py
@@ -30,7 +30,7 @@ async def run_pick_flow(
     - 只做条码 / 商品 / 包装识别；
     - 不扣库存；
     - 不写出库执行事实；
-    - 真正执行入口是 /orders/{platform}/{shop_id}/{ext_order_no}/pick。
+    - 真正执行入口已迁移到正式 WMS 出库提交链路；/scan 仅保留 probe，不承担落账。
     """
     parse_kwargs = {
         "item_id": item_id,


### PR DESCRIPTION
## Summary

- clean stale scan probe wording that still referenced the retired `/orders/{platform}/{shop_id}/{ext_order_no}/pick` route
- keep `/scan` probe-only semantics unchanged

## Verification

- python3 -m compileall app/wms/scan/services/scan_orchestrator_ingest.py app/wms/scan/services/scan_orchestrator_ingest_pick.py
- rg retired pick route references
