### PR TITLE
refactor(tms): rebuild shipping assist page tree

### DIFF
--- a/alembic/versions/2a8be0e16db9_tms_shipping_assist_level3_page_tree.py
+++ b/alembic/versions/2a8be0e16db9_tms_shipping_assist_level3_page_tree.py
@@ -1,0 +1,275 @@
+"""tms shipping assist level3 page tree
+
+Revision ID: 2a8be0e16db9
+Revises: 1f23051286cd
+Create Date: 2026-04-25 17:53:32.353550
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "2a8be0e16db9"
+down_revision: Union[str, Sequence[str], None] = "1f23051286cd"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+
+    # 1) 一级模块：技术 code 仍保留 tms，产品名称改为“发货辅助”。
+    # 本刀只治理导航 truth，不同步改 app/tms 目录、不改接口 URL、不引入新权限名。
+    op.execute(
+        """
+        UPDATE page_registry
+           SET name = '发货辅助',
+               parent_code = NULL,
+               level = 1,
+               domain_code = 'tms',
+               show_in_topbar = TRUE,
+               show_in_sidebar = FALSE,
+               inherit_permissions = FALSE,
+               read_permission_id = (SELECT id FROM permissions WHERE name = 'page.tms.read'),
+               write_permission_id = (SELECT id FROM permissions WHERE name = 'page.tms.write'),
+               sort_order = 40,
+               is_active = TRUE
+         WHERE code = 'tms'
+        """
+    )
+
+    # 2) 建立“发货辅助系统”三级页面树。
+    op.execute(
+        """
+        INSERT INTO page_registry (
+          code,
+          name,
+          parent_code,
+          level,
+          domain_code,
+          show_in_topbar,
+          show_in_sidebar,
+          inherit_permissions,
+          read_permission_id,
+          write_permission_id,
+          sort_order,
+          is_active
+        )
+        VALUES
+          ('tms.shipping', '发货', 'tms', 2, 'tms', FALSE, TRUE, TRUE, NULL, NULL, 10, TRUE),
+          ('tms.shipping.quote', '发货算价', 'tms.shipping', 3, 'tms', FALSE, TRUE, TRUE, NULL, NULL, 10, TRUE),
+          ('tms.shipping.records', '发货记录', 'tms.shipping', 3, 'tms', FALSE, TRUE, TRUE, NULL, NULL, 20, TRUE),
+
+          ('tms.pricing', '运价', 'tms', 2, 'tms', FALSE, TRUE, TRUE, NULL, NULL, 20, TRUE),
+          ('tms.pricing.providers', '快递网点', 'tms.pricing', 3, 'tms', FALSE, TRUE, TRUE, NULL, NULL, 10, TRUE),
+          ('tms.pricing.bindings', '运价管理', 'tms.pricing', 3, 'tms', FALSE, TRUE, TRUE, NULL, NULL, 20, TRUE),
+          ('tms.pricing.templates', '运价表', 'tms.pricing', 3, 'tms', FALSE, TRUE, TRUE, NULL, NULL, 30, TRUE),
+
+          ('tms.billing', '对账', 'tms', 2, 'tms', FALSE, TRUE, TRUE, NULL, NULL, 30, TRUE),
+          ('tms.billing.items', '快递账单', 'tms.billing', 3, 'tms', FALSE, TRUE, TRUE, NULL, NULL, 10, TRUE),
+          ('tms.billing.reconciliation', '物流对账', 'tms.billing', 3, 'tms', FALSE, TRUE, TRUE, NULL, NULL, 20, TRUE),
+
+          ('tms.settings', '设置', 'tms', 2, 'tms', FALSE, TRUE, TRUE, NULL, NULL, 40, TRUE),
+          ('tms.settings.waybill', '电子面单配置', 'tms.settings', 3, 'tms', FALSE, TRUE, TRUE, NULL, NULL, 10, TRUE)
+        ON CONFLICT (code) DO UPDATE
+        SET
+          name = EXCLUDED.name,
+          parent_code = EXCLUDED.parent_code,
+          level = EXCLUDED.level,
+          domain_code = EXCLUDED.domain_code,
+          show_in_topbar = EXCLUDED.show_in_topbar,
+          show_in_sidebar = EXCLUDED.show_in_sidebar,
+          inherit_permissions = EXCLUDED.inherit_permissions,
+          read_permission_id = EXCLUDED.read_permission_id,
+          write_permission_id = EXCLUDED.write_permission_id,
+          sort_order = EXCLUDED.sort_order,
+          is_active = EXCLUDED.is_active
+        """
+    )
+
+    # 3) 现有 URL 不改，只把 route_prefix 重新绑定到新三级 page_code。
+    op.execute(
+        """
+        INSERT INTO page_route_prefixes (
+          route_prefix,
+          page_code,
+          sort_order,
+          is_active
+        )
+        VALUES
+          ('/tms/shipment-prepare', 'tms.shipping.quote', 10, TRUE),
+          ('/tms/dispatch', 'tms.shipping.quote', 20, TRUE),
+          ('/tms/records', 'tms.shipping.records', 30, TRUE),
+
+          ('/tms/providers', 'tms.pricing.providers', 40, TRUE),
+          ('/tms/pricing', 'tms.pricing.bindings', 50, TRUE),
+          ('/tms/templates', 'tms.pricing.templates', 60, TRUE),
+
+          ('/tms/billing/items', 'tms.billing.items', 70, TRUE),
+          ('/tms/reconciliation', 'tms.billing.reconciliation', 80, TRUE),
+
+          ('/tms/waybill-configs', 'tms.settings.waybill', 90, TRUE)
+        ON CONFLICT (route_prefix) DO UPDATE
+        SET
+          page_code = EXCLUDED.page_code,
+          sort_order = EXCLUDED.sort_order,
+          is_active = EXCLUDED.is_active
+        """
+    )
+
+    # 4) /tms/reports 暂不作为“发货辅助”主链路页面暴露。
+    # 后续如果要保留，应单独设计为“成本报表”，再挂到对账/分析分支。
+    op.execute(
+        """
+        DELETE FROM page_route_prefixes
+         WHERE route_prefix = '/tms/reports'
+        """
+    )
+
+    # 5) 删除旧 wms.logistics.* 页面壳。
+    # route_prefix 已经先改绑，因此这里不会删除现役 /tms 页面映射。
+    op.execute(
+        """
+        DELETE FROM page_registry
+         WHERE code IN (
+           'wms.logistics.shipment_prepare',
+           'wms.logistics.dispatch',
+           'wms.logistics.providers',
+           'wms.logistics.waybill_configs',
+           'wms.logistics.pricing',
+           'wms.logistics.templates',
+           'wms.logistics.records',
+           'wms.logistics.billing_items',
+           'wms.logistics.reconciliation',
+           'wms.logistics.reports'
+         )
+        """
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+
+    # 1) 恢复旧一级模块名称。
+    op.execute(
+        """
+        UPDATE page_registry
+           SET name = '物流',
+               parent_code = NULL,
+               level = 1,
+               domain_code = 'tms',
+               show_in_topbar = TRUE,
+               show_in_sidebar = FALSE,
+               inherit_permissions = FALSE,
+               read_permission_id = (SELECT id FROM permissions WHERE name = 'page.tms.read'),
+               write_permission_id = (SELECT id FROM permissions WHERE name = 'page.tms.write'),
+               sort_order = 40,
+               is_active = TRUE
+         WHERE code = 'tms'
+        """
+    )
+
+    # 2) 恢复旧 wms.logistics.* 二级页面。
+    op.execute(
+        """
+        INSERT INTO page_registry (
+          code,
+          name,
+          parent_code,
+          level,
+          domain_code,
+          show_in_topbar,
+          show_in_sidebar,
+          inherit_permissions,
+          read_permission_id,
+          write_permission_id,
+          sort_order,
+          is_active
+        )
+        VALUES
+          ('wms.logistics.shipment_prepare', '发运准备', 'tms', 2, 'tms', FALSE, TRUE, TRUE, NULL, NULL, 10, TRUE),
+          ('wms.logistics.dispatch', '发货作业', 'tms', 2, 'tms', FALSE, TRUE, TRUE, NULL, NULL, 20, TRUE),
+          ('wms.logistics.providers', '承运商配置', 'tms', 2, 'tms', FALSE, TRUE, TRUE, NULL, NULL, 30, TRUE),
+          ('wms.logistics.waybill_configs', '电子面单配置', 'tms', 2, 'tms', FALSE, TRUE, TRUE, NULL, NULL, 40, TRUE),
+          ('wms.logistics.pricing', '运价管理', 'tms', 2, 'tms', FALSE, TRUE, TRUE, NULL, NULL, 50, TRUE),
+          ('wms.logistics.templates', '运价模板', 'tms', 2, 'tms', FALSE, TRUE, TRUE, NULL, NULL, 60, TRUE),
+          ('wms.logistics.records', '物流记录', 'tms', 2, 'tms', FALSE, TRUE, TRUE, NULL, NULL, 70, TRUE),
+          ('wms.logistics.billing_items', '对账项管理', 'tms', 2, 'tms', FALSE, TRUE, TRUE, NULL, NULL, 80, TRUE),
+          ('wms.logistics.reconciliation', '物流对账', 'tms', 2, 'tms', FALSE, TRUE, TRUE, NULL, NULL, 90, TRUE),
+          ('wms.logistics.reports', '物流报表', 'tms', 2, 'tms', FALSE, TRUE, TRUE, NULL, NULL, 100, TRUE)
+        ON CONFLICT (code) DO UPDATE
+        SET
+          name = EXCLUDED.name,
+          parent_code = EXCLUDED.parent_code,
+          level = EXCLUDED.level,
+          domain_code = EXCLUDED.domain_code,
+          show_in_topbar = EXCLUDED.show_in_topbar,
+          show_in_sidebar = EXCLUDED.show_in_sidebar,
+          inherit_permissions = EXCLUDED.inherit_permissions,
+          read_permission_id = EXCLUDED.read_permission_id,
+          write_permission_id = EXCLUDED.write_permission_id,
+          sort_order = EXCLUDED.sort_order,
+          is_active = EXCLUDED.is_active
+        """
+    )
+
+    # 3) 恢复旧 route_prefix -> wms.logistics.* 映射。
+    op.execute(
+        """
+        INSERT INTO page_route_prefixes (
+          route_prefix,
+          page_code,
+          sort_order,
+          is_active
+        )
+        VALUES
+          ('/tms/shipment-prepare', 'wms.logistics.shipment_prepare', 10, TRUE),
+          ('/tms/dispatch', 'wms.logistics.dispatch', 20, TRUE),
+          ('/tms/providers', 'wms.logistics.providers', 30, TRUE),
+          ('/tms/waybill-configs', 'wms.logistics.waybill_configs', 40, TRUE),
+          ('/tms/pricing', 'wms.logistics.pricing', 50, TRUE),
+          ('/tms/templates', 'wms.logistics.templates', 60, TRUE),
+          ('/tms/records', 'wms.logistics.records', 70, TRUE),
+          ('/tms/billing/items', 'wms.logistics.billing_items', 80, TRUE),
+          ('/tms/reconciliation', 'wms.logistics.reconciliation', 90, TRUE),
+          ('/tms/reports', 'wms.logistics.reports', 100, TRUE)
+        ON CONFLICT (route_prefix) DO UPDATE
+        SET
+          page_code = EXCLUDED.page_code,
+          sort_order = EXCLUDED.sort_order,
+          is_active = EXCLUDED.is_active
+        """
+    )
+
+    # 4) 删除新三级树：先删三级，再删二级。
+    op.execute(
+        """
+        DELETE FROM page_registry
+         WHERE code IN (
+           'tms.shipping.quote',
+           'tms.shipping.records',
+           'tms.pricing.providers',
+           'tms.pricing.bindings',
+           'tms.pricing.templates',
+           'tms.billing.items',
+           'tms.billing.reconciliation',
+           'tms.settings.waybill'
+         )
+        """
+    )
+
+    op.execute(
+        """
+        DELETE FROM page_registry
+         WHERE code IN (
+           'tms.shipping',
+           'tms.pricing',
+           'tms.billing',
+           'tms.settings'
+         )
+        """
+    )

--- a/app/user/models/page_route_prefix.py
+++ b/app/user/models/page_route_prefix.py
@@ -15,7 +15,7 @@ class PageRoutePrefix(Base):
 
     当前主线：
     - route_prefix 真相源 = page_route_prefixes
-    - 当前应指向二级页面
+    - route_prefix 应指向具体业务页；三级页面存在时优先指向三级 page_code
     """
 
     __tablename__ = "page_route_prefixes"

--- a/tests/api/test_user_navigation_api.py
+++ b/tests/api/test_user_navigation_api.py
@@ -16,7 +16,7 @@ async def _reset_navigation_registry_state(session: AsyncSession) -> None:
     仅恢复本文件测试会临时修改的导航状态，不破坏静态 seed 真相。
 
     当前主线要求：
-    - tms 下子页在相关测试前恢复为可见
+    - 发货辅助页在相关测试前恢复为可见
     - wms.inventory_adjustment 下子页保持可见
     - wms.inbound 只保留 atomic / purchase / manual 可见
     - wms.inbound.operations / wms.inbound.returns 保持隐藏
@@ -27,7 +27,8 @@ async def _reset_navigation_registry_state(session: AsyncSession) -> None:
             """
             UPDATE page_registry
                SET is_active = TRUE
-             WHERE parent_code = 'tms'
+             WHERE code = 'tms'
+                OR code LIKE 'tms.%'
             """
         )
     )
@@ -69,6 +70,16 @@ async def _reset_navigation_registry_state(session: AsyncSession) -> None:
                'wms.inbound.returns',
                'inbound.returns'
              )
+            """
+        )
+    )
+
+    await session.execute(
+        text(
+            """
+            UPDATE page_route_prefixes
+               SET is_active = FALSE
+             WHERE route_prefix = '/tms/reports'
             """
         )
     )
@@ -260,6 +271,16 @@ async def test_my_navigation_admin_contains_new_wms_tree_and_filters_legacy_shel
     assert "wms.order_outbound" not in nodes
     assert "wms.order_management" not in nodes
     assert "wms.logistics" not in nodes
+    assert "wms.logistics.shipment_prepare" not in nodes
+    assert "wms.logistics.dispatch" not in nodes
+    assert "wms.logistics.providers" not in nodes
+    assert "wms.logistics.waybill_configs" not in nodes
+    assert "wms.logistics.pricing" not in nodes
+    assert "wms.logistics.templates" not in nodes
+    assert "wms.logistics.records" not in nodes
+    assert "wms.logistics.billing_items" not in nodes
+    assert "wms.logistics.reconciliation" not in nodes
+    assert "wms.logistics.reports" not in nodes
     assert "wms.analytics" not in nodes
     assert "wms.masterdata" not in nodes
     assert "wms.internal_ops" not in nodes
@@ -336,7 +357,7 @@ async def test_my_navigation_route_prefix_mapping_and_effective_permissions(clie
     nodes = _walk_pages(data["pages"])
     route_map = _index_route_prefixes(data["route_prefixes"])
 
-    pricing_page = nodes["wms.logistics.pricing"]
+    pricing_page = nodes["tms.pricing.bindings"]
     items_page = nodes["wms.masterdata.items"]
     suppliers_page = nodes["wms.masterdata.suppliers"]
     inventory_page = nodes["wms.inventory.main"]
@@ -375,7 +396,7 @@ async def test_my_navigation_route_prefix_mapping_and_effective_permissions(clie
     assert warehouses_route is not None, "/warehouses should exist in route_prefixes"
     assert inventory_adjustment_route is not None, "/inventory-adjustment should exist in route_prefixes"
 
-    assert pricing_route["page_code"] == "wms.logistics.pricing"
+    assert pricing_route["page_code"] == "tms.pricing.bindings"
     assert items_route["page_code"] == "wms.masterdata.items"
     assert suppliers_route["page_code"] == "wms.masterdata.suppliers"
     assert inventory_route["page_code"] == "wms.inventory.main"
@@ -444,32 +465,45 @@ async def test_my_navigation_filters_to_only_directly_visible_parent_tree(
     assert [page["code"] for page in pages] == ["tms"]
 
     parent = pages[0]
+    assert parent["name"] == "发货辅助"
+
     child_codes = [child["code"] for child in parent["children"]]
     assert child_codes == [
-        "wms.logistics.shipment_prepare",
-        "wms.logistics.dispatch",
-        "wms.logistics.providers",
-        "wms.logistics.waybill_configs",
-        "wms.logistics.pricing",
-        "wms.logistics.templates",
-        "wms.logistics.records",
-        "wms.logistics.billing_items",
-        "wms.logistics.reconciliation",
-        "wms.logistics.reports",
+        "tms.shipping",
+        "tms.pricing",
+        "tms.billing",
+        "tms.settings",
     ]
 
-    assert all(item["page_code"].startswith("wms.logistics.") for item in route_prefixes)
+    nodes = _walk_pages(pages)
+    assert _child_codes(nodes["tms.shipping"]) == [
+        "tms.shipping.quote",
+        "tms.shipping.records",
+    ]
+    assert _child_codes(nodes["tms.pricing"]) == [
+        "tms.pricing.providers",
+        "tms.pricing.bindings",
+        "tms.pricing.templates",
+    ]
+    assert _child_codes(nodes["tms.billing"]) == [
+        "tms.billing.items",
+        "tms.billing.reconciliation",
+    ]
+    assert _child_codes(nodes["tms.settings"]) == [
+        "tms.settings.waybill",
+    ]
+
+    assert all(item["page_code"].startswith("tms.") for item in route_prefixes)
     assert [item["route_prefix"] for item in route_prefixes] == [
         "/tms/shipment-prepare",
         "/tms/dispatch",
+        "/tms/records",
         "/tms/providers",
-        "/tms/waybill-configs",
         "/tms/pricing",
         "/tms/templates",
-        "/tms/records",
         "/tms/billing/items",
         "/tms/reconciliation",
-        "/tms/reports",
+        "/tms/waybill-configs",
     ]
 
 
@@ -489,7 +523,7 @@ async def test_my_navigation_keeps_parent_visible_when_no_visible_children(
             """
             UPDATE page_registry
                SET is_active = FALSE
-             WHERE parent_code = 'tms'
+             WHERE code LIKE 'tms.%'
             """
         )
     )
@@ -502,5 +536,68 @@ async def test_my_navigation_keeps_parent_visible_when_no_visible_children(
 
     data = r.json()
     assert [page["code"] for page in data["pages"]] == ["tms"]
+    assert data["pages"][0]["name"] == "发货辅助"
     assert data["pages"][0]["children"] == []
     assert data["route_prefixes"] == []
+
+
+@pytest.mark.asyncio
+async def test_my_navigation_contains_shipping_assist_level3_tree(client: AsyncClient) -> None:
+    headers = await _login_admin_headers(client)
+
+    r = await client.get("/users/me/navigation", headers=headers)
+    assert r.status_code == 200, r.text
+
+    data = r.json()
+    nodes = _walk_pages(data["pages"])
+    route_map = _index_route_prefixes(data["route_prefixes"])
+
+    root = nodes["tms"]
+    assert root["name"] == "发货辅助"
+    assert root["effective_read_permission"] == "page.tms.read"
+    assert root["effective_write_permission"] == "page.tms.write"
+
+    assert _child_codes(root) == [
+        "tms.shipping",
+        "tms.pricing",
+        "tms.billing",
+        "tms.settings",
+    ]
+
+    assert _child_codes(nodes["tms.shipping"]) == [
+        "tms.shipping.quote",
+        "tms.shipping.records",
+    ]
+    assert _child_codes(nodes["tms.pricing"]) == [
+        "tms.pricing.providers",
+        "tms.pricing.bindings",
+        "tms.pricing.templates",
+    ]
+    assert _child_codes(nodes["tms.billing"]) == [
+        "tms.billing.items",
+        "tms.billing.reconciliation",
+    ]
+    assert _child_codes(nodes["tms.settings"]) == [
+        "tms.settings.waybill",
+    ]
+
+    expected_route_map = {
+        "/tms/shipment-prepare": "tms.shipping.quote",
+        "/tms/dispatch": "tms.shipping.quote",
+        "/tms/records": "tms.shipping.records",
+        "/tms/providers": "tms.pricing.providers",
+        "/tms/pricing": "tms.pricing.bindings",
+        "/tms/templates": "tms.pricing.templates",
+        "/tms/billing/items": "tms.billing.items",
+        "/tms/reconciliation": "tms.billing.reconciliation",
+        "/tms/waybill-configs": "tms.settings.waybill",
+    }
+
+    for route_prefix, page_code in expected_route_map.items():
+        route = route_map.get(route_prefix)
+        assert route is not None, f"{route_prefix} should exist in route_prefixes"
+        assert route["page_code"] == page_code
+        assert route["effective_read_permission"] == "page.tms.read"
+        assert route["effective_write_permission"] == "page.tms.write"
+
+    assert "/tms/reports" not in route_map


### PR DESCRIPTION
## Summary
- Rename TMS navigation root from 物流 to 发货辅助
- Replace legacy wms.logistics.* page codes with tms.* three-level shipping assist page tree
- Rebind existing /tms route prefixes to concrete third-level page codes
- Retire /tms/reports from the current shipping-assist navigation surface
- Update navigation tests and page_route_prefix model semantics

## Validation
- python3 -m compileall app/user/models/page_route_prefix.py tests/api/test_user_navigation_api.py alembic/versions/2a8be0e16db9_tms_shipping_assist_level3_page_tree.py
- make test TESTS=tests/api/test_user_navigation_api.py
- make alembic-check