### PR TITLE
refactor(shipping-assist): rename backend api path contract

### DIFF
--- a/app/tms/billing/router.py
+++ b/app/tms/billing/router.py
@@ -15,7 +15,7 @@ from . import routes_items
 from . import routes_reconcile
 from . import routes_reconciliations
 
-router = APIRouter(prefix="/tms/billing", tags=["tms-billing"])
+router = APIRouter(prefix="/shipping-assist/billing", tags=["shipping-assist-billing"])
 
 
 def _register_all_routes() -> None:

--- a/app/tms/phase1_boundary.py
+++ b/app/tms/phase1_boundary.py
@@ -250,13 +250,13 @@ FILE_OWNERSHIP_RULES: tuple[FileOwnershipRule, ...] = (
         path_prefix="app/tms/shipment/contracts_calc.py",
         owner_domain=DomainOwner.TMS,
         owner_subdomain=TmsSubdomain.SHIPPING_ASSIST_SHIPMENT,
-        note="发货辅助 /ship/calc 合同定义。",
+        note="发货辅助 /shipping-assist/shipping/calc 合同定义。",
     ),
     FileOwnershipRule(
         path_prefix="app/tms/shipment/contracts_prepare.py",
         owner_domain=DomainOwner.TMS,
         owner_subdomain=TmsSubdomain.SHIPPING_ASSIST_SHIPMENT,
-        note="发货辅助 /ship/prepare-from-order 合同定义。",
+        note="发货辅助 /shipping-assist/shipping/prepare-from-order 合同定义。",
     ),
     FileOwnershipRule(
         path_prefix="app/tms/shipment/router.py",
@@ -268,13 +268,13 @@ FILE_OWNERSHIP_RULES: tuple[FileOwnershipRule, ...] = (
         path_prefix="app/tms/shipment/routes_calc.py",
         owner_domain=DomainOwner.TMS,
         owner_subdomain=TmsSubdomain.SHIPPING_ASSIST_SHIPMENT,
-        note="发货辅助 /ship/calc 路由实现。",
+        note="发货辅助 /shipping-assist/shipping/calc 路由实现。",
     ),
     FileOwnershipRule(
         path_prefix="app/tms/shipment/routes_prepare.py",
         owner_domain=DomainOwner.TMS,
         owner_subdomain=TmsSubdomain.SHIPPING_ASSIST_SHIPMENT,
-        note="发货辅助 /ship/prepare-from-order 路由实现。",
+        note="发货辅助 /shipping-assist/shipping/prepare-from-order 路由实现。",
     ),
     FileOwnershipRule(
         path_prefix="app/tms/shipment/routes_ship_with_waybill.py",

--- a/app/tms/pricing/router.py
+++ b/app/tms/pricing/router.py
@@ -10,7 +10,7 @@ from .summary.contracts import PricingListResponse
 from .summary.repository import list_pricing_view
 from .templates.router import router as templates_router
 
-router = APIRouter(prefix="/tms/pricing", tags=["tms-pricing"])
+router = APIRouter(prefix="/shipping-assist/pricing", tags=["shipping-assist-pricing"])
 
 
 @router.get("/list", response_model=PricingListResponse, name="pricing_list_view")

--- a/app/tms/pricing/templates/read/list_routes.py
+++ b/app/tms/pricing/templates/read/list_routes.py
@@ -55,7 +55,7 @@ def register_list_routes(router: APIRouter) -> None:
         )
 
     @router.get(
-        "/shipping-providers/{provider_id}/templates",
+        "/providers/{provider_id}/templates",
         response_model=TemplateListOut,
         name="pricing_templates_provider_list",
     )

--- a/app/tms/pricing/templates/router.py
+++ b/app/tms/pricing/templates/router.py
@@ -10,7 +10,7 @@ from .read.list_routes import register_list_routes
 from .surcharge_configs.routes import router as surcharge_router
 from .write.router import register as register_write_routes
 
-router = APIRouter(tags=["tms-pricing-templates"])
+router = APIRouter(tags=["shipping-assist-pricing-templates"])
 
 register_list_routes(router)
 register_detail_routes(router)

--- a/app/tms/providers/router.py
+++ b/app/tms/providers/router.py
@@ -2,14 +2,14 @@
 # 分拆说明：
 # - 本文件是 TMS / providers 子域路由壳；
 # - 统一装配 providers 读写接口与 contacts 子资源接口；
-# - 当前 URL 保持 /shipping-providers 与 /shipping-provider-contacts 不变。
+# - 当前 URL 保持 /shipping-assist/pricing/providers 与 /shipping-assist/pricing/provider-contacts 不变。
 from __future__ import annotations
 
 from fastapi import APIRouter
 
 from . import routes_contacts, routes_read, routes_write
 
-router = APIRouter(tags=["shipping-providers"])
+router = APIRouter(tags=["shipping-assist-providers"])
 
 
 def _register_all_routes() -> None:

--- a/app/tms/providers/routes_contacts.py
+++ b/app/tms/providers/routes_contacts.py
@@ -108,7 +108,7 @@ async def _clear_primary_contact(
 
 def register(router: APIRouter) -> None:
     @router.post(
-        "/shipping-providers/{provider_id}/contacts",
+        "/shipping-assist/pricing/providers/{provider_id}/contacts",
         response_model=ShippingProviderContactOut,
         status_code=status.HTTP_201_CREATED,
         name="shipping_provider_create_contact",
@@ -194,7 +194,7 @@ def register(router: APIRouter) -> None:
         return _to_out(dict(row))
 
     @router.patch(
-        "/shipping-provider-contacts/{contact_id}",
+        "/shipping-assist/pricing/provider-contacts/{contact_id}",
         response_model=ShippingProviderContactOut,
         name="shipping_provider_update_contact",
     )
@@ -284,7 +284,7 @@ def register(router: APIRouter) -> None:
         return _to_out(dict(row))
 
     @router.delete(
-        "/shipping-provider-contacts/{contact_id}",
+        "/shipping-assist/pricing/provider-contacts/{contact_id}",
         status_code=status.HTTP_200_OK,
         name="shipping_provider_delete_contact",
     )

--- a/app/tms/providers/routes_read.py
+++ b/app/tms/providers/routes_read.py
@@ -23,7 +23,7 @@ from .mappers import row_to_contact, row_to_provider
 
 
 def register(router: APIRouter) -> None:
-    @router.get("/shipping-providers", response_model=ShippingProviderListOut)
+    @router.get("/shipping-assist/pricing/providers", response_model=ShippingProviderListOut)
     async def list_shipping_providers(
         active: Optional[bool] = Query(None, description="按启用状态筛选；active=true 用于下拉。"),
         q: Optional[str] = Query(None, description="按名称 / 联系人模糊搜索（基于 contacts 子表）。"),
@@ -120,7 +120,7 @@ def register(router: APIRouter) -> None:
 
         return ShippingProviderListOut(ok=True, data=data)
 
-    @router.get("/shipping-providers/{provider_id}", response_model=ShippingProviderDetailOut)
+    @router.get("/shipping-assist/pricing/providers/{provider_id}", response_model=ShippingProviderDetailOut)
     async def get_shipping_provider(
         provider_id: int = Path(..., ge=1),
         session: AsyncSession = Depends(get_session),

--- a/app/tms/providers/routes_write.py
+++ b/app/tms/providers/routes_write.py
@@ -57,7 +57,7 @@ async def _assert_code_unique_or_409(
 
 def register(router: APIRouter) -> None:
     @router.post(
-        "/shipping-providers",
+        "/shipping-assist/pricing/providers",
         status_code=status.HTTP_201_CREATED,
         response_model=ShippingProviderCreateOut,
     )
@@ -119,7 +119,7 @@ def register(router: APIRouter) -> None:
 
         return ShippingProviderCreateOut(ok=True, data=row_to_provider(row, []))
 
-    @router.patch("/shipping-providers/{provider_id}", response_model=ShippingProviderUpdateOut)
+    @router.patch("/shipping-assist/pricing/providers/{provider_id}", response_model=ShippingProviderUpdateOut)
     async def update_shipping_provider(
         provider_id: int = Path(..., ge=1),
         payload: ShippingProviderUpdateIn = ...,

--- a/app/tms/quote/metrics/routes_failures.py
+++ b/app/tms/quote/metrics/routes_failures.py
@@ -1,0 +1,30 @@
+# app/tms/quote/metrics/routes_failures.py
+from __future__ import annotations
+
+from datetime import date
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.analytics.contracts.metrics_shipping_quote import ShippingQuoteFailuresMetricsResponse
+from app.db.deps import get_async_session as get_session
+from app.tms.quote.metrics.failures import load_shipping_quote_failures
+
+
+def register(router: APIRouter) -> None:
+    @router.get(
+        "/metrics/shipping-assist/shipping/quote/failures",
+        response_model=ShippingQuoteFailuresMetricsResponse,
+    )
+    async def get_shipping_quote_failures(
+        day: date = Query(..., description="UTC date, format YYYY-MM-DD"),
+        platform: str | None = Query(None),
+        limit: int = Query(200, ge=1, le=500),
+        session: AsyncSession = Depends(get_session),
+    ) -> ShippingQuoteFailuresMetricsResponse:
+        return await load_shipping_quote_failures(
+            session,
+            day=day,
+            platform=platform,
+            limit=limit,
+        )

--- a/app/tms/quote/router.py
+++ b/app/tms/quote/router.py
@@ -4,8 +4,10 @@ from fastapi import APIRouter
 
 from .routes_calc import register as register_calc_routes
 from .routes_recommend import register as register_recommend_routes
+from .metrics.routes_failures import register as register_failure_routes
 
-router = APIRouter(tags=["tms-quote"])
+router = APIRouter(tags=["shipping-assist-quote"])
 
 register_calc_routes(router)
 register_recommend_routes(router)
+register_failure_routes(router)

--- a/app/tms/quote/routes_calc.py
+++ b/app/tms/quote/routes_calc.py
@@ -21,7 +21,7 @@ from .helpers import check_perm, dims_from_payload
 
 def register(router: APIRouter) -> None:
     @router.post(
-        "/shipping-quote/calc",
+        "/shipping-assist/shipping/quote/calc",
         response_model=QuoteCalcOut,
         status_code=status.HTTP_200_OK,
     )
@@ -67,7 +67,7 @@ def register(router: APIRouter) -> None:
                 ref=audit_ref,
                 trace_id=None,
                 meta={
-                    "endpoint": "/shipping-quote/calc",
+                    "endpoint": "/shipping-assist/shipping/quote/calc",
                     "error_code": code,
                     "message": msg,
                     "template_id": int(payload.template_id),
@@ -90,7 +90,7 @@ def register(router: APIRouter) -> None:
                 ref=audit_ref,
                 trace_id=None,
                 meta={
-                    "endpoint": "/shipping-quote/calc",
+                    "endpoint": "/shipping-assist/shipping/quote/calc",
                     "error_code": QuoteCalcErrorCode.FAILED,
                     "message": msg,
                     "template_id": int(payload.template_id),

--- a/app/tms/quote/routes_recommend.py
+++ b/app/tms/quote/routes_recommend.py
@@ -14,7 +14,7 @@ from app.tms.quote.recommend import recommend_quotes
 
 def register(router: APIRouter) -> None:
     @router.post(
-        "/shipping-quote/recommend",
+        "/shipping-assist/shipping/quote/recommend",
         response_model=QuoteRecommendOut,
         status_code=status.HTTP_200_OK,
     )

--- a/app/tms/records/router.py
+++ b/app/tms/records/router.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter
 from app.tms.records import routes_cost_analysis
 from app.tms.records import routes_read
 
-router = APIRouter(prefix="/tms/records", tags=["tms-records"])
+router = APIRouter(prefix="/shipping-assist/shipping/records", tags=["shipping-assist-records"])
 
 
 def _register_all_routes() -> None:

--- a/app/tms/reports/router.py
+++ b/app/tms/reports/router.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter
 from app.tms.reports import routes_aggregates
 from app.tms.reports import routes_options
 
-router = APIRouter(tags=["shipping-reports"])
+router = APIRouter(tags=["shipping-assist-reports"])
 
 
 def _register_all_routes() -> None:

--- a/app/tms/reports/routes_by_carrier.py
+++ b/app/tms/reports/routes_by_carrier.py
@@ -15,7 +15,7 @@ from app.tms.reports.helpers import build_where_clause, clean_opt_str, parse_dat
 
 def register(router: APIRouter) -> None:
     @router.get(
-        "/shipping-reports/by-carrier",
+        "/shipping-assist/reports/by-carrier",
         response_model=ShippingByCarrierResponse,
     )
     async def shipping_reports_by_carrier(

--- a/app/tms/reports/routes_by_province.py
+++ b/app/tms/reports/routes_by_province.py
@@ -15,7 +15,7 @@ from app.tms.reports.helpers import build_where_clause, clean_opt_str, parse_dat
 
 def register(router: APIRouter) -> None:
     @router.get(
-        "/shipping-reports/by-province",
+        "/shipping-assist/reports/by-province",
         response_model=ShippingByProvinceResponse,
     )
     async def shipping_reports_by_province(

--- a/app/tms/reports/routes_by_shop.py
+++ b/app/tms/reports/routes_by_shop.py
@@ -15,7 +15,7 @@ from app.tms.reports.helpers import build_where_clause, clean_opt_str, parse_dat
 
 def register(router: APIRouter) -> None:
     @router.get(
-        "/shipping-reports/by-shop",
+        "/shipping-assist/reports/by-shop",
         response_model=ShippingByShopResponse,
     )
     async def shipping_reports_by_shop(

--- a/app/tms/reports/routes_by_warehouse.py
+++ b/app/tms/reports/routes_by_warehouse.py
@@ -15,7 +15,7 @@ from app.tms.reports.helpers import build_where_clause, clean_opt_str, parse_dat
 
 def register(router: APIRouter) -> None:
     @router.get(
-        "/shipping-reports/by-warehouse",
+        "/shipping-assist/reports/by-warehouse",
         response_model=ShippingByWarehouseResponse,
     )
     async def shipping_reports_by_warehouse(

--- a/app/tms/reports/routes_daily.py
+++ b/app/tms/reports/routes_daily.py
@@ -15,7 +15,7 @@ from app.tms.reports.helpers import build_where_clause, clean_opt_str, parse_dat
 
 def register(router: APIRouter) -> None:
     @router.get(
-        "/shipping-reports/daily",
+        "/shipping-assist/reports/daily",
         response_model=ShippingDailyResponse,
     )
     async def shipping_reports_daily(

--- a/app/tms/reports/routes_options.py
+++ b/app/tms/reports/routes_options.py
@@ -15,7 +15,7 @@ from app.tms.reports.helpers import build_where_clause, parse_date_param
 
 def register(router: APIRouter) -> None:
     @router.get(
-        "/shipping-reports/options",
+        "/shipping-assist/reports/options",
         response_model=ShippingReportFilterOptions,
     )
     async def shipping_reports_options(

--- a/app/tms/shipment/router.py
+++ b/app/tms/shipment/router.py
@@ -2,7 +2,7 @@
 #
 # 分拆说明：
 # - 本文件承载 TMS / Shipment 在 /ship 下的查询/准备类入口。
-# - /ship/calc 与 /ship/prepare-from-order 属于 Shipment 应用层入口：
+# - /shipping-assist/shipping/calc 与 /shipping-assist/shipping/prepare-from-order 属于 Shipment 应用层入口：
 #   内部可调用 Quote 能力，但物理归属属于 Shipment。
 # - /ship-with-waybill 不在此路由壳，仍走 orders_v2_router。
 from __future__ import annotations
@@ -13,7 +13,7 @@ from .routes_calc import register as register_calc_routes
 from .routes_prepare import register as register_prepare_routes
 from .routes_waybill_config import register as register_waybill_config_routes
 
-router = APIRouter(tags=["ship"])
+router = APIRouter(tags=["shipping-assist-shipping"])
 
 
 register_calc_routes(router)

--- a/app/tms/shipment/routes_calc.py
+++ b/app/tms/shipment/routes_calc.py
@@ -26,7 +26,7 @@ class ShipCalcErrorCode:
 
 
 def register(router: APIRouter) -> None:
-    @router.post("/ship/calc", response_model=ShipCalcResponse)
+    @router.post("/shipping-assist/shipping/calc", response_model=ShipCalcResponse)
     async def calc_shipping_quotes(
         payload: ShipCalcRequest,
         db: Session = Depends(get_db),

--- a/app/tms/shipment/routes_prepare_orders.py
+++ b/app/tms/shipment/routes_prepare_orders.py
@@ -29,7 +29,7 @@ from .service_prepare_orders import ShipmentPrepareOrdersService
 
 def register(router: APIRouter) -> None:
     @router.get(
-        "/ship/prepare/orders",
+        "/shipping-assist/shipping/prepare/orders",
         response_model=ShipPrepareOrdersListResponse,
     )
     async def list_prepare_orders(
@@ -43,7 +43,7 @@ def register(router: APIRouter) -> None:
         return ShipPrepareOrdersListResponse(ok=True, items=items)
 
     @router.get(
-        "/ship/prepare/orders/{platform}/{shop_id}/{ext_order_no}",
+        "/shipping-assist/shipping/prepare/orders/{platform}/{shop_id}/{ext_order_no}",
         response_model=ShipPrepareOrderDetailResponse,
     )
     async def get_prepare_order_detail(
@@ -63,7 +63,7 @@ def register(router: APIRouter) -> None:
         return ShipPrepareOrderDetailResponse(ok=True, item=item)
 
     @router.post(
-        "/ship/prepare/orders/import",
+        "/shipping-assist/shipping/prepare/orders/import",
         response_model=ShipPrepareImportResponse,
     )
     async def import_prepare_order(
@@ -81,7 +81,7 @@ def register(router: APIRouter) -> None:
         )
 
     @router.post(
-        "/ship/prepare/orders/{platform}/{shop_id}/{ext_order_no}/address-confirm",
+        "/shipping-assist/shipping/prepare/orders/{platform}/{shop_id}/{ext_order_no}/address-confirm",
         response_model=ShipPrepareAddressConfirmResponse,
     )
     async def confirm_prepare_order_address(

--- a/app/tms/shipment/routes_prepare_packages.py
+++ b/app/tms/shipment/routes_prepare_packages.py
@@ -26,7 +26,7 @@ from .service_prepare_packages import ShipmentPreparePackagesService
 
 def register(router: APIRouter) -> None:
     @router.get(
-        "/ship/prepare/orders/{platform}/{shop_id}/{ext_order_no}/packages",
+        "/shipping-assist/shipping/prepare/orders/{platform}/{shop_id}/{ext_order_no}/packages",
         response_model=ShipPreparePackagesResponse,
     )
     async def list_prepare_packages(
@@ -46,7 +46,7 @@ def register(router: APIRouter) -> None:
         return ShipPreparePackagesResponse(ok=True, items=items)
 
     @router.post(
-        "/ship/prepare/orders/{platform}/{shop_id}/{ext_order_no}/packages",
+        "/shipping-assist/shipping/prepare/orders/{platform}/{shop_id}/{ext_order_no}/packages",
         response_model=ShipPreparePackageCreateResponse,
     )
     async def create_prepare_package(
@@ -66,7 +66,7 @@ def register(router: APIRouter) -> None:
         return ShipPreparePackageCreateResponse(ok=True, item=item)
 
     @router.patch(
-        "/ship/prepare/orders/{platform}/{shop_id}/{ext_order_no}/packages/{package_no}",
+        "/shipping-assist/shipping/prepare/orders/{platform}/{shop_id}/{ext_order_no}/packages/{package_no}",
         response_model=ShipPreparePackageUpdateResponse,
     )
     async def update_prepare_package(

--- a/app/tms/shipment/routes_prepare_quotes.py
+++ b/app/tms/shipment/routes_prepare_quotes.py
@@ -24,7 +24,7 @@ from .service_prepare_quotes import ShipmentPrepareQuotesService
 
 def register(router: APIRouter) -> None:
     @router.post(
-        "/ship/prepare/orders/{platform}/{shop_id}/{ext_order_no}/packages/{package_no}/quote",
+        "/shipping-assist/shipping/prepare/orders/{platform}/{shop_id}/{ext_order_no}/packages/{package_no}/quote",
         response_model=ShipPreparePackageQuoteResponse,
     )
     async def quote_prepare_package(
@@ -46,7 +46,7 @@ def register(router: APIRouter) -> None:
         return ShipPreparePackageQuoteResponse(ok=True, item=item)
 
     @router.post(
-        "/ship/prepare/orders/{platform}/{shop_id}/{ext_order_no}/packages/{package_no}/quote/confirm",
+        "/shipping-assist/shipping/prepare/orders/{platform}/{shop_id}/{ext_order_no}/packages/{package_no}/quote/confirm",
         response_model=ShipPreparePackageQuoteConfirmResponse,
     )
     async def confirm_prepare_package_quote(

--- a/app/tms/shipment/routes_waybill_config.py
+++ b/app/tms/shipment/routes_waybill_config.py
@@ -30,7 +30,7 @@ from .repository_waybill_config import (
 
 
 def register(router: APIRouter) -> None:
-    @router.get("/ship/waybill-configs", response_model=WaybillConfigListOut)
+    @router.get("/shipping-assist/settings/waybill-configs", response_model=WaybillConfigListOut)
     async def list_waybill_configs_route(
         active: Optional[bool] = Query(None),
         platform: Optional[str] = Query(None),
@@ -52,7 +52,7 @@ def register(router: APIRouter) -> None:
         )
         return WaybillConfigListOut(ok=True, data=data)
 
-    @router.get("/ship/waybill-configs/{config_id}", response_model=WaybillConfigDetailOut)
+    @router.get("/shipping-assist/settings/waybill-configs/{config_id}", response_model=WaybillConfigDetailOut)
     async def get_waybill_config_route(
         config_id: int = Path(..., ge=1),
         session: AsyncSession = Depends(get_session),
@@ -65,7 +65,7 @@ def register(router: APIRouter) -> None:
             raise HTTPException(status_code=404, detail="waybill_config not found")
         return WaybillConfigDetailOut(ok=True, data=data)
 
-    @router.post("/ship/waybill-configs", response_model=WaybillConfigCreateOut, status_code=201)
+    @router.post("/shipping-assist/settings/waybill-configs", response_model=WaybillConfigCreateOut, status_code=201)
     async def create_waybill_config_route(
         payload: WaybillConfigCreateIn,
         session: AsyncSession = Depends(get_session),
@@ -98,7 +98,7 @@ def register(router: APIRouter) -> None:
             await session.rollback()
             raise HTTPException(status_code=422, detail=str(e)) from e
 
-    @router.patch("/ship/waybill-configs/{config_id}", response_model=WaybillConfigUpdateOut)
+    @router.patch("/shipping-assist/settings/waybill-configs/{config_id}", response_model=WaybillConfigUpdateOut)
     async def update_waybill_config_route(
         payload: WaybillConfigUpdateIn,
         config_id: int = Path(..., ge=1),

--- a/tests/api/_helpers_shipping_quote.py
+++ b/tests/api/_helpers_shipping_quote.py
@@ -34,12 +34,12 @@ def pick_warehouse_id(client: TestClient, token: str) -> int:
 
 def clear_warehouse_bindings(client: TestClient, token: str, warehouse_id: int) -> None:
     h = auth_headers(token)
-    r = client.get(f"/tms/pricing/warehouses/{warehouse_id}/bindings", headers=h)
+    r = client.get(f"/shipping-assist/pricing/warehouses/{warehouse_id}/bindings", headers=h)
     assert r.status_code == 200, r.text
     data = r.json()["data"] or []
     for it in data:
         pid = int(it["shipping_provider_id"])
-        dr = client.delete(f"/tms/pricing/warehouses/{warehouse_id}/bindings/{pid}", headers=h)
+        dr = client.delete(f"/shipping-assist/pricing/warehouses/{warehouse_id}/bindings/{pid}", headers=h)
         assert dr.status_code in (200, 404), dr.text
 
 
@@ -53,7 +53,7 @@ def bind_provider_to_warehouse(
 ) -> None:
     h = auth_headers(token)
     r = client.post(
-        f"/tms/pricing/warehouses/{warehouse_id}/bindings",
+        f"/shipping-assist/pricing/warehouses/{warehouse_id}/bindings",
         headers=h,
         json={
             "shipping_provider_id": int(provider_id),
@@ -70,7 +70,7 @@ def bind_provider_to_warehouse(
         if active_template_id is not None:
             patch_payload["active_template_id"] = active_template_id
         pr = client.patch(
-            f"/tms/pricing/warehouses/{warehouse_id}/bindings/{provider_id}",
+            f"/shipping-assist/pricing/warehouses/{warehouse_id}/bindings/{provider_id}",
             headers=h,
             json=patch_payload,
         )
@@ -79,14 +79,14 @@ def bind_provider_to_warehouse(
 
 def ensure_second_provider(client: TestClient, token: str) -> int:
     h = auth_headers(token)
-    pr = client.get("/shipping-providers", headers=h)
+    pr = client.get("/shipping-assist/pricing/providers", headers=h)
     assert pr.status_code == 200, pr.text
     pdata = pr.json()["data"] or []
     if len(pdata) >= 2:
         return int(pdata[1]["id"])
 
     cr = client.post(
-        "/shipping-providers",
+        "/shipping-assist/pricing/providers",
         headers=h,
         json={
             "name": "TEST-PROVIDER-2",
@@ -117,7 +117,7 @@ def _put_template_groups(
 
     for g in groups:
         r = client.post(
-            f"/tms/pricing/templates/{template_id}/groups",
+            f"/shipping-assist/pricing/templates/{template_id}/groups",
             headers=h,
             json={
                 "name": g["name"],
@@ -147,7 +147,7 @@ def _put_template_ranges(
     h = auth_headers(token)
 
     r = client.put(
-        f"/tms/pricing/templates/{template_id}/ranges",
+        f"/shipping-assist/pricing/templates/{template_id}/ranges",
         headers=h,
         json={"ranges": ranges},
     )
@@ -168,7 +168,7 @@ def _put_template_matrix_cells(
     h = auth_headers(token)
 
     r = client.put(
-        f"/tms/pricing/templates/{template_id}/matrix-cells",
+        f"/shipping-assist/pricing/templates/{template_id}/matrix-cells",
         headers=h,
         json={"cells": cells},
     )
@@ -188,7 +188,7 @@ def _submit_template_validation(
     h = auth_headers(token)
 
     r = client.post(
-        f"/tms/pricing/templates/{template_id}/submit-validation",
+        f"/shipping-assist/pricing/templates/{template_id}/submit-validation",
         headers=h,
         json={"confirm_validated": True},
     )
@@ -294,14 +294,14 @@ def create_template_bundle(client: TestClient, token: str) -> Dict[str, int]:
 
     wid = pick_warehouse_id(client, token)
 
-    pr = client.get("/shipping-providers", headers=h)
+    pr = client.get("/shipping-assist/pricing/providers", headers=h)
     assert pr.status_code == 200, pr.text
     pdata = pr.json()["data"]
     assert pdata, "no shipping providers"
     provider_id = int(pdata[0]["id"])
 
     tr = client.post(
-        "/tms/pricing/templates",
+        "/shipping-assist/pricing/templates",
         headers=h,
         json={
             "shipping_provider_id": int(provider_id),
@@ -348,7 +348,7 @@ def create_template_bundle(client: TestClient, token: str) -> Dict[str, int]:
     )
 
     sur = client.post(
-        f"/tms/pricing/templates/{template_id}/surcharge-configs",
+        f"/shipping-assist/pricing/templates/{template_id}/surcharge-configs",
         headers=h,
         json={
             "province_code": "110000",
@@ -396,7 +396,7 @@ def create_template_bundle_for_provider(
     wid = pick_warehouse_id(client, token)
 
     tr = client.post(
-        "/tms/pricing/templates",
+        "/shipping-assist/pricing/templates",
         headers=h,
         json={
             "shipping_provider_id": int(provider_id),

--- a/tests/api/test_metrics_shipping_quote_failures.py
+++ b/tests/api/test_metrics_shipping_quote_failures.py
@@ -23,7 +23,7 @@ def test_metrics_shipping_quote_failures_collects_quote_calc_reject(client: Test
 
     # 触发一次 QUOTE_CALC_REJECT（template 不存在）
     r = client.post(
-        "/shipping-quote/calc",
+        "/shipping-assist/shipping/quote/calc",
         headers=h,
         json={
             "warehouse_id": wid,
@@ -45,12 +45,12 @@ def test_metrics_shipping_quote_failures_collects_quote_calc_reject(client: Test
     assert p["error_code"] == "QUOTE_CALC_TEMPLATE_NOT_FOUND"
 
     # 查询当日 failures（UTC day 由服务端取 created_at 统计；这里用固定 day 可能受时区影响）
-    # 为保证稳定，这里用 /metrics/shipping-quote/failures 的 day=今天（UTC）：
+    # 为保证稳定，这里用 /metrics/shipping-assist/shipping/quote/failures 的 day=今天（UTC）：
     from datetime import datetime, timezone
 
     day = datetime.now(timezone.utc).date().isoformat()
 
-    m = client.get(f"/metrics/shipping-quote/failures?day={day}&limit=50", headers=h)
+    m = client.get(f"/metrics/shipping-assist/shipping/quote/failures?day={day}&limit=50", headers=h)
     assert m.status_code == 200, m.text
     body = m.json()
 

--- a/tests/api/test_pricing_template_binding_runtime_guards.py
+++ b/tests/api/test_pricing_template_binding_runtime_guards.py
@@ -37,7 +37,7 @@ async def _list_shipping_providers(
     client: AsyncClient,
     headers: dict[str, str],
 ) -> list[dict]:
-    r = await client.get("/shipping-providers", headers=headers)
+    r = await client.get("/shipping-assist/pricing/providers", headers=headers)
     assert r.status_code == 200, r.text
     rows = r.json()["data"] or []
     assert isinstance(rows, list), rows
@@ -51,7 +51,7 @@ async def _list_warehouse_bindings(
     warehouse_id: int,
 ) -> list[dict]:
     r = await client.get(
-        f"/tms/pricing/warehouses/{warehouse_id}/bindings",
+        f"/shipping-assist/pricing/warehouses/{warehouse_id}/bindings",
         headers=headers,
     )
     assert r.status_code == 200, r.text
@@ -68,7 +68,7 @@ async def _create_shipping_provider(
     code: str,
 ) -> int:
     r = await client.post(
-        "/shipping-providers",
+        "/shipping-assist/pricing/providers",
         headers=headers,
         json={
             "name": name,
@@ -117,7 +117,7 @@ async def _create_template(
     expected_groups_count: int = 1,
 ) -> int:
     r = await client.post(
-        "/tms/pricing/templates",
+        "/shipping-assist/pricing/templates",
         headers=headers,
         json={
             "shipping_provider_id": int(shipping_provider_id),
@@ -143,7 +143,7 @@ async def _put_ranges(
     template_id: int,
 ) -> int:
     r = await client.put(
-        f"/tms/pricing/templates/{template_id}/ranges",
+        f"/shipping-assist/pricing/templates/{template_id}/ranges",
         headers=headers,
         json={
             "ranges": [
@@ -169,7 +169,7 @@ async def _post_group(
     template_id: int,
 ) -> int:
     r = await client.post(
-        f"/tms/pricing/templates/{template_id}/groups",
+        f"/shipping-assist/pricing/templates/{template_id}/groups",
         headers=headers,
         json={
             "sort_order": 0,
@@ -192,7 +192,7 @@ async def _put_single_matrix_cell(
     range_id: int,
 ) -> None:
     r = await client.put(
-        f"/tms/pricing/templates/{template_id}/matrix-cells",
+        f"/shipping-assist/pricing/templates/{template_id}/matrix-cells",
         headers=headers,
         json={
             "cells": [
@@ -219,7 +219,7 @@ async def _submit_validation(
     template_id: int,
 ) -> None:
     r = await client.post(
-        f"/tms/pricing/templates/{template_id}/submit-validation",
+        f"/shipping-assist/pricing/templates/{template_id}/submit-validation",
         headers=headers,
         json={"confirm_validated": True},
     )
@@ -238,7 +238,7 @@ async def _bind_template(
     template_id: int,
 ):
     return await client.post(
-        f"/tms/pricing/warehouses/{warehouse_id}/bindings",
+        f"/shipping-assist/pricing/warehouses/{warehouse_id}/bindings",
         headers=headers,
         json={
             "shipping_provider_id": int(shipping_provider_id),
@@ -259,7 +259,7 @@ async def _list_template_candidates(
     shipping_provider_id: int,
 ) -> list[dict]:
     r = await client.get(
-        f"/tms/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/template-candidates",
+        f"/shipping-assist/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/template-candidates",
         headers=headers,
     )
     assert r.status_code == 200, r.text
@@ -394,7 +394,7 @@ async def test_incomplete_structure_cannot_enter_bindable_state(
 
     if with_ranges or with_groups or with_matrix:
         submit_resp = await client.post(
-            f"/tms/pricing/templates/{template_id}/submit-validation",
+            f"/shipping-assist/pricing/templates/{template_id}/submit-validation",
             headers=headers,
             json={"confirm_validated": True},
         )
@@ -432,7 +432,7 @@ async def test_validation_rejects_when_expected_counts_not_met(
     )
 
     r_submit = await client.post(
-        f"/tms/pricing/templates/{template_id}/submit-validation",
+        f"/shipping-assist/pricing/templates/{template_id}/submit-validation",
         headers=headers,
         json={"confirm_validated": True},
     )

--- a/tests/api/test_pricing_template_update_contract.py
+++ b/tests/api/test_pricing_template_update_contract.py
@@ -32,7 +32,7 @@ async def _create_template(
     expected_groups_count: int = 1,
 ) -> dict:
     r = await client.post(
-        "/tms/pricing/templates",
+        "/shipping-assist/pricing/templates",
         headers=headers,
         json={
             "shipping_provider_id": int(shipping_provider_id),
@@ -68,7 +68,7 @@ async def _list_shipping_providers(
     client: AsyncClient,
     headers: dict[str, str],
 ) -> list[dict]:
-    r = await client.get("/shipping-providers", headers=headers)
+    r = await client.get("/shipping-assist/pricing/providers", headers=headers)
     assert r.status_code == 200, r.text
     rows = r.json()["data"] or []
     assert isinstance(rows, list), rows
@@ -82,7 +82,7 @@ async def _list_warehouse_bindings(
     warehouse_id: int,
 ) -> list[dict]:
     r = await client.get(
-        f"/tms/pricing/warehouses/{warehouse_id}/bindings",
+        f"/shipping-assist/pricing/warehouses/{warehouse_id}/bindings",
         headers=headers,
     )
     assert r.status_code == 200, r.text
@@ -99,7 +99,7 @@ async def _create_shipping_provider(
     code: str,
 ) -> int:
     r = await client.post(
-        "/shipping-providers",
+        "/shipping-assist/pricing/providers",
         headers=headers,
         json={
             "name": name,
@@ -155,7 +155,7 @@ async def _build_template_resources(
     ]
 
     r1 = await client.put(
-        f"/tms/pricing/templates/{template_id}/ranges",
+        f"/shipping-assist/pricing/templates/{template_id}/ranges",
         headers=headers,
         json={"ranges": ranges},
     )
@@ -163,7 +163,7 @@ async def _build_template_resources(
     range_id = int(r1.json()["ranges"][0]["id"])
 
     r2 = await client.post(
-        f"/tms/pricing/templates/{template_id}/groups",
+        f"/shipping-assist/pricing/templates/{template_id}/groups",
         headers=headers,
         json={
             "sort_order": 0,
@@ -175,7 +175,7 @@ async def _build_template_resources(
     group_id = int(r2.json()["group"]["id"])
 
     r3 = await client.put(
-        f"/tms/pricing/templates/{template_id}/matrix-cells",
+        f"/shipping-assist/pricing/templates/{template_id}/matrix-cells",
         headers=headers,
         json={
             "cells": [
@@ -199,7 +199,7 @@ async def _submit_template_validation(
     template_id: int,
 ) -> dict:
     r = await client.post(
-        f"/tms/pricing/templates/{template_id}/submit-validation",
+        f"/shipping-assist/pricing/templates/{template_id}/submit-validation",
         headers=headers,
         json={"confirm_validated": True},
     )
@@ -219,7 +219,7 @@ async def _bind_template_to_warehouse(
     template_id: int,
 ) -> dict:
     r = await client.post(
-        f"/tms/pricing/warehouses/{warehouse_id}/bindings",
+        f"/shipping-assist/pricing/warehouses/{warehouse_id}/bindings",
         headers=headers,
         json={
             "shipping_provider_id": int(shipping_provider_id),
@@ -280,7 +280,7 @@ async def test_template_create_requires_expected_counts(client: AsyncClient) -> 
     headers = auth_headers(token)
 
     r = await client.post(
-        "/tms/pricing/templates",
+        "/shipping-assist/pricing/templates",
         headers=headers,
         json={
             "shipping_provider_id": 1,
@@ -299,7 +299,7 @@ async def test_template_update_rejects_active_status(client: AsyncClient) -> Non
     template_id = int(created["id"])
 
     r = await client.patch(
-        f"/tms/pricing/templates/{template_id}",
+        f"/shipping-assist/pricing/templates/{template_id}",
         headers=headers,
         json={"status": "active"},
     )
@@ -316,7 +316,7 @@ async def test_template_can_archive_then_restore_to_draft(client: AsyncClient) -
     template_id = int(created["id"])
 
     r1 = await client.patch(
-        f"/tms/pricing/templates/{template_id}",
+        f"/shipping-assist/pricing/templates/{template_id}",
         headers=headers,
         json={"status": "archived"},
     )
@@ -327,7 +327,7 @@ async def test_template_can_archive_then_restore_to_draft(client: AsyncClient) -
     assert body1["data"]["archived_at"] is not None
 
     r2 = await client.patch(
-        f"/tms/pricing/templates/{template_id}",
+        f"/shipping-assist/pricing/templates/{template_id}",
         headers=headers,
         json={"status": "draft"},
     )
@@ -347,14 +347,14 @@ async def test_archived_template_cannot_modify_assets_directly(client: AsyncClie
     template_id = int(created["id"])
 
     r1 = await client.patch(
-        f"/tms/pricing/templates/{template_id}",
+        f"/shipping-assist/pricing/templates/{template_id}",
         headers=headers,
         json={"status": "archived"},
     )
     assert r1.status_code == 200, r1.text
 
     r2 = await client.patch(
-        f"/tms/pricing/templates/{template_id}",
+        f"/shipping-assist/pricing/templates/{template_id}",
         headers=headers,
         json={"name": "should-fail-when-archived"},
     )
@@ -371,21 +371,21 @@ async def test_restored_template_can_modify_assets_again(client: AsyncClient) ->
     template_id = int(created["id"])
 
     r1 = await client.patch(
-        f"/tms/pricing/templates/{template_id}",
+        f"/shipping-assist/pricing/templates/{template_id}",
         headers=headers,
         json={"status": "archived"},
     )
     assert r1.status_code == 200, r1.text
 
     r2 = await client.patch(
-        f"/tms/pricing/templates/{template_id}",
+        f"/shipping-assist/pricing/templates/{template_id}",
         headers=headers,
         json={"status": "draft"},
     )
     assert r2.status_code == 200, r2.text
 
     r3 = await client.patch(
-        f"/tms/pricing/templates/{template_id}",
+        f"/shipping-assist/pricing/templates/{template_id}",
         headers=headers,
         json={"name": "restored-template-new-name"},
     )
@@ -413,7 +413,7 @@ async def test_unbound_draft_template_can_update_expected_counts(client: AsyncCl
     template_id = int(created["id"])
 
     r = await client.patch(
-        f"/tms/pricing/templates/{template_id}",
+        f"/shipping-assist/pricing/templates/{template_id}",
         headers=headers,
         json={
             "expected_ranges_count": 5,
@@ -448,7 +448,7 @@ async def test_bound_template_cannot_rename(client: AsyncClient) -> None:
     )
 
     r = await client.patch(
-        f"/tms/pricing/templates/{template_id}",
+        f"/shipping-assist/pricing/templates/{template_id}",
         headers=headers,
         json={"name": "bound-template-renamed"},
     )
@@ -475,7 +475,7 @@ async def test_bound_template_cannot_update_expected_counts(client: AsyncClient)
     )
 
     r = await client.patch(
-        f"/tms/pricing/templates/{template_id}",
+        f"/shipping-assist/pricing/templates/{template_id}",
         headers=headers,
         json={"expected_ranges_count": 2},
     )
@@ -502,7 +502,7 @@ async def test_bound_template_cannot_archive(client: AsyncClient) -> None:
     )
 
     r = await client.patch(
-        f"/tms/pricing/templates/{template_id}",
+        f"/shipping-assist/pricing/templates/{template_id}",
         headers=headers,
         json={"status": "archived"},
     )

--- a/tests/api/test_shipping_pricing_modules_api.py
+++ b/tests/api/test_shipping_pricing_modules_api.py
@@ -26,7 +26,7 @@ async def _create_template(client: AsyncClient, token: str) -> int:
     h = auth_headers(token)
 
     r = await client.post(
-        "/tms/pricing/templates",
+        "/shipping-assist/pricing/templates",
         headers=h,
         json={
             "shipping_provider_id": 1,
@@ -54,7 +54,7 @@ async def _build_template_resources(client: AsyncClient, h, template_id: int) ->
     ]
 
     r = await client.put(
-        f"/tms/pricing/templates/{template_id}/ranges",
+        f"/shipping-assist/pricing/templates/{template_id}/ranges",
         headers=h,
         json={"ranges": ranges},
     )
@@ -64,7 +64,7 @@ async def _build_template_resources(client: AsyncClient, h, template_id: int) ->
     range_id = int(r.json()["ranges"][0]["id"])
 
     r = await client.post(
-        f"/tms/pricing/templates/{template_id}/groups",
+        f"/shipping-assist/pricing/templates/{template_id}/groups",
         headers=h,
         json={
             "sort_order": 0,
@@ -88,7 +88,7 @@ async def _build_template_resources(client: AsyncClient, h, template_id: int) ->
     ]
 
     r = await client.put(
-        f"/tms/pricing/templates/{template_id}/matrix-cells",
+        f"/shipping-assist/pricing/templates/{template_id}/matrix-cells",
         headers=h,
         json={"cells": cells},
     )
@@ -96,7 +96,7 @@ async def _build_template_resources(client: AsyncClient, h, template_id: int) ->
     assert r.status_code == 200, r.text
 
     r = await client.get(
-        f"/tms/pricing/templates/{template_id}/matrix-cells",
+        f"/shipping-assist/pricing/templates/{template_id}/matrix-cells",
         headers=h,
     )
 
@@ -115,7 +115,7 @@ async def test_ranges_groups_cells_replace_and_detail_readable(client: AsyncClie
     await _build_template_resources(client, h, template_id)
 
     detail = await client.get(
-        f"/tms/pricing/templates/{template_id}",
+        f"/shipping-assist/pricing/templates/{template_id}",
         headers=h,
     )
 
@@ -130,7 +130,7 @@ async def test_ranges_groups_cells_replace_and_detail_readable(client: AsyncClie
     assert isinstance(body["data"]["surcharge_configs"], list)
 
     matrix = await client.get(
-        f"/tms/pricing/templates/{template_id}/matrix-cells",
+        f"/shipping-assist/pricing/templates/{template_id}/matrix-cells",
         headers=h,
     )
     assert matrix.status_code == 200, matrix.text

--- a/tests/api/test_shipping_providers_warehouse_contract.py
+++ b/tests/api/test_shipping_providers_warehouse_contract.py
@@ -31,8 +31,8 @@ def _pick_warehouse_id(engine) -> int | None:
 def test_shipping_provider_create_then_bind_to_warehouse_contract():
     """
     最新合同（Phase 6+）：
-    - /shipping-providers 创建网点实体不再要求 warehouse_id（M:N 绑定关系在 warehouse_shipping_providers）
-    - 绑定关系通过 /tms/pricing/warehouses/{warehouse_id}/bindings 建立
+    - /shipping-assist/pricing/providers 创建网点实体不再要求 warehouse_id（M:N 绑定关系在 warehouse_shipping_providers）
+    - 绑定关系通过 /shipping-assist/pricing/warehouses/{warehouse_id}/bindings 建立
     """
     dsn = _dsn()
     if not dsn:
@@ -57,7 +57,7 @@ def test_shipping_provider_create_then_bind_to_warehouse_contract():
 
     # 1) 创建网点实体（不需要 warehouse_id）
     r1 = c.post(
-        "/shipping-providers",
+        "/shipping-assist/pricing/providers",
         json={"name": name, "code": code, "active": True, "priority": 100},
         headers=headers,
     )
@@ -70,7 +70,7 @@ def test_shipping_provider_create_then_bind_to_warehouse_contract():
 
     # 2) 绑定到仓库（M:N）
     r2 = c.post(
-        f"/tms/pricing/warehouses/{wid}/bindings",
+        f"/shipping-assist/pricing/warehouses/{wid}/bindings",
         json={"shipping_provider_id": provider_id, "active": True, "priority": 100},
         headers=headers,
     )
@@ -81,13 +81,13 @@ def test_shipping_provider_create_then_bind_to_warehouse_contract():
     assert int(body2["data"]["shipping_provider_id"]) == provider_id
 
     # 3) 从仓库绑定列表中可见
-    r3 = c.get(f"/tms/pricing/warehouses/{wid}/bindings", headers=headers)
+    r3 = c.get(f"/shipping-assist/pricing/warehouses/{wid}/bindings", headers=headers)
     assert r3.status_code == 200, r3.text
     rows = r3.json()["data"]
     assert any(int(x["shipping_provider_id"]) == provider_id for x in rows)
 
     # 4) 全局网点列表可见（不要求 warehouse_id 字段存在）
-    r4 = c.get("/shipping-providers", headers=headers)
+    r4 = c.get("/shipping-assist/pricing/providers", headers=headers)
     assert r4.status_code == 200, r4.text
     data = r4.json()["data"]
     assert any(int(x["id"]) == provider_id for x in data)

--- a/tests/api/test_shipping_quote_calc_api.py
+++ b/tests/api/test_shipping_quote_calc_api.py
@@ -50,7 +50,7 @@ def test_shipping_quote_calc_flat_and_surcharge(client: TestClient) -> None:
     wid = pick_warehouse_id(client, token)
 
     r = client.post(
-        "/shipping-quote/calc",
+        "/shipping-assist/shipping/quote/calc",
         headers=auth_headers(token),
         json={
             "warehouse_id": wid,
@@ -91,7 +91,7 @@ def test_shipping_quote_calc_linear_total(client: TestClient) -> None:
     wid = pick_warehouse_id(client, token)
 
     r = client.post(
-        "/shipping-quote/calc",
+        "/shipping-assist/shipping/quote/calc",
         headers=auth_headers(token),
         json={
             "warehouse_id": wid,
@@ -132,7 +132,7 @@ def test_shipping_quote_calc_boundary_1kg_enters_second_pricing_matrix(client: T
     wid = pick_warehouse_id(client, token)
 
     r = client.post(
-        "/shipping-quote/calc",
+        "/shipping-assist/shipping/quote/calc",
         headers=auth_headers(token),
         json={
             "warehouse_id": wid,
@@ -172,7 +172,7 @@ def test_shipping_quote_calc_boundary_30kg_enters_open_ended_pricing_matrix(clie
     wid = pick_warehouse_id(client, token)
 
     r = client.post(
-        "/shipping-quote/calc",
+        "/shipping-assist/shipping/quote/calc",
         headers=auth_headers(token),
         json={
             "warehouse_id": wid,
@@ -212,7 +212,7 @@ def test_shipping_quote_calc_returns_level3_contract_shape(client: TestClient) -
     wid = pick_warehouse_id(client, token)
 
     r = client.post(
-        "/shipping-quote/calc",
+        "/shipping-assist/shipping/quote/calc",
         headers=auth_headers(token),
         json={
             "warehouse_id": wid,
@@ -271,7 +271,7 @@ def test_shipping_quote_calc_error_code_template_not_found(client: TestClient) -
     wid = pick_warehouse_id(client, token)
 
     r = client.post(
-        "/shipping-quote/calc",
+        "/shipping-assist/shipping/quote/calc",
         headers=auth_headers(token),
         json={
             "warehouse_id": wid,

--- a/tests/api/test_shipping_quote_recommend_contract.py
+++ b/tests/api/test_shipping_quote_recommend_contract.py
@@ -49,7 +49,7 @@ def test_shipping_quote_recommend_respects_warehouse_bound_candidates_phase3(cli
     wid = pick_warehouse_id(client, token)
     clear_warehouse_bindings(client, token, wid)
 
-    pr = client.get("/shipping-providers", headers=h)
+    pr = client.get("/shipping-assist/pricing/providers", headers=h)
     assert pr.status_code == 200, pr.text
     pdata = pr.json()["data"]
     assert pdata, "no shipping providers"
@@ -57,7 +57,7 @@ def test_shipping_quote_recommend_respects_warehouse_bound_candidates_phase3(cli
 
     ids_a = create_template_bundle_for_provider(client, token, provider_a, name_suffix="A")
     cr = client.post(
-        "/shipping-quote/calc",
+        "/shipping-assist/shipping/quote/calc",
         headers=h,
         json={
             "warehouse_id": wid,
@@ -82,7 +82,7 @@ def test_shipping_quote_recommend_respects_warehouse_bound_candidates_phase3(cli
     _assert_quote_snapshot_shape(calc_body["quote_snapshot"])
 
     rr = client.post(
-        "/shipping-quote/recommend",
+        "/shipping-assist/shipping/quote/recommend",
         headers=h,
         json={
             "warehouse_id": wid,
@@ -125,7 +125,7 @@ def test_shipping_quote_recommend_provider_ids_intersect_warehouse_phase3(client
     wid = pick_warehouse_id(client, token)
     clear_warehouse_bindings(client, token, wid)
 
-    pr = client.get("/shipping-providers", headers=h)
+    pr = client.get("/shipping-assist/pricing/providers", headers=h)
     assert pr.status_code == 200, pr.text
     pdata = pr.json()["data"]
     assert pdata, "no shipping providers"
@@ -137,7 +137,7 @@ def test_shipping_quote_recommend_provider_ids_intersect_warehouse_phase3(client
     provider_b = ensure_second_provider(client, token)
 
     rr = client.post(
-        "/shipping-quote/recommend",
+        "/shipping-assist/shipping/quote/recommend",
         headers=h,
         json={
             "warehouse_id": wid,

--- a/tests/api/test_shipping_quote_recommend_effective_from.py
+++ b/tests/api/test_shipping_quote_recommend_effective_from.py
@@ -31,7 +31,7 @@ def _recommend(
 ) -> dict:
     h = auth_headers(token)
     rr = client.post(
-        "/shipping-quote/recommend",
+        "/shipping-assist/shipping/quote/recommend",
         headers=h,
         json={
             "warehouse_id": warehouse_id,
@@ -61,7 +61,7 @@ def test_shipping_quote_recommend_excludes_scheduled_binding(client: TestClient)
     wid = pick_warehouse_id(client, token)
     clear_warehouse_bindings(client, token, wid)
 
-    pr = client.get("/shipping-providers", headers=h)
+    pr = client.get("/shipping-assist/pricing/providers", headers=h)
     assert pr.status_code == 200, pr.text
     pdata = pr.json()["data"]
     assert pdata, "no shipping providers"
@@ -75,7 +75,7 @@ def test_shipping_quote_recommend_excludes_scheduled_binding(client: TestClient)
     )
 
     deactivate_resp = client.post(
-        f"/tms/pricing/warehouses/{wid}/bindings/{provider_id}/deactivate",
+        f"/shipping-assist/pricing/warehouses/{wid}/bindings/{provider_id}/deactivate",
         headers=h,
         json={},
     )
@@ -83,7 +83,7 @@ def test_shipping_quote_recommend_excludes_scheduled_binding(client: TestClient)
 
     future_time = (datetime.now(timezone.utc) + timedelta(hours=4)).isoformat()
     activate_resp = client.post(
-        f"/tms/pricing/warehouses/{wid}/bindings/{provider_id}/activate",
+        f"/shipping-assist/pricing/warehouses/{wid}/bindings/{provider_id}/activate",
         headers=h,
         json={"effective_from": future_time},
     )
@@ -108,7 +108,7 @@ def test_shipping_quote_recommend_includes_active_binding(client: TestClient) ->
     wid = pick_warehouse_id(client, token)
     clear_warehouse_bindings(client, token, wid)
 
-    pr = client.get("/shipping-providers", headers=h)
+    pr = client.get("/shipping-assist/pricing/providers", headers=h)
     assert pr.status_code == 200, pr.text
     pdata = pr.json()["data"]
     assert pdata, "no shipping providers"

--- a/tests/api/test_surcharge_config_invariants_audit.py
+++ b/tests/api/test_surcharge_config_invariants_audit.py
@@ -82,7 +82,7 @@ async def _bind_provider_to_warehouse(
     provider_id: int,
 ) -> None:
     r = await async_client.post(
-        f"/tms/pricing/warehouses/{int(warehouse_id)}/bindings",
+        f"/shipping-assist/pricing/warehouses/{int(warehouse_id)}/bindings",
         headers=headers,
         json={
             "shipping_provider_id": int(provider_id),
@@ -95,7 +95,7 @@ async def _bind_provider_to_warehouse(
     assert r.status_code in (200, 201, 409), r.text
     if r.status_code == 409:
         pr = await async_client.patch(
-            f"/tms/pricing/warehouses/{int(warehouse_id)}/bindings/{int(provider_id)}",
+            f"/shipping-assist/pricing/warehouses/{int(warehouse_id)}/bindings/{int(provider_id)}",
             headers=headers,
             json={"active": True, "priority": 0},
         )
@@ -105,7 +105,7 @@ async def _bind_provider_to_warehouse(
 async def _ensure_template_id(async_client, headers: Dict[str, str]) -> int:
     wid = await _pick_warehouse_id(async_client, headers)
 
-    pr = await async_client.get("/shipping-providers", headers=headers)
+    pr = await async_client.get("/shipping-assist/pricing/providers", headers=headers)
     assert pr.status_code == 200, pr.text
     providers_body = pr.json()
     providers = providers_body.get("data") if isinstance(providers_body, dict) else providers_body
@@ -123,7 +123,7 @@ async def _ensure_template_id(async_client, headers: Dict[str, str]) -> int:
 
         post_schema = (
             spec.get("paths", {})
-            .get("/shipping-providers", {})
+            .get("/shipping-assist/pricing/providers", {})
             .get("post", {})
             .get("requestBody", {})
             .get("content", {})
@@ -136,7 +136,7 @@ async def _ensure_template_id(async_client, headers: Dict[str, str]) -> int:
         payload.setdefault("code", f"UTP{seed}".upper())
         payload.setdefault("warehouse_id", int(wid))
 
-        cr = await async_client.post("/shipping-providers", headers=headers, json=payload)
+        cr = await async_client.post("/shipping-assist/pricing/providers", headers=headers, json=payload)
         assert cr.status_code in (200, 201), cr.text
         data = cr.json()
         pid = data.get("id") if isinstance(data, dict) else None
@@ -148,7 +148,7 @@ async def _ensure_template_id(async_client, headers: Dict[str, str]) -> int:
     await _bind_provider_to_warehouse(async_client, headers, int(wid), int(provider_id))
 
     tr = await async_client.get(
-        f"/tms/pricing/shipping-providers/{int(provider_id)}/templates",
+        f"/shipping-assist/pricing/providers/{int(provider_id)}/templates",
         headers=headers,
     )
     assert tr.status_code == 200, tr.text
@@ -179,7 +179,7 @@ async def _ensure_template_id(async_client, headers: Dict[str, str]) -> int:
 
     post_schema = (
         spec.get("paths", {})
-        .get("/tms/pricing/templates", {})
+        .get("/shipping-assist/pricing/templates", {})
         .get("post", {})
         .get("requestBody", {})
         .get("content", {})
@@ -196,7 +196,7 @@ async def _ensure_template_id(async_client, headers: Dict[str, str]) -> int:
     payload.setdefault("billable_weight_strategy", "actual_only")
     payload.setdefault("rounding_mode", "none")
 
-    cr = await async_client.post("/tms/pricing/templates", headers=headers, json=payload)
+    cr = await async_client.post("/shipping-assist/pricing/templates", headers=headers, json=payload)
     assert cr.status_code in (200, 201), cr.text
     data = cr.json()
     tid = (data.get("data", {}) or {}).get("id") if isinstance(data, dict) else None
@@ -218,7 +218,7 @@ async def _create_config(
     cities: List[Dict[str, object]],
 ) -> tuple[int, dict]:
     r = await async_client.post(
-        f"/tms/pricing/templates/{template_id}/surcharge-configs",
+        f"/shipping-assist/pricing/templates/{template_id}/surcharge-configs",
         headers=headers,
         json={
             "province_code": province_code,
@@ -242,7 +242,7 @@ async def test_surcharge_config_invariant_province_mode_rejects_non_empty_cities
     template_id = await _ensure_template_id(client, h)
 
     r = await client.post(
-        f"/tms/pricing/templates/{template_id}/surcharge-configs",
+        f"/shipping-assist/pricing/templates/{template_id}/surcharge-configs",
         headers=h,
         json={
             "province_code": "110000",
@@ -271,7 +271,7 @@ async def test_surcharge_config_invariant_cities_mode_allows_empty_container(cli
     template_id = await _ensure_template_id(client, h)
 
     r = await client.post(
-        f"/tms/pricing/templates/{template_id}/surcharge-configs",
+        f"/shipping-assist/pricing/templates/{template_id}/surcharge-configs",
         headers=h,
         json={
             "province_code": "120000",
@@ -298,7 +298,7 @@ async def test_surcharge_config_invariant_cities_mode_requires_zero_fixed_amount
     template_id = await _ensure_template_id(client, h)
 
     r = await client.post(
-        f"/tms/pricing/templates/{template_id}/surcharge-configs",
+        f"/shipping-assist/pricing/templates/{template_id}/surcharge-configs",
         headers=h,
         json={
             "province_code": "310000",
@@ -345,7 +345,7 @@ async def test_surcharge_config_patch_invariant_switch_to_province_requires_empt
     )
 
     r = await client.patch(
-        f"/tms/pricing/surcharge-configs/{config_id}",
+        f"/shipping-assist/pricing/surcharge-configs/{config_id}",
         headers=h,
         json={
             "province_mode": "province",
@@ -384,7 +384,7 @@ async def test_surcharge_config_patch_invariant_switch_to_cities_requires_zero_f
     )
 
     r1 = await client.patch(
-        f"/tms/pricing/surcharge-configs/{config_id}",
+        f"/shipping-assist/pricing/surcharge-configs/{config_id}",
         headers=h,
         json={
             "province_mode": "cities",
@@ -396,7 +396,7 @@ async def test_surcharge_config_patch_invariant_switch_to_cities_requires_zero_f
     assert "fixed_amount" in r1.text
 
     r2 = await client.patch(
-        f"/tms/pricing/surcharge-configs/{config_id}",
+        f"/shipping-assist/pricing/surcharge-configs/{config_id}",
         headers=h,
         json={
             "province_mode": "cities",
@@ -419,7 +419,7 @@ async def test_surcharge_config_city_container_route_allows_empty_container(clie
     template_id = await _ensure_template_id(client, h)
 
     r = await client.post(
-        f"/tms/pricing/templates/{template_id}/surcharge-configs/city-container",
+        f"/shipping-assist/pricing/templates/{template_id}/surcharge-configs/city-container",
         headers=h,
         json={
             "province_code": "500000",

--- a/tests/api/test_surcharge_upsert_mutual_exclusion_409.py
+++ b/tests/api/test_surcharge_upsert_mutual_exclusion_409.py
@@ -82,7 +82,7 @@ async def _bind_provider_to_warehouse(
     provider_id: int,
 ) -> None:
     r = await async_client.post(
-        f"/tms/pricing/warehouses/{int(warehouse_id)}/bindings",
+        f"/shipping-assist/pricing/warehouses/{int(warehouse_id)}/bindings",
         headers=headers,
         json={
             "shipping_provider_id": int(provider_id),
@@ -95,7 +95,7 @@ async def _bind_provider_to_warehouse(
     assert r.status_code in (200, 201, 409), r.text
     if r.status_code == 409:
         pr = await async_client.patch(
-            f"/tms/pricing/warehouses/{int(warehouse_id)}/bindings/{int(provider_id)}",
+            f"/shipping-assist/pricing/warehouses/{int(warehouse_id)}/bindings/{int(provider_id)}",
             headers=headers,
             json={"active": True, "priority": 0},
         )
@@ -105,7 +105,7 @@ async def _bind_provider_to_warehouse(
 async def _ensure_template_id(async_client, headers: Dict[str, str]) -> int:
     wid = await _pick_warehouse_id(async_client, headers)
 
-    pr = await async_client.get("/shipping-providers", headers=headers)
+    pr = await async_client.get("/shipping-assist/pricing/providers", headers=headers)
     assert pr.status_code == 200, pr.text
     providers_body = pr.json()
     providers = providers_body.get("data") if isinstance(providers_body, dict) else providers_body
@@ -123,7 +123,7 @@ async def _ensure_template_id(async_client, headers: Dict[str, str]) -> int:
 
         post_schema = (
             spec.get("paths", {})
-            .get("/shipping-providers", {})
+            .get("/shipping-assist/pricing/providers", {})
             .get("post", {})
             .get("requestBody", {})
             .get("content", {})
@@ -136,7 +136,7 @@ async def _ensure_template_id(async_client, headers: Dict[str, str]) -> int:
         payload.setdefault("code", f"UTP{seed}".upper())
         payload.setdefault("warehouse_id", int(wid))
 
-        cr = await async_client.post("/shipping-providers", headers=headers, json=payload)
+        cr = await async_client.post("/shipping-assist/pricing/providers", headers=headers, json=payload)
         assert cr.status_code in (200, 201), cr.text
         data = cr.json()
         pid = data.get("id") if isinstance(data, dict) else None
@@ -148,7 +148,7 @@ async def _ensure_template_id(async_client, headers: Dict[str, str]) -> int:
     await _bind_provider_to_warehouse(async_client, headers, int(wid), int(provider_id))
 
     tr = await async_client.get(
-        f"/tms/pricing/shipping-providers/{int(provider_id)}/templates",
+        f"/shipping-assist/pricing/providers/{int(provider_id)}/templates",
         headers=headers,
     )
     assert tr.status_code == 200, tr.text
@@ -179,7 +179,7 @@ async def _ensure_template_id(async_client, headers: Dict[str, str]) -> int:
 
     post_schema = (
         spec.get("paths", {})
-        .get("/tms/pricing/templates", {})
+        .get("/shipping-assist/pricing/templates", {})
         .get("post", {})
         .get("requestBody", {})
         .get("content", {})
@@ -196,7 +196,7 @@ async def _ensure_template_id(async_client, headers: Dict[str, str]) -> int:
     payload.setdefault("billable_weight_strategy", "actual_only")
     payload.setdefault("rounding_mode", "none")
 
-    cr = await async_client.post("/tms/pricing/templates", headers=headers, json=payload)
+    cr = await async_client.post("/shipping-assist/pricing/templates", headers=headers, json=payload)
     assert cr.status_code in (200, 201), cr.text
     data = cr.json()
     tid = (data.get("data", {}) or {}).get("id") if isinstance(data, dict) else None
@@ -218,7 +218,7 @@ async def _create_surcharge_config(
     cities: list[dict[str, object]],
 ) -> dict:
     r = await async_client.post(
-        f"/tms/pricing/templates/{template_id}/surcharge-configs",
+        f"/shipping-assist/pricing/templates/{template_id}/surcharge-configs",
         headers=headers,
         json={
             "province_code": province_code,
@@ -275,7 +275,7 @@ async def test_surcharge_config_create_city_mode_then_patch_to_province_mode(cli
     config_id = int(body1["id"])
 
     r2 = await client.patch(
-        f"/tms/pricing/surcharge-configs/{config_id}",
+        f"/shipping-assist/pricing/surcharge-configs/{config_id}",
         headers=h,
         json={
             "province_code": province_code,
@@ -326,7 +326,7 @@ async def test_surcharge_config_create_province_mode_then_patch_to_cities_mode(c
     config_id = int(body1["id"])
 
     r2 = await client.patch(
-        f"/tms/pricing/surcharge-configs/{config_id}",
+        f"/shipping-assist/pricing/surcharge-configs/{config_id}",
         headers=h,
         json={
             "province_code": province_code,
@@ -376,7 +376,7 @@ async def test_surcharge_config_batch_province_create_skips_existing_and_payload
     assert existing["province_code"] == "110000"
 
     r = await client.post(
-        f"/tms/pricing/templates/{template_id}/surcharge-configs/batch-province",
+        f"/shipping-assist/pricing/templates/{template_id}/surcharge-configs/batch-province",
         headers=h,
         json={
             "items": [
@@ -443,7 +443,7 @@ async def test_surcharge_config_city_container_create_then_patch_add_cities(clie
     template_id = await _ensure_template_id(client, h)
 
     r1 = await client.post(
-        f"/tms/pricing/templates/{template_id}/surcharge-configs/city-container",
+        f"/shipping-assist/pricing/templates/{template_id}/surcharge-configs/city-container",
         headers=h,
         json={
             "province_code": "320000",
@@ -462,7 +462,7 @@ async def test_surcharge_config_city_container_create_then_patch_add_cities(clie
     config_id = int(body1["id"])
 
     r2 = await client.patch(
-        f"/tms/pricing/surcharge-configs/{config_id}",
+        f"/shipping-assist/pricing/surcharge-configs/{config_id}",
         headers=h,
         json={
             "cities": [
@@ -496,7 +496,7 @@ async def test_surcharge_config_city_container_create_rejects_duplicate_province
     template_id = await _ensure_template_id(client, h)
 
     r1 = await client.post(
-        f"/tms/pricing/templates/{template_id}/surcharge-configs/city-container",
+        f"/shipping-assist/pricing/templates/{template_id}/surcharge-configs/city-container",
         headers=h,
         json={
             "province_code": "330000",
@@ -507,7 +507,7 @@ async def test_surcharge_config_city_container_create_rejects_duplicate_province
     assert r1.status_code == 201, r1.text
 
     r2 = await client.post(
-        f"/tms/pricing/templates/{template_id}/surcharge-configs/city-container",
+        f"/shipping-assist/pricing/templates/{template_id}/surcharge-configs/city-container",
         headers=h,
         json={
             "province_code": "330000",

--- a/tests/api/test_tms_billing_reconciliations.py
+++ b/tests/api/test_tms_billing_reconciliations.py
@@ -328,7 +328,7 @@ async def test_tms_billing_reconciliations_list_contract_is_table_only(client, s
     )
 
     resp = await client.get(
-        "/tms/billing/reconciliations",
+        "/shipping-assist/billing/reconciliations",
         params={"carrier_code": carrier_code, "tracking_no": tracking_no},
         headers=headers,
     )
@@ -420,7 +420,7 @@ async def test_tms_billing_reconciliation_histories_list_contract_is_table_only(
     )
 
     resp = await client.get(
-        "/tms/billing/reconciliation-histories",
+        "/shipping-assist/billing/reconciliation-histories",
         params={"carrier_code": carrier_code, "tracking_no": tracking_no},
         headers=headers,
     )
@@ -479,7 +479,7 @@ async def test_tms_billing_approve_bill_only_requires_approved_bill_only(client,
     )
 
     bad_resp = await client.post(
-        f"/tms/billing/reconciliations/{reconciliation_id}/approve",
+        f"/shipping-assist/billing/reconciliations/{reconciliation_id}/approve",
         json={
             "approved_reason_code": "resolved",
             "adjust_amount": 0,
@@ -490,7 +490,7 @@ async def test_tms_billing_approve_bill_only_requires_approved_bill_only(client,
     assert bad_resp.status_code == 422, bad_resp.text
 
     ok_resp = await client.post(
-        f"/tms/billing/reconciliations/{reconciliation_id}/approve",
+        f"/shipping-assist/billing/reconciliations/{reconciliation_id}/approve",
         json={
             "approved_reason_code": "approved_bill_only",
             "adjust_amount": 0,
@@ -569,7 +569,7 @@ async def test_tms_billing_approve_diff_requires_resolved(client, session: Async
     )
 
     bad_resp = await client.post(
-        f"/tms/billing/reconciliations/{reconciliation_id}/approve",
+        f"/shipping-assist/billing/reconciliations/{reconciliation_id}/approve",
         json={
             "approved_reason_code": "approved_bill_only",
             "adjust_amount": 1.25,
@@ -580,7 +580,7 @@ async def test_tms_billing_approve_diff_requires_resolved(client, session: Async
     assert bad_resp.status_code == 422, bad_resp.text
 
     ok_resp = await client.post(
-        f"/tms/billing/reconciliations/{reconciliation_id}/approve",
+        f"/shipping-assist/billing/reconciliations/{reconciliation_id}/approve",
         json={
             "approved_reason_code": "resolved",
             "adjust_amount": 1.25,

--- a/tests/api/test_tms_pricing_active_carriers_summary_api.py
+++ b/tests/api/test_tms_pricing_active_carriers_summary_api.py
@@ -38,7 +38,7 @@ async def _list_shipping_providers(
     client: AsyncClient,
     headers: dict[str, str],
 ) -> list[dict]:
-    r = await client.get("/shipping-providers", headers=headers)
+    r = await client.get("/shipping-assist/pricing/providers", headers=headers)
     assert r.status_code == 200, r.text
     rows = r.json()["data"] or []
     assert isinstance(rows, list), rows
@@ -52,7 +52,7 @@ async def _list_warehouse_bindings(
     warehouse_id: int,
 ) -> list[dict]:
     r = await client.get(
-        f"/tms/pricing/warehouses/{warehouse_id}/bindings",
+        f"/shipping-assist/pricing/warehouses/{warehouse_id}/bindings",
         headers=headers,
     )
     assert r.status_code == 200, r.text
@@ -69,7 +69,7 @@ async def _create_shipping_provider(
     code: str,
 ) -> int:
     r = await client.post(
-        "/shipping-providers",
+        "/shipping-assist/pricing/providers",
         headers=headers,
         json={
             "name": name,
@@ -116,7 +116,7 @@ async def _create_template(
     name: str,
 ) -> int:
     r = await client.post(
-        "/tms/pricing/templates",
+        "/shipping-assist/pricing/templates",
         headers=headers,
         json={
             "shipping_provider_id": int(shipping_provider_id),
@@ -138,7 +138,7 @@ async def _put_ranges(
     template_id: int,
 ) -> int:
     r = await client.put(
-        f"/tms/pricing/templates/{template_id}/ranges",
+        f"/shipping-assist/pricing/templates/{template_id}/ranges",
         headers=headers,
         json={
             "ranges": [
@@ -164,7 +164,7 @@ async def _post_group(
     template_id: int,
 ) -> int:
     r = await client.post(
-        f"/tms/pricing/templates/{template_id}/groups",
+        f"/shipping-assist/pricing/templates/{template_id}/groups",
         headers=headers,
         json={
             "sort_order": 0,
@@ -187,7 +187,7 @@ async def _put_single_matrix_cell(
     range_id: int,
 ) -> None:
     r = await client.put(
-        f"/tms/pricing/templates/{template_id}/matrix-cells",
+        f"/shipping-assist/pricing/templates/{template_id}/matrix-cells",
         headers=headers,
         json={
             "cells": [
@@ -214,7 +214,7 @@ async def _submit_validation(
     template_id: int,
 ) -> None:
     r = await client.post(
-        f"/tms/pricing/templates/{template_id}/submit-validation",
+        f"/shipping-assist/pricing/templates/{template_id}/submit-validation",
         headers=headers,
         json={"confirm_validated": True},
     )
@@ -233,7 +233,7 @@ async def _bind_template(
     template_id: int,
 ):
     return await client.post(
-        f"/tms/pricing/warehouses/{warehouse_id}/bindings",
+        f"/shipping-assist/pricing/warehouses/{warehouse_id}/bindings",
         headers=headers,
         json={
             "shipping_provider_id": int(shipping_provider_id),
@@ -282,7 +282,7 @@ async def _fetch_summary(
     headers: dict[str, str],
 ) -> list[dict]:
     r = await client.get(
-        "/tms/pricing/warehouses/active-carriers/summary",
+        "/shipping-assist/pricing/warehouses/active-carriers/summary",
         headers=headers,
     )
     assert r.status_code == 200, r.text
@@ -324,7 +324,7 @@ async def test_scheduled_binding_not_in_active_carriers_summary(
 
     future_time = (datetime.now(timezone.utc) + timedelta(hours=3)).isoformat()
     activate_resp = await client.post(
-        f"/tms/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/activate",
+        f"/shipping-assist/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/activate",
         headers=headers,
         json={"effective_from": future_time},
     )
@@ -364,7 +364,7 @@ async def test_active_binding_appears_in_active_carriers_summary(
     assert bind_resp.status_code == 201, bind_resp.text
 
     activate_resp = await client.post(
-        f"/tms/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/activate",
+        f"/shipping-assist/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/activate",
         headers=headers,
         json={"effective_from": None},
     )

--- a/tests/api/test_tms_pricing_bindings_runtime_api.py
+++ b/tests/api/test_tms_pricing_bindings_runtime_api.py
@@ -38,7 +38,7 @@ async def _list_shipping_providers(
     client: AsyncClient,
     headers: dict[str, str],
 ) -> list[dict]:
-    r = await client.get("/shipping-providers", headers=headers)
+    r = await client.get("/shipping-assist/pricing/providers", headers=headers)
     assert r.status_code == 200, r.text
     rows = r.json()["data"] or []
     assert isinstance(rows, list), rows
@@ -52,7 +52,7 @@ async def _list_warehouse_bindings(
     warehouse_id: int,
 ) -> list[dict]:
     r = await client.get(
-        f"/tms/pricing/warehouses/{warehouse_id}/bindings",
+        f"/shipping-assist/pricing/warehouses/{warehouse_id}/bindings",
         headers=headers,
     )
     assert r.status_code == 200, r.text
@@ -69,7 +69,7 @@ async def _create_shipping_provider(
     code: str,
 ) -> int:
     r = await client.post(
-        "/shipping-providers",
+        "/shipping-assist/pricing/providers",
         headers=headers,
         json={
             "name": name,
@@ -118,7 +118,7 @@ async def _create_template(
     expected_groups_count: int = 1,
 ) -> int:
     r = await client.post(
-        "/tms/pricing/templates",
+        "/shipping-assist/pricing/templates",
         headers=headers,
         json={
             "shipping_provider_id": int(shipping_provider_id),
@@ -140,7 +140,7 @@ async def _put_ranges(
     template_id: int,
 ) -> int:
     r = await client.put(
-        f"/tms/pricing/templates/{template_id}/ranges",
+        f"/shipping-assist/pricing/templates/{template_id}/ranges",
         headers=headers,
         json={
             "ranges": [
@@ -166,7 +166,7 @@ async def _post_group(
     template_id: int,
 ) -> int:
     r = await client.post(
-        f"/tms/pricing/templates/{template_id}/groups",
+        f"/shipping-assist/pricing/templates/{template_id}/groups",
         headers=headers,
         json={
             "sort_order": 0,
@@ -189,7 +189,7 @@ async def _put_single_matrix_cell(
     range_id: int,
 ) -> None:
     r = await client.put(
-        f"/tms/pricing/templates/{template_id}/matrix-cells",
+        f"/shipping-assist/pricing/templates/{template_id}/matrix-cells",
         headers=headers,
         json={
             "cells": [
@@ -216,7 +216,7 @@ async def _submit_validation(
     template_id: int,
 ) -> None:
     r = await client.post(
-        f"/tms/pricing/templates/{template_id}/submit-validation",
+        f"/shipping-assist/pricing/templates/{template_id}/submit-validation",
         headers=headers,
         json={"confirm_validated": True},
     )
@@ -246,7 +246,7 @@ async def _bind_template(
         payload["active_template_id"] = int(template_id)
 
     return await client.post(
-        f"/tms/pricing/warehouses/{warehouse_id}/bindings",
+        f"/shipping-assist/pricing/warehouses/{warehouse_id}/bindings",
         headers=headers,
         json=payload,
     )
@@ -320,7 +320,7 @@ async def test_activate_binding_immediately_returns_active_runtime_status(
     assert bind_resp.status_code == 201, bind_resp.text
 
     activate_resp = await client.post(
-        f"/tms/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/activate",
+        f"/shipping-assist/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/activate",
         headers=headers,
         json={"effective_from": None},
     )
@@ -359,7 +359,7 @@ async def test_activate_binding_in_future_returns_scheduled_runtime_status(
     future_time = (datetime.now(timezone.utc) + timedelta(hours=2)).isoformat()
 
     activate_resp = await client.post(
-        f"/tms/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/activate",
+        f"/shipping-assist/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/activate",
         headers=headers,
         json={"effective_from": future_time},
     )
@@ -396,7 +396,7 @@ async def test_deactivate_binding_returns_binding_disabled_runtime_status(
     assert bind_resp.status_code == 201, bind_resp.text
 
     deactivate_resp = await client.post(
-        f"/tms/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/deactivate",
+        f"/shipping-assist/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/deactivate",
         headers=headers,
         json={},
     )
@@ -433,7 +433,7 @@ async def test_activate_binding_without_template_returns_409(
     assert bind_resp.status_code == 201, bind_resp.text
 
     activate_resp = await client.post(
-        f"/tms/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/activate",
+        f"/shipping-assist/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/activate",
         headers=headers,
         json={"effective_from": None},
     )

--- a/tests/api/test_tms_pricing_summary_api.py
+++ b/tests/api/test_tms_pricing_summary_api.py
@@ -27,7 +27,7 @@ async def test_pricing_list_returns_active_row_from_seed_bound_draft_template(
     token = await _login(client)
     h = _auth_headers(token)
 
-    r = await client.get("/tms/pricing/list", headers=h)
+    r = await client.get("/shipping-assist/pricing/list", headers=h)
     assert r.status_code == 200, r.text
 
     body = r.json()
@@ -58,7 +58,7 @@ async def test_pricing_list_returns_no_active_template_for_bound_provider_withou
     h = _auth_headers(token)
 
     create_provider = await client.post(
-        "/shipping-providers",
+        "/shipping-assist/pricing/providers",
         headers=h,
         json={
             "name": "UT-SUMMARY-NO-TEMPLATE",
@@ -76,7 +76,7 @@ async def test_pricing_list_returns_no_active_template_for_bound_provider_withou
     assert isinstance(provider_id, int) and provider_id > 0, provider_body
 
     bind = await client.post(
-        "/tms/pricing/warehouses/1/bindings",
+        "/shipping-assist/pricing/warehouses/1/bindings",
         headers=h,
         json={
             "shipping_provider_id": provider_id,
@@ -90,7 +90,7 @@ async def test_pricing_list_returns_no_active_template_for_bound_provider_withou
 
     if bind.status_code == 409:
         patch = await client.patch(
-            f"/tms/pricing/warehouses/1/bindings/{provider_id}",
+            f"/shipping-assist/pricing/warehouses/1/bindings/{provider_id}",
             headers=h,
             json={
                 "active": True,
@@ -100,7 +100,7 @@ async def test_pricing_list_returns_no_active_template_for_bound_provider_withou
         )
         assert patch.status_code == 200, patch.text
 
-    r = await client.get("/tms/pricing/list", headers=h)
+    r = await client.get("/shipping-assist/pricing/list", headers=h)
     assert r.status_code == 200, r.text
 
     body = r.json()

--- a/tests/api/test_warehouse_shipping_providers_bulk_upsert_api.py
+++ b/tests/api/test_warehouse_shipping_providers_bulk_upsert_api.py
@@ -1,7 +1,7 @@
 # tests/api/test_warehouse_shipping_providers_bulk_upsert_api.py
 #
 # 合同级 smoke tests for:
-#   PUT /tms/pricing/warehouses/{warehouse_id}/bindings  (bulk upsert)
+#   PUT /shipping-assist/pricing/warehouses/{warehouse_id}/bindings  (bulk upsert)
 #
 # 目标：
 # - 覆盖 disable_missing 的关键语义：未出现的绑定会被置 inactive（不删除）
@@ -134,7 +134,7 @@ def test_bulk_upsert_contract_smoke():
             {"shipping_provider_id": pid3, "active": True, "priority": 300},
         ],
     }
-    r0 = client.put(f"/tms/pricing/warehouses/{wid}/bindings", json=payload_all3, headers=headers)
+    r0 = client.put(f"/shipping-assist/pricing/warehouses/{wid}/bindings", json=payload_all3, headers=headers)
     assert r0.status_code == 200, r0.text
     assert r0.json().get("ok") is True
 
@@ -146,7 +146,7 @@ def test_bulk_upsert_contract_smoke():
             {"shipping_provider_id": pid2, "active": True, "priority": 200},
         ],
     }
-    r1 = client.put(f"/tms/pricing/warehouses/{wid}/bindings", json=payload_2, headers=headers)
+    r1 = client.put(f"/shipping-assist/pricing/warehouses/{wid}/bindings", json=payload_2, headers=headers)
     assert r1.status_code == 200, r1.text
     body = r1.json()
     assert body.get("ok") is True
@@ -157,15 +157,15 @@ def test_bulk_upsert_contract_smoke():
     assert by_pid[pid3]["active"] is False, "pid3 should be set inactive when disable_missing=true"
 
     # Step C) 幂等：同 payload 再来一次仍 200
-    r2 = client.put(f"/tms/pricing/warehouses/{wid}/bindings", json=payload_2, headers=headers)
+    r2 = client.put(f"/shipping-assist/pricing/warehouses/{wid}/bindings", json=payload_2, headers=headers)
     assert r2.status_code == 200, r2.text
     assert r2.json().get("ok") is True
 
     # warehouse not found -> 404
-    r3 = client.put("/tms/pricing/warehouses/999999/bindings", json=payload_2, headers=headers)
+    r3 = client.put("/shipping-assist/pricing/warehouses/999999/bindings", json=payload_2, headers=headers)
     assert r3.status_code == 404
 
     # provider not found -> 404
     bad = {"disable_missing": False, "items": [{"shipping_provider_id": 999999, "active": True, "priority": 0}]}
-    r4 = client.put(f"/tms/pricing/warehouses/{wid}/bindings", json=bad, headers=headers)
+    r4 = client.put(f"/shipping-assist/pricing/warehouses/{wid}/bindings", json=bad, headers=headers)
     assert r4.status_code == 404


### PR DESCRIPTION
## Summary
- Rename shipping-assist backend business API paths from legacy /tms, /ship, /shipping-quote, /shipping-providers, /shipping-reports prefixes to /shipping-assist/*
- Update related API tests to the new endpoint contract
- Add shipping quote failures metrics route under /metrics/shipping-assist/shipping/quote/failures
- Keep app/tms physical package and imports unchanged for a later dedicated migration

## Validation
- python3 -m compileall app/tms tests/api tests/unit
- make test TESTS="tests/api/test_surcharge_config_invariants_audit.py tests/api/test_surcharge_upsert_mutual_exclusion_409.py tests/api/test_metrics_shipping_quote_failures.py"
- make test TESTS="tests/api/test_shipping_quote_calc_api.py tests/api/test_shipping_quote_recommend_contract.py tests/api/test_shipping_quote_recommend_effective_from.py tests/api/test_metrics_shipping_quote_failures.py tests/api/test_shipping_providers_warehouse_contract.py tests/api/test_warehouse_shipping_providers_bulk_upsert_api.py tests/api/test_tms_pricing_summary_api.py tests/api/test_tms_pricing_bindings_runtime_api.py tests/api/test_tms_pricing_active_carriers_summary_api.py tests/api/test_pricing_template_binding_runtime_guards.py tests/api/test_pricing_template_update_contract.py tests/api/test_shipping_pricing_modules_api.py tests/api/test_surcharge_config_invariants_audit.py tests/api/test_surcharge_upsert_mutual_exclusion_409.py tests/api/test_tms_billing_reconciliations.py tests/api/test_user_navigation_api.py"
- make alembic-check