### PR TITLE
feat(oms): add PDD real order ingest endpoint

### DIFF
--- a/app/oms/platforms/pdd/contracts_ingest.py
+++ b/app/oms/platforms/pdd/contracts_ingest.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class PddOrderIngestRequest(BaseModel):
+    start_confirm_at: Optional[str] = Field(
+        default=None,
+        description="PDD 成交开始时间，格式 yyyy-MM-dd HH:mm:ss；为空时由服务使用默认窗口",
+    )
+    end_confirm_at: Optional[str] = Field(
+        default=None,
+        description="PDD 成交结束时间，格式 yyyy-MM-dd HH:mm:ss；为空时由服务使用默认窗口",
+    )
+    order_status: int = Field(
+        default=1,
+        ge=1,
+        description="PDD 订单状态；默认 1",
+    )
+    page: int = Field(
+        default=1,
+        ge=1,
+        description="页码，从 1 开始",
+    )
+    page_size: int = Field(
+        default=50,
+        ge=1,
+        le=100,
+        description="每页数量，PDD 当前最大 100",
+    )
+
+
+class PddOrderIngestRowOut(BaseModel):
+    order_sn: str
+    pdd_order_id: Optional[int] = None
+    status: str
+    error: Optional[str] = None
+
+
+class PddOrderIngestDataOut(BaseModel):
+    platform: str
+    store_id: int
+    store_code: str
+    page: int
+    page_size: int
+    orders_count: int
+    success_count: int
+    failed_count: int
+    has_more: bool
+    start_confirm_at: Optional[str] = None
+    end_confirm_at: Optional[str] = None
+    rows: List[PddOrderIngestRowOut]
+
+
+class PddOrderIngestEnvelopeOut(BaseModel):
+    ok: bool
+    data: PddOrderIngestDataOut

--- a/app/oms/platforms/pdd/repo_orders.py
+++ b/app/oms/platforms/pdd/repo_orders.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from decimal import Decimal, InvalidOperation
 from typing import List, Optional, Sequence
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -26,6 +26,43 @@ def _money_from_cent(raw: object) -> Decimal | None:
     except (InvalidOperation, ValueError, TypeError):
         return None
     return (value / _MONEY_SCALE).quantize(Decimal("0.01"))
+
+
+async def load_store_code_by_store_id_for_pdd(
+    session: AsyncSession,
+    *,
+    store_id: int,
+) -> str:
+    """
+    PDD 拉单入库使用的店铺编码读取入口。
+
+    边界：
+    - 只读取 stores.store_code；
+    - 只接受 platform=PDD 的店铺；
+    - 不创建店铺；
+    - 不修正平台；
+    - 找不到即抛 LookupError，由调用方转为 400。
+    """
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT store_code
+                  FROM stores
+                 WHERE id = :store_id
+                   AND upper(platform) = 'PDD'
+                 LIMIT 1
+                """
+            ),
+            {"store_id": int(store_id)},
+        )
+    ).mappings().first()
+
+    store_code = row.get("store_code") if row else None
+    if not store_code:
+        raise LookupError(f"pdd store not found: store_id={int(store_id)}")
+
+    return str(store_code)
 
 
 async def get_pdd_order_by_store_and_order_sn(

--- a/app/oms/platforms/pdd/router_ingest.py
+++ b/app/oms/platforms/pdd/router_ingest.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Body, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.deps import get_async_session as get_session
+from app.oms.platforms.pdd.contracts_ingest import (
+    PddOrderIngestDataOut,
+    PddOrderIngestEnvelopeOut,
+    PddOrderIngestRequest,
+    PddOrderIngestRowOut,
+)
+from app.oms.platforms.pdd.service_ingest import (
+    PddOrderIngestService,
+    PddOrderIngestServiceError,
+)
+from app.oms.platforms.pdd.service_real_pull import PddRealPullParams
+
+router = APIRouter(tags=["oms-pdd-ingest"])
+
+
+@router.post(
+    "/stores/{store_id}/pdd/orders/ingest",
+    response_model=PddOrderIngestEnvelopeOut,
+    summary="PDD 真实拉单入平台事实表",
+)
+async def ingest_store_pdd_orders(
+    store_id: int,
+    payload: PddOrderIngestRequest = Body(default_factory=PddOrderIngestRequest),
+    session: AsyncSession = Depends(get_session),
+) -> PddOrderIngestEnvelopeOut:
+    """
+    PDD 真实订单入库入口。
+
+    边界：
+    - 拉 PDD 订单摘要页；
+    - 逐单补详情并解密；
+    - 写入 pdd_orders / pdd_order_items；
+    - 不写 platform_order_lines；
+    - 不解析 FSKU；
+    - 不建内部 orders/order_items；
+    - 不写 pdd_order_order_mappings；
+    - 不触碰 finance。
+    """
+
+    try:
+        service = PddOrderIngestService()
+        result = await service.ingest_order_page(
+            session=session,
+            params=PddRealPullParams(
+                store_id=int(store_id),
+                start_confirm_at=payload.start_confirm_at,
+                end_confirm_at=payload.end_confirm_at,
+                order_status=int(payload.order_status),
+                page=int(payload.page),
+                page_size=int(payload.page_size),
+            ),
+        )
+        await session.commit()
+    except (ValueError, LookupError, PddOrderIngestServiceError) as exc:
+        await session.rollback()
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:  # noqa: BLE001
+        await session.rollback()
+        raise HTTPException(
+            status_code=500,
+            detail=f"failed to ingest pdd orders: {exc}",
+        ) from exc
+
+    return PddOrderIngestEnvelopeOut(
+        ok=True,
+        data=PddOrderIngestDataOut(
+            platform="pdd",
+            store_id=int(result.store_id),
+            store_code=str(result.store_code),
+            page=int(result.page),
+            page_size=int(result.page_size),
+            orders_count=int(result.orders_count),
+            success_count=int(result.success_count),
+            failed_count=int(result.failed_count),
+            has_more=bool(result.has_more),
+            start_confirm_at=result.start_confirm_at,
+            end_confirm_at=result.end_confirm_at,
+            rows=[
+                PddOrderIngestRowOut(
+                    order_sn=row.order_sn,
+                    pdd_order_id=row.pdd_order_id,
+                    status=row.status,
+                    error=row.error,
+                )
+                for row in result.rows
+            ],
+        ),
+    )

--- a/app/oms/platforms/pdd/service_ingest.py
+++ b/app/oms/platforms/pdd/service_ingest.py
@@ -91,7 +91,7 @@ class PddOrderIngestService:
                 session,
                 store_id=store_id,
             )
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             raise PddOrderIngestServiceError(
                 f"failed to load pdd store_code by store_id={store_id}: {exc}"
             ) from exc
@@ -163,7 +163,6 @@ class PddOrderIngestService:
             pdd_order: PddOrder = await upsert_pdd_order(
                 session,
                 store_id=store_id,
-                store_code=store_code,
                 summary_raw_payload=summary.raw_order,
                 detail=detail,
                 order_status=summary.order_status,
@@ -190,7 +189,7 @@ class PddOrderIngestService:
                 status="FAILED",
                 error=f"detail_failed: {exc}",
             )
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             return PddOrderIngestRowResult(
                 order_sn=order_sn,
                 pdd_order_id=None,

--- a/app/oms/router.py
+++ b/app/oms/router.py
@@ -9,6 +9,7 @@ from app.oms.platforms.jd.router_pull import router as jd_pull_router
 from app.oms.platforms.pdd.router_app_config import router as pdd_app_config_router
 from app.oms.platforms.pdd.router_auth import router as pdd_auth_router
 from app.oms.platforms.pdd.router_connection import router as pdd_connection_router
+from app.oms.platforms.pdd.router_ingest import router as pdd_ingest_router
 from app.oms.platforms.pdd.router_pull import router as pdd_pull_router
 from app.oms.platforms.pdd.router_orders import router as pdd_orders_router
 from app.oms.platforms.pdd.router_mock import router as pdd_mock_router
@@ -46,6 +47,7 @@ router.include_router(pdd_app_config_router)
 router.include_router(pdd_auth_router)
 router.include_router(pdd_connection_router)
 router.include_router(pdd_pull_router)
+router.include_router(pdd_ingest_router)
 router.include_router(pdd_orders_router)
 router.include_router(pdd_mock_router)
 

--- a/tests/api/test_pdd_real_ingest_contract.py
+++ b/tests/api/test_pdd_real_ingest_contract.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import pytest
+
+from app.oms.platforms.pdd import router_ingest as pdd_router_ingest
+from app.oms.platforms.pdd.service_ingest import (
+    PddOrderIngestPageResult,
+    PddOrderIngestRowResult,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_post_store_pdd_orders_ingest_returns_page_result(client, session, monkeypatch):
+    captured = {}
+
+    async def _fake_ingest_order_page(self, *, session, params):
+        captured["store_id"] = params.store_id
+        captured["start_confirm_at"] = params.start_confirm_at
+        captured["end_confirm_at"] = params.end_confirm_at
+        captured["order_status"] = params.order_status
+        captured["page"] = params.page
+        captured["page_size"] = params.page_size
+
+        return PddOrderIngestPageResult(
+            store_id=123,
+            store_code="pdd-store-123",
+            page=1,
+            page_size=50,
+            orders_count=2,
+            success_count=1,
+            failed_count=1,
+            has_more=False,
+            start_confirm_at="2026-03-29 00:00:00",
+            end_confirm_at="2026-03-29 23:59:59",
+            rows=[
+                PddOrderIngestRowResult(
+                    order_sn="PDD-ORDER-001",
+                    pdd_order_id=101,
+                    status="OK",
+                    error=None,
+                ),
+                PddOrderIngestRowResult(
+                    order_sn="PDD-ORDER-002",
+                    pdd_order_id=None,
+                    status="FAILED",
+                    error="detail_failed: boom",
+                ),
+            ],
+        )
+
+    monkeypatch.setattr(
+        pdd_router_ingest.PddOrderIngestService,
+        "ingest_order_page",
+        _fake_ingest_order_page,
+    )
+
+    resp = await client.post(
+        "/oms/stores/123/pdd/orders/ingest",
+        json={
+            "start_confirm_at": "2026-03-29 00:00:00",
+            "end_confirm_at": "2026-03-29 23:59:59",
+            "order_status": 1,
+            "page": 1,
+            "page_size": 50,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    assert captured == {
+        "store_id": 123,
+        "start_confirm_at": "2026-03-29 00:00:00",
+        "end_confirm_at": "2026-03-29 23:59:59",
+        "order_status": 1,
+        "page": 1,
+        "page_size": 50,
+    }
+
+    body = resp.json()
+    assert body["ok"] is True
+
+    data = body["data"]
+    assert data["platform"] == "pdd"
+    assert data["store_id"] == 123
+    assert data["store_code"] == "pdd-store-123"
+    assert data["page"] == 1
+    assert data["page_size"] == 50
+    assert data["orders_count"] == 2
+    assert data["success_count"] == 1
+    assert data["failed_count"] == 1
+    assert data["has_more"] is False
+    assert data["start_confirm_at"] == "2026-03-29 00:00:00"
+    assert data["end_confirm_at"] == "2026-03-29 23:59:59"
+
+    assert len(data["rows"]) == 2
+    assert data["rows"][0]["order_sn"] == "PDD-ORDER-001"
+    assert data["rows"][0]["pdd_order_id"] == 101
+    assert data["rows"][0]["status"] == "OK"
+    assert data["rows"][0]["error"] is None
+
+    assert data["rows"][1]["order_sn"] == "PDD-ORDER-002"
+    assert data["rows"][1]["pdd_order_id"] is None
+    assert data["rows"][1]["status"] == "FAILED"
+    assert data["rows"][1]["error"] == "detail_failed: boom"
+
+
+async def test_post_store_pdd_orders_ingest_returns_400_on_service_error(client, session, monkeypatch):
+    async def _fake_ingest_order_page(self, *, session, params):
+        raise pdd_router_ingest.PddOrderIngestServiceError("pdd pull failed: credential expired")
+
+    monkeypatch.setattr(
+        pdd_router_ingest.PddOrderIngestService,
+        "ingest_order_page",
+        _fake_ingest_order_page,
+    )
+
+    resp = await client.post(
+        "/oms/stores/123/pdd/orders/ingest",
+        json={
+            "start_confirm_at": "2026-03-29 00:00:00",
+            "end_confirm_at": "2026-03-29 23:59:59",
+            "page": 1,
+            "page_size": 50,
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    assert "pdd pull failed: credential expired" in resp.text
+
+
+async def test_post_store_pdd_orders_ingest_rejects_invalid_page_size(client):
+    resp = await client.post(
+        "/oms/stores/123/pdd/orders/ingest",
+        json={
+            "start_confirm_at": "2026-03-29 00:00:00",
+            "end_confirm_at": "2026-03-29 23:59:59",
+            "page": 1,
+            "page_size": 101,
+        },
+    )
+    assert resp.status_code == 422, resp.text


### PR DESCRIPTION
## Summary
- add formal PDD real order ingest endpoint: POST /oms/stores/{store_id}/pdd/orders/ingest
- keep test-pull probe semantics unchanged
- persist real pull results into pdd_orders / pdd_order_items only
- do not write platform_order_lines, do not resolve FSKU, do not create internal orders, do not touch finance

## Tests
- make test TESTS="tests/api/test_pdd_real_ingest_contract.py tests/api/test_pdd_real_pull_contract.py tests/api/test_pdd_connection_and_pull_contract.py"