### PR TITLE
feat(finance): persist purchase price ledger lines

### DIFF
--- a/alembic/versions/3f940aff7149_finance_purchase_price_ledger_lines.py
+++ b/alembic/versions/3f940aff7149_finance_purchase_price_ledger_lines.py
@@ -1,0 +1,311 @@
+"""finance purchase price ledger lines
+
+Revision ID: 3f940aff7149
+Revises: c3c25b634e54
+Create Date: auto
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = '3f940aff7149'
+down_revision: Union[str, Sequence[str], None] = 'c3c25b634e54'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+TABLE_NAME = "finance_purchase_price_ledger_lines"
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+
+    op.create_table(
+        TABLE_NAME,
+        sa.Column("id", sa.BigInteger(), sa.Identity(), primary_key=True),
+        sa.Column("po_line_id", sa.Integer(), nullable=False),
+        sa.Column("po_id", sa.Integer(), nullable=False),
+        sa.Column("po_no", sa.String(length=64), nullable=False),
+        sa.Column("line_no", sa.Integer(), nullable=False),
+        sa.Column("item_id", sa.Integer(), nullable=False),
+        sa.Column("item_sku", sa.String(length=64), nullable=True),
+        sa.Column("item_name", sa.String(length=255), nullable=True),
+        sa.Column("spec_text", sa.String(length=255), nullable=True),
+        sa.Column("supplier_id", sa.Integer(), nullable=False),
+        sa.Column("supplier_name", sa.String(length=255), nullable=False),
+        sa.Column("warehouse_id", sa.Integer(), nullable=False),
+        sa.Column("warehouse_name", sa.String(length=100), nullable=False),
+        sa.Column("purchase_time", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("purchase_date", sa.Date(), nullable=False),
+        sa.Column("qty_ordered_input", sa.Integer(), nullable=False),
+        sa.Column("purchase_uom_name_snapshot", sa.String(length=64), nullable=False),
+        sa.Column("purchase_ratio_to_base_snapshot", sa.Integer(), nullable=False),
+        sa.Column("qty_ordered_base", sa.Integer(), nullable=False),
+        sa.Column("purchase_unit_price", sa.Numeric(12, 2), nullable=True),
+        sa.Column(
+            "planned_line_amount",
+            sa.Numeric(14, 2),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("source_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "calculated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint(
+            "po_line_id",
+            name="uq_finance_purchase_price_ledger_lines_po_line_id",
+        ),
+        sa.CheckConstraint("qty_ordered_input > 0", name="ck_fpp_ledger_qty_input_positive"),
+        sa.CheckConstraint("qty_ordered_base > 0", name="ck_fpp_ledger_qty_base_positive"),
+        sa.CheckConstraint(
+            "purchase_ratio_to_base_snapshot >= 1",
+            name="ck_fpp_ledger_ratio_positive",
+        ),
+    )
+
+    op.create_index("ix_fpp_ledger_item_id", TABLE_NAME, ["item_id"])
+    op.create_index("ix_fpp_ledger_item_sku", TABLE_NAME, ["item_sku"])
+    op.create_index("ix_fpp_ledger_supplier_id", TABLE_NAME, ["supplier_id"])
+    op.create_index("ix_fpp_ledger_warehouse_id", TABLE_NAME, ["warehouse_id"])
+    op.create_index("ix_fpp_ledger_purchase_date", TABLE_NAME, ["purchase_date"])
+    op.create_index("ix_fpp_ledger_item_warehouse", TABLE_NAME, ["item_id", "warehouse_id"])
+    op.create_index("ix_fpp_ledger_item_supplier", TABLE_NAME, ["item_id", "supplier_id"])
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION finance_refresh_purchase_price_ledger_line(p_po_line_id integer)
+        RETURNS void
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+          INSERT INTO finance_purchase_price_ledger_lines (
+            po_line_id,
+            po_id,
+            po_no,
+            line_no,
+            item_id,
+            item_sku,
+            item_name,
+            spec_text,
+            supplier_id,
+            supplier_name,
+            warehouse_id,
+            warehouse_name,
+            purchase_time,
+            purchase_date,
+            qty_ordered_input,
+            purchase_uom_name_snapshot,
+            purchase_ratio_to_base_snapshot,
+            qty_ordered_base,
+            purchase_unit_price,
+            planned_line_amount,
+            source_updated_at,
+            calculated_at
+          )
+          SELECT
+            pol.id AS po_line_id,
+            po.id AS po_id,
+            po.po_no AS po_no,
+            pol.line_no AS line_no,
+            pol.item_id AS item_id,
+            pol.item_sku AS item_sku,
+            pol.item_name AS item_name,
+            pol.spec_text AS spec_text,
+            po.supplier_id AS supplier_id,
+            COALESCE(po.supplier_name, '') AS supplier_name,
+            po.warehouse_id AS warehouse_id,
+            COALESCE(wh.name, '') AS warehouse_name,
+            po.purchase_time AS purchase_time,
+            DATE(po.purchase_time) AS purchase_date,
+            pol.qty_ordered_input AS qty_ordered_input,
+            pol.purchase_uom_name_snapshot AS purchase_uom_name_snapshot,
+            pol.purchase_ratio_to_base_snapshot AS purchase_ratio_to_base_snapshot,
+            pol.qty_ordered_base AS qty_ordered_base,
+            pol.supply_price AS purchase_unit_price,
+            (
+              COALESCE(pol.supply_price, 0::numeric(12, 2))
+              * COALESCE(pol.qty_ordered_base, 0)
+            )::numeric(14, 2) AS planned_line_amount,
+            GREATEST(pol.updated_at, po.updated_at) AS source_updated_at,
+            now() AS calculated_at
+          FROM purchase_order_lines pol
+          JOIN purchase_orders po ON po.id = pol.po_id
+          JOIN warehouses wh ON wh.id = po.warehouse_id
+          WHERE pol.id = p_po_line_id
+          ON CONFLICT (po_line_id) DO UPDATE SET
+            po_id = EXCLUDED.po_id,
+            po_no = EXCLUDED.po_no,
+            line_no = EXCLUDED.line_no,
+            item_id = EXCLUDED.item_id,
+            item_sku = EXCLUDED.item_sku,
+            item_name = EXCLUDED.item_name,
+            spec_text = EXCLUDED.spec_text,
+            supplier_id = EXCLUDED.supplier_id,
+            supplier_name = EXCLUDED.supplier_name,
+            warehouse_id = EXCLUDED.warehouse_id,
+            warehouse_name = EXCLUDED.warehouse_name,
+            purchase_time = EXCLUDED.purchase_time,
+            purchase_date = EXCLUDED.purchase_date,
+            qty_ordered_input = EXCLUDED.qty_ordered_input,
+            purchase_uom_name_snapshot = EXCLUDED.purchase_uom_name_snapshot,
+            purchase_ratio_to_base_snapshot = EXCLUDED.purchase_ratio_to_base_snapshot,
+            qty_ordered_base = EXCLUDED.qty_ordered_base,
+            purchase_unit_price = EXCLUDED.purchase_unit_price,
+            planned_line_amount = EXCLUDED.planned_line_amount,
+            source_updated_at = EXCLUDED.source_updated_at,
+            calculated_at = now();
+        END;
+        $$;
+        """
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION finance_trg_purchase_price_ledger_line_upsert()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+          PERFORM finance_refresh_purchase_price_ledger_line(NEW.id);
+          RETURN NEW;
+        END;
+        $$;
+        """
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION finance_trg_purchase_price_ledger_line_delete()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+          DELETE FROM finance_purchase_price_ledger_lines
+          WHERE po_line_id = OLD.id;
+          RETURN OLD;
+        END;
+        $$;
+        """
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION finance_trg_purchase_price_ledger_po_refresh()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $$
+        DECLARE
+          v_line_id integer;
+        BEGIN
+          FOR v_line_id IN
+            SELECT id FROM purchase_order_lines WHERE po_id = NEW.id
+          LOOP
+            PERFORM finance_refresh_purchase_price_ledger_line(v_line_id);
+          END LOOP;
+          RETURN NEW;
+        END;
+        $$;
+        """
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION finance_trg_purchase_price_ledger_warehouse_refresh()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $$
+        DECLARE
+          v_line_id integer;
+        BEGIN
+          FOR v_line_id IN
+            SELECT pol.id
+            FROM purchase_order_lines pol
+            JOIN purchase_orders po ON po.id = pol.po_id
+            WHERE po.warehouse_id = NEW.id
+          LOOP
+            PERFORM finance_refresh_purchase_price_ledger_line(v_line_id);
+          END LOOP;
+          RETURN NEW;
+        END;
+        $$;
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TRIGGER trg_fpp_ledger_pol_upsert
+        AFTER INSERT OR UPDATE ON purchase_order_lines
+        FOR EACH ROW
+        EXECUTE FUNCTION finance_trg_purchase_price_ledger_line_upsert()
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TRIGGER trg_fpp_ledger_pol_delete
+        AFTER DELETE ON purchase_order_lines
+        FOR EACH ROW
+        EXECUTE FUNCTION finance_trg_purchase_price_ledger_line_delete()
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TRIGGER trg_fpp_ledger_po_refresh
+        AFTER UPDATE OF po_no, warehouse_id, supplier_id, supplier_name, purchase_time, updated_at
+        ON purchase_orders
+        FOR EACH ROW
+        EXECUTE FUNCTION finance_trg_purchase_price_ledger_po_refresh()
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TRIGGER trg_fpp_ledger_warehouse_refresh
+        AFTER UPDATE OF name
+        ON warehouses
+        FOR EACH ROW
+        EXECUTE FUNCTION finance_trg_purchase_price_ledger_warehouse_refresh()
+        """
+    )
+
+    op.execute(
+        """
+        SELECT finance_refresh_purchase_price_ledger_line(pol.id)
+        FROM purchase_order_lines pol
+        """
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+
+    op.execute("DROP TRIGGER IF EXISTS trg_fpp_ledger_warehouse_refresh ON warehouses")
+    op.execute("DROP TRIGGER IF EXISTS trg_fpp_ledger_po_refresh ON purchase_orders")
+    op.execute("DROP TRIGGER IF EXISTS trg_fpp_ledger_pol_delete ON purchase_order_lines")
+    op.execute("DROP TRIGGER IF EXISTS trg_fpp_ledger_pol_upsert ON purchase_order_lines")
+
+    op.execute("DROP FUNCTION IF EXISTS finance_trg_purchase_price_ledger_warehouse_refresh()")
+    op.execute("DROP FUNCTION IF EXISTS finance_trg_purchase_price_ledger_po_refresh()")
+    op.execute("DROP FUNCTION IF EXISTS finance_trg_purchase_price_ledger_line_delete()")
+    op.execute("DROP FUNCTION IF EXISTS finance_trg_purchase_price_ledger_line_upsert()")
+    op.execute("DROP FUNCTION IF EXISTS finance_refresh_purchase_price_ledger_line(integer)")
+
+    op.drop_index("ix_fpp_ledger_item_supplier", table_name=TABLE_NAME)
+    op.drop_index("ix_fpp_ledger_item_warehouse", table_name=TABLE_NAME)
+    op.drop_index("ix_fpp_ledger_purchase_date", table_name=TABLE_NAME)
+    op.drop_index("ix_fpp_ledger_warehouse_id", table_name=TABLE_NAME)
+    op.drop_index("ix_fpp_ledger_supplier_id", table_name=TABLE_NAME)
+    op.drop_index("ix_fpp_ledger_item_sku", table_name=TABLE_NAME)
+    op.drop_index("ix_fpp_ledger_item_id", table_name=TABLE_NAME)
+
+    op.drop_table(TABLE_NAME)

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -133,6 +133,7 @@ def init_models(
 
     for pkg_name in (
         "app.procurement.models",
+        "app.finance.models",
         "app.pms.items.models",
         "app.pms.suppliers.models",
         "app.wms.inventory_adjustment.return_inbound.models",

--- a/app/finance/models/purchase_price_ledger_line.py
+++ b/app/finance/models/purchase_price_ledger_line.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class FinancePurchasePriceLedgerLine(Base):
+    """
+    财务侧 SKU / 商品采购价格核算明细表。
+
+    定位：
+    - 一行 = 一条 purchase_order_lines 采购发生；
+    - 保留每次采购明细，不合并行；
+    - 相同商品通过 item_id 分组汇集；
+    - accounting_unit_price 不落库，由查询按当前筛选范围窗口聚合计算。
+    """
+
+    __tablename__ = "finance_purchase_price_ledger_lines"
+
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "po_line_id",
+            name="uq_finance_purchase_price_ledger_lines_po_line_id",
+        ),
+        sa.Index("ix_fpp_ledger_item_id", "item_id"),
+        sa.Index("ix_fpp_ledger_item_sku", "item_sku"),
+        sa.Index("ix_fpp_ledger_supplier_id", "supplier_id"),
+        sa.Index("ix_fpp_ledger_warehouse_id", "warehouse_id"),
+        sa.Index("ix_fpp_ledger_purchase_date", "purchase_date"),
+        sa.Index("ix_fpp_ledger_item_warehouse", "item_id", "warehouse_id"),
+        sa.Index("ix_fpp_ledger_item_supplier", "item_id", "supplier_id"),
+    )
+
+    id: Mapped[int] = mapped_column(sa.BigInteger, sa.Identity(), primary_key=True)
+
+    po_line_id: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    po_id: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    po_no: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+    line_no: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+
+    item_id: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    item_sku: Mapped[str | None] = mapped_column(sa.String(64), nullable=True)
+    item_name: Mapped[str | None] = mapped_column(sa.String(255), nullable=True)
+    spec_text: Mapped[str | None] = mapped_column(sa.String(255), nullable=True)
+
+    supplier_id: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    supplier_name: Mapped[str] = mapped_column(sa.String(255), nullable=False)
+
+    warehouse_id: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    warehouse_name: Mapped[str] = mapped_column(sa.String(100), nullable=False)
+
+    purchase_time: Mapped[datetime] = mapped_column(sa.DateTime(timezone=True), nullable=False)
+    purchase_date: Mapped[date] = mapped_column(sa.Date, nullable=False)
+
+    qty_ordered_input: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    purchase_uom_name_snapshot: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+    purchase_ratio_to_base_snapshot: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    qty_ordered_base: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+
+    purchase_unit_price: Mapped[Decimal | None] = mapped_column(sa.Numeric(12, 2), nullable=True)
+    planned_line_amount: Mapped[Decimal] = mapped_column(
+        sa.Numeric(14, 2),
+        nullable=False,
+        server_default=sa.text("0"),
+    )
+
+    source_updated_at: Mapped[datetime | None] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=True,
+    )
+    calculated_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )

--- a/app/finance/sources/purchase_cost_source.py
+++ b/app/finance/sources/purchase_cost_source.py
@@ -60,75 +60,46 @@ class PurchaseCostSource:
 
         if from_date is not None:
             params["from_date"] = from_date
-            where_clauses.append("DATE(po.purchase_time) >= :from_date")
+            where_clauses.append("purchase_date >= :from_date")
 
         if to_date is not None:
             params["to_date"] = to_date
-            where_clauses.append("DATE(po.purchase_time) <= :to_date")
+            where_clauses.append("purchase_date <= :to_date")
 
         if supplier_id is not None:
             params["supplier_id"] = int(supplier_id)
-            where_clauses.append("po.supplier_id = :supplier_id")
+            where_clauses.append("supplier_id = :supplier_id")
 
         if warehouse_id is not None:
             params["warehouse_id"] = int(warehouse_id)
-            where_clauses.append("po.warehouse_id = :warehouse_id")
+            where_clauses.append("warehouse_id = :warehouse_id")
 
         where_sql = "\n               AND ".join(where_clauses)
 
         sql = text(
             f"""
-            WITH ledger AS (
-              SELECT
-                pol.id AS po_line_id,
-                po.id AS po_id,
-                po.po_no AS po_no,
-                pol.line_no AS line_no,
-
-                pol.item_id AS item_id,
-                pol.item_sku AS item_sku,
-                pol.item_name AS item_name,
-                pol.spec_text AS spec_text,
-
-                po.supplier_id AS supplier_id,
-                COALESCE(po.supplier_name, '') AS supplier_name,
-
-                po.warehouse_id AS warehouse_id,
-                COALESCE(wh.name, '') AS warehouse_name,
-
-                po.purchase_time AS purchase_time,
-                DATE(po.purchase_time) AS purchase_date,
-
-                pol.qty_ordered_input AS qty_ordered_input,
-                pol.purchase_uom_name_snapshot AS purchase_uom_name_snapshot,
-                pol.purchase_ratio_to_base_snapshot AS purchase_ratio_to_base_snapshot,
-                pol.qty_ordered_base AS qty_ordered_base,
-
-                pol.supply_price AS purchase_unit_price,
-                {self._line_amount_expr()}::numeric(14, 2) AS planned_line_amount
-
-                FROM purchase_orders po
-                JOIN purchase_order_lines pol ON pol.po_id = po.id
-                JOIN warehouses wh ON wh.id = po.warehouse_id
-               WHERE {where_sql}
-                 AND (
-                   :item_keyword = ''
-                   OR pol.item_sku ILIKE :item_keyword_like
-                   OR pol.item_name ILIKE :item_keyword_like
-                   OR pol.spec_text ILIKE :item_keyword_like
-                   OR CAST(pol.item_id AS text) = :item_keyword
-                 )
+            WITH filtered AS (
+              SELECT *
+              FROM finance_purchase_price_ledger_lines
+              WHERE {where_sql}
+                AND (
+                  :item_keyword = ''
+                  OR item_sku ILIKE :item_keyword_like
+                  OR item_name ILIKE :item_keyword_like
+                  OR spec_text ILIKE :item_keyword_like
+                  OR CAST(item_id AS text) = :item_keyword
+                )
             ),
             weighted AS (
               SELECT
-                ledger.*,
-                SUM(ledger.planned_line_amount) OVER (
-                  PARTITION BY ledger.item_id
+                filtered.*,
+                SUM(filtered.planned_line_amount) OVER (
+                  PARTITION BY filtered.item_id
                 ) AS item_purchase_amount,
-                SUM(ledger.qty_ordered_base) OVER (
-                  PARTITION BY ledger.item_id
+                SUM(filtered.qty_ordered_base) OVER (
+                  PARTITION BY filtered.item_id
                 ) AS item_base_qty
-              FROM ledger
+              FROM filtered
             )
             SELECT
               po_line_id,
@@ -158,7 +129,6 @@ class PurchaseCostSource:
               END AS accounting_unit_price
             FROM weighted
             ORDER BY
-              item_sku ASC NULLS LAST,
               item_id ASC,
               purchase_time DESC,
               po_id DESC,
@@ -212,13 +182,13 @@ class PurchaseCostSource:
                 text(
                     """
                     SELECT
-                      pol.item_id,
-                      MAX(pol.item_sku) AS item_sku,
-                      MAX(pol.item_name) AS item_name,
-                      MAX(pol.spec_text) AS spec_text
-                    FROM purchase_order_lines pol
-                    GROUP BY pol.item_id
-                    ORDER BY MAX(pol.item_sku) ASC NULLS LAST, pol.item_id ASC
+                      item_id,
+                      MAX(item_sku) AS item_sku,
+                      MAX(item_name) AS item_name,
+                      MAX(spec_text) AS spec_text
+                    FROM finance_purchase_price_ledger_lines
+                    GROUP BY item_id
+                    ORDER BY MAX(item_sku) ASC NULLS LAST, item_id ASC
                     LIMIT 500
                     """
                 )
@@ -230,12 +200,11 @@ class PurchaseCostSource:
                 text(
                     """
                     SELECT
-                      po.supplier_id,
-                      COALESCE(po.supplier_name, '') AS supplier_name
-                    FROM purchase_orders po
-                    JOIN purchase_order_lines pol ON pol.po_id = po.id
-                    GROUP BY po.supplier_id, COALESCE(po.supplier_name, '')
-                    ORDER BY supplier_name ASC, po.supplier_id ASC
+                      supplier_id,
+                      COALESCE(supplier_name, '') AS supplier_name
+                    FROM finance_purchase_price_ledger_lines
+                    GROUP BY supplier_id, COALESCE(supplier_name, '')
+                    ORDER BY supplier_name ASC, supplier_id ASC
                     """
                 )
             )
@@ -246,13 +215,11 @@ class PurchaseCostSource:
                 text(
                     """
                     SELECT
-                      po.warehouse_id,
-                      COALESCE(wh.name, '') AS warehouse_name
-                    FROM purchase_orders po
-                    JOIN purchase_order_lines pol ON pol.po_id = po.id
-                    JOIN warehouses wh ON wh.id = po.warehouse_id
-                    GROUP BY po.warehouse_id, COALESCE(wh.name, '')
-                    ORDER BY warehouse_name ASC, po.warehouse_id ASC
+                      warehouse_id,
+                      COALESCE(warehouse_name, '') AS warehouse_name
+                    FROM finance_purchase_price_ledger_lines
+                    GROUP BY warehouse_id, COALESCE(warehouse_name, '')
+                    ORDER BY warehouse_name ASC, warehouse_id ASC
                     """
                 )
             )


### PR DESCRIPTION
## Summary
- Add `finance_purchase_price_ledger_lines` as the physical SKU / item purchase price ledger table
- Store one row per `purchase_order_lines` purchase occurrence
- Backfill existing purchase lines into the finance ledger table
- Add DB trigger functions to keep the ledger synchronized with purchase line, purchase order, and warehouse name changes
- Change `/finance/purchase-costs/sku-purchase-ledger` and options to read from the finance ledger table
- Keep `accounting_unit_price` as a query-time weighted value:
  - SUM(planned_line_amount) / SUM(qty_ordered_base)

## Validation
- python3 -m compileall app/finance/models/purchase_price_ledger_line.py app/finance/contracts/purchase_cost.py app/finance/sources/purchase_cost_source.py app/finance/services/purchase_cost_service.py app/finance/routers/purchase_cost.py app/db/base.py tests/api/test_finance_purchase_sku_ledger_api.py
- make alembic-check
- make test TESTS="tests/api/test_finance_purchase_sku_ledger_api.py tests/api/test_finance_api_contract.py"
- psql confirmed `finance_purchase_price_ledger_lines` row count matches `purchase_order_lines`
- psql confirmed purchase line / purchase order / warehouse sync triggers are installed
- curl /finance/purchase-costs/sku-purchase-ledger?warehouse_id=1 returns persisted purchase ledger rows