### PR TITLE
refactor(procurement): expose receipt event lot code

### DIFF
--- a/app/procurement/contracts/purchase_order_receipts.py
+++ b/app/procurement/contracts/purchase_order_receipts.py
@@ -23,7 +23,7 @@ class PurchaseOrderReceiptEventOut(BaseModel):
     item_id: int = Field(..., gt=0, description="商品 ID")
     line_no: Optional[int] = Field(None, description="采购单行号（若可映射）")
 
-    batch_code: str = Field(..., description="批次号（展示码）")
+    lot_code: Optional[str] = Field(None, description="批次展示码，来自 lots.lot_code")
     qty: int = Field(..., description="本次收货数量（delta）")
     after_qty: int = Field(..., description="收货后库存余额（after_qty）")
 

--- a/app/procurement/services/purchase_order_receipts.py
+++ b/app/procurement/services/purchase_order_receipts.py
@@ -67,7 +67,7 @@ async def list_po_receipt_events(session: AsyncSession, po_id: int) -> List[Purc
 
     ⚠️ 重要：避免 join 放大导致同一 ledger 行重复（ref_line 重复）。
     做法：先把 inbound_receipt_lines 按 (receipt_id,item_id,lot_id) 聚合成唯一映射。
-    batch_code 仅展示字段，不参与 identity。
+    lot_code 仅展示字段，不参与 identity。
     """
     po = await _load_po_exists(session, po_id)
     if po is None:
@@ -97,7 +97,7 @@ async def list_po_receipt_events(session: AsyncSession, po_id: int) -> List[Purc
               sl.ref_line,
               sl.warehouse_id,
               sl.item_id,
-              COALESCE(lo.lot_code, '') AS batch_code,
+              lo.lot_code AS lot_code,
               sl.delta,
               sl.after_qty,
               sl.occurred_at,
@@ -144,7 +144,7 @@ async def list_po_receipt_events(session: AsyncSession, po_id: int) -> List[Purc
                 warehouse_id=int(r["warehouse_id"]),
                 item_id=item_id,
                 line_no=int(po_line_no) if po_line_no is not None else None,
-                batch_code=r.get("batch_code"),
+                lot_code=r.get("lot_code"),
                 qty=int(r["delta"]),
                 after_qty=int(r["after_qty"]),
                 occurred_at=r["occurred_at"],


### PR DESCRIPTION
## Summary

- rename procurement purchase order receipt event display field from `batch_code` to `lot_code`
- keep structural identity unchanged: receipt/ledger facts remain anchored by `lot_id`
- align backend read model with existing frontend usage of `lot_code`
- regenerate OpenAPI

## Verification

- make openapi
- python3 -m compileall app/procurement/contracts/purchase_order_receipts.py app/procurement/services/purchase_order_receipts.py
- make test TESTS="tests/api/test_inbound_receipts_manual_api.py tests/api/test_wms_receiving_batch_no_lot_code_contract_api.py"
