### PR TITLE
chore(tests): retire ensure batch helper naming

### DIFF
--- a/tests/api/test_outbound_lot_candidates_api.py
+++ b/tests/api/test_outbound_lot_candidates_api.py
@@ -4,7 +4,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from tests.utils.ensure_minimal import ensure_batch_with_stock
+from tests.utils.ensure_minimal import ensure_supplier_lot_with_stock
 
 
 async def _login_admin_headers(client: AsyncClient) -> dict[str, str]:
@@ -21,14 +21,14 @@ async def test_outbound_lot_candidates_returns_seeded_positive_supplier_lot(
 ) -> None:
     warehouse_id = 1
     item_id = 910001
-    batch_code = "UT-OUTBOUND-LOT-CAND-1"
+    lot_code = "UT-OUTBOUND-LOT-CAND-1"
     qty = 7
 
-    await ensure_batch_with_stock(
+    await ensure_supplier_lot_with_stock(
         session,
         item_id=item_id,
         warehouse_id=warehouse_id,
-        batch_code=batch_code,
+        lot_code=lot_code,
         qty=qty,
     )
     await session.commit()
@@ -49,7 +49,7 @@ async def test_outbound_lot_candidates_returns_seeded_positive_supplier_lot(
     assert data["candidates"], "seeded positive supplier lot should be returned"
 
     matched = next(
-        (row for row in data["candidates"] if row["lot_code"] == batch_code),
+        (row for row in data["candidates"] if row["lot_code"] == lot_code),
         None,
     )
     assert matched is not None, data

--- a/tests/utils/ensure_minimal.py
+++ b/tests/utils/ensure_minimal.py
@@ -295,21 +295,42 @@ async def set_stock_qty(session: AsyncSession, *, item_id: int, warehouse_id: in
     )
 
 
-# ---------- legacy-named helpers (kept for compatibility) ----------
-async def ensure_batch(session: AsyncSession, *, item_id: int, warehouse_id: int, batch_code: str) -> None:
-    _ = await ensure_supplier_lot(session, item_id=int(item_id), warehouse_id=int(warehouse_id), lot_code=str(batch_code))
-
-
-async def ensure_batch_with_stock(
+# ---------- lot-code-named test helpers ----------
+async def ensure_supplier_lot_with_stock(
     session: AsyncSession,
     *,
     item_id: int,
     warehouse_id: int,
-    batch_code: str,
+    lot_code: str,
     qty: int,
 ) -> None:
+    """
+    Test helper: create a SUPPLIER lot by display lot_code and set its stocks_lot qty.
+
+    lot_code is display/input text only; stock identity remains lot_id.
+    """
+    code_raw = str(lot_code).strip()
+    if not code_raw:
+        raise ValueError("lot_code empty")
+
     await ensure_item(session, id=int(item_id))
     await ensure_warehouse(session, id=int(warehouse_id))
-    await ensure_batch(session, item_id=int(item_id), warehouse_id=int(warehouse_id), batch_code=str(batch_code))
-    await ensure_stock_slot(session, item_id=int(item_id), warehouse_id=int(warehouse_id), batch_code=str(batch_code))
-    await set_stock_qty(session, item_id=int(item_id), warehouse_id=int(warehouse_id), batch_code=str(batch_code), qty=int(qty))
+    _ = await ensure_supplier_lot(
+        session,
+        item_id=int(item_id),
+        warehouse_id=int(warehouse_id),
+        lot_code=code_raw,
+    )
+    await ensure_stock_slot(
+        session,
+        item_id=int(item_id),
+        warehouse_id=int(warehouse_id),
+        batch_code=code_raw,
+    )
+    await set_stock_qty(
+        session,
+        item_id=int(item_id),
+        warehouse_id=int(warehouse_id),
+        batch_code=code_raw,
+        qty=int(qty),
+    )


### PR DESCRIPTION
## Summary

- retire legacy-named test helpers `ensure_batch` and `ensure_batch_with_stock`
- introduce `ensure_supplier_lot_with_stock` to express the actual test helper semantics
- update outbound lot candidates test to use lot_code naming
- keep `set_stock_qty(batch_code=...)` unchanged for now because it is a broad central helper

## Verification

- python3 -m compileall tests/utils/ensure_minimal.py tests/api/test_outbound_lot_candidates_api.py
- make test TESTS="tests/api/test_outbound_lot_candidates_api.py tests/api/test_order_outbound_submit_api.py tests/api/test_manual_outbound_submit_api.py"
- rg ensure_batch/ensure_batch_with_stock
