### PR TITLE
chore(tests): rename inventory lot helpers

### DIFF
--- a/tests/api/test_stock_inventory_read_api.py
+++ b/tests/api/test_stock_inventory_read_api.py
@@ -6,7 +6,7 @@ from httpx import AsyncClient
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from tests.helpers.inventory import ensure_wh_loc_item, seed_batch_slot
+from tests.helpers.inventory import ensure_wh_loc_item, seed_supplier_lot_slot
 
 
 async def _login_admin_headers(client: AsyncClient) -> dict[str, str]:
@@ -105,11 +105,11 @@ async def test_stock_inventory_detail_returns_totals_and_slices(
         {"i": int(item_id)},
     )
 
-    await seed_batch_slot(
+    await seed_supplier_lot_slot(
         session,
         item=item_id,
         loc=warehouse_id,
-        code=lot_code,
+        lot_code=lot_code,
         qty=7,
         days=180,
     )

--- a/tests/api/test_stock_ledger_lot_code_alias_api.py
+++ b/tests/api/test_stock_ledger_lot_code_alias_api.py
@@ -7,7 +7,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from tests.helpers.inventory import ensure_wh_loc_item, seed_batch_slot
+from tests.helpers.inventory import ensure_wh_loc_item, seed_supplier_lot_slot
 
 
 async def _login_admin_headers(client: AsyncClient) -> dict[str, str]:
@@ -71,11 +71,11 @@ async def test_stock_ledger_query_accepts_lot_code_only(
         loc=warehouse_id,
         item=item_id,
     )
-    await seed_batch_slot(
+    await seed_supplier_lot_slot(
         session,
         item=item_id,
         loc=warehouse_id,
-        code=lot_code,
+        lot_code=lot_code,
         qty=11,
         days=180,
     )

--- a/tests/ci/test_db_invariants_helpers.py
+++ b/tests/ci/test_db_invariants_helpers.py
@@ -21,7 +21,7 @@ import pytest
 from sqlalchemy import text as SA
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from tests.helpers.inventory import ensure_wh_loc_item, seed_batch_slot, sum_on_hand
+from tests.helpers.inventory import ensure_wh_loc_item, seed_supplier_lot_slot, sum_on_hand
 
 pytestmark = pytest.mark.contract
 
@@ -37,9 +37,9 @@ async def test_lots_unique_supplier_4d(session: AsyncSession):
     wh, loc, item, code = 1, 1, 99001, "UNI-99001"
     await ensure_wh_loc_item(session, wh=wh, loc=loc, item=item)
 
-    # 复用 seed_batch_slot：内部会写 lots + stocks_lot（Phase 4E+：不触碰 legacy batches/stocks）
-    await seed_batch_slot(session, item=item, loc=loc, code=code, qty=3, days=365)
-    await seed_batch_slot(session, item=item, loc=loc, code=code, qty=3, days=365)
+    # 复用 seed_supplier_lot_slot：内部会写 lots + stocks_lot（Phase 4E+：不触碰 legacy batches/stocks）
+    await seed_supplier_lot_slot(session, item=item, loc=loc, lot_code=code, qty=3, days=365)
+    await seed_supplier_lot_slot(session, item=item, loc=loc, lot_code=code, qty=3, days=365)
     await session.commit()
 
     # lots(SUPPLIER) 中应只有一条记录
@@ -87,8 +87,8 @@ async def test_sum_on_hand_consistency(session: AsyncSession):
     wh, loc, item = 1, 1, 99002
     await ensure_wh_loc_item(session, wh=wh, loc=loc, item=item)
 
-    await seed_batch_slot(session, item=item, loc=loc, code="Q-99002-A", qty=4, days=365)
-    await seed_batch_slot(session, item=item, loc=loc, code="Q-99002-B", qty=6, days=365)
+    await seed_supplier_lot_slot(session, item=item, loc=loc, lot_code="Q-99002-A", qty=4, days=365)
+    await seed_supplier_lot_slot(session, item=item, loc=loc, lot_code="Q-99002-B", qty=6, days=365)
     await session.commit()
 
     assert await sum_on_hand(session, item=item, loc=loc) == 10
@@ -104,7 +104,7 @@ async def test_stocks_lot_fk_minimal(session: AsyncSession):
     """
     wh, loc, item = 1, 1, 99003
     await ensure_wh_loc_item(session, wh=wh, loc=loc, item=item)
-    await seed_batch_slot(session, item=item, loc=loc, code="FK-CHK", qty=1, days=365)
+    await seed_supplier_lot_slot(session, item=item, loc=loc, lot_code="FK-CHK", qty=1, days=365)
     await session.commit()
 
     row = await session.execute(

--- a/tests/fixtures/base_seed.sql
+++ b/tests/fixtures/base_seed.sql
@@ -14,7 +14,7 @@
 -- 库存/lot 事实必须在 tests 中显式通过统一入口构造：
 --   - ensure_lot_full / ensure_internal_lot_singleton
 --   - adjust_lot_impl / lot-only stock write primitives
---   - tests/helpers/inventory.py: seed_batch_slot 等
+--   - tests/helpers/inventory.py: seed_supplier_lot_slot 等
 --
 -- Pricing Phase-3：
 -- - template 生命周期改为 draft / archived

--- a/tests/helpers/inventory.py
+++ b/tests/helpers/inventory.py
@@ -19,9 +19,9 @@ __all__ = [
     "_has_table",
     "_columns_of",
     "ensure_wh_loc_item",
-    "seed_batch_slot",
+    "seed_supplier_lot_slot",
     "seed_many",
-    "qty_by_code",
+    "qty_by_lot_code",
     "sum_on_hand",
     "available",
     "insert_snapshot",
@@ -135,12 +135,12 @@ async def _get_stock_qty(session: AsyncSession, *, item: int, wh: int, lot_id: i
     return int(v) if v is not None else 0
 
 
-async def seed_batch_slot(
+async def seed_supplier_lot_slot(
     session: AsyncSession,
     *,
     item: int,
     loc: int,
-    code: str,
+    lot_code: str,
     qty: int,
     days: int = 365,
 ) -> None:
@@ -153,11 +153,11 @@ async def seed_batch_slot(
       （等价于旧实现的 ON CONFLICT DO UPDATE SET qty）
 
     关键：日期合同必须认真对待
-    - seed_batch_slot 的语义就是“造一个 SUPPLIER batch slot”，因此商品必须走 REQUIRED
+    - seed_supplier_lot_slot 的语义就是“造一个 SUPPLIER lot slot”，因此商品必须走 REQUIRED
     - REQUIRED 且发生入库（delta>0）时，必须提供 production/expiry 事实
     """
     wh = _wh_from_loc(loc)
-    code_raw = str(code).strip()
+    code_raw = str(lot_code).strip()
     if not code_raw:
         raise ValueError("code empty")
 
@@ -204,7 +204,7 @@ async def seed_batch_slot(
     if expiry_policy == "REQUIRED" and int(delta) > 0 and expiry_date is None:
         production_date, expiry_date = _stable_required_dates_from_code(code_raw, days=int(days))
 
-    ref = f"ut:seed_batch_slot:set:{int(wh)}:{int(item)}:{code_raw}:{int(target)}"
+    ref = f"ut:seed_supplier_lot_slot:set:{int(wh)}:{int(item)}:{code_raw}:{int(target)}"
 
     await adjust_lot_impl(
         session=session,
@@ -227,7 +227,7 @@ async def seed_batch_slot(
 
 async def seed_many(session: AsyncSession, entries: Iterable[Tuple[int, int, str, int, int]]) -> None:
     for item, loc, code, qty, days in entries:
-        await seed_batch_slot(session, item=item, loc=loc, code=code, qty=qty, days=days)
+        await seed_supplier_lot_slot(session, item=item, loc=loc, lot_lot_code=code, qty=qty, days=days)
 
 
 async def sum_on_hand(session: AsyncSession, *, item: int, loc: int) -> int:
@@ -243,7 +243,7 @@ async def available(session: AsyncSession, *, item: int, loc: int) -> int:
     return await sum_on_hand(session, item=item, loc=loc)
 
 
-async def qty_by_code(session: AsyncSession, *, item: int, loc: int, code: str) -> int:
+async def qty_by_lot_code(session: AsyncSession, *, item: int, loc: int, lot_code: str) -> int:
     wh = _wh_from_loc(loc)
     row = await session.execute(
         SA(
@@ -256,7 +256,7 @@ async def qty_by_code(session: AsyncSession, *, item: int, loc: int, code: str) 
                AND lo.lot_code = :code
             """
         ),
-        {"i": int(item), "w": int(wh), "code": str(code)},
+        {"i": int(item), "w": int(wh), "code": str(lot_code)},
     )
     return int(row.scalar_one() or 0)
 

--- a/tests/services/test_inbound_service.py
+++ b/tests/services/test_inbound_service.py
@@ -6,7 +6,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 # 测试辅助：按项目实际路径导入
-from tests.helpers.inventory import ensure_wh_loc_item, qty_by_code
+from tests.helpers.inventory import ensure_wh_loc_item, qty_by_lot_code
 
 from app.wms.shared.enums import MovementType
 from app.wms.stock.services.lots import ensure_lot_full
@@ -27,7 +27,7 @@ async def test_inbound_creates_batch_and_increases_stock(session: AsyncSession):
     - 库存真相在 stocks_lot（lot-world），因此本用例改为：
       * 先创建 SUPPLIER lot（lot_code=code）
       * 再用 StockService.adjust_lot 入库（写 stocks_lot + ledger(lot_id)）
-      * 最终用 qty_by_code（lot-world 口径）断言 qty=6
+      * 最终用 qty_by_lot_code（lot-world 口径）断言 qty=6
 
     当前终态：
     - REQUIRED lot 身份 = (warehouse_id, item_id, production_date)
@@ -75,4 +75,4 @@ async def test_inbound_creates_batch_and_increases_stock(session: AsyncSession):
         )
 
     await session.commit()
-    assert await qty_by_code(session, item=item, loc=loc, code=code) == 6
+    assert await qty_by_lot_code(session, item=item, loc=loc, lot_code=code) == 6


### PR DESCRIPTION
## Summary

- rename `seed_batch_slot` test helper to `seed_supplier_lot_slot`
- rename `qty_by_code` test helper to `qty_by_lot_code`
- update selected call sites to use `lot_code=`
- keep production stock write parameters unchanged

## Verification

- python3 -m compileall tests/helpers/inventory.py tests/services/test_inbound_service.py tests/ci/test_db_invariants_helpers.py tests/api/test_stock_inventory_read_api.py tests/api/test_stock_ledger_lot_code_alias_api.py
- make test TESTS="tests/services/test_inbound_service.py tests/ci/test_db_invariants_helpers.py tests/api/test_stock_inventory_read_api.py tests/api/test_stock_ledger_lot_code_alias_api.py"
- rg seed_batch_slot/qty_by_code
