### PR TITLE
chore(shipping-assist): clean final tms runtime residues

### DIFF
--- a/scripts/geo/build_geo_cn.py
+++ b/scripts/geo/build_geo_cn.py
@@ -97,7 +97,7 @@ def main() -> None:
     for pc in list(cities_by_prov.keys()):
         cities_by_prov[pc] = sorted(cities_by_prov[pc], key=lambda x: x["code"])
 
-    out_dir = root / "app" / "tms" / "geo" / "resources"
+    out_dir = root / "app" / "shipping_assist" / "geo" / "resources"
     out_dir.mkdir(parents=True, exist_ok=True)
 
     (out_dir / "cn_provinces.json").write_text(

--- a/tests/api/test_admin_user_permission_matrix_save_api.py
+++ b/tests/api/test_admin_user_permission_matrix_save_api.py
@@ -113,7 +113,7 @@ def test_admin_can_save_user_permission_matrix(client: TestClient) -> None:
     user_id = created["id"]
 
     page_codes = _get_matrix_page_codes(client, headers)
-    assert {"admin", "wms", "oms", "tms", "analytics", "pms"} <= set(page_codes)
+    assert {"admin", "wms", "oms", "shipping_assist", "analytics", "pms"} <= set(page_codes)
 
     pages = _build_empty_pages(page_codes)
     pages["wms"] = {"read": False, "write": True}


### PR DESCRIPTION
## Summary
- Update geo resource generation output path from app/tms to app/shipping_assist
- Update admin permission matrix test expectation from tms to shipping_assist
- Keep historical Alembic references unchanged

## Validation
- python3 -m compileall scripts/geo/build_geo_cn.py tests/api/test_admin_user_permission_matrix_save_api.py
- make test TESTS=tests/api/test_admin_user_permission_matrix_save_api.py
- rg final tms runtime residues