### PR TITLE
feat(finance): persist order sales ledger lines

### DIFF
--- a/alembic/versions/f0acefab2386_finance_order_sales_lines.py
+++ b/alembic/versions/f0acefab2386_finance_order_sales_lines.py
@@ -1,0 +1,418 @@
+"""finance_order_sales_lines
+
+Revision ID: f0acefab2386
+Revises: 28e74f19a54f
+Create Date: 2026-04-27 01:15:56.857980
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f0acefab2386"
+down_revision: Union[str, Sequence[str], None] = "28e74f19a54f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+TABLE_NAME = "finance_order_sales_lines"
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+
+    op.create_table(
+        TABLE_NAME,
+        sa.Column("id", sa.BigInteger(), sa.Identity(), nullable=False),
+        sa.Column("order_id", sa.BigInteger(), nullable=False),
+        sa.Column("order_item_id", sa.BigInteger(), nullable=False),
+        sa.Column("platform", sa.String(length=32), nullable=False),
+        sa.Column("store_id", sa.BigInteger(), nullable=False),
+        sa.Column("store_code", sa.String(length=64), nullable=False),
+        sa.Column("store_name", sa.String(length=256), nullable=True),
+        sa.Column("ext_order_no", sa.String(length=128), nullable=False),
+        sa.Column("order_ref", sa.String(length=256), nullable=False),
+        sa.Column("order_status", sa.String(length=32), nullable=True),
+        sa.Column("order_created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("order_date", sa.Date(), nullable=False),
+        sa.Column("receiver_province", sa.String(length=64), nullable=True),
+        sa.Column("receiver_city", sa.String(length=64), nullable=True),
+        sa.Column("receiver_district", sa.String(length=64), nullable=True),
+        sa.Column("item_id", sa.Integer(), nullable=False),
+        sa.Column("sku_id", sa.String(length=128), nullable=True),
+        sa.Column("title", sa.String(length=255), nullable=True),
+        sa.Column("qty_sold", sa.Integer(), server_default=sa.text("0"), nullable=False),
+        sa.Column("unit_price", sa.Numeric(12, 2), nullable=True),
+        sa.Column("discount_amount", sa.Numeric(12, 2), nullable=True),
+        sa.Column("line_amount", sa.Numeric(14, 2), server_default=sa.text("0"), nullable=False),
+        sa.Column("order_amount", sa.Numeric(14, 2), nullable=True),
+        sa.Column("pay_amount", sa.Numeric(14, 2), nullable=True),
+        sa.Column("source_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("calculated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.CheckConstraint("qty_sold >= 0", name="ck_fosl_qty_sold_nonneg"),
+        sa.CheckConstraint("line_amount >= 0", name="ck_fosl_line_amount_nonneg"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("order_item_id", name="uq_finance_order_sales_lines_order_item_id"),
+    )
+
+    op.create_index("ix_fosl_order_id", TABLE_NAME, ["order_id"])
+    op.create_index("ix_fosl_order_item_id", TABLE_NAME, ["order_item_id"])
+    op.create_index("ix_fosl_platform_store", TABLE_NAME, ["platform", "store_code"])
+    op.create_index("ix_fosl_store_id", TABLE_NAME, ["store_id"])
+    op.create_index("ix_fosl_store_code", TABLE_NAME, ["store_code"])
+    op.create_index("ix_fosl_order_ref", TABLE_NAME, ["order_ref"])
+    op.create_index("ix_fosl_ext_order_no", TABLE_NAME, ["ext_order_no"])
+    op.create_index("ix_fosl_order_date", TABLE_NAME, ["order_date"])
+    op.create_index("ix_fosl_item_id", TABLE_NAME, ["item_id"])
+    op.create_index("ix_fosl_sku_id", TABLE_NAME, ["sku_id"])
+
+    op.execute(
+        "COMMENT ON COLUMN orders.store_code IS '店铺 ID（字符串，与 stores.store_code 对齐）'"
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION finance_refresh_order_sales_line(p_order_item_id bigint)
+        RETURNS void
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+          INSERT INTO finance_order_sales_lines (
+            order_id,
+            order_item_id,
+            platform,
+            store_id,
+            store_code,
+            store_name,
+            ext_order_no,
+            order_ref,
+            order_status,
+            order_created_at,
+            order_date,
+            receiver_province,
+            receiver_city,
+            receiver_district,
+            item_id,
+            sku_id,
+            title,
+            qty_sold,
+            unit_price,
+            discount_amount,
+            line_amount,
+            order_amount,
+            pay_amount,
+            source_updated_at,
+            calculated_at
+          )
+          WITH src AS (
+            SELECT
+              o.id AS order_id,
+              oi.id AS order_item_id,
+              o.platform AS platform,
+              o.store_id AS store_id,
+              o.store_code AS store_code,
+              s.store_name AS store_name,
+              o.ext_order_no AS ext_order_no,
+              ('ORD:' || o.platform || ':' || o.store_code || ':' || o.ext_order_no) AS order_ref,
+              o.status AS order_status,
+              o.created_at AS order_created_at,
+              DATE(o.created_at) AS order_date,
+              oa.province AS receiver_province,
+              oa.city AS receiver_city,
+              oa.district AS receiver_district,
+              oi.item_id AS item_id,
+              oi.sku_id AS sku_id,
+              oi.title AS title,
+              COALESCE(oi.qty, 0) AS qty_sold,
+              oi.price AS price,
+              oi.unit_price AS unit_price_raw,
+              COALESCE(oi.discount, 0) AS discount_amount,
+              CASE
+                WHEN oi.amount IS NOT NULL AND oi.amount > 0 THEN oi.amount
+                WHEN oi.line_amount IS NOT NULL AND oi.line_amount > 0 THEN oi.line_amount
+                ELSE COALESCE(oi.qty, 0) * COALESCE(oi.price, oi.unit_price, 0)
+              END AS line_amount,
+              o.order_amount AS order_amount,
+              o.pay_amount AS pay_amount,
+              GREATEST(
+                COALESCE(o.updated_at, o.created_at),
+                COALESCE(oa.created_at, o.created_at)
+              ) AS source_updated_at
+              FROM order_items oi
+              JOIN orders o
+                ON o.id = oi.order_id
+              LEFT JOIN stores s
+                ON s.id = o.store_id
+              LEFT JOIN order_address oa
+                ON oa.order_id = o.id
+             WHERE oi.id = p_order_item_id
+          )
+          SELECT
+            order_id,
+            order_item_id,
+            platform,
+            store_id,
+            store_code,
+            store_name,
+            ext_order_no,
+            order_ref,
+            order_status,
+            order_created_at,
+            order_date,
+            receiver_province,
+            receiver_city,
+            receiver_district,
+            item_id,
+            sku_id,
+            title,
+            qty_sold,
+            CASE
+              WHEN price IS NOT NULL AND price > 0 THEN price
+              WHEN unit_price_raw IS NOT NULL AND unit_price_raw > 0 THEN unit_price_raw
+              WHEN qty_sold > 0 THEN line_amount / qty_sold
+              ELSE NULL
+            END AS unit_price,
+            discount_amount,
+            line_amount,
+            order_amount,
+            pay_amount,
+            source_updated_at,
+            now()
+            FROM src
+          ON CONFLICT (order_item_id)
+          DO UPDATE SET
+            order_id = EXCLUDED.order_id,
+            platform = EXCLUDED.platform,
+            store_id = EXCLUDED.store_id,
+            store_code = EXCLUDED.store_code,
+            store_name = EXCLUDED.store_name,
+            ext_order_no = EXCLUDED.ext_order_no,
+            order_ref = EXCLUDED.order_ref,
+            order_status = EXCLUDED.order_status,
+            order_created_at = EXCLUDED.order_created_at,
+            order_date = EXCLUDED.order_date,
+            receiver_province = EXCLUDED.receiver_province,
+            receiver_city = EXCLUDED.receiver_city,
+            receiver_district = EXCLUDED.receiver_district,
+            item_id = EXCLUDED.item_id,
+            sku_id = EXCLUDED.sku_id,
+            title = EXCLUDED.title,
+            qty_sold = EXCLUDED.qty_sold,
+            unit_price = EXCLUDED.unit_price,
+            discount_amount = EXCLUDED.discount_amount,
+            line_amount = EXCLUDED.line_amount,
+            order_amount = EXCLUDED.order_amount,
+            pay_amount = EXCLUDED.pay_amount,
+            source_updated_at = EXCLUDED.source_updated_at,
+            calculated_at = now();
+        END;
+        $$;
+        """
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION finance_refresh_order_sales_lines_for_order(p_order_id bigint)
+        RETURNS void
+        LANGUAGE plpgsql
+        AS $$
+        DECLARE
+          v_order_item_id bigint;
+        BEGIN
+          FOR v_order_item_id IN
+            SELECT oi.id
+              FROM order_items oi
+             WHERE oi.order_id = p_order_id
+          LOOP
+            PERFORM finance_refresh_order_sales_line(v_order_item_id);
+          END LOOP;
+
+          DELETE FROM finance_order_sales_lines f
+           WHERE f.order_id = p_order_id
+             AND NOT EXISTS (
+               SELECT 1
+                 FROM order_items oi
+                WHERE oi.id = f.order_item_id
+             );
+        END;
+        $$;
+        """
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION finance_trg_order_sales_line_upsert()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+          PERFORM finance_refresh_order_sales_line(NEW.id);
+          RETURN NEW;
+        END;
+        $$;
+        """
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION finance_trg_order_sales_line_delete()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+          DELETE FROM finance_order_sales_lines
+           WHERE order_item_id = OLD.id;
+          RETURN OLD;
+        END;
+        $$;
+        """
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION finance_trg_order_sales_order_refresh()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+          IF TG_OP = 'DELETE' THEN
+            DELETE FROM finance_order_sales_lines
+             WHERE order_id = OLD.id;
+            RETURN OLD;
+          END IF;
+
+          PERFORM finance_refresh_order_sales_lines_for_order(NEW.id);
+          RETURN NEW;
+        END;
+        $$;
+        """
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION finance_trg_order_sales_address_refresh()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+          IF TG_OP = 'DELETE' THEN
+            PERFORM finance_refresh_order_sales_lines_for_order(OLD.order_id);
+            RETURN OLD;
+          END IF;
+
+          PERFORM finance_refresh_order_sales_lines_for_order(NEW.order_id);
+          RETURN NEW;
+        END;
+        $$;
+        """
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION finance_trg_order_sales_store_refresh()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $$
+        DECLARE
+          v_order_id bigint;
+        BEGIN
+          FOR v_order_id IN
+            SELECT o.id
+              FROM orders o
+             WHERE o.store_id = NEW.id
+          LOOP
+            PERFORM finance_refresh_order_sales_lines_for_order(v_order_id);
+          END LOOP;
+
+          RETURN NEW;
+        END;
+        $$;
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TRIGGER trg_finance_order_sales_line_upsert
+        AFTER INSERT OR UPDATE ON order_items
+        FOR EACH ROW
+        EXECUTE FUNCTION finance_trg_order_sales_line_upsert()
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TRIGGER trg_finance_order_sales_line_delete
+        AFTER DELETE ON order_items
+        FOR EACH ROW
+        EXECUTE FUNCTION finance_trg_order_sales_line_delete()
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TRIGGER trg_finance_order_sales_order_refresh
+        AFTER UPDATE OF platform, store_id, store_code, ext_order_no, status, order_amount, pay_amount, created_at, updated_at ON orders
+        FOR EACH ROW
+        EXECUTE FUNCTION finance_trg_order_sales_order_refresh()
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TRIGGER trg_finance_order_sales_order_delete
+        AFTER DELETE ON orders
+        FOR EACH ROW
+        EXECUTE FUNCTION finance_trg_order_sales_order_refresh()
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TRIGGER trg_finance_order_sales_address_refresh
+        AFTER INSERT OR UPDATE OR DELETE ON order_address
+        FOR EACH ROW
+        EXECUTE FUNCTION finance_trg_order_sales_address_refresh()
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TRIGGER trg_finance_order_sales_store_refresh
+        AFTER UPDATE OF store_name, platform, store_code ON stores
+        FOR EACH ROW
+        EXECUTE FUNCTION finance_trg_order_sales_store_refresh()
+        """
+    )
+
+    op.execute(
+        """
+        SELECT finance_refresh_order_sales_line(oi.id)
+          FROM order_items oi
+        """
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+
+    op.execute("DROP TRIGGER IF EXISTS trg_finance_order_sales_store_refresh ON stores")
+    op.execute("DROP TRIGGER IF EXISTS trg_finance_order_sales_address_refresh ON order_address")
+    op.execute("DROP TRIGGER IF EXISTS trg_finance_order_sales_order_delete ON orders")
+    op.execute("DROP TRIGGER IF EXISTS trg_finance_order_sales_order_refresh ON orders")
+    op.execute("DROP TRIGGER IF EXISTS trg_finance_order_sales_line_delete ON order_items")
+    op.execute("DROP TRIGGER IF EXISTS trg_finance_order_sales_line_upsert ON order_items")
+
+    op.execute("DROP FUNCTION IF EXISTS finance_trg_order_sales_store_refresh()")
+    op.execute("DROP FUNCTION IF EXISTS finance_trg_order_sales_address_refresh()")
+    op.execute("DROP FUNCTION IF EXISTS finance_trg_order_sales_order_refresh()")
+    op.execute("DROP FUNCTION IF EXISTS finance_trg_order_sales_line_delete()")
+    op.execute("DROP FUNCTION IF EXISTS finance_trg_order_sales_line_upsert()")
+    op.execute("DROP FUNCTION IF EXISTS finance_refresh_order_sales_lines_for_order(bigint)")
+    op.execute("DROP FUNCTION IF EXISTS finance_refresh_order_sales_line(bigint)")
+
+    op.drop_table(TABLE_NAME)

--- a/app/finance/contracts/order_sales.py
+++ b/app/finance/contracts/order_sales.py
@@ -8,6 +8,8 @@ from pydantic import BaseModel
 
 class OrderSalesSummary(BaseModel):
     order_count: int
+    line_count: int
+    qty_sold: int
     revenue: Decimal
     avg_order_value: Decimal | None = None
     median_order_value: Decimal | None = None
@@ -16,13 +18,18 @@ class OrderSalesSummary(BaseModel):
 class OrderSalesDailyRow(BaseModel):
     day: date
     order_count: int
+    line_count: int
+    qty_sold: int
     revenue: Decimal
 
 
-class OrderSalesShopRow(BaseModel):
+class OrderSalesStoreRow(BaseModel):
     platform: str
     store_code: str
+    store_name: str | None = None
     order_count: int
+    line_count: int
+    qty_sold: int
     revenue: Decimal
 
 
@@ -34,18 +41,45 @@ class OrderSalesItemRow(BaseModel):
     revenue: Decimal
 
 
-class OrderSalesTopOrderRow(BaseModel):
+class OrderSalesLineRow(BaseModel):
+    id: int
     order_id: int
+    order_item_id: int
+
     platform: str
+    store_id: int
     store_code: str
+    store_name: str | None = None
+
     ext_order_no: str
-    order_value: Decimal
-    created_at: datetime
+    order_ref: str
+    order_status: str | None = None
+    order_created_at: datetime
+    order_date: date
+
+    receiver_province: str | None = None
+    receiver_city: str | None = None
+    receiver_district: str | None = None
+
+    item_id: int
+    sku_id: str | None = None
+    title: str | None = None
+
+    qty_sold: int
+    unit_price: Decimal | None = None
+    discount_amount: Decimal | None = None
+    line_amount: Decimal
+
+    order_amount: Decimal | None = None
+    pay_amount: Decimal | None = None
 
 
 class OrderSalesResponse(BaseModel):
     summary: OrderSalesSummary
     daily: list[OrderSalesDailyRow]
-    by_store: list[OrderSalesShopRow]
+    by_store: list[OrderSalesStoreRow]
     by_item: list[OrderSalesItemRow]
-    top_orders: list[OrderSalesTopOrderRow]
+    items: list[OrderSalesLineRow]
+    total: int
+    limit: int
+    offset: int

--- a/app/finance/models/order_sales_line.py
+++ b/app/finance/models/order_sales_line.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class FinanceOrderSalesLine(Base):
+    """
+    财务侧订单销售核算明细表。
+
+    定位：
+    - 一行 = 一个 order_items.id 销售订单行；
+    - 主源来自 orders + order_items + stores + order_address；
+    - 不读取 order_lines 作为销售金额主源；
+    - 不读取 platform_order_lines 作为财务金额主源；
+    - order_ref 用于后续与物流成本事实表按订单维度闭环。
+    """
+
+    __tablename__ = "finance_order_sales_lines"
+
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "order_item_id",
+            name="uq_finance_order_sales_lines_order_item_id",
+        ),
+        sa.Index("ix_fosl_order_id", "order_id"),
+        sa.Index("ix_fosl_order_item_id", "order_item_id"),
+        sa.Index("ix_fosl_platform_store", "platform", "store_code"),
+        sa.Index("ix_fosl_store_id", "store_id"),
+        sa.Index("ix_fosl_store_code", "store_code"),
+        sa.Index("ix_fosl_order_ref", "order_ref"),
+        sa.Index("ix_fosl_ext_order_no", "ext_order_no"),
+        sa.Index("ix_fosl_order_date", "order_date"),
+        sa.Index("ix_fosl_item_id", "item_id"),
+        sa.Index("ix_fosl_sku_id", "sku_id"),
+    )
+
+    id: Mapped[int] = mapped_column(sa.BigInteger, sa.Identity(), primary_key=True)
+
+    order_id: Mapped[int] = mapped_column(sa.BigInteger, nullable=False)
+    order_item_id: Mapped[int] = mapped_column(sa.BigInteger, nullable=False)
+
+    platform: Mapped[str] = mapped_column(sa.String(32), nullable=False)
+    store_id: Mapped[int] = mapped_column(sa.BigInteger, nullable=False)
+    store_code: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+    store_name: Mapped[str | None] = mapped_column(sa.String(256), nullable=True)
+
+    ext_order_no: Mapped[str] = mapped_column(sa.String(128), nullable=False)
+    order_ref: Mapped[str] = mapped_column(sa.String(256), nullable=False)
+    order_status: Mapped[str | None] = mapped_column(sa.String(32), nullable=True)
+
+    order_created_at: Mapped[datetime] = mapped_column(sa.DateTime(timezone=True), nullable=False)
+    order_date: Mapped[date] = mapped_column(sa.Date, nullable=False)
+
+    receiver_province: Mapped[str | None] = mapped_column(sa.String(64), nullable=True)
+    receiver_city: Mapped[str | None] = mapped_column(sa.String(64), nullable=True)
+    receiver_district: Mapped[str | None] = mapped_column(sa.String(64), nullable=True)
+
+    item_id: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    sku_id: Mapped[str | None] = mapped_column(sa.String(128), nullable=True)
+    title: Mapped[str | None] = mapped_column(sa.String(255), nullable=True)
+
+    qty_sold: Mapped[int] = mapped_column(
+        sa.Integer,
+        nullable=False,
+        server_default=sa.text("0"),
+    )
+    unit_price: Mapped[Decimal | None] = mapped_column(sa.Numeric(12, 2), nullable=True)
+    discount_amount: Mapped[Decimal | None] = mapped_column(sa.Numeric(12, 2), nullable=True)
+    line_amount: Mapped[Decimal] = mapped_column(
+        sa.Numeric(14, 2),
+        nullable=False,
+        server_default=sa.text("0"),
+    )
+
+    order_amount: Mapped[Decimal | None] = mapped_column(sa.Numeric(14, 2), nullable=True)
+    pay_amount: Mapped[Decimal | None] = mapped_column(sa.Numeric(14, 2), nullable=True)
+
+    source_updated_at: Mapped[datetime | None] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=True,
+    )
+    calculated_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )

--- a/app/finance/routers/order_sales.py
+++ b/app/finance/routers/order_sales.py
@@ -30,6 +30,9 @@ def register(router: APIRouter) -> None:
         to_date: str | None = Query(None, description="结束日期 YYYY-MM-DD，默认今天"),
         platform: str | None = Query(None, description="平台过滤，可选"),
         store_code: str | None = Query(None, description="店铺过滤，可选"),
+        order_no: str | None = Query(None, description="订单号 / 订单引用模糊搜索，可选"),
+        limit: int = Query(100, ge=1, le=500, description="分页大小"),
+        offset: int = Query(0, ge=0, description="分页偏移量"),
     ) -> OrderSalesResponse:
         _ = current_user
         from_dt, to_dt = await ensure_default_range(
@@ -42,4 +45,7 @@ def register(router: APIRouter) -> None:
             to_date=to_dt,
             platform=clean_platform(platform),
             store_code=clean_store_code(store_code),
+            order_no=(order_no or "").strip(),
+            limit=int(limit),
+            offset=int(offset),
         )

--- a/app/finance/services/order_sales_service.py
+++ b/app/finance/services/order_sales_service.py
@@ -19,6 +19,9 @@ class FinanceOrderSalesService:
         to_date: date,
         platform: str = "",
         store_code: str = "",
+        order_no: str = "",
+        limit: int = 100,
+        offset: int = 0,
     ) -> OrderSalesResponse:
         source = OrderSalesSource(self.session)
         data = await source.fetch(
@@ -26,5 +29,8 @@ class FinanceOrderSalesService:
             to_date=to_date,
             platform=platform,
             store_code=store_code,
+            order_no=order_no,
+            limit=limit,
+            offset=offset,
         )
         return OrderSalesResponse(**data)

--- a/app/finance/sources/order_sales_source.py
+++ b/app/finance/sources/order_sales_source.py
@@ -15,10 +15,11 @@ class OrderSalesSource:
     订单销售只读来源。
 
     边界：
-    - 只读 OMS 订单事实：orders / order_items
-    - 不读取采购
-    - 不读取发货辅助
-    - 不计算利润
+    - 只读财务侧订单销售事实表 finance_order_sales_lines；
+    - 不让 finance read API 直接跨 OMS 表拼装页面数据；
+    - 不读取采购；
+    - 不读取发货辅助；
+    - 不计算利润。
     """
 
     def __init__(self, session: AsyncSession) -> None:
@@ -31,61 +32,91 @@ class OrderSalesSource:
         to_date: date,
         platform: str = "",
         store_code: str = "",
+        order_no: str = "",
+        limit: int = 100,
+        offset: int = 0,
     ) -> dict[str, Any]:
         params = {
             "from_date": from_date,
             "to_date": to_date,
             "platform": platform,
             "store_code": store_code,
+            "order_no": order_no,
+            "limit": int(limit),
+            "offset": int(offset),
         }
 
         summary = await self._summary(params)
         daily = await self._daily(params)
         by_store = await self._by_store(params)
         by_item = await self._by_item(params)
-        top_orders = await self._top_orders(params)
+        items = await self._items(params)
+        total = await self._total(params)
 
         return {
             "summary": summary,
             "daily": daily,
             "by_store": by_store,
             "by_item": by_item,
-            "top_orders": top_orders,
+            "items": items,
+            "total": total,
+            "limit": int(limit),
+            "offset": int(offset),
         }
 
-    def _base_where(self) -> str:
-        return """
-        DATE(o.created_at) BETWEEN :from_date AND :to_date
-        AND (:platform = '' OR o.platform = :platform)
-        AND (:store_code = '' OR o.store_code = :store_code)
+    def _base_where(self, alias: str = "f") -> str:
+        return f"""
+        {alias}.order_date BETWEEN :from_date AND :to_date
+        AND (:platform = '' OR {alias}.platform = :platform)
+        AND (:store_code = '' OR {alias}.store_code = :store_code)
+        AND (
+          :order_no = ''
+          OR {alias}.ext_order_no ILIKE ('%' || :order_no || '%')
+          OR {alias}.order_ref ILIKE ('%' || :order_no || '%')
+        )
         AND NOT EXISTS (
           SELECT 1
             FROM platform_test_stores pts
            WHERE pts.code = 'DEFAULT'
-             AND upper(pts.platform) = upper(o.platform)
-             AND btrim(CAST(pts.store_code AS text)) = btrim(CAST(o.store_code AS text))
+             AND (
+               (pts.store_id IS NOT NULL AND pts.store_id = {alias}.store_id)
+               OR (
+                 upper(pts.platform) = upper({alias}.platform)
+                 AND btrim(CAST(pts.store_code AS text)) = btrim(CAST({alias}.store_code AS text))
+               )
+             )
         )
         """
 
     async def _summary(self, params: dict[str, object]) -> dict[str, object]:
         sql = text(
             f"""
-            WITH order_values AS (
-              SELECT COALESCE(o.pay_amount, o.order_amount, 0) AS order_value
-                FROM orders o
-               WHERE {self._base_where()}
+            WITH filtered AS (
+              SELECT *
+                FROM finance_order_sales_lines f
+               WHERE {self._base_where("f")}
+            ),
+            order_values AS (
+              SELECT
+                order_id,
+                MAX(COALESCE(pay_amount, order_amount, 0)) AS order_value
+                FROM filtered
+               GROUP BY order_id
             )
             SELECT
-              COUNT(*) AS order_count,
-              COALESCE(SUM(order_value), 0) AS revenue,
-              CASE WHEN COUNT(*) > 0 THEN AVG(order_value) ELSE NULL END AS avg_order_value,
-              percentile_disc(0.5) WITHIN GROUP (ORDER BY order_value) AS median_order_value
-              FROM order_values
+              (SELECT COUNT(*) FROM order_values) AS order_count,
+              (SELECT COUNT(*) FROM filtered) AS line_count,
+              (SELECT COALESCE(SUM(qty_sold), 0) FROM filtered) AS qty_sold,
+              (SELECT COALESCE(SUM(order_value), 0) FROM order_values) AS revenue,
+              (SELECT CASE WHEN COUNT(*) > 0 THEN AVG(order_value) ELSE NULL END FROM order_values) AS avg_order_value,
+              (SELECT percentile_disc(0.5) WITHIN GROUP (ORDER BY order_value) FROM order_values) AS median_order_value
             """
         )
         row = (await self.session.execute(sql, params)).mappings().one()
         return {
             "order_count": int(row["order_count"] or 0),
+            "line_count": int(row["line_count"] or 0),
+            "qty_sold": int(row["qty_sold"] or 0),
             "revenue": to_decimal(row["revenue"]),
             "avg_order_value": to_decimal(row["avg_order_value"]).quantize(Decimal("0.01"))
             if row["avg_order_value"] is not None
@@ -101,21 +132,44 @@ class OrderSalesSource:
             WITH day_dim AS (
               SELECT generate_series(:from_date, :to_date, interval '1 day')::date AS day
             ),
-            agg AS (
+            filtered AS (
+              SELECT *
+                FROM finance_order_sales_lines f
+               WHERE {self._base_where("f")}
+            ),
+            order_values AS (
               SELECT
-                DATE(o.created_at) AS day,
+                order_date AS day,
+                order_id,
+                MAX(COALESCE(pay_amount, order_amount, 0)) AS order_value
+                FROM filtered
+               GROUP BY order_date, order_id
+            ),
+            order_agg AS (
+              SELECT
+                day,
                 COUNT(*) AS order_count,
-                COALESCE(SUM(COALESCE(o.pay_amount, o.order_amount, 0)), 0) AS revenue
-                FROM orders o
-               WHERE {self._base_where()}
-               GROUP BY DATE(o.created_at)
+                COALESCE(SUM(order_value), 0) AS revenue
+                FROM order_values
+               GROUP BY day
+            ),
+            line_agg AS (
+              SELECT
+                order_date AS day,
+                COUNT(*) AS line_count,
+                COALESCE(SUM(qty_sold), 0) AS qty_sold
+                FROM filtered
+               GROUP BY order_date
             )
             SELECT
               d.day,
-              COALESCE(a.order_count, 0) AS order_count,
-              COALESCE(a.revenue, 0) AS revenue
+              COALESCE(oa.order_count, 0) AS order_count,
+              COALESCE(la.line_count, 0) AS line_count,
+              COALESCE(la.qty_sold, 0) AS qty_sold,
+              COALESCE(oa.revenue, 0) AS revenue
               FROM day_dim d
-              LEFT JOIN agg a ON a.day = d.day
+              LEFT JOIN order_agg oa ON oa.day = d.day
+              LEFT JOIN line_agg la ON la.day = d.day
              ORDER BY d.day ASC
             """
         )
@@ -124,6 +178,8 @@ class OrderSalesSource:
             {
                 "day": row["day"],
                 "order_count": int(row["order_count"] or 0),
+                "line_count": int(row["line_count"] or 0),
+                "qty_sold": int(row["qty_sold"] or 0),
                 "revenue": to_decimal(row["revenue"]),
             }
             for row in rows
@@ -132,15 +188,55 @@ class OrderSalesSource:
     async def _by_store(self, params: dict[str, object]) -> list[dict[str, object]]:
         sql = text(
             f"""
+            WITH filtered AS (
+              SELECT *
+                FROM finance_order_sales_lines f
+               WHERE {self._base_where("f")}
+            ),
+            order_values AS (
+              SELECT
+                platform,
+                store_code,
+                store_name,
+                order_id,
+                MAX(COALESCE(pay_amount, order_amount, 0)) AS order_value
+                FROM filtered
+               GROUP BY platform, store_code, store_name, order_id
+            ),
+            order_agg AS (
+              SELECT
+                platform,
+                store_code,
+                store_name,
+                COUNT(*) AS order_count,
+                COALESCE(SUM(order_value), 0) AS revenue
+                FROM order_values
+               GROUP BY platform, store_code, store_name
+            ),
+            line_agg AS (
+              SELECT
+                platform,
+                store_code,
+                store_name,
+                COUNT(*) AS line_count,
+                COALESCE(SUM(qty_sold), 0) AS qty_sold
+                FROM filtered
+               GROUP BY platform, store_code, store_name
+            )
             SELECT
-              o.platform,
-              o.store_code,
-              COUNT(*) AS order_count,
-              COALESCE(SUM(COALESCE(o.pay_amount, o.order_amount, 0)), 0) AS revenue
-              FROM orders o
-             WHERE {self._base_where()}
-             GROUP BY o.platform, o.store_code
-             ORDER BY revenue DESC, o.platform ASC, o.store_code ASC
+              oa.platform,
+              oa.store_code,
+              oa.store_name,
+              oa.order_count,
+              COALESCE(la.line_count, 0) AS line_count,
+              COALESCE(la.qty_sold, 0) AS qty_sold,
+              oa.revenue
+              FROM order_agg oa
+              LEFT JOIN line_agg la
+                ON la.platform = oa.platform
+               AND la.store_code = oa.store_code
+               AND COALESCE(la.store_name, '') = COALESCE(oa.store_name, '')
+             ORDER BY oa.revenue DESC, oa.platform ASC, oa.store_code ASC
             """
         )
         rows = (await self.session.execute(sql, params)).mappings().all()
@@ -148,7 +244,10 @@ class OrderSalesSource:
             {
                 "platform": str(row["platform"]),
                 "store_code": str(row["store_code"]),
+                "store_name": row["store_name"],
                 "order_count": int(row["order_count"] or 0),
+                "line_count": int(row["line_count"] or 0),
+                "qty_sold": int(row["qty_sold"] or 0),
                 "revenue": to_decimal(row["revenue"]),
             }
             for row in rows
@@ -158,17 +257,16 @@ class OrderSalesSource:
         sql = text(
             f"""
             SELECT
-              oi.item_id,
-              MAX(oi.sku_id) AS sku_id,
-              MAX(oi.title) AS title,
-              COALESCE(SUM(COALESCE(oi.qty, 0)), 0) AS qty_sold,
-              COALESCE(SUM(COALESCE(oi.amount, COALESCE(oi.qty, 0) * COALESCE(oi.price, 0))), 0) AS revenue
-              FROM orders o
-              JOIN order_items oi ON oi.order_id = o.id
-             WHERE {self._base_where()}
-             GROUP BY oi.item_id
-             HAVING COALESCE(SUM(COALESCE(oi.qty, 0)), 0) > 0
-             ORDER BY revenue DESC, oi.item_id ASC
+              f.item_id,
+              MAX(f.sku_id) AS sku_id,
+              MAX(f.title) AS title,
+              COALESCE(SUM(f.qty_sold), 0) AS qty_sold,
+              COALESCE(SUM(f.line_amount), 0) AS revenue
+              FROM finance_order_sales_lines f
+             WHERE {self._base_where("f")}
+             GROUP BY f.item_id
+             HAVING COALESCE(SUM(f.qty_sold), 0) > 0
+             ORDER BY revenue DESC, f.item_id ASC
              LIMIT 100
             """
         )
@@ -184,31 +282,79 @@ class OrderSalesSource:
             for row in rows
         ]
 
-    async def _top_orders(self, params: dict[str, object]) -> list[dict[str, object]]:
+    async def _total(self, params: dict[str, object]) -> int:
+        sql = text(
+            f"""
+            SELECT COUNT(*) AS total
+              FROM finance_order_sales_lines f
+             WHERE {self._base_where("f")}
+            """
+        )
+        return int((await self.session.execute(sql, params)).scalar_one() or 0)
+
+    async def _items(self, params: dict[str, object]) -> list[dict[str, object]]:
         sql = text(
             f"""
             SELECT
-              o.id AS order_id,
-              o.platform,
-              o.store_code,
-              o.ext_order_no,
-              COALESCE(o.pay_amount, o.order_amount, 0) AS order_value,
-              o.created_at
-              FROM orders o
-             WHERE {self._base_where()}
-             ORDER BY order_value DESC, o.created_at DESC, o.id DESC
-             LIMIT 50
+              f.id,
+              f.order_id,
+              f.order_item_id,
+              f.platform,
+              f.store_id,
+              f.store_code,
+              f.store_name,
+              f.ext_order_no,
+              f.order_ref,
+              f.order_status,
+              f.order_created_at,
+              f.order_date,
+              f.receiver_province,
+              f.receiver_city,
+              f.receiver_district,
+              f.item_id,
+              f.sku_id,
+              f.title,
+              f.qty_sold,
+              f.unit_price,
+              f.discount_amount,
+              f.line_amount,
+              f.order_amount,
+              f.pay_amount
+              FROM finance_order_sales_lines f
+             WHERE {self._base_where("f")}
+             ORDER BY f.order_created_at DESC, f.id DESC
+             LIMIT :limit OFFSET :offset
             """
         )
         rows = (await self.session.execute(sql, params)).mappings().all()
         return [
             {
+                "id": int(row["id"]),
                 "order_id": int(row["order_id"]),
+                "order_item_id": int(row["order_item_id"]),
                 "platform": str(row["platform"]),
+                "store_id": int(row["store_id"]),
                 "store_code": str(row["store_code"]),
+                "store_name": row["store_name"],
                 "ext_order_no": str(row["ext_order_no"]),
-                "order_value": to_decimal(row["order_value"]),
-                "created_at": row["created_at"],
+                "order_ref": str(row["order_ref"]),
+                "order_status": row["order_status"],
+                "order_created_at": row["order_created_at"],
+                "order_date": row["order_date"],
+                "receiver_province": row["receiver_province"],
+                "receiver_city": row["receiver_city"],
+                "receiver_district": row["receiver_district"],
+                "item_id": int(row["item_id"]),
+                "sku_id": row["sku_id"],
+                "title": row["title"],
+                "qty_sold": int(row["qty_sold"] or 0),
+                "unit_price": to_decimal(row["unit_price"]) if row["unit_price"] is not None else None,
+                "discount_amount": to_decimal(row["discount_amount"])
+                if row["discount_amount"] is not None
+                else None,
+                "line_amount": to_decimal(row["line_amount"]),
+                "order_amount": to_decimal(row["order_amount"]) if row["order_amount"] is not None else None,
+                "pay_amount": to_decimal(row["pay_amount"]) if row["pay_amount"] is not None else None,
             }
             for row in rows
         ]

--- a/tests/api/test_finance_api_contract.py
+++ b/tests/api/test_finance_api_contract.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from decimal import Decimal
+from uuid import uuid4
+
+from sqlalchemy import text
+
 
 async def _headers(client) -> dict[str, str]:
     login = await client.post(
@@ -8,6 +13,163 @@ async def _headers(client) -> dict[str, str]:
     )
     assert login.status_code == 200, login.text
     return {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+
+async def _seed_finance_order_sales_line(db_session) -> str:
+    platform = "PDD"
+    store_code = f"FIN-ORDER-STORE-{uuid4().hex[:8]}"
+    ext_order_no = f"FIN-ORDER-{uuid4().hex[:8]}"
+
+    store_row = (
+        await db_session.execute(
+            text(
+                """
+                INSERT INTO stores (
+                  platform,
+                  store_code,
+                  store_name,
+                  active,
+                  created_at,
+                  updated_at
+                )
+                VALUES (
+                  :platform,
+                  :store_code,
+                  :store_name,
+                  TRUE,
+                  now(),
+                  now()
+                )
+                ON CONFLICT (platform, store_code)
+                DO UPDATE SET
+                  store_name = EXCLUDED.store_name,
+                  updated_at = now()
+                RETURNING id
+                """
+            ),
+            {
+                "platform": platform,
+                "store_code": store_code,
+                "store_name": "FIN-订单销售测试店铺",
+            },
+        )
+    ).mappings().one()
+    store_id = int(store_row["id"])
+
+    order_row = (
+        await db_session.execute(
+            text(
+                """
+                INSERT INTO orders (
+                  platform,
+                  store_id,
+                  store_code,
+                  ext_order_no,
+                  status,
+                  order_amount,
+                  pay_amount,
+                  buyer_name,
+                  buyer_phone,
+                  created_at,
+                  updated_at
+                )
+                VALUES (
+                  :platform,
+                  :store_id,
+                  :store_code,
+                  :ext_order_no,
+                  'PAID',
+                  49.90,
+                  39.90,
+                  'finance-buyer',
+                  '13000000000',
+                  '2026-01-03 10:00:00+00',
+                  '2026-01-03 10:00:00+00'
+                )
+                RETURNING id
+                """
+            ),
+            {
+                "platform": platform,
+                "store_id": store_id,
+                "store_code": store_code,
+                "ext_order_no": ext_order_no,
+            },
+        )
+    ).mappings().one()
+    order_id = int(order_row["id"])
+
+    await db_session.execute(
+        text(
+            """
+            INSERT INTO order_address (
+              order_id,
+              receiver_name,
+              receiver_phone,
+              province,
+              city,
+              district,
+              detail,
+              zipcode,
+              created_at
+            )
+            VALUES (
+              :order_id,
+              'finance-receiver',
+              '13000000000',
+              '浙江省',
+              '杭州市',
+              '西湖区',
+              '测试地址',
+              '310000',
+              now()
+            )
+            ON CONFLICT (order_id)
+            DO UPDATE SET
+              province = EXCLUDED.province,
+              city = EXCLUDED.city,
+              district = EXCLUDED.district
+            """
+        ),
+        {"order_id": order_id},
+    )
+
+    await db_session.execute(
+        text(
+            """
+            INSERT INTO order_items (
+              order_id,
+              item_id,
+              qty,
+              sku_id,
+              title,
+              price,
+              discount,
+              amount,
+              extras,
+              shipped_qty,
+              returned_qty
+            )
+            VALUES (
+              :order_id,
+              1,
+              2,
+              'FIN-SKU-1',
+              '订单销售测试商品',
+              19.95,
+              0,
+              39.90,
+              '{}'::jsonb,
+              0,
+              0
+            )
+            """
+        ),
+        {"order_id": order_id},
+    )
+
+    await db_session.commit()
+    return ext_order_no
 
 
 async def test_finance_overview_page_contract(client):
@@ -54,9 +216,20 @@ async def test_finance_order_sales_contract(client):
     assert resp.status_code == 200, resp.text
 
     body = resp.json()
-    assert set(body) == {"summary", "daily", "by_store", "by_item", "top_orders"}
+    assert set(body) == {
+        "summary",
+        "daily",
+        "by_store",
+        "by_item",
+        "items",
+        "total",
+        "limit",
+        "offset",
+    }
     assert set(body["summary"]) == {
         "order_count",
+        "line_count",
+        "qty_sold",
         "revenue",
         "avg_order_value",
         "median_order_value",
@@ -64,7 +237,43 @@ async def test_finance_order_sales_contract(client):
     assert isinstance(body["daily"], list)
     assert isinstance(body["by_store"], list)
     assert isinstance(body["by_item"], list)
-    assert isinstance(body["top_orders"], list)
+    assert isinstance(body["items"], list)
+    assert isinstance(body["total"], int)
+    assert isinstance(body["limit"], int)
+    assert isinstance(body["offset"], int)
+
+
+async def test_finance_order_sales_reads_physical_sales_lines(client, session):
+    ext_order_no = await _seed_finance_order_sales_line(session)
+    headers = await _headers(client)
+
+    resp = await client.get(
+        "/finance/order-sales"
+        f"?from_date=2026-01-01&to_date=2026-01-07&order_no={ext_order_no}",
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    body = resp.json()
+    assert body["total"] == 1, body
+    assert body["summary"]["order_count"] == 1, body
+    assert body["summary"]["line_count"] == 1, body
+    assert body["summary"]["qty_sold"] == 2, body
+    assert Decimal(str(body["summary"]["revenue"])) == Decimal("39.90")
+
+    item = body["items"][0]
+    assert item["ext_order_no"] == ext_order_no
+    assert item["order_ref"].endswith(f":{ext_order_no}")
+    assert item["store_code"].startswith("FIN-ORDER-STORE-")
+    assert item["store_name"] == "FIN-订单销售测试店铺"
+    assert item["receiver_province"] == "浙江省"
+    assert item["receiver_city"] == "杭州市"
+    assert item["receiver_district"] == "西湖区"
+    assert item["item_id"] == 1
+    assert item["sku_id"] == "FIN-SKU-1"
+    assert item["title"] == "订单销售测试商品"
+    assert item["qty_sold"] == 2
+    assert Decimal(str(item["line_amount"])) == Decimal("39.90")
 
 
 async def test_finance_purchase_costs_contract(client):


### PR DESCRIPTION
## Summary

- Add finance_order_sales_lines as the finance-side order sales fact table
- Use one row per order_items.id
- Refresh from orders + order_items + stores + order_address
- Keep order_lines and platform_order_lines out of the finance sales amount source
- Add order_ref for future sales/shipping/profit joins
- Switch /finance/order-sales to read from finance_order_sales_lines
- Replace top_orders with paged items table contract
- Keep frontend untouched in this PR

## Validation

- python3 -m compileall app tests alembic/versions/f0acefab2386_finance_order_sales_lines.py
- make alembic-check
- make test TESTS=tests/api/test_finance_api_contract.py
- make test