### PR TITLE
feat(finance): add purchase cost SKU ledger

### DIFF
--- a/app/finance/contracts/purchase_cost.py
+++ b/app/finance/contracts/purchase_cost.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 from decimal import Decimal
 
 from pydantic import BaseModel
@@ -42,3 +42,34 @@ class PurchaseCostResponse(BaseModel):
     daily: list[PurchaseCostDailyRow]
     by_supplier: list[PurchaseCostSupplierRow]
     by_item: list[PurchaseCostItemRow]
+
+
+class SkuPurchaseLedgerRow(BaseModel):
+    po_line_id: int
+    po_id: int
+    po_no: str
+    line_no: int
+
+    item_id: int
+    item_sku: str | None = None
+    item_name: str | None = None
+    spec_text: str | None = None
+
+    supplier_id: int
+    supplier_name: str
+
+    purchase_time: datetime
+    purchase_date: date
+
+    qty_ordered_input: int
+    purchase_uom_name_snapshot: str
+    purchase_ratio_to_base_snapshot: int
+    qty_ordered_base: int
+
+    purchase_unit_price: Decimal | None = None
+    planned_line_amount: Decimal
+    accounting_unit_price: Decimal | None = None
+
+
+class SkuPurchaseLedgerResponse(BaseModel):
+    rows: list[SkuPurchaseLedgerRow]

--- a/app/finance/routers/purchase_cost.py
+++ b/app/finance/routers/purchase_cost.py
@@ -6,7 +6,10 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.deps import get_async_session as get_session
-from app.finance.contracts.purchase_cost import PurchaseCostResponse
+from app.finance.contracts.purchase_cost import (
+    PurchaseCostResponse,
+    SkuPurchaseLedgerResponse,
+)
 from app.finance.services.common import ensure_default_range, parse_date_param
 from app.finance.services.purchase_cost_service import FinancePurchaseCostService
 from app.user.deps.auth import get_current_user
@@ -33,4 +36,30 @@ def register(router: APIRouter) -> None:
         return await FinancePurchaseCostService(session).get_purchase_costs(
             from_date=from_dt,
             to_date=to_dt,
+        )
+
+    @router.get(
+        "/purchase-costs/sku-purchase-ledger",
+        response_model=SkuPurchaseLedgerResponse,
+        summary="财务分析 SKU 采购价格核算表",
+    )
+    async def get_finance_sku_purchase_ledger(
+        session: AsyncSession = Depends(get_session),
+        current_user: Any = Depends(get_current_user),
+        from_date: str | None = Query(None, description="起始日期 YYYY-MM-DD，默认最近 30 天"),
+        to_date: str | None = Query(None, description="结束日期 YYYY-MM-DD，默认今天"),
+        supplier_id: int | None = Query(None, description="供应商过滤，可选"),
+        item_keyword: str | None = Query(None, description="商品名 / SKU / item_id 过滤，可选"),
+    ) -> SkuPurchaseLedgerResponse:
+        _ = current_user
+        from_dt, to_dt = await ensure_default_range(
+            session,
+            from_dt=parse_date_param(from_date),
+            to_dt=parse_date_param(to_date),
+        )
+        return await FinancePurchaseCostService(session).get_sku_purchase_ledger(
+            from_date=from_dt,
+            to_date=to_dt,
+            supplier_id=supplier_id,
+            item_keyword=item_keyword or "",
         )

--- a/app/finance/services/purchase_cost_service.py
+++ b/app/finance/services/purchase_cost_service.py
@@ -4,7 +4,10 @@ from datetime import date
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.finance.contracts.purchase_cost import PurchaseCostResponse
+from app.finance.contracts.purchase_cost import (
+    PurchaseCostResponse,
+    SkuPurchaseLedgerResponse,
+)
 from app.finance.sources.purchase_cost_source import PurchaseCostSource
 
 
@@ -24,3 +27,20 @@ class FinancePurchaseCostService:
             to_date=to_date,
         )
         return PurchaseCostResponse(**data)
+
+    async def get_sku_purchase_ledger(
+        self,
+        *,
+        from_date: date,
+        to_date: date,
+        supplier_id: int | None = None,
+        item_keyword: str = "",
+    ) -> SkuPurchaseLedgerResponse:
+        source = PurchaseCostSource(self.session)
+        data = await source.fetch_sku_purchase_ledger(
+            from_date=from_date,
+            to_date=to_date,
+            supplier_id=supplier_id,
+            item_keyword=item_keyword,
+        )
+        return SkuPurchaseLedgerResponse(**data)

--- a/app/finance/sources/purchase_cost_source.py
+++ b/app/finance/sources/purchase_cost_source.py
@@ -15,7 +15,8 @@ class PurchaseCostSource:
 
     边界：
     - 只读 procurement 采购计划事实：purchase_orders / purchase_order_lines
-    - 当前表达采购计划成本 / 采购均价
+    - supply_price 是已折扣后的实际基础单位采购价
+    - 采购金额 = supply_price * qty_ordered_base
     - 不表达已售成本 COGS
     """
 
@@ -38,6 +39,154 @@ class PurchaseCostSource:
             "daily": daily,
             "by_supplier": by_supplier,
             "by_item": by_item,
+        }
+
+    async def fetch_sku_purchase_ledger(
+        self,
+        *,
+        from_date: date,
+        to_date: date,
+        supplier_id: int | None = None,
+        item_keyword: str = "",
+    ) -> dict[str, Any]:
+        keyword = item_keyword.strip()
+        params: dict[str, object] = {
+            "from_date": from_date,
+            "to_date": to_date,
+            "item_keyword": keyword,
+            "item_keyword_like": f"%{keyword}%",
+        }
+
+        supplier_filter = ""
+        if supplier_id is not None:
+            params["supplier_id"] = int(supplier_id)
+            supplier_filter = "AND po.supplier_id = :supplier_id"
+
+        sql = text(
+            f"""
+            WITH ledger AS (
+              SELECT
+                pol.id AS po_line_id,
+                po.id AS po_id,
+                po.po_no AS po_no,
+                pol.line_no AS line_no,
+
+                pol.item_id AS item_id,
+                pol.item_sku AS item_sku,
+                pol.item_name AS item_name,
+                pol.spec_text AS spec_text,
+
+                po.supplier_id AS supplier_id,
+                COALESCE(po.supplier_name, '') AS supplier_name,
+
+                po.purchase_time AS purchase_time,
+                DATE(po.purchase_time) AS purchase_date,
+
+                pol.qty_ordered_input AS qty_ordered_input,
+                pol.purchase_uom_name_snapshot AS purchase_uom_name_snapshot,
+                pol.purchase_ratio_to_base_snapshot AS purchase_ratio_to_base_snapshot,
+                pol.qty_ordered_base AS qty_ordered_base,
+
+                pol.supply_price AS purchase_unit_price,
+                {self._line_amount_expr()}::numeric(14, 2) AS planned_line_amount
+
+                FROM purchase_orders po
+                JOIN purchase_order_lines pol ON pol.po_id = po.id
+               WHERE {self._base_where()}
+                 {supplier_filter}
+                 AND (
+                   :item_keyword = ''
+                   OR pol.item_sku ILIKE :item_keyword_like
+                   OR pol.item_name ILIKE :item_keyword_like
+                   OR pol.spec_text ILIKE :item_keyword_like
+                   OR CAST(pol.item_id AS text) = :item_keyword
+                 )
+            ),
+            weighted AS (
+              SELECT
+                ledger.*,
+                SUM(ledger.planned_line_amount) OVER (
+                  PARTITION BY ledger.item_id
+                ) AS item_purchase_amount,
+                SUM(ledger.qty_ordered_base) OVER (
+                  PARTITION BY ledger.item_id
+                ) AS item_base_qty
+              FROM ledger
+            )
+            SELECT
+              po_line_id,
+              po_id,
+              po_no,
+              line_no,
+              item_id,
+              item_sku,
+              item_name,
+              spec_text,
+              supplier_id,
+              supplier_name,
+              purchase_time,
+              purchase_date,
+              qty_ordered_input,
+              purchase_uom_name_snapshot,
+              purchase_ratio_to_base_snapshot,
+              qty_ordered_base,
+              purchase_unit_price,
+              planned_line_amount,
+              CASE
+                WHEN item_base_qty > 0
+                THEN (item_purchase_amount / item_base_qty)::numeric(14, 4)
+                ELSE NULL
+              END AS accounting_unit_price
+            FROM weighted
+            ORDER BY
+              item_sku ASC NULLS LAST,
+              item_id ASC,
+              purchase_time DESC,
+              po_id DESC,
+              line_no ASC,
+              po_line_id ASC
+            LIMIT 500
+            """
+        )
+        rows = (await self.session.execute(sql, params)).mappings().all()
+
+        return {
+            "rows": [
+                {
+                    "po_line_id": int(row["po_line_id"]),
+                    "po_id": int(row["po_id"]),
+                    "po_no": str(row["po_no"]),
+                    "line_no": int(row["line_no"]),
+                    "item_id": int(row["item_id"]),
+                    "item_sku": row["item_sku"],
+                    "item_name": row["item_name"],
+                    "spec_text": row["spec_text"],
+                    "supplier_id": int(row["supplier_id"]),
+                    "supplier_name": str(row["supplier_name"] or ""),
+                    "purchase_time": row["purchase_time"],
+                    "purchase_date": row["purchase_date"],
+                    "qty_ordered_input": int(row["qty_ordered_input"] or 0),
+                    "purchase_uom_name_snapshot": str(
+                        row["purchase_uom_name_snapshot"] or ""
+                    ),
+                    "purchase_ratio_to_base_snapshot": int(
+                        row["purchase_ratio_to_base_snapshot"] or 0
+                    ),
+                    "qty_ordered_base": int(row["qty_ordered_base"] or 0),
+                    "purchase_unit_price": (
+                        to_decimal(row["purchase_unit_price"])
+                        if row["purchase_unit_price"] is not None
+                        else None
+                    ),
+                    "planned_line_amount": to_decimal(row["planned_line_amount"]),
+                    "accounting_unit_price": (
+                        to_decimal(row["accounting_unit_price"])
+                        if row["accounting_unit_price"] is not None
+                        else None
+                    ),
+                }
+                for row in rows
+            ]
         }
 
     def _base_where(self) -> str:

--- a/tests/api/test_finance_purchase_sku_ledger_api.py
+++ b/tests/api/test_finance_purchase_sku_ledger_api.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import httpx
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def _headers(client: httpx.AsyncClient) -> dict[str, str]:
+    login = await client.post(
+        "/users/login",
+        json={"username": "admin", "password": "admin123"},
+    )
+    assert login.status_code == 200, login.text
+    return {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+
+async def _pick_supplier_item(client: httpx.AsyncClient, headers: dict[str, str]) -> int:
+    resp = await client.get("/items?supplier_id=1&enabled=true", headers=headers)
+    assert resp.status_code == 200, resp.text
+    items = resp.json()
+    assert items, items
+    return int(items[0]["id"])
+
+
+async def _pick_purchase_uom(session: AsyncSession, *, item_id: int) -> tuple[int, int]:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT id, ratio_to_base
+                  FROM item_uoms
+                 WHERE item_id = :item_id
+                 ORDER BY is_purchase_default DESC, is_base DESC, id ASC
+                 LIMIT 1
+                """
+            ),
+            {"item_id": int(item_id)},
+        )
+    ).mappings().first()
+    assert row is not None
+    return int(row["id"]), int(row["ratio_to_base"])
+
+
+def _decimal(value: object) -> Decimal:
+    return Decimal(str(value))
+
+
+@pytest.mark.asyncio
+async def test_finance_purchase_sku_ledger_returns_po_line_level_prices_and_accounting_unit_price(
+    client: httpx.AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _headers(client)
+    item_id = await _pick_supplier_item(client, headers)
+    uom_id, ratio_to_base = await _pick_purchase_uom(session, item_id=item_id)
+
+    payload_1 = {
+        "warehouse_id": 1,
+        "supplier_id": 1,
+        "purchaser": "UT",
+        "purchase_time": "2036-01-14T10:00:00Z",
+        "lines": [
+            {
+                "line_no": 1,
+                "item_id": item_id,
+                "uom_id": uom_id,
+                "qty_input": 2,
+                "supply_price": "2.50",
+            }
+        ],
+    }
+    payload_2 = {
+        "warehouse_id": 1,
+        "supplier_id": 1,
+        "purchaser": "UT",
+        "purchase_time": "2036-01-14T12:00:00Z",
+        "lines": [
+            {
+                "line_no": 1,
+                "item_id": item_id,
+                "uom_id": uom_id,
+                "qty_input": 1,
+                "supply_price": "3.50",
+            }
+        ],
+    }
+
+    created_1 = await client.post("/purchase-orders/", json=payload_1, headers=headers)
+    assert created_1.status_code == 200, created_1.text
+    po_1 = created_1.json()
+    po_line_id_1 = int(po_1["lines"][0]["id"])
+
+    created_2 = await client.post("/purchase-orders/", json=payload_2, headers=headers)
+    assert created_2.status_code == 200, created_2.text
+    po_2 = created_2.json()
+    po_line_id_2 = int(po_2["lines"][0]["id"])
+
+    resp = await client.get(
+        "/finance/purchase-costs/sku-purchase-ledger?from_date=2036-01-14&to_date=2036-01-14",
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    body = resp.json()
+    assert set(body) == {"rows"}
+    assert isinstance(body["rows"], list)
+
+    rows_by_id = {int(row["po_line_id"]): row for row in body["rows"]}
+    assert po_line_id_1 in rows_by_id, body
+    assert po_line_id_2 in rows_by_id, body
+
+    row_1 = rows_by_id[po_line_id_1]
+    row_2 = rows_by_id[po_line_id_2]
+
+    expected_fields = {
+        "po_line_id",
+        "po_id",
+        "po_no",
+        "line_no",
+        "item_id",
+        "item_sku",
+        "item_name",
+        "spec_text",
+        "supplier_id",
+        "supplier_name",
+        "purchase_time",
+        "purchase_date",
+        "qty_ordered_input",
+        "purchase_uom_name_snapshot",
+        "purchase_ratio_to_base_snapshot",
+        "qty_ordered_base",
+        "purchase_unit_price",
+        "planned_line_amount",
+        "accounting_unit_price",
+    }
+    assert set(row_1) == expected_fields
+    assert set(row_2) == expected_fields
+
+    assert row_1["po_no"] == po_1["po_no"]
+    assert row_2["po_no"] == po_2["po_no"]
+    assert int(row_1["item_id"]) == item_id
+    assert int(row_2["item_id"]) == item_id
+    assert int(row_1["supplier_id"]) == 1
+    assert int(row_2["supplier_id"]) == 1
+    assert row_1["purchase_date"] == "2036-01-14"
+    assert row_2["purchase_date"] == "2036-01-14"
+
+    base_qty_1 = 2 * ratio_to_base
+    base_qty_2 = 1 * ratio_to_base
+
+    assert int(row_1["qty_ordered_input"]) == 2
+    assert int(row_1["purchase_ratio_to_base_snapshot"]) == ratio_to_base
+    assert int(row_1["qty_ordered_base"]) == base_qty_1
+    assert _decimal(row_1["purchase_unit_price"]) == Decimal("2.50")
+    assert _decimal(row_1["planned_line_amount"]) == Decimal("2.50") * Decimal(base_qty_1)
+
+    assert int(row_2["qty_ordered_input"]) == 1
+    assert int(row_2["purchase_ratio_to_base_snapshot"]) == ratio_to_base
+    assert int(row_2["qty_ordered_base"]) == base_qty_2
+    assert _decimal(row_2["purchase_unit_price"]) == Decimal("3.50")
+    assert _decimal(row_2["planned_line_amount"]) == Decimal("3.50") * Decimal(base_qty_2)
+
+    expected_accounting_unit_price = (
+        (
+            Decimal("2.50") * Decimal(base_qty_1)
+            + Decimal("3.50") * Decimal(base_qty_2)
+        )
+        / Decimal(base_qty_1 + base_qty_2)
+    ).quantize(Decimal("0.0001"))
+
+    assert _decimal(row_1["accounting_unit_price"]) == expected_accounting_unit_price
+    assert _decimal(row_2["accounting_unit_price"]) == expected_accounting_unit_price
+
+    assert "supply_price" not in row_1
+    assert "discount_amount" not in row_1
+    assert "discount_note" not in row_1
+    assert "discount_amount_snapshot" not in row_1
+
+
+@pytest.mark.asyncio
+async def test_finance_purchase_sku_ledger_filters_by_item_keyword_and_supplier(
+    client: httpx.AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _headers(client)
+    item_id = await _pick_supplier_item(client, headers)
+    uom_id, _ratio_to_base = await _pick_purchase_uom(session, item_id=item_id)
+
+    payload = {
+        "warehouse_id": 1,
+        "supplier_id": 1,
+        "purchaser": "UT",
+        "purchase_time": "2036-01-15T10:00:00Z",
+        "lines": [
+            {
+                "line_no": 1,
+                "item_id": item_id,
+                "uom_id": uom_id,
+                "qty_input": 1,
+                "supply_price": "3.00",
+            }
+        ],
+    }
+
+    created = await client.post("/purchase-orders/", json=payload, headers=headers)
+    assert created.status_code == 200, created.text
+    po_line_id = int(created.json()["lines"][0]["id"])
+
+    resp = await client.get(
+        f"/finance/purchase-costs/sku-purchase-ledger"
+        f"?from_date=2036-01-15"
+        f"&to_date=2036-01-15"
+        f"&supplier_id=1"
+        f"&item_keyword={item_id}",
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    rows = resp.json()["rows"]
+    assert any(int(row["po_line_id"]) == po_line_id for row in rows), rows


### PR DESCRIPTION
## Summary
- Add `/finance/purchase-costs/sku-purchase-ledger`
- Return one row per purchase order line for SKU purchase price verification
- Expose purchase_unit_price for single purchase-line price
- Expose accounting_unit_price as weighted SKU purchase cost:
  - SUM(planned_line_amount) / SUM(qty_ordered_base)
- Keep the ledger read-only and line-level
- Do not reintroduce discount fields

## Validation
- python3 -m compileall app/finance/contracts/purchase_cost.py app/finance/sources/purchase_cost_source.py app/finance/services/purchase_cost_service.py app/finance/routers/purchase_cost.py tests/api/test_finance_purchase_sku_ledger_api.py
- make test TESTS="tests/api/test_finance_purchase_sku_ledger_api.py tests/api/test_finance_api_contract.py"