### PR TITLE
refactor(analytics): use order fulfillment shipped time for SLA

### DIFF
--- a/app/analytics/routers/orders_sla_stats_routes.py
+++ b/app/analytics/routers/orders_sla_stats_routes.py
@@ -24,11 +24,11 @@ def register(router: APIRouter) -> None:
     async def get_orders_sla_stats(
         time_from: Optional[datetime] = Query(
             None,
-            description="起始时间（含），用于过滤发货时间 outbound_commits_v2.created_at",
+            description="起始时间（含），用于过滤发货完成时间 order_fulfillment.shipped_at",
         ),
         time_to: Optional[datetime] = Query(
             None,
-            description="结束时间（含），用于过滤发货时间 outbound_commits_v2.created_at",
+            description="结束时间（含），用于过滤发货完成时间 order_fulfillment.shipped_at",
         ),
         platform: Optional[str] = Query(
             None,
@@ -49,10 +49,10 @@ def register(router: APIRouter) -> None:
         订单发货 SLA 统计：
 
         - 以 orders.created_at 为下单时间；
-        - 以 outbound_commits_v2.created_at 为发货时间（state=COMPLETED）；
-        - 两表通过 trace_id 关联。
+        - 以 order_fulfillment.shipped_at 为发货完成时间；
+        - 通过 order_fulfillment.order_id 关联 orders.id。
 
-        只统计在给定时间窗口内发货的订单（按 outbound_commits_v2.created_at 过滤）。
+        只统计在给定时间窗口内发货的订单（按 order_fulfillment.shipped_at 过滤）。
 
         ✅ PROD-only（简化口径）：
         - 排除测试店铺（platform_test_shops.code='DEFAULT'，以 store_id 为事实锚点）
@@ -68,25 +68,22 @@ def register(router: APIRouter) -> None:
             o.platform              AS platform,
             o.shop_id               AS shop_id,
             o.created_at            AS created_at,
-            oc.created_at           AS shipped_at,
-            EXTRACT(EPOCH FROM (oc.created_at - o.created_at)) / 3600.0
+            f.shipped_at            AS shipped_at,
+            EXTRACT(EPOCH FROM (f.shipped_at - o.created_at)) / 3600.0
                                     AS latency_hours
           FROM orders AS o
-          JOIN outbound_commits_v2 AS oc
-            ON oc.trace_id = o.trace_id
-          WHERE oc.state = 'COMPLETED'
-            AND oc.created_at >= :start
-            AND oc.created_at <= :end
+          JOIN order_fulfillment AS f
+            ON f.order_id = o.id
+          WHERE f.shipped_at IS NOT NULL
+            AND f.shipped_at >= :start
+            AND f.shipped_at <= :end
 
             -- ----------------- PROD-only：测试店铺门禁（store_id 级别） -----------------
             AND NOT EXISTS (
               SELECT 1
-                FROM stores s
-                JOIN platform_test_shops pts
-                  ON pts.store_id = s.id
+                FROM platform_test_shops pts
+               WHERE pts.store_id = o.store_id
                  AND pts.code = 'DEFAULT'
-               WHERE upper(s.platform) = upper(o.platform)
-                 AND btrim(CAST(s.shop_id AS text)) = btrim(CAST(o.shop_id AS text))
             )
         {plat_clause}
         {shop_clause}

--- a/openapi/_current.json
+++ b/openapi/_current.json
@@ -16475,7 +16475,7 @@
           "orders-sla"
         ],
         "summary": "Get Orders Sla Stats",
-        "description": "订单发货 SLA 统计：\n\n- 以 orders.created_at 为下单时间；\n- 以 outbound_commits_v2.created_at 为发货时间（state=COMPLETED）；\n- 两表通过 trace_id 关联。\n\n只统计在给定时间窗口内发货的订单（按 outbound_commits_v2.created_at 过滤）。\n\n✅ PROD-only（简化口径）：\n- 排除测试店铺（platform_test_shops.code='DEFAULT'，以 store_id 为事实锚点）",
+        "description": "订单发货 SLA 统计：\n\n- 以 orders.created_at 为下单时间；\n- 以 order_fulfillment.shipped_at 为发货完成时间；\n- 通过 order_fulfillment.order_id 关联 orders.id。\n\n只统计在给定时间窗口内发货的订单（按 order_fulfillment.shipped_at 过滤）。\n\n✅ PROD-only（简化口径）：\n- 排除测试店铺（platform_test_shops.code='DEFAULT'，以 store_id 为事实锚点）",
         "operationId": "get_orders_sla_stats_orders_stats_sla_get",
         "parameters": [
           {
@@ -16492,10 +16492,10 @@
                   "type": "null"
                 }
               ],
-              "description": "起始时间（含），用于过滤发货时间 outbound_commits_v2.created_at",
+              "description": "起始时间（含），用于过滤发货完成时间 order_fulfillment.shipped_at",
               "title": "Time From"
             },
-            "description": "起始时间（含），用于过滤发货时间 outbound_commits_v2.created_at"
+            "description": "起始时间（含），用于过滤发货完成时间 order_fulfillment.shipped_at"
           },
           {
             "name": "time_to",
@@ -16511,10 +16511,10 @@
                   "type": "null"
                 }
               ],
-              "description": "结束时间（含），用于过滤发货时间 outbound_commits_v2.created_at",
+              "description": "结束时间（含），用于过滤发货完成时间 order_fulfillment.shipped_at",
               "title": "Time To"
             },
-            "description": "结束时间（含），用于过滤发货时间 outbound_commits_v2.created_at"
+            "description": "结束时间（含），用于过滤发货完成时间 order_fulfillment.shipped_at"
           },
           {
             "name": "platform",

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -16475,7 +16475,7 @@
           "orders-sla"
         ],
         "summary": "Get Orders Sla Stats",
-        "description": "订单发货 SLA 统计：\n\n- 以 orders.created_at 为下单时间；\n- 以 outbound_commits_v2.created_at 为发货时间（state=COMPLETED）；\n- 两表通过 trace_id 关联。\n\n只统计在给定时间窗口内发货的订单（按 outbound_commits_v2.created_at 过滤）。\n\n✅ PROD-only（简化口径）：\n- 排除测试店铺（platform_test_shops.code='DEFAULT'，以 store_id 为事实锚点）",
+        "description": "订单发货 SLA 统计：\n\n- 以 orders.created_at 为下单时间；\n- 以 order_fulfillment.shipped_at 为发货完成时间；\n- 通过 order_fulfillment.order_id 关联 orders.id。\n\n只统计在给定时间窗口内发货的订单（按 order_fulfillment.shipped_at 过滤）。\n\n✅ PROD-only（简化口径）：\n- 排除测试店铺（platform_test_shops.code='DEFAULT'，以 store_id 为事实锚点）",
         "operationId": "get_orders_sla_stats_orders_stats_sla_get",
         "parameters": [
           {
@@ -16492,10 +16492,10 @@
                   "type": "null"
                 }
               ],
-              "description": "起始时间（含），用于过滤发货时间 outbound_commits_v2.created_at",
+              "description": "起始时间（含），用于过滤发货完成时间 order_fulfillment.shipped_at",
               "title": "Time From"
             },
-            "description": "起始时间（含），用于过滤发货时间 outbound_commits_v2.created_at"
+            "description": "起始时间（含），用于过滤发货完成时间 order_fulfillment.shipped_at"
           },
           {
             "name": "time_to",
@@ -16511,10 +16511,10 @@
                   "type": "null"
                 }
               ],
-              "description": "结束时间（含），用于过滤发货时间 outbound_commits_v2.created_at",
+              "description": "结束时间（含），用于过滤发货完成时间 order_fulfillment.shipped_at",
               "title": "Time To"
             },
-            "description": "结束时间（含），用于过滤发货时间 outbound_commits_v2.created_at"
+            "description": "结束时间（含），用于过滤发货完成时间 order_fulfillment.shipped_at"
           },
           {
             "name": "platform",

--- a/tests/api/test_orders_sla_stats_api.py
+++ b/tests/api/test_orders_sla_stats_api.py
@@ -1,0 +1,164 @@
+# tests/api/test_orders_sla_stats_api.py
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests.services._helpers import ensure_store
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_shipped_order(
+    session: AsyncSession,
+    *,
+    platform: str = "PDD",
+    shop_id: str = "UT-SLA-SHOP",
+    created_at: datetime,
+    shipped_at: datetime,
+) -> int:
+    store_id = await ensure_store(
+        session,
+        platform=platform,
+        shop_id=shop_id,
+        name=f"UT-{platform}-{shop_id}",
+    )
+    ext_order_no = f"UT-SLA-{uuid4().hex[:10]}"
+    row = await session.execute(
+        text(
+            """
+            INSERT INTO orders(
+              platform,
+              shop_id,
+              store_id,
+              ext_order_no,
+              status,
+              created_at,
+              updated_at
+            )
+            VALUES (
+              :platform,
+              :shop_id,
+              :store_id,
+              :ext_order_no,
+              'CREATED',
+              :created_at,
+              :created_at
+            )
+            RETURNING id
+            """
+        ),
+        {
+            "platform": platform,
+            "shop_id": shop_id,
+            "store_id": int(store_id),
+            "ext_order_no": ext_order_no,
+            "created_at": created_at,
+        },
+    )
+    order_id = int(row.scalar_one())
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO order_fulfillment(
+              order_id,
+              actual_warehouse_id,
+              execution_stage,
+              ship_committed_at,
+              shipped_at,
+              updated_at
+            )
+            VALUES (
+              :order_id,
+              1,
+              'SHIP',
+              :shipped_at,
+              :shipped_at,
+              :shipped_at
+            )
+            ON CONFLICT (order_id) DO UPDATE
+               SET actual_warehouse_id = EXCLUDED.actual_warehouse_id,
+                   execution_stage = EXCLUDED.execution_stage,
+                   ship_committed_at = EXCLUDED.ship_committed_at,
+                   shipped_at = EXCLUDED.shipped_at,
+                   updated_at = EXCLUDED.updated_at
+            """
+        ),
+        {
+            "order_id": order_id,
+            "shipped_at": shipped_at,
+        },
+    )
+    await session.commit()
+    return order_id
+
+
+async def test_orders_sla_stats_uses_order_fulfillment_shipped_at(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    created_at = now - timedelta(hours=2)
+    shipped_at = now - timedelta(hours=1)
+
+    await _seed_shipped_order(
+        session,
+        created_at=created_at,
+        shipped_at=shipped_at,
+    )
+
+    resp = await client.get(
+        "/orders/stats/sla",
+        params={
+            "time_from": (shipped_at - timedelta(minutes=1)).isoformat(),
+            "time_to": (shipped_at + timedelta(minutes=1)).isoformat(),
+            "platform": "PDD",
+            "shop_id": "UT-SLA-SHOP",
+            "sla_hours": 2,
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["total_orders"] == 1
+    assert data["on_time_orders"] == 1
+    assert data["on_time_rate"] == 1.0
+    assert data["avg_ship_hours"] is not None
+    assert 0.9 <= float(data["avg_ship_hours"]) <= 1.1
+
+
+async def test_orders_sla_stats_filters_by_shipped_at_window(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+
+    await _seed_shipped_order(
+        session,
+        platform="PDD",
+        shop_id="UT-SLA-WINDOW",
+        created_at=now - timedelta(hours=5),
+        shipped_at=now - timedelta(hours=4),
+    )
+
+    resp = await client.get(
+        "/orders/stats/sla",
+        params={
+            "time_from": (now - timedelta(hours=2)).isoformat(),
+            "time_to": now.isoformat(),
+            "platform": "PDD",
+            "shop_id": "UT-SLA-WINDOW",
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["total_orders"] == 0
+    assert data["on_time_orders"] == 0
+    assert data["on_time_rate"] == 0.0


### PR DESCRIPTION
## Summary

- move `/orders/stats/sla` from retired `outbound_commits_v2` to `order_fulfillment.shipped_at`
- use `order_fulfillment.order_id -> orders.id` as the hard join instead of trace_id
- keep PROD-only test shop exclusion by `orders.store_id`
- add API coverage proving SLA works without `outbound_commits_v2`
- regenerate OpenAPI

## Verification

- make openapi
- python3 -m compileall app/analytics/routers/orders_sla_stats_routes.py tests/api/test_orders_sla_stats_api.py
- make test TESTS="tests/api/test_orders_sla_stats_api.py"
