### PR TITLE
refactor(procurement): make PO line price actual cost contract

### DIFF
--- a/alembic/versions/c3c25b634e54_procurement_po_line_actual_price_.py
+++ b/alembic/versions/c3c25b634e54_procurement_po_line_actual_price_.py
@@ -1,0 +1,166 @@
+"""procurement po line actual price contract
+
+Revision ID: c3c25b634e54
+Revises: b5a434c26633
+Create Date: 2026-04-25 22:30:42.154449
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c3c25b634e54"
+down_revision: Union[str, Sequence[str], None] = "b5a434c26633"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+
+    # 终态口径：
+    # supply_price = 已折扣后的实际基础单位采购价
+    # 采购总价 = supply_price * qty_ordered_base
+    op.execute(
+        """
+        UPDATE purchase_order_line_completion
+           SET planned_line_amount = (
+             COALESCE(supply_price_snapshot, 0::numeric(12, 2))
+             * COALESCE(qty_ordered_base, 0)
+           )::numeric(14, 2)
+        """
+    )
+
+    op.execute(
+        """
+        UPDATE purchase_orders po
+           SET total_amount = COALESCE(src.total_amount, 0::numeric(14, 2))
+          FROM (
+            SELECT
+              pol.po_id,
+              SUM(
+                COALESCE(pol.supply_price, 0::numeric(12, 2))
+                * COALESCE(pol.qty_ordered_base, 0)
+              )::numeric(14, 2) AS total_amount
+            FROM purchase_order_lines pol
+            GROUP BY pol.po_id
+          ) src
+         WHERE src.po_id = po.id
+        """
+    )
+
+    op.execute(
+        """
+        ALTER TABLE purchase_order_line_completion
+        DROP CONSTRAINT IF EXISTS ck_polc_discount_amount_snapshot_nonneg
+        """
+    )
+
+    op.execute(
+        """
+        ALTER TABLE purchase_order_line_completion
+        DROP COLUMN IF EXISTS discount_amount_snapshot
+        """
+    )
+
+    op.execute(
+        """
+        ALTER TABLE purchase_order_lines
+        DROP CONSTRAINT IF EXISTS ck_po_lines_discount_amount_nonneg
+        """
+    )
+
+    op.execute(
+        """
+        ALTER TABLE purchase_order_lines
+        DROP COLUMN IF EXISTS discount_note
+        """
+    )
+
+    op.execute(
+        """
+        ALTER TABLE purchase_order_lines
+        DROP COLUMN IF EXISTS discount_amount
+        """
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+
+    op.execute(
+        """
+        ALTER TABLE purchase_order_lines
+        ADD COLUMN IF NOT EXISTS discount_amount numeric(14, 2) NOT NULL DEFAULT 0
+        """
+    )
+
+    op.execute(
+        """
+        COMMENT ON COLUMN purchase_order_lines.discount_amount
+        IS '整行减免金额（>=0）'
+        """
+    )
+
+    op.execute(
+        """
+        ALTER TABLE purchase_order_lines
+        ADD COLUMN IF NOT EXISTS discount_note text
+        """
+    )
+
+    op.execute(
+        """
+        COMMENT ON COLUMN purchase_order_lines.discount_note
+        IS '折扣说明（可选）'
+        """
+    )
+
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF NOT EXISTS (
+            SELECT 1
+              FROM pg_constraint
+             WHERE conname = 'ck_po_lines_discount_amount_nonneg'
+               AND conrelid = 'purchase_order_lines'::regclass
+          ) THEN
+            ALTER TABLE purchase_order_lines
+            ADD CONSTRAINT ck_po_lines_discount_amount_nonneg
+            CHECK (discount_amount >= 0);
+          END IF;
+        END
+        $$;
+        """
+    )
+
+    op.execute(
+        """
+        ALTER TABLE purchase_order_line_completion
+        ADD COLUMN IF NOT EXISTS discount_amount_snapshot numeric(14, 2) NOT NULL DEFAULT 0
+        """
+    )
+
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF NOT EXISTS (
+            SELECT 1
+              FROM pg_constraint
+             WHERE conname = 'ck_polc_discount_amount_snapshot_nonneg'
+               AND conrelid = 'purchase_order_line_completion'::regclass
+          ) THEN
+            ALTER TABLE purchase_order_line_completion
+            ADD CONSTRAINT ck_polc_discount_amount_snapshot_nonneg
+            CHECK (discount_amount_snapshot >= 0);
+          END IF;
+        END
+        $$;
+        """
+    )

--- a/app/finance/sources/purchase_cost_source.py
+++ b/app/finance/sources/purchase_cost_source.py
@@ -56,7 +56,6 @@ class PurchaseCostSource:
         return """
         (
           COALESCE(pol.supply_price, 0) * COALESCE(pol.qty_ordered_base, 0)
-          - COALESCE(pol.discount_amount, 0)
         )
         """
 

--- a/app/procurement/contracts/purchase_order.py
+++ b/app/procurement/contracts/purchase_order.py
@@ -25,9 +25,6 @@ class PurchaseOrderLineListOut(BaseModel):
     qty_ordered_base: int
 
     supply_price: Optional[Decimal] = None
-    discount_amount: Decimal = Field(default=Decimal("0"), ge=0)
-    discount_note: Optional[str] = None
-
     remark: Optional[str] = None
 
     created_at: datetime
@@ -122,7 +119,7 @@ class PurchaseOrderCreateLineV2(BaseModel):
 
     严格合同：
     - 必填：line_no / item_id / uom_id / qty_input
-    - 可选商业字段：supply_price / discount_amount / discount_note / remark
+    - 可选商业字段：supply_price / remark
     - 快照与派生字段（item_name / ratio_to_base / qty_ordered_base）不允许前端直传
     """
 
@@ -132,13 +129,11 @@ class PurchaseOrderCreateLineV2(BaseModel):
     qty_input: int = Field(gt=0)
 
     supply_price: Optional[Decimal] = Field(default=None, ge=0)
-    discount_amount: Decimal = Field(default=Decimal("0"), ge=0)
-    discount_note: Optional[str] = None
     remark: Optional[str] = None
 
     model_config = ConfigDict(extra="forbid")
 
-    @field_validator("discount_note", "remark")
+    @field_validator("remark")
     @classmethod
     def _blank_to_none(cls, v: Optional[str]) -> Optional[str]:
         if v is None:

--- a/app/procurement/contracts/purchase_report.py
+++ b/app/procurement/contracts/purchase_report.py
@@ -68,7 +68,6 @@ class ItemPurchaseReportLineItem(_Base):
     qty_ordered_base: int
 
     supply_price_snapshot: Decimal | None = None
-    discount_amount_snapshot: Decimal
     planned_line_amount: Decimal
 
 

--- a/app/procurement/models/purchase_order_line.py
+++ b/app/procurement/models/purchase_order_line.py
@@ -24,10 +24,6 @@ class PurchaseOrderLine(Base):
             name="uq_purchase_order_lines_po_id_line_no",
         ),
         sa.CheckConstraint(
-            "discount_amount >= 0",
-            name="ck_po_lines_discount_amount_nonneg",
-        ),
-        sa.CheckConstraint(
             "qty_ordered_base > 0",
             name="ck_po_lines_qty_ordered_base_positive",
         ),
@@ -88,19 +84,7 @@ class PurchaseOrderLine(Base):
         nullable=True,
     )
 
-    discount_amount: Mapped[Decimal] = mapped_column(
-        sa.Numeric(14, 2),
-        nullable=False,
-        default=Decimal("0"),
-        server_default="0",
-        comment="整行减免金额（>=0）",
-    )
 
-    discount_note: Mapped[Optional[str]] = mapped_column(
-        sa.Text,
-        nullable=True,
-        comment="折扣说明（可选）",
-    )
 
     remark: Mapped[Optional[str]] = mapped_column(sa.String(255), nullable=True)
 

--- a/app/procurement/models/purchase_order_line_completion.py
+++ b/app/procurement/models/purchase_order_line_completion.py
@@ -29,7 +29,6 @@ class PurchaseOrderLineCompletion(Base):
         CheckConstraint("qty_received_base >= 0", name="ck_polc_qty_received_base_nonneg"),
         CheckConstraint("qty_remaining_base >= 0", name="ck_polc_qty_remaining_base_nonneg"),
         CheckConstraint("purchase_ratio_to_base_snapshot >= 1", name="ck_polc_ratio_positive"),
-        CheckConstraint("discount_amount_snapshot >= 0", name="ck_polc_discount_amount_snapshot_nonneg"),
         CheckConstraint(
             "qty_remaining_base = GREATEST(qty_ordered_base - qty_received_base, 0)",
             name="ck_polc_qty_remaining_consistent",
@@ -86,11 +85,6 @@ class PurchaseOrderLineCompletion(Base):
     supply_price_snapshot: Mapped[Decimal | None] = mapped_column(
         sa.Numeric(12, 2),
         nullable=True,
-    )
-    discount_amount_snapshot: Mapped[Decimal] = mapped_column(
-        sa.Numeric(14, 2),
-        nullable=False,
-        server_default=text("0"),
     )
     planned_line_amount: Mapped[Decimal] = mapped_column(
         sa.Numeric(14, 2),

--- a/app/procurement/repos/purchase_order_line_completion_repo.py
+++ b/app/procurement/repos/purchase_order_line_completion_repo.py
@@ -41,7 +41,6 @@ async def upsert_completion_rows_for_po(
           qty_ordered_input,
           qty_ordered_base,
           supply_price_snapshot,
-          discount_amount_snapshot,
           planned_line_amount,
           qty_received_base,
           qty_remaining_base,
@@ -68,10 +67,8 @@ async def upsert_completion_rows_for_po(
           pol.qty_ordered_input AS qty_ordered_input,
           pol.qty_ordered_base AS qty_ordered_base,
           pol.supply_price AS supply_price_snapshot,
-          COALESCE(pol.discount_amount, 0::numeric(14, 2)) AS discount_amount_snapshot,
           (
             COALESCE(pol.supply_price, 0::numeric(12, 2)) * pol.qty_ordered_base
-            - COALESCE(pol.discount_amount, 0::numeric(14, 2))
           )::numeric(14, 2) AS planned_line_amount,
           0 AS qty_received_base,
           pol.qty_ordered_base AS qty_remaining_base,
@@ -103,7 +100,6 @@ async def upsert_completion_rows_for_po(
           qty_ordered_input = EXCLUDED.qty_ordered_input,
           qty_ordered_base = EXCLUDED.qty_ordered_base,
           supply_price_snapshot = EXCLUDED.supply_price_snapshot,
-          discount_amount_snapshot = EXCLUDED.discount_amount_snapshot,
           planned_line_amount = EXCLUDED.planned_line_amount,
           qty_remaining_base = GREATEST(
             EXCLUDED.qty_ordered_base - purchase_order_line_completion.qty_received_base,

--- a/app/procurement/routers/purchase_reports_routes_daily.py
+++ b/app/procurement/routers/purchase_reports_routes_daily.py
@@ -40,7 +40,6 @@ def register(router: APIRouter) -> None:
         planned_line_amount_expr = (
             func.coalesce(PurchaseOrderLine.supply_price, 0)
             * PurchaseOrderLine.qty_ordered_base
-            - func.coalesce(PurchaseOrderLine.discount_amount, 0)
         )
 
         stmt = (

--- a/app/procurement/routers/purchase_reports_routes_item_lines.py
+++ b/app/procurement/routers/purchase_reports_routes_item_lines.py
@@ -29,7 +29,6 @@ def register(router: APIRouter) -> None:
         planned_line_amount_expr = (
             func.coalesce(PurchaseOrderLine.supply_price, 0)
             * PurchaseOrderLine.qty_ordered_base
-            - func.coalesce(PurchaseOrderLine.discount_amount, 0)
         )
 
         stmt = (
@@ -48,7 +47,6 @@ def register(router: APIRouter) -> None:
                 PurchaseOrderLine.qty_ordered_input.label("qty_ordered_input"),
                 PurchaseOrderLine.qty_ordered_base.label("qty_ordered_base"),
                 PurchaseOrderLine.supply_price.label("supply_price_snapshot"),
-                PurchaseOrderLine.discount_amount.label("discount_amount_snapshot"),
                 planned_line_amount_expr.label("planned_line_amount"),
             )
             .select_from(PurchaseOrderLine)
@@ -102,7 +100,6 @@ def register(router: APIRouter) -> None:
                         if r["supply_price_snapshot"] is not None
                         else None
                     ),
-                    discount_amount_snapshot=Decimal(str(r["discount_amount_snapshot"] or 0)),
                     planned_line_amount=Decimal(str(r["planned_line_amount"] or 0)),
                 )
             )

--- a/app/procurement/routers/purchase_reports_routes_items.py
+++ b/app/procurement/routers/purchase_reports_routes_items.py
@@ -76,7 +76,6 @@ def register(router: APIRouter) -> None:
         planned_line_amount_expr = (
             func.coalesce(PurchaseOrderLine.supply_price, 0)
             * PurchaseOrderLine.qty_ordered_base
-            - func.coalesce(PurchaseOrderLine.discount_amount, 0)
         )
 
         stmt = (

--- a/app/procurement/routers/purchase_reports_routes_summary.py
+++ b/app/procurement/routers/purchase_reports_routes_summary.py
@@ -51,7 +51,6 @@ def register(router: APIRouter) -> None:
         planned_line_amount_expr = (
             func.coalesce(PurchaseOrderLine.supply_price, 0)
             * PurchaseOrderLine.qty_ordered_base
-            - func.coalesce(PurchaseOrderLine.discount_amount, 0)
         )
 
         stmt = (

--- a/app/procurement/routers/purchase_reports_routes_suppliers.py
+++ b/app/procurement/routers/purchase_reports_routes_suppliers.py
@@ -43,7 +43,6 @@ def register(router: APIRouter) -> None:
         planned_line_amount_expr = (
             func.coalesce(PurchaseOrderLine.supply_price, 0)
             * PurchaseOrderLine.qty_ordered_base
-            - func.coalesce(PurchaseOrderLine.discount_amount, 0)
         )
 
         stmt = (

--- a/app/procurement/services/purchase_order_create.py
+++ b/app/procurement/services/purchase_order_create.py
@@ -59,17 +59,6 @@ def _trim_or_none(v: Any) -> Optional[str]:
     return s or None
 
 
-def _parse_discount_amount(v: Any) -> Decimal:
-    if v is None or (isinstance(v, str) and not v.strip()):
-        return Decimal("0")
-    try:
-        d = Decimal(str(v))
-    except Exception as e:
-        raise ValueError("discount_amount 必须为数字") from e
-    if d < 0:
-        raise ValueError("discount_amount 必须 >= 0")
-    return d
-
 
 def _require_qty_input_from_raw(raw: Dict[str, Any]) -> int:
     """
@@ -161,10 +150,8 @@ async def create_po_v2(
         if supply_price is not None:
             supply_price = Decimal(str(supply_price))
 
-        discount_amount = _parse_discount_amount(raw.get("discount_amount"))
-        line_total = (
-            (Decimal("0") if supply_price is None else (supply_price * Decimal(qty_ordered_base)))
-            - discount_amount
+        line_total = Decimal("0") if supply_price is None else (
+            supply_price * Decimal(qty_ordered_base)
         )
         total_amount += line_total
 
@@ -181,8 +168,6 @@ async def create_po_v2(
                 "qty_ordered_input": qty_input,
                 "qty_ordered_base": qty_ordered_base,
                 "supply_price": supply_price,
-                "discount_amount": discount_amount,
-                "discount_note": raw.get("discount_note"),
                 "remark": _trim_or_none(raw.get("remark")),
             }
         )

--- a/app/procurement/services/purchase_order_line_mapper.py
+++ b/app/procurement/services/purchase_order_line_mapper.py
@@ -1,7 +1,6 @@
 # app/procurement/services/purchase_order_line_mapper.py
 from __future__ import annotations
 
-from decimal import Decimal
 from typing import Any, Dict
 
 from app.procurement.contracts.purchase_order import PurchaseOrderLineListOut
@@ -18,12 +17,6 @@ def _safe_int(v: object, default: int) -> int:
 def build_line_base_data(*, ln: Any) -> Dict[str, Any]:
     ordered_base = get_qty_ordered_base(ln)
 
-    discount_amount = getattr(ln, "discount_amount", None)
-    try:
-        discount_amount_val = Decimal(str(discount_amount or 0))
-    except Exception:
-        discount_amount_val = Decimal("0")
-
     return {
         "id": _safe_int(getattr(ln, "id"), 0),
         "po_id": _safe_int(getattr(ln, "po_id"), 0),
@@ -32,13 +25,16 @@ def build_line_base_data(*, ln: Any) -> Dict[str, Any]:
         "item_name": getattr(ln, "item_name", None),
         "item_sku": getattr(ln, "item_sku", None),
         "spec_text": getattr(ln, "spec_text", None),
-        "purchase_uom_id_snapshot": _safe_int(getattr(ln, "purchase_uom_id_snapshot"), 0),
+        "purchase_uom_id_snapshot": _safe_int(
+            getattr(ln, "purchase_uom_id_snapshot"),
+            0,
+        ),
         "supply_price": getattr(ln, "supply_price", None),
-        "discount_amount": discount_amount_val,
-        "discount_note": getattr(ln, "discount_note", None),
         "qty_ordered_input": getattr(ln, "qty_ordered_input", 0),
         "purchase_ratio_to_base_snapshot": getattr(
-            ln, "purchase_ratio_to_base_snapshot", 1
+            ln,
+            "purchase_ratio_to_base_snapshot",
+            1,
         ),
         "qty_ordered_base": ordered_base,
         "remark": getattr(ln, "remark", None),

--- a/app/procurement/services/purchase_order_update.py
+++ b/app/procurement/services/purchase_order_update.py
@@ -26,7 +26,6 @@ from app.procurement.repos.purchase_order_update_repo import (
 from app.procurement.services.purchase_order_create import (
     _load_items_map,
     _maybe_uom_id_from_raw,
-    _parse_discount_amount,
     _require_qty_input_from_raw,
     _require_supplier_snapshot_via_pms,
     _trim_or_none,
@@ -105,10 +104,8 @@ async def _normalize_update_payload(
         if supply_price is not None:
             supply_price = Decimal(str(supply_price))
 
-        discount_amount = _parse_discount_amount(raw.get("discount_amount"))
-        line_total = (
-            (Decimal("0") if supply_price is None else (supply_price * Decimal(qty_ordered_base)))
-            - discount_amount
+        line_total = Decimal("0") if supply_price is None else (
+            supply_price * Decimal(qty_ordered_base)
         )
         total_amount += line_total
 
@@ -125,8 +122,6 @@ async def _normalize_update_payload(
                 "qty_ordered_input": int(qty_input),
                 "qty_ordered_base": int(qty_ordered_base),
                 "supply_price": supply_price,
-                "discount_amount": discount_amount,
-                "discount_note": raw.get("discount_note"),
                 "remark": _trim_or_none(raw.get("remark")),
             }
         )

--- a/tests/api/test_purchase_order_update_api.py
+++ b/tests/api/test_purchase_order_update_api.py
@@ -205,8 +205,6 @@ async def test_purchase_order_update_replaces_head_and_lines_and_rebuilds_comple
                 "uom_id": int(uom_b),
                 "qty_input": 4,
                 "supply_price": "2.50",
-                "discount_amount": "1.50",
-                "discount_note": "L1-DISCOUNT",
                 "remark": "LINE-1-UPDATED",
             },
             {
@@ -215,8 +213,6 @@ async def test_purchase_order_update_replaces_head_and_lines_and_rebuilds_comple
                 "uom_id": int(uom_c),
                 "qty_input": 5,
                 "supply_price": "1.00",
-                "discount_amount": "0.50",
-                "discount_note": "L2-DISCOUNT",
                 "remark": "LINE-2-UPDATED",
             },
         ],
@@ -241,14 +237,12 @@ async def test_purchase_order_update_replaces_head_and_lines_and_rebuilds_comple
     assert int(line1["item_id"]) == int(item_b), line1
     assert int(line1["qty_ordered_input"]) == 4, line1
     assert int(line1["qty_ordered_base"]) == 4, line1
-    assert str(line1["discount_note"]) == "L1-DISCOUNT", line1
     assert str(line1["remark"]) == "LINE-1-UPDATED", line1
 
     line2 = lines_by_no[2]
     assert int(line2["item_id"]) == int(item_c), line2
     assert int(line2["qty_ordered_input"]) == 5, line2
     assert int(line2["qty_ordered_base"]) == 5, line2
-    assert str(line2["discount_note"]) == "L2-DISCOUNT", line2
     assert str(line2["remark"]) == "LINE-2-UPDATED", line2
 
     old_item_ids = {int(item_a)}

--- a/tests/fixtures/po_batch_semantics_fixtures.py
+++ b/tests/fixtures/po_batch_semantics_fixtures.py
@@ -113,8 +113,6 @@ async def _create_po_with_one_line(
         qty_ordered_input=qty_base,
         qty_ordered_base=qty_base,
         supply_price=None,
-        discount_amount=0,
-        discount_note=None,
         remark=None,
     )
     session.add(line)

--- a/tests/helpers/po_testkit.py
+++ b/tests/helpers/po_testkit.py
@@ -125,7 +125,6 @@ async def create_po_with_line(
     - purchase_ratio_to_base_snapshot
     - qty_ordered_input
     - qty_ordered_base（>0）
-    - discount_amount（NOT NULL）
     """
     if qty_ordered_base <= 0:
         raise ValueError("qty_ordered_base must be > 0 (ck_po_lines_qty_ordered_base_positive).")
@@ -210,7 +209,6 @@ async def create_po_with_line(
                 purchase_ratio_to_base_snapshot,
                 qty_ordered_input,
                 qty_ordered_base,
-                discount_amount
             )
             VALUES (
                 :po_id, 1, :item_id,
@@ -220,7 +218,6 @@ async def create_po_with_line(
                 :ratio,
                 :qty_input,
                 :qty_ordered_base,
-                0
             )
             RETURNING id
             """


### PR DESCRIPTION
## Summary
- Retire purchase line discount fields from runtime contract:
  - purchase_order_lines.discount_amount
  - purchase_order_lines.discount_note
  - purchase_order_line_completion.discount_amount_snapshot
- Define supply_price as the actual discounted base-unit purchase price
- Recompute purchase line amount as supply_price * qty_ordered_base
- Align procurement reports and finance purchase cost source to the terminal price contract
- Update purchase order create/update and completion read-model rebuild logic
- Update affected tests and fixtures

## Validation
- python3 -m compileall app/procurement/models/purchase_order_line.py app/procurement/models/purchase_order_line_completion.py app/procurement/contracts/purchase_order.py app/procurement/contracts/purchase_report.py app/procurement/services/purchase_order_create.py app/procurement/services/purchase_order_update.py app/procurement/services/purchase_order_line_mapper.py app/procurement/repos/purchase_order_line_completion_repo.py app/procurement/routers/purchase_reports_routes_summary.py app/procurement/routers/purchase_reports_routes_daily.py app/procurement/routers/purchase_reports_routes_items.py app/procurement/routers/purchase_reports_routes_item_lines.py app/procurement/routers/purchase_reports_routes_suppliers.py app/finance/sources/purchase_cost_source.py alembic/versions/c3c25b634e54_procurement_po_line_actual_price_.py
- make alembic-check
- make test TESTS="tests/api/test_purchase_order_update_api.py tests/api/test_purchase_orders_completion_api.py tests/api/test_purchase_orders_supplier_item_contract.py tests/api/test_finance_api_contract.py"