### PR TITLE
feat(oms): bridge PDD native orders to platform facts

### DIFF
--- a/app/oms/platforms/pdd/contracts_fact_bridge.py
+++ b/app/oms/platforms/pdd/contracts_fact_bridge.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class PddFactBridgeDataOut(BaseModel):
+    platform: str
+    store_id: int
+    store_code: str
+    pdd_order_id: int
+    ext_order_no: str
+    lines_count: int
+    facts_written: int
+
+
+class PddFactBridgeEnvelopeOut(BaseModel):
+    ok: bool
+    data: PddFactBridgeDataOut

--- a/app/oms/platforms/pdd/router_fact_bridge.py
+++ b/app/oms/platforms/pdd/router_fact_bridge.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Path
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.deps import get_async_session as get_session
+from app.oms.platforms.pdd.contracts_fact_bridge import (
+    PddFactBridgeDataOut,
+    PddFactBridgeEnvelopeOut,
+)
+from app.oms.platforms.pdd.service_fact_bridge import (
+    PddFactBridgeService,
+    PddFactBridgeServiceError,
+)
+
+router = APIRouter(tags=["oms-pdd-fact-bridge"])
+
+
+@router.post(
+    "/pdd/orders/{pdd_order_id}/facts/bridge",
+    response_model=PddFactBridgeEnvelopeOut,
+    summary="PDD 专表事实桥接为 OMS 归一订单事实行",
+)
+async def bridge_pdd_order_to_platform_facts(
+    pdd_order_id: int = Path(..., ge=1),
+    session: AsyncSession = Depends(get_session),
+) -> PddFactBridgeEnvelopeOut:
+    """
+    只桥接事实行，不做 FSKU 解析、内部建单或财务计算。
+    """
+
+    try:
+        result = await PddFactBridgeService().bridge_one_order(
+            session,
+            pdd_order_id=int(pdd_order_id),
+        )
+        await session.commit()
+    except (ValueError, LookupError, PddFactBridgeServiceError) as exc:
+        await session.rollback()
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:  # noqa: BLE001
+        await session.rollback()
+        raise HTTPException(
+            status_code=500,
+            detail=f"failed to bridge pdd order facts: {exc}",
+        ) from exc
+
+    return PddFactBridgeEnvelopeOut(
+        ok=True,
+        data=PddFactBridgeDataOut(
+            platform=result.platform,
+            store_id=result.store_id,
+            store_code=result.store_code,
+            pdd_order_id=result.pdd_order_id,
+            ext_order_no=result.ext_order_no,
+            lines_count=result.lines_count,
+            facts_written=result.facts_written,
+        ),
+    )

--- a/app/oms/platforms/pdd/service_fact_bridge.py
+++ b/app/oms/platforms/pdd/service_fact_bridge.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Dict, List
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.oms.repos.platform_order_fact_service import upsert_platform_order_lines
+
+
+class PddFactBridgeServiceError(Exception):
+    """PDD 专表事实桥接到 OMS 归一事实行异常。"""
+
+
+@dataclass(frozen=True)
+class PddFactBridgeResult:
+    platform: str
+    store_id: int
+    store_code: str
+    pdd_order_id: int
+    ext_order_no: str
+    lines_count: int
+    facts_written: int
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        return str(value)
+    return value
+
+
+def _build_spec(*, platform_goods_id: Any, platform_sku_id: Any) -> str | None:
+    parts: list[str] = []
+    if platform_goods_id:
+        parts.append(f"goods_id:{platform_goods_id}")
+    if platform_sku_id:
+        parts.append(f"sku_id:{platform_sku_id}")
+    return " / ".join(parts) if parts else None
+
+
+class PddFactBridgeService:
+    """
+    PDD 专表事实 → OMS 归一事实行桥接。
+
+    边界：
+    - 读取 pdd_orders / pdd_order_items；
+    - 转换为 platform_order_lines 所需 raw_lines；
+    - 调用 upsert_platform_order_lines；
+    - 不解析 FSKU；
+    - 不建内部 orders/order_items；
+    - 不写 pdd_order_order_mappings；
+    - 不触碰 finance。
+    """
+
+    async def bridge_one_order(
+        self,
+        session: AsyncSession,
+        *,
+        pdd_order_id: int,
+    ) -> PddFactBridgeResult:
+        oid = int(pdd_order_id)
+        if oid <= 0:
+            raise PddFactBridgeServiceError("pdd_order_id must be positive")
+
+        head = (
+            await session.execute(
+                text(
+                    """
+                    SELECT
+                      po.id,
+                      po.store_id,
+                      po.order_sn,
+                      po.raw_detail_payload,
+                      s.store_code
+                    FROM pdd_orders po
+                    JOIN stores s ON s.id = po.store_id
+                    WHERE po.id = :pdd_order_id
+                      AND upper(s.platform) = 'PDD'
+                    LIMIT 1
+                    """
+                ),
+                {"pdd_order_id": oid},
+            )
+        ).mappings().first()
+
+        if not head:
+            raise PddFactBridgeServiceError(f"pdd order not found: pdd_order_id={oid}")
+
+        rows = (
+            await session.execute(
+                text(
+                    """
+                    SELECT
+                      id,
+                      pdd_order_id,
+                      order_sn,
+                      platform_goods_id,
+                      platform_sku_id,
+                      outer_id,
+                      goods_name,
+                      goods_count,
+                      goods_price,
+                      raw_item_payload
+                    FROM pdd_order_items
+                    WHERE pdd_order_id = :pdd_order_id
+                    ORDER BY id ASC
+                    """
+                ),
+                {"pdd_order_id": oid},
+            )
+        ).mappings().all()
+
+        raw_lines: List[Dict[str, Any]] = []
+        for idx, item in enumerate(rows, start=1):
+            goods_count = int(item.get("goods_count") or 0)
+            qty = goods_count if goods_count > 0 else 1
+            platform_goods_id = item.get("platform_goods_id")
+            platform_sku_id = item.get("platform_sku_id")
+            outer_id = item.get("outer_id")
+
+            extras = {
+                "source": "pdd_order_items",
+                "pdd_order_id": int(item["pdd_order_id"]),
+                "pdd_order_item_id": int(item["id"]),
+                "platform_goods_id": platform_goods_id,
+                "platform_sku_id": platform_sku_id,
+                "outer_id": outer_id,
+                "goods_price": _json_safe(item.get("goods_price")),
+                "raw_item_payload": item.get("raw_item_payload"),
+            }
+
+            raw_lines.append(
+                {
+                    "line_no": idx,
+                    "filled_code": str(outer_id).strip() if outer_id else None,
+                    "qty": qty,
+                    "title": item.get("goods_name"),
+                    "spec": _build_spec(
+                        platform_goods_id=platform_goods_id,
+                        platform_sku_id=platform_sku_id,
+                    ),
+                    "extras": extras,
+                }
+            )
+
+        facts_written = await upsert_platform_order_lines(
+            session,
+            platform="PDD",
+            store_code=str(head["store_code"]),
+            store_id=int(head["store_id"]),
+            ext_order_no=str(head["order_sn"]),
+            lines=raw_lines,
+            raw_payload=head.get("raw_detail_payload") or {},
+        )
+
+        return PddFactBridgeResult(
+            platform="PDD",
+            store_id=int(head["store_id"]),
+            store_code=str(head["store_code"]),
+            pdd_order_id=oid,
+            ext_order_no=str(head["order_sn"]),
+            lines_count=len(raw_lines),
+            facts_written=int(facts_written),
+        )

--- a/app/oms/router.py
+++ b/app/oms/router.py
@@ -9,6 +9,7 @@ from app.oms.platforms.jd.router_pull import router as jd_pull_router
 from app.oms.platforms.pdd.router_app_config import router as pdd_app_config_router
 from app.oms.platforms.pdd.router_auth import router as pdd_auth_router
 from app.oms.platforms.pdd.router_connection import router as pdd_connection_router
+from app.oms.platforms.pdd.router_fact_bridge import router as pdd_fact_bridge_router
 from app.oms.platforms.pdd.router_ingest import router as pdd_ingest_router
 from app.oms.platforms.pdd.router_pull import router as pdd_pull_router
 from app.oms.platforms.pdd.router_orders import router as pdd_orders_router
@@ -48,6 +49,7 @@ router.include_router(pdd_auth_router)
 router.include_router(pdd_connection_router)
 router.include_router(pdd_pull_router)
 router.include_router(pdd_ingest_router)
+router.include_router(pdd_fact_bridge_router)
 router.include_router(pdd_orders_router)
 router.include_router(pdd_mock_router)
 

--- a/tests/api/test_pdd_fact_bridge_contract.py
+++ b/tests/api/test_pdd_fact_bridge_contract.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import text
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _insert_pdd_order_with_items(session) -> int:
+    row = (
+        await session.execute(
+            text(
+                """
+                INSERT INTO stores(platform, store_code, store_name, active, created_at, updated_at)
+                VALUES ('PDD', 'PDD-BRIDGE-STORE', 'PDD Bridge Store', true, now(), now())
+                ON CONFLICT (platform, store_code) DO UPDATE
+                  SET store_name = EXCLUDED.store_name,
+                      active = true,
+                      updated_at = now()
+                RETURNING id
+                """
+            )
+        )
+    ).mappings().first()
+    assert row and row.get("id") is not None
+    store_id = int(row["id"])
+
+    order_row = (
+        await session.execute(
+            text(
+                """
+                INSERT INTO pdd_orders(
+                  store_id,
+                  order_sn,
+                  order_status,
+                  receiver_name,
+                  receiver_phone,
+                  receiver_province,
+                  receiver_city,
+                  receiver_district,
+                  receiver_address,
+                  buyer_memo,
+                  remark,
+                  confirm_at,
+                  goods_amount,
+                  pay_amount,
+                  raw_summary_payload,
+                  raw_detail_payload,
+                  pulled_at,
+                  last_synced_at,
+                  created_at,
+                  updated_at
+                )
+                VALUES (
+                  :store_id,
+                  :order_sn,
+                  '1',
+                  '张三',
+                  '13800138000',
+                  '上海市',
+                  '上海市',
+                  '浦东新区',
+                  '科苑路 88 号',
+                  '请尽快发货',
+                  '桥接测试',
+                  now(),
+                  41.57,
+                  41.57,
+                  '{"source":"unit-summary"}'::jsonb,
+                  '{"source":"unit-detail"}'::jsonb,
+                  now(),
+                  now(),
+                  now(),
+                  now()
+                )
+                ON CONFLICT (store_id, order_sn) DO UPDATE
+                  SET updated_at = now()
+                RETURNING id
+                """
+            ),
+            {
+                "store_id": store_id,
+                "order_sn": "PDD-BRIDGE-ORDER-001",
+            },
+        )
+    ).mappings().first()
+    assert order_row and order_row.get("id") is not None
+    pdd_order_id = int(order_row["id"])
+
+    await session.execute(
+        text("DELETE FROM pdd_order_items WHERE pdd_order_id = :pdd_order_id"),
+        {"pdd_order_id": pdd_order_id},
+    )
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO pdd_order_items(
+              pdd_order_id,
+              order_sn,
+              platform_goods_id,
+              platform_sku_id,
+              outer_id,
+              goods_name,
+              goods_count,
+              goods_price,
+              raw_item_payload,
+              created_at,
+              updated_at
+            )
+            VALUES
+              (
+                :pdd_order_id,
+                'PDD-BRIDGE-ORDER-001',
+                'G-001',
+                'SKU-001',
+                'OUTER-FSKU-001',
+                '拼多多桥接商品A',
+                2,
+                12.99,
+                '{"source":"unit-item-a"}'::jsonb,
+                now(),
+                now()
+              ),
+              (
+                :pdd_order_id,
+                'PDD-BRIDGE-ORDER-001',
+                'G-002',
+                'SKU-002',
+                NULL,
+                '拼多多桥接商品B',
+                1,
+                15.59,
+                '{"source":"unit-item-b"}'::jsonb,
+                now(),
+                now()
+              )
+            """
+        ),
+        {"pdd_order_id": pdd_order_id},
+    )
+
+    await session.commit()
+    return pdd_order_id
+
+
+async def test_post_pdd_order_fact_bridge_writes_platform_order_lines(client, session):
+    pdd_order_id = await _insert_pdd_order_with_items(session)
+
+    resp = await client.post(f"/oms/pdd/orders/{pdd_order_id}/facts/bridge")
+    assert resp.status_code == 200, resp.text
+
+    body = resp.json()
+    assert body["ok"] is True
+    data = body["data"]
+    assert data["platform"] == "PDD"
+    assert data["store_code"] == "PDD-BRIDGE-STORE"
+    assert data["pdd_order_id"] == pdd_order_id
+    assert data["ext_order_no"] == "PDD-BRIDGE-ORDER-001"
+    assert data["lines_count"] == 2
+    assert data["facts_written"] == 2
+
+    rows = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  line_no,
+                  line_key,
+                  locator_kind,
+                  locator_value,
+                  filled_code,
+                  qty,
+                  title,
+                  spec,
+                  extras
+                FROM platform_order_lines
+                WHERE platform = 'PDD'
+                  AND store_code = 'PDD-BRIDGE-STORE'
+                  AND ext_order_no = 'PDD-BRIDGE-ORDER-001'
+                ORDER BY line_no ASC
+                """
+            )
+        )
+    ).mappings().all()
+
+    assert len(rows) == 2
+
+    first = rows[0]
+    assert first["line_no"] == 1
+    assert first["line_key"] == "PSKU:OUTER-FSKU-001"
+    assert first["locator_kind"] == "FILLED_CODE"
+    assert first["locator_value"] == "OUTER-FSKU-001"
+    assert first["filled_code"] == "OUTER-FSKU-001"
+    assert first["qty"] == 2
+    assert first["title"] == "拼多多桥接商品A"
+    assert first["spec"] == "goods_id:G-001 / sku_id:SKU-001"
+    assert first["extras"]["source"] == "pdd_order_items"
+    assert first["extras"]["platform_goods_id"] == "G-001"
+    assert first["extras"]["platform_sku_id"] == "SKU-001"
+    assert first["extras"]["outer_id"] == "OUTER-FSKU-001"
+    assert Decimal(str(first["extras"]["goods_price"])) == Decimal("12.99")
+
+    second = rows[1]
+    assert second["line_no"] == 2
+    assert second["line_key"] == "NO_PSKU:2"
+    assert second["locator_kind"] == "LINE_NO"
+    assert second["locator_value"] == "2"
+    assert second["filled_code"] is None
+    assert second["qty"] == 1
+    assert second["title"] == "拼多多桥接商品B"
+    assert second["spec"] == "goods_id:G-002 / sku_id:SKU-002"
+
+
+async def test_post_pdd_order_fact_bridge_is_idempotent(client, session):
+    pdd_order_id = await _insert_pdd_order_with_items(session)
+
+    r1 = await client.post(f"/oms/pdd/orders/{pdd_order_id}/facts/bridge")
+    assert r1.status_code == 200, r1.text
+
+    r2 = await client.post(f"/oms/pdd/orders/{pdd_order_id}/facts/bridge")
+    assert r2.status_code == 200, r2.text
+
+    count_row = (
+        await session.execute(
+            text(
+                """
+                SELECT count(*) AS n
+                FROM platform_order_lines
+                WHERE platform = 'PDD'
+                  AND store_code = 'PDD-BRIDGE-STORE'
+                  AND ext_order_no = 'PDD-BRIDGE-ORDER-001'
+                """
+            )
+        )
+    ).mappings().one()
+
+    assert int(count_row["n"]) == 2
+
+
+async def test_post_pdd_order_fact_bridge_returns_400_when_missing(client):
+    resp = await client.post("/oms/pdd/orders/999999999/facts/bridge")
+    assert resp.status_code == 400, resp.text
+    assert "pdd order not found" in resp.text


### PR DESCRIPTION
## Summary
- add PDD native order fact bridge endpoint: POST /oms/pdd/orders/{pdd_order_id}/facts/bridge
- convert pdd_order_items into platform_order_lines through the existing upsert_platform_order_lines writer
- preserve fact-only boundary: no FSKU resolution, no internal order creation, no finance writes

## Tests
- make test TESTS="tests/api/test_pdd_fact_bridge_contract.py tests/api/test_pdd_real_ingest_contract.py tests/api/test_platform_orders_replay_contract.py"