### PR TITLE
refactor(stock): retire ensure batch full wrapper

### DIFF
--- a/app/wms/stock/services/lots.py
+++ b/app/wms/stock/services/lots.py
@@ -518,28 +518,8 @@ async def ensure_lot_full(
     raise ValueError("supplier_lot_not_allowed_for_nonrequired_item")
 
 
-async def ensure_batch_full(
-    session: AsyncSession,
-    *,
-    item_id: int,
-    warehouse_id: int,
-    batch_code: str,
-    production_date,
-    expiry_date,
-) -> int:
-    return await ensure_lot_full(
-        session,
-        item_id=item_id,
-        warehouse_id=warehouse_id,
-        lot_code=batch_code,
-        production_date=production_date,
-        expiry_date=expiry_date,
-    )
-
-
 __all__ = [
     "normalize_lot_code",
     "ensure_internal_lot_singleton",
     "ensure_lot_full",
-    "ensure_batch_full",
 ]


### PR DESCRIPTION
## Summary

- remove unused `ensure_batch_full` wrapper from stock lot service
- keep `ensure_lot_full` as the single supplier lot materialization helper
- remove the last runtime `batch_code -> lot_code` wrapper in lots.py

## Verification

- python3 -m compileall app/wms/stock/services/lots.py
- make test TESTS="tests/unit/test_stock_service_v2.py tests/services/test_stock_adjust_trace_id.py tests/ci/test_db_invariants.py tests/unit/test_fefo_query_v2.py"
- rg ensure_batch_full/batch_code wrapper references
