### PR TITLE
refactor(wms): use lot code in readonly display surfaces

### DIFF
--- a/app/analytics/contracts/metrics_outbound_v2.py
+++ b/app/analytics/contracts/metrics_outbound_v2.py
@@ -28,7 +28,7 @@ class OutboundMetricsV2(BaseModel):
 
     - expiry_pick_hit_rate
         “临期优先”贴合度（%）：
-        仅用于风险分析口径：对比拣货实际 batch_code 与“当前仍有库存的最早到期 lot_code”。
+        仅用于风险分析口径：对比拣货实际 lot_code 与“当前仍有库存的最早到期 lot_code”。
 
     - distribution      当天按小时的出库分布（orders + pick_qty）
     """

--- a/app/wms/analysis/services/multi_reconcile_service.py
+++ b/app/wms/analysis/services/multi_reconcile_service.py
@@ -16,7 +16,7 @@ class MultiReconcileService:
     Phase 3 终态（lot-only）：
     - three_books_compare：stocks 侧为 stocks_lot（lot-world）
     - 对齐维度： (warehouse_id, item_id, lot_id)
-    - batch_code 仅为展示值：lots.lot_code
+    - lot_code 仅为展示值：lots.lot_code
     """
 
     @staticmethod
@@ -31,7 +31,7 @@ class MultiReconcileService:
                 l.warehouse_id,
                 l.item_id,
                 l.lot_id,
-                lo.lot_code AS batch_code,
+                lo.lot_code AS lot_code,
                 SUM(l.delta) AS qty
             FROM stock_ledger l
             JOIN lots lo ON lo.id = l.lot_id
@@ -130,7 +130,7 @@ class MultiReconcileService:
                 x.warehouse_id,
                 x.item_id,
                 x.lot_id,
-                x.batch_code,
+                x.lot_code,
                 x.ledger_qty,
                 COALESCE(st.qty, 0) AS stock_qty,
                 COALESCE(sn.qty, 0) AS snapshot_qty,
@@ -141,7 +141,7 @@ class MultiReconcileService:
                     l.warehouse_id,
                     l.item_id,
                     l.lot_id,
-                    lo.lot_code AS batch_code,
+                    lo.lot_code AS lot_code,
                     SUM(l.delta) AS ledger_qty
                 FROM stock_ledger l
                 JOIN lots lo

--- a/app/wms/shared/services/batch_ageing_service.py
+++ b/app/wms/shared/services/batch_ageing_service.py
@@ -30,7 +30,7 @@ class BatchAgeingService:
             SELECT
                 s.warehouse_id,
                 s.item_id,
-                lo.lot_code AS batch_code,
+                lo.lot_code AS lot_code,
                 lo.expiry_date,
                 COALESCE(SUM(s.qty), 0) AS qty
             FROM stocks_lot s
@@ -57,7 +57,7 @@ class BatchAgeingService:
                     {
                         "warehouse_id": int(r["warehouse_id"]),
                         "item_id": int(r["item_id"]),
-                        "batch_code": r["batch_code"],
+                        "lot_code": r["lot_code"],
                         "expiry_date": str(exp),
                         "days_left": int(days_left),
                         "risk_level": "HIGH" if days_left <= 7 else "MEDIUM" if days_left <= 14 else "LOW",

--- a/app/wms/shared/services/expiry_analytics_allocator.py
+++ b/app/wms/shared/services/expiry_analytics_allocator.py
@@ -20,12 +20,12 @@ class Allocation(TypedDict):
 
     语义：
     - stock_id   : lot_id
-    - batch_code : lots.lot_code（展示用）
+    - lot_code   : lots.lot_code（展示用）
     - expiry_date: lots.expiry_date（canonical）
     """
 
     stock_id: int
-    batch_code: Optional[str]
+    lot_code: Optional[str]
     take_qty: int
     expiry_date: Optional[date]
 
@@ -66,7 +66,7 @@ class ExpiryAnalyticsAllocator:
             plan.append(
                 Allocation(
                     stock_id=int(r["stock_id"]),
-                    batch_code=r.get("batch_code"),
+                    lot_code=r.get("lot_code"),
                     take_qty=take_int,
                     expiry_date=r.get("expiry_date"),
                 )
@@ -88,7 +88,7 @@ class ExpiryAnalyticsAllocator:
         sql = """
             SELECT
                 s.lot_id AS stock_id,
-                l.lot_code AS batch_code,
+                l.lot_code AS lot_code,
                 GREATEST(COALESCE(s.qty, 0), 0) AS avail,
                 l.expiry_date AS expiry_date
             FROM   stocks_lot s

--- a/app/wms/snapshot/services/snapshot_v3_service.py
+++ b/app/wms/snapshot/services/snapshot_v3_service.py
@@ -15,7 +15,7 @@ class SnapshotV3Service:
     Phase 3 终态（lot-only）：
     - 快照 grain： (snapshot_date, warehouse_id, item_id, lot_id)
     - 台账聚合维度： (warehouse_id, item_id, lot_id)
-    - batch_code 仅为展示码（lots.lot_code），不参与任何维度事实/聚合键
+    - lot_code 仅为展示码（lots.lot_code），不参与任何维度事实/聚合键
     """
 
     @staticmethod
@@ -29,7 +29,7 @@ class SnapshotV3Service:
 
         注意：
         - 维度事实为 lot_id
-        - batch_code 仅为展示：lots.lot_code（可能为 NULL）
+        - lot_code 仅为展示：lots.lot_code（可能为 NULL）
         """
         await session.execute(text("DROP TABLE IF EXISTS snapshot_cut_result"))
         await session.execute(
@@ -40,7 +40,7 @@ class SnapshotV3Service:
                   l.warehouse_id,
                   l.item_id,
                   l.lot_id,
-                  lo.lot_code AS batch_code,
+                  lo.lot_code AS lot_code,
                   SUM(l.delta) AS qty
                 FROM stock_ledger l
                 JOIN lots lo ON lo.id = l.lot_id
@@ -155,7 +155,7 @@ class SnapshotV3Service:
                 l.warehouse_id,
                 l.item_id,
                 l.lot_id,
-                lo.lot_code AS batch_code,
+                lo.lot_code AS lot_code,
                 SUM(l.delta) AS ledger_qty
             FROM stock_ledger l
             JOIN lots lo ON lo.id = l.lot_id
@@ -175,7 +175,7 @@ class SnapshotV3Service:
             x.warehouse_id,
             x.item_id,
             x.lot_id,
-            x.batch_code,
+            x.lot_code,
             x.ledger_qty,
             COALESCE(sn.qty, 0) AS snapshot_qty,
             COALESCE(la.qty, 0) AS stocks_lot_qty,

--- a/tests/unit/test_fefo_query_v2.py
+++ b/tests/unit/test_fefo_query_v2.py
@@ -103,5 +103,5 @@ async def test_expiry_analytics_query_returns_sorted_not_enforcing(session: Asyn
     plan = await alloc.allocate(session, item_id=3003, need_qty=2, warehouse_id=1)
 
     assert len(plan) >= 1
-    assert plan[0]["batch_code"] == "A_NEAR"
+    assert plan[0]["lot_code"] == "A_NEAR"
     assert int(plan[0]["take_qty"]) == 2


### PR DESCRIPTION
## Summary

- rename read-only WMS analysis/snapshot display projections from `batch_code` to `lot_code`
- keep structural identity anchored by `lot_id`
- update expiry analytics allocator output and FEFO test assertion
- do not touch procurement/PMS public contracts or core stock write parameters in this PR

## Verification

- python3 -m compileall app/wms/analysis/services/multi_reconcile_service.py app/wms/snapshot/services/snapshot_v3_service.py app/wms/shared/services/batch_ageing_service.py app/wms/shared/services/expiry_analytics_allocator.py app/analytics/contracts/metrics_outbound_v2.py tests/unit/test_fefo_query_v2.py
- make test TESTS="tests/unit/test_fefo_query_v2.py"
- rg retired read-only batch_code projection patterns
