### PR TITLE
feat(finance): cascade purchase ledger options

### DIFF
--- a/app/finance/routers/purchase_cost.py
+++ b/app/finance/routers/purchase_cost.py
@@ -47,9 +47,16 @@ def register(router: APIRouter) -> None:
     async def get_finance_sku_purchase_ledger_options(
         session: AsyncSession = Depends(get_session),
         current_user: Any = Depends(get_current_user),
+        supplier_id: int | None = Query(None, description="供应商过滤，可选"),
+        warehouse_id: int | None = Query(None, description="仓库过滤，可选"),
+        item_keyword: str | None = Query(None, description="商品名 / SKU / item_id 过滤，可选"),
     ) -> SkuPurchaseLedgerOptionsResponse:
         _ = current_user
-        return await FinancePurchaseCostService(session).get_sku_purchase_ledger_options()
+        return await FinancePurchaseCostService(session).get_sku_purchase_ledger_options(
+            supplier_id=supplier_id,
+            warehouse_id=warehouse_id,
+            item_keyword=item_keyword or "",
+        )
 
     @router.get(
         "/purchase-costs/sku-purchase-ledger",

--- a/app/finance/services/purchase_cost_service.py
+++ b/app/finance/services/purchase_cost_service.py
@@ -48,7 +48,17 @@ class FinancePurchaseCostService:
         )
         return SkuPurchaseLedgerResponse(**data)
 
-    async def get_sku_purchase_ledger_options(self) -> SkuPurchaseLedgerOptionsResponse:
+    async def get_sku_purchase_ledger_options(
+        self,
+        *,
+        supplier_id: int | None = None,
+        warehouse_id: int | None = None,
+        item_keyword: str = "",
+    ) -> SkuPurchaseLedgerOptionsResponse:
         source = PurchaseCostSource(self.session)
-        data = await source.fetch_sku_purchase_ledger_options()
+        data = await source.fetch_sku_purchase_ledger_options(
+            supplier_id=supplier_id,
+            warehouse_id=warehouse_id,
+            item_keyword=item_keyword,
+        )
         return SkuPurchaseLedgerOptionsResponse(**data)

--- a/app/finance/sources/purchase_cost_source.py
+++ b/app/finance/sources/purchase_cost_source.py
@@ -176,52 +176,106 @@ class PurchaseCostSource:
             ]
         }
 
-    async def fetch_sku_purchase_ledger_options(self) -> dict[str, Any]:
+    def _build_purchase_ledger_filters(
+        self,
+        *,
+        supplier_id: int | None = None,
+        warehouse_id: int | None = None,
+        item_keyword: str = "",
+    ) -> tuple[str, dict[str, object]]:
+        keyword = item_keyword.strip()
+        params: dict[str, object] = {
+            "item_keyword": keyword,
+            "item_keyword_like": f"%{keyword}%",
+        }
+        where_clauses: list[str] = ["1 = 1"]
+
+        if supplier_id is not None:
+            params["supplier_id"] = int(supplier_id)
+            where_clauses.append("supplier_id = :supplier_id")
+
+        if warehouse_id is not None:
+            params["warehouse_id"] = int(warehouse_id)
+            where_clauses.append("warehouse_id = :warehouse_id")
+
+        if keyword:
+            where_clauses.append(
+                """
+                (
+                  item_sku ILIKE :item_keyword_like
+                  OR item_name ILIKE :item_keyword_like
+                  OR spec_text ILIKE :item_keyword_like
+                  OR CAST(item_id AS text) = :item_keyword
+                )
+                """
+            )
+
+        return "\n                      AND ".join(where_clauses), params
+
+    async def fetch_sku_purchase_ledger_options(
+        self,
+        *,
+        supplier_id: int | None = None,
+        warehouse_id: int | None = None,
+        item_keyword: str = "",
+    ) -> dict[str, Any]:
+        where_sql, params = self._build_purchase_ledger_filters(
+            supplier_id=supplier_id,
+            warehouse_id=warehouse_id,
+            item_keyword=item_keyword,
+        )
+
         item_rows = (
             await self.session.execute(
                 text(
-                    """
+                    f"""
                     SELECT
                       item_id,
                       MAX(item_sku) AS item_sku,
                       MAX(item_name) AS item_name,
                       MAX(spec_text) AS spec_text
                     FROM finance_purchase_price_ledger_lines
+                    WHERE {where_sql}
                     GROUP BY item_id
                     ORDER BY MAX(item_sku) ASC NULLS LAST, item_id ASC
                     LIMIT 500
                     """
-                )
+                ),
+                params,
             )
         ).mappings().all()
 
         supplier_rows = (
             await self.session.execute(
                 text(
-                    """
+                    f"""
                     SELECT
                       supplier_id,
                       COALESCE(supplier_name, '') AS supplier_name
                     FROM finance_purchase_price_ledger_lines
+                    WHERE {where_sql}
                     GROUP BY supplier_id, COALESCE(supplier_name, '')
                     ORDER BY supplier_name ASC, supplier_id ASC
                     """
-                )
+                ),
+                params,
             )
         ).mappings().all()
 
         warehouse_rows = (
             await self.session.execute(
                 text(
-                    """
+                    f"""
                     SELECT
                       warehouse_id,
                       COALESCE(warehouse_name, '') AS warehouse_name
                     FROM finance_purchase_price_ledger_lines
+                    WHERE {where_sql}
                     GROUP BY warehouse_id, COALESCE(warehouse_name, '')
                     ORDER BY warehouse_name ASC, warehouse_id ASC
                     """
-                )
+                ),
+                params,
             )
         ).mappings().all()
 

--- a/tests/api/test_finance_purchase_sku_ledger_api.py
+++ b/tests/api/test_finance_purchase_sku_ledger_api.py
@@ -269,3 +269,52 @@ async def test_finance_purchase_sku_ledger_options_include_items_suppliers_and_w
     assert any(int(row["item_id"]) == item_id for row in body["items"]), body
     assert any(int(row["supplier_id"]) == 1 for row in body["suppliers"]), body
     assert any(int(row["warehouse_id"]) == 1 for row in body["warehouses"]), body
+
+
+@pytest.mark.asyncio
+async def test_finance_purchase_sku_ledger_options_are_cascading(
+    client: httpx.AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _headers(client)
+    item_id = await _pick_supplier_item(client, headers)
+    uom_id, _ratio_to_base = await _pick_purchase_uom(session, item_id=item_id)
+
+    payload = {
+        "warehouse_id": 1,
+        "supplier_id": 1,
+        "purchaser": "UT",
+        "purchase_time": "2036-01-17T10:00:00Z",
+        "lines": [
+            {
+                "line_no": 1,
+                "item_id": item_id,
+                "uom_id": uom_id,
+                "qty_input": 1,
+                "supply_price": "5.00",
+            }
+        ],
+    }
+
+    created = await client.post("/purchase-orders/", json=payload, headers=headers)
+    assert created.status_code == 200, created.text
+
+    resp = await client.get(
+        f"/finance/purchase-costs/sku-purchase-ledger/options"
+        f"?supplier_id=1"
+        f"&warehouse_id=1"
+        f"&item_keyword={item_id}",
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    body = resp.json()
+    assert set(body) == {"items", "suppliers", "warehouses"}
+
+    assert body["items"], body
+    assert body["suppliers"], body
+    assert body["warehouses"], body
+
+    assert all(int(row["item_id"]) == item_id for row in body["items"]), body
+    assert all(int(row["supplier_id"]) == 1 for row in body["suppliers"]), body
+    assert all(int(row["warehouse_id"]) == 1 for row in body["warehouses"]), body


### PR DESCRIPTION
## Summary
- Make `/finance/purchase-costs/sku-purchase-ledger/options` accept supplier_id, warehouse_id, and item_keyword
- Return item / supplier / warehouse options from the filtered purchase price ledger line set
- Keep SKU purchase ledger backed by `finance_purchase_price_ledger_lines`
- Add API coverage for cascading option behavior

## Validation
- python3 -m compileall app/finance/sources/purchase_cost_source.py app/finance/services/purchase_cost_service.py app/finance/routers/purchase_cost.py tests/api/test_finance_purchase_sku_ledger_api.py
- make test TESTS="tests/api/test_finance_purchase_sku_ledger_api.py tests/api/test_finance_api_contract.py"
- curl `/finance/purchase-costs/sku-purchase-ledger/options?supplier_id=3&warehouse_id=1&item_keyword=1` returns narrowed item / supplier / warehouse options