### PR TITLE
fix(finance): show purchase lines in SKU ledger

### DIFF
--- a/app/finance/contracts/purchase_cost.py
+++ b/app/finance/contracts/purchase_cost.py
@@ -58,6 +58,9 @@ class SkuPurchaseLedgerRow(BaseModel):
     supplier_id: int
     supplier_name: str
 
+    warehouse_id: int
+    warehouse_name: str | None = None
+
     purchase_time: datetime
     purchase_date: date
 
@@ -73,3 +76,26 @@ class SkuPurchaseLedgerRow(BaseModel):
 
 class SkuPurchaseLedgerResponse(BaseModel):
     rows: list[SkuPurchaseLedgerRow]
+
+
+class SkuPurchaseLedgerItemOption(BaseModel):
+    item_id: int
+    item_sku: str | None = None
+    item_name: str | None = None
+    spec_text: str | None = None
+
+
+class SkuPurchaseLedgerSupplierOption(BaseModel):
+    supplier_id: int
+    supplier_name: str
+
+
+class SkuPurchaseLedgerWarehouseOption(BaseModel):
+    warehouse_id: int
+    warehouse_name: str
+
+
+class SkuPurchaseLedgerOptionsResponse(BaseModel):
+    items: list[SkuPurchaseLedgerItemOption]
+    suppliers: list[SkuPurchaseLedgerSupplierOption]
+    warehouses: list[SkuPurchaseLedgerWarehouseOption]

--- a/app/finance/routers/purchase_cost.py
+++ b/app/finance/routers/purchase_cost.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.db.deps import get_async_session as get_session
 from app.finance.contracts.purchase_cost import (
     PurchaseCostResponse,
+    SkuPurchaseLedgerOptionsResponse,
     SkuPurchaseLedgerResponse,
 )
 from app.finance.services.common import ensure_default_range, parse_date_param
@@ -39,6 +40,18 @@ def register(router: APIRouter) -> None:
         )
 
     @router.get(
+        "/purchase-costs/sku-purchase-ledger/options",
+        response_model=SkuPurchaseLedgerOptionsResponse,
+        summary="财务分析 SKU 采购价格核算表筛选选项",
+    )
+    async def get_finance_sku_purchase_ledger_options(
+        session: AsyncSession = Depends(get_session),
+        current_user: Any = Depends(get_current_user),
+    ) -> SkuPurchaseLedgerOptionsResponse:
+        _ = current_user
+        return await FinancePurchaseCostService(session).get_sku_purchase_ledger_options()
+
+    @router.get(
         "/purchase-costs/sku-purchase-ledger",
         response_model=SkuPurchaseLedgerResponse,
         summary="财务分析 SKU 采购价格核算表",
@@ -46,9 +59,10 @@ def register(router: APIRouter) -> None:
     async def get_finance_sku_purchase_ledger(
         session: AsyncSession = Depends(get_session),
         current_user: Any = Depends(get_current_user),
-        from_date: str | None = Query(None, description="起始日期 YYYY-MM-DD，默认最近 30 天"),
-        to_date: str | None = Query(None, description="结束日期 YYYY-MM-DD，默认今天"),
+        from_date: str | None = Query(None, description="起始日期 YYYY-MM-DD，可选"),
+        to_date: str | None = Query(None, description="结束日期 YYYY-MM-DD，可选"),
         supplier_id: int | None = Query(None, description="供应商过滤，可选"),
+        warehouse_id: int | None = Query(None, description="仓库过滤，可选"),
         item_keyword: str | None = Query(None, description="商品名 / SKU / item_id 过滤，可选"),
     ) -> SkuPurchaseLedgerResponse:
         _ = current_user
@@ -58,5 +72,6 @@ def register(router: APIRouter) -> None:
             from_date=from_dt,
             to_date=to_dt,
             supplier_id=supplier_id,
+            warehouse_id=warehouse_id,
             item_keyword=item_keyword or "",
         )

--- a/app/finance/routers/purchase_cost.py
+++ b/app/finance/routers/purchase_cost.py
@@ -52,11 +52,8 @@ def register(router: APIRouter) -> None:
         item_keyword: str | None = Query(None, description="商品名 / SKU / item_id 过滤，可选"),
     ) -> SkuPurchaseLedgerResponse:
         _ = current_user
-        from_dt, to_dt = await ensure_default_range(
-            session,
-            from_dt=parse_date_param(from_date),
-            to_dt=parse_date_param(to_date),
-        )
+        from_dt = parse_date_param(from_date)
+        to_dt = parse_date_param(to_date)
         return await FinancePurchaseCostService(session).get_sku_purchase_ledger(
             from_date=from_dt,
             to_date=to_dt,

--- a/app/finance/services/purchase_cost_service.py
+++ b/app/finance/services/purchase_cost_service.py
@@ -31,8 +31,8 @@ class FinancePurchaseCostService:
     async def get_sku_purchase_ledger(
         self,
         *,
-        from_date: date,
-        to_date: date,
+        from_date: date | None,
+        to_date: date | None,
         supplier_id: int | None = None,
         item_keyword: str = "",
     ) -> SkuPurchaseLedgerResponse:

--- a/app/finance/services/purchase_cost_service.py
+++ b/app/finance/services/purchase_cost_service.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.finance.contracts.purchase_cost import (
     PurchaseCostResponse,
+    SkuPurchaseLedgerOptionsResponse,
     SkuPurchaseLedgerResponse,
 )
 from app.finance.sources.purchase_cost_source import PurchaseCostSource
@@ -34,6 +35,7 @@ class FinancePurchaseCostService:
         from_date: date | None,
         to_date: date | None,
         supplier_id: int | None = None,
+        warehouse_id: int | None = None,
         item_keyword: str = "",
     ) -> SkuPurchaseLedgerResponse:
         source = PurchaseCostSource(self.session)
@@ -41,6 +43,12 @@ class FinancePurchaseCostService:
             from_date=from_date,
             to_date=to_date,
             supplier_id=supplier_id,
+            warehouse_id=warehouse_id,
             item_keyword=item_keyword,
         )
         return SkuPurchaseLedgerResponse(**data)
+
+    async def get_sku_purchase_ledger_options(self) -> SkuPurchaseLedgerOptionsResponse:
+        source = PurchaseCostSource(self.session)
+        data = await source.fetch_sku_purchase_ledger_options()
+        return SkuPurchaseLedgerOptionsResponse(**data)

--- a/app/finance/sources/purchase_cost_source.py
+++ b/app/finance/sources/purchase_cost_source.py
@@ -47,6 +47,7 @@ class PurchaseCostSource:
         from_date: date | None,
         to_date: date | None,
         supplier_id: int | None = None,
+        warehouse_id: int | None = None,
         item_keyword: str = "",
     ) -> dict[str, Any]:
         keyword = item_keyword.strip()
@@ -69,6 +70,10 @@ class PurchaseCostSource:
             params["supplier_id"] = int(supplier_id)
             where_clauses.append("po.supplier_id = :supplier_id")
 
+        if warehouse_id is not None:
+            params["warehouse_id"] = int(warehouse_id)
+            where_clauses.append("po.warehouse_id = :warehouse_id")
+
         where_sql = "\n               AND ".join(where_clauses)
 
         sql = text(
@@ -88,6 +93,9 @@ class PurchaseCostSource:
                 po.supplier_id AS supplier_id,
                 COALESCE(po.supplier_name, '') AS supplier_name,
 
+                po.warehouse_id AS warehouse_id,
+                COALESCE(wh.name, '') AS warehouse_name,
+
                 po.purchase_time AS purchase_time,
                 DATE(po.purchase_time) AS purchase_date,
 
@@ -101,6 +109,7 @@ class PurchaseCostSource:
 
                 FROM purchase_orders po
                 JOIN purchase_order_lines pol ON pol.po_id = po.id
+                JOIN warehouses wh ON wh.id = po.warehouse_id
                WHERE {where_sql}
                  AND (
                    :item_keyword = ''
@@ -132,6 +141,8 @@ class PurchaseCostSource:
               spec_text,
               supplier_id,
               supplier_name,
+              warehouse_id,
+              warehouse_name,
               purchase_time,
               purchase_date,
               qty_ordered_input,
@@ -171,15 +182,13 @@ class PurchaseCostSource:
                     "spec_text": row["spec_text"],
                     "supplier_id": int(row["supplier_id"]),
                     "supplier_name": str(row["supplier_name"] or ""),
+                    "warehouse_id": int(row["warehouse_id"]),
+                    "warehouse_name": str(row["warehouse_name"] or ""),
                     "purchase_time": row["purchase_time"],
                     "purchase_date": row["purchase_date"],
                     "qty_ordered_input": int(row["qty_ordered_input"] or 0),
-                    "purchase_uom_name_snapshot": str(
-                        row["purchase_uom_name_snapshot"] or ""
-                    ),
-                    "purchase_ratio_to_base_snapshot": int(
-                        row["purchase_ratio_to_base_snapshot"] or 0
-                    ),
+                    "purchase_uom_name_snapshot": str(row["purchase_uom_name_snapshot"] or ""),
+                    "purchase_ratio_to_base_snapshot": int(row["purchase_ratio_to_base_snapshot"] or 0),
                     "qty_ordered_base": int(row["qty_ordered_base"] or 0),
                     "purchase_unit_price": (
                         to_decimal(row["purchase_unit_price"])
@@ -195,6 +204,84 @@ class PurchaseCostSource:
                 }
                 for row in rows
             ]
+        }
+
+    async def fetch_sku_purchase_ledger_options(self) -> dict[str, Any]:
+        item_rows = (
+            await self.session.execute(
+                text(
+                    """
+                    SELECT
+                      pol.item_id,
+                      MAX(pol.item_sku) AS item_sku,
+                      MAX(pol.item_name) AS item_name,
+                      MAX(pol.spec_text) AS spec_text
+                    FROM purchase_order_lines pol
+                    GROUP BY pol.item_id
+                    ORDER BY MAX(pol.item_sku) ASC NULLS LAST, pol.item_id ASC
+                    LIMIT 500
+                    """
+                )
+            )
+        ).mappings().all()
+
+        supplier_rows = (
+            await self.session.execute(
+                text(
+                    """
+                    SELECT
+                      po.supplier_id,
+                      COALESCE(po.supplier_name, '') AS supplier_name
+                    FROM purchase_orders po
+                    JOIN purchase_order_lines pol ON pol.po_id = po.id
+                    GROUP BY po.supplier_id, COALESCE(po.supplier_name, '')
+                    ORDER BY supplier_name ASC, po.supplier_id ASC
+                    """
+                )
+            )
+        ).mappings().all()
+
+        warehouse_rows = (
+            await self.session.execute(
+                text(
+                    """
+                    SELECT
+                      po.warehouse_id,
+                      COALESCE(wh.name, '') AS warehouse_name
+                    FROM purchase_orders po
+                    JOIN purchase_order_lines pol ON pol.po_id = po.id
+                    JOIN warehouses wh ON wh.id = po.warehouse_id
+                    GROUP BY po.warehouse_id, COALESCE(wh.name, '')
+                    ORDER BY warehouse_name ASC, po.warehouse_id ASC
+                    """
+                )
+            )
+        ).mappings().all()
+
+        return {
+            "items": [
+                {
+                    "item_id": int(row["item_id"]),
+                    "item_sku": row["item_sku"],
+                    "item_name": row["item_name"],
+                    "spec_text": row["spec_text"],
+                }
+                for row in item_rows
+            ],
+            "suppliers": [
+                {
+                    "supplier_id": int(row["supplier_id"]),
+                    "supplier_name": str(row["supplier_name"] or ""),
+                }
+                for row in supplier_rows
+            ],
+            "warehouses": [
+                {
+                    "warehouse_id": int(row["warehouse_id"]),
+                    "warehouse_name": str(row["warehouse_name"] or ""),
+                }
+                for row in warehouse_rows
+            ],
         }
 
     def _base_where(self) -> str:

--- a/app/finance/sources/purchase_cost_source.py
+++ b/app/finance/sources/purchase_cost_source.py
@@ -44,23 +44,32 @@ class PurchaseCostSource:
     async def fetch_sku_purchase_ledger(
         self,
         *,
-        from_date: date,
-        to_date: date,
+        from_date: date | None,
+        to_date: date | None,
         supplier_id: int | None = None,
         item_keyword: str = "",
     ) -> dict[str, Any]:
         keyword = item_keyword.strip()
         params: dict[str, object] = {
-            "from_date": from_date,
-            "to_date": to_date,
             "item_keyword": keyword,
             "item_keyword_like": f"%{keyword}%",
         }
 
-        supplier_filter = ""
+        where_clauses: list[str] = ["1 = 1"]
+
+        if from_date is not None:
+            params["from_date"] = from_date
+            where_clauses.append("DATE(po.purchase_time) >= :from_date")
+
+        if to_date is not None:
+            params["to_date"] = to_date
+            where_clauses.append("DATE(po.purchase_time) <= :to_date")
+
         if supplier_id is not None:
             params["supplier_id"] = int(supplier_id)
-            supplier_filter = "AND po.supplier_id = :supplier_id"
+            where_clauses.append("po.supplier_id = :supplier_id")
+
+        where_sql = "\n               AND ".join(where_clauses)
 
         sql = text(
             f"""
@@ -92,8 +101,7 @@ class PurchaseCostSource:
 
                 FROM purchase_orders po
                 JOIN purchase_order_lines pol ON pol.po_id = po.id
-               WHERE {self._base_where()}
-                 {supplier_filter}
+               WHERE {where_sql}
                  AND (
                    :item_keyword = ''
                    OR pol.item_sku ILIKE :item_keyword_like
@@ -192,13 +200,6 @@ class PurchaseCostSource:
     def _base_where(self) -> str:
         return """
         DATE(po.purchase_time) BETWEEN :from_date AND :to_date
-        AND NOT EXISTS (
-          SELECT 1
-            FROM item_test_set_items its
-            JOIN item_test_sets ts ON ts.id = its.set_id
-           WHERE ts.code = 'DEFAULT'
-             AND its.item_id = pol.item_id
-        )
         """
 
     def _line_amount_expr(self) -> str:

--- a/tests/api/test_finance_purchase_sku_ledger_api.py
+++ b/tests/api/test_finance_purchase_sku_ledger_api.py
@@ -126,6 +126,8 @@ async def test_finance_purchase_sku_ledger_returns_po_line_level_prices_and_acco
         "spec_text",
         "supplier_id",
         "supplier_name",
+        "warehouse_id",
+        "warehouse_name",
         "purchase_time",
         "purchase_date",
         "qty_ordered_input",
@@ -145,6 +147,10 @@ async def test_finance_purchase_sku_ledger_returns_po_line_level_prices_and_acco
     assert int(row_2["item_id"]) == item_id
     assert int(row_1["supplier_id"]) == 1
     assert int(row_2["supplier_id"]) == 1
+    assert int(row_1["warehouse_id"]) == 1
+    assert int(row_2["warehouse_id"]) == 1
+    assert str(row_1["warehouse_name"]).strip()
+    assert str(row_2["warehouse_name"]).strip()
     assert row_1["purchase_date"] == "2036-01-14"
     assert row_2["purchase_date"] == "2036-01-14"
 
@@ -214,6 +220,7 @@ async def test_finance_purchase_sku_ledger_filters_by_item_keyword_and_supplier(
         f"?from_date=2036-01-15"
         f"&to_date=2036-01-15"
         f"&supplier_id=1"
+        f"&warehouse_id=1"
         f"&item_keyword={item_id}",
         headers=headers,
     )
@@ -221,3 +228,44 @@ async def test_finance_purchase_sku_ledger_filters_by_item_keyword_and_supplier(
 
     rows = resp.json()["rows"]
     assert any(int(row["po_line_id"]) == po_line_id for row in rows), rows
+
+
+@pytest.mark.asyncio
+async def test_finance_purchase_sku_ledger_options_include_items_suppliers_and_warehouses(
+    client: httpx.AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _headers(client)
+    item_id = await _pick_supplier_item(client, headers)
+    uom_id, _ratio_to_base = await _pick_purchase_uom(session, item_id=item_id)
+
+    payload = {
+        "warehouse_id": 1,
+        "supplier_id": 1,
+        "purchaser": "UT",
+        "purchase_time": "2036-01-16T10:00:00Z",
+        "lines": [
+            {
+                "line_no": 1,
+                "item_id": item_id,
+                "uom_id": uom_id,
+                "qty_input": 1,
+                "supply_price": "4.00",
+            }
+        ],
+    }
+
+    created = await client.post("/purchase-orders/", json=payload, headers=headers)
+    assert created.status_code == 200, created.text
+
+    resp = await client.get(
+        "/finance/purchase-costs/sku-purchase-ledger/options",
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    body = resp.json()
+    assert set(body) == {"items", "suppliers", "warehouses"}
+    assert any(int(row["item_id"]) == item_id for row in body["items"]), body
+    assert any(int(row["supplier_id"]) == 1 for row in body["suppliers"]), body
+    assert any(int(row["warehouse_id"]) == 1 for row in body["warehouses"]), body


### PR DESCRIPTION
## Summary
- Make SKU purchase ledger product-first by allowing no date filters
- Remove finance purchase-cost default filtering of DEFAULT test-set items
- Keep optional date, supplier, and item keyword filters
- Preserve accounting_unit_price calculation

## Validation
- python3 -m compileall app/finance/sources/purchase_cost_source.py app/finance/services/purchase_cost_service.py app/finance/routers/purchase_cost.py
- make test TESTS="tests/api/test_finance_purchase_sku_ledger_api.py tests/api/test_finance_api_contract.py"
- curl /finance/purchase-costs/sku-purchase-ledger returns purchase lines