### PR TITLE
refactor(pms): retire default batch code output

### DIFF
--- a/app/pms/items/contracts/item.py
+++ b/app/pms/items/contracts/item.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Annotated, Literal, Optional
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -177,7 +177,6 @@ class ItemOut(ItemBase):
 
     requires_batch: bool = True
     requires_dates: bool = True
-    default_batch_code: Optional[str] = None
 
     is_test: bool = False
 

--- a/app/pms/items/services/item_presenter.py
+++ b/app/pms/items/services/item_presenter.py
@@ -16,7 +16,7 @@ class ItemPresenter:
     输出投影层（Presentation / Projection）：
 
     - 负责把“裸 Item ORM”变成“对外契约 Item”：
-      * decorate_rules（requires_batch / default_batch_code 等规则投影）
+      * decorate_rules（requires_batch / requires_dates 等规则投影）
       * is_test（DEFAULT test set membership）
       * primary_barcode（主条码真相）
     - 不负责 CRUD / 事务

--- a/app/pms/items/services/item_rules.py
+++ b/app/pms/items/services/item_rules.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 
 from app.pms.items.models.item import Item
 
-NOEXP_BATCH_CODE = "NOEXP"
-
-
 def _is_required_expiry_policy(v: object) -> bool:
     return str(v or "").strip().upper() == "REQUIRED"
 
@@ -13,7 +10,7 @@ def _is_required_expiry_policy(v: object) -> bool:
 def decorate_rules(obj: Item) -> Item:
     """
     给 Item 注入一些“运行时派生规则”（不落库）：
-    - requires_batch / requires_dates / default_batch_code
+    - requires_batch / requires_dates
 
     Phase M 第一阶段：
     - 真相源：expiry_policy
@@ -22,6 +19,4 @@ def decorate_rules(obj: Item) -> Item:
     requires_batch = _is_required_expiry_policy(getattr(obj, "expiry_policy", None))
     setattr(obj, "requires_batch", True if requires_batch else False)
     setattr(obj, "requires_dates", True if requires_batch else False)
-    # ✅ NONE：历史兼容默认 NOEXP（仅用于展示/旧调用），不作为写入语义
-    setattr(obj, "default_batch_code", None if requires_batch else NOEXP_BATCH_CODE)
     return obj

--- a/openapi/_current.json
+++ b/openapi/_current.json
@@ -26752,17 +26752,6 @@
             "title": "Requires Dates",
             "default": true
           },
-          "default_batch_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Default Batch Code"
-          },
           "is_test": {
             "type": "boolean",
             "title": "Is Test",

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -26752,17 +26752,6 @@
             "title": "Requires Dates",
             "default": true
           },
-          "default_batch_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Default Batch Code"
-          },
           "is_test": {
             "type": "boolean",
             "title": "Is Test",


### PR DESCRIPTION
## Summary

- retire PMS owner item output field `default_batch_code`
- remove legacy `NOEXP` default batch projection from item rule decoration
- keep `requires_batch` and `requires_dates` unchanged
- regenerate OpenAPI

## Verification

- make openapi
- python3 -m compileall app/pms/items/contracts/item.py app/pms/items/services/item_rules.py app/pms/items/services/item_presenter.py
- make test TESTS="tests/api/test_items_main_contract_api.py tests/api/test_item_owner_aggregate_api.py tests/services/test_pms_public_item_read_service.py"
- rg default_batch_code/NOEXP_BATCH_CODE
