### PR TITLE
fix(tests): correct seed many lot code keyword

### DIFF
--- a/tests/helpers/inventory.py
+++ b/tests/helpers/inventory.py
@@ -227,7 +227,7 @@ async def seed_supplier_lot_slot(
 
 async def seed_many(session: AsyncSession, entries: Iterable[Tuple[int, int, str, int, int]]) -> None:
     for item, loc, code, qty, days in entries:
-        await seed_supplier_lot_slot(session, item=item, loc=loc, lot_lot_code=code, qty=qty, days=days)
+        await seed_supplier_lot_slot(session, item=item, loc=loc, lot_code=code, qty=qty, days=days)
 
 
 async def sum_on_hand(session: AsyncSession, *, item: int, loc: int) -> int:


### PR DESCRIPTION
## Summary

- fix `seed_many` call to use `lot_code=`
- remove accidental `lot_lot_code=` typo from inventory test helper

## Verification

- python3 -m compileall tests/helpers/inventory.py
- make test TESTS="tests/ci/test_db_invariants_helpers.py tests/api/test_stock_inventory_read_api.py tests/api/test_stock_ledger_lot_code_alias_api.py"
- rg lot_lot_code/retired helper names
