### PR TITLE
feat(finance): expose order sales display contract

### DIFF
--- a/app/finance/contracts/order_sales.py
+++ b/app/finance/contracts/order_sales.py
@@ -35,6 +35,8 @@ class OrderSalesStoreRow(BaseModel):
 
 class OrderSalesItemRow(BaseModel):
     item_id: int
+    item_sku: str | None = None
+    item_name: str | None = None
     sku_id: str | None = None
     title: str | None = None
     qty_sold: int
@@ -61,7 +63,13 @@ class OrderSalesLineRow(BaseModel):
     receiver_city: str | None = None
     receiver_district: str | None = None
 
+    warehouse_id: int | None = None
+    warehouse_name: str | None = None
+    warehouse_source: str
+
     item_id: int
+    item_sku: str | None = None
+    item_name: str | None = None
     sku_id: str | None = None
     title: str | None = None
 

--- a/app/finance/sources/order_sales_source.py
+++ b/app/finance/sources/order_sales_source.py
@@ -258,11 +258,15 @@ class OrderSalesSource:
             f"""
             SELECT
               f.item_id,
+              MAX(i.sku) AS item_sku,
+              MAX(i.name) AS item_name,
               MAX(f.sku_id) AS sku_id,
               MAX(f.title) AS title,
               COALESCE(SUM(f.qty_sold), 0) AS qty_sold,
               COALESCE(SUM(f.line_amount), 0) AS revenue
               FROM finance_order_sales_lines f
+              LEFT JOIN items i
+                ON i.id = f.item_id
              WHERE {self._base_where("f")}
              GROUP BY f.item_id
              HAVING COALESCE(SUM(f.qty_sold), 0) > 0
@@ -274,6 +278,8 @@ class OrderSalesSource:
         return [
             {
                 "item_id": int(row["item_id"]),
+                "item_sku": row["item_sku"],
+                "item_name": row["item_name"],
                 "sku_id": row["sku_id"],
                 "title": row["title"],
                 "qty_sold": int(row["qty_sold"] or 0),
@@ -311,7 +317,20 @@ class OrderSalesSource:
               f.receiver_province,
               f.receiver_city,
               f.receiver_district,
+              CASE
+                WHEN ofl.actual_warehouse_id IS NOT NULL THEN ofl.actual_warehouse_id
+                WHEN ofl.planned_warehouse_id IS NOT NULL THEN ofl.planned_warehouse_id
+                ELSE NULL
+              END AS warehouse_id,
+              COALESCE(wha.name, whp.name) AS warehouse_name,
+              CASE
+                WHEN ofl.actual_warehouse_id IS NOT NULL THEN 'actual'
+                WHEN ofl.planned_warehouse_id IS NOT NULL THEN 'planned'
+                ELSE 'none'
+              END AS warehouse_source,
               f.item_id,
+              i.sku AS item_sku,
+              i.name AS item_name,
               f.sku_id,
               f.title,
               f.qty_sold,
@@ -321,6 +340,14 @@ class OrderSalesSource:
               f.order_amount,
               f.pay_amount
               FROM finance_order_sales_lines f
+              LEFT JOIN order_fulfillment ofl
+                ON ofl.order_id = f.order_id
+              LEFT JOIN warehouses whp
+                ON whp.id = ofl.planned_warehouse_id
+              LEFT JOIN warehouses wha
+                ON wha.id = ofl.actual_warehouse_id
+              LEFT JOIN items i
+                ON i.id = f.item_id
              WHERE {self._base_where("f")}
              ORDER BY f.order_created_at DESC, f.id DESC
              LIMIT :limit OFFSET :offset
@@ -344,7 +371,12 @@ class OrderSalesSource:
                 "receiver_province": row["receiver_province"],
                 "receiver_city": row["receiver_city"],
                 "receiver_district": row["receiver_district"],
+                "warehouse_id": int(row["warehouse_id"]) if row["warehouse_id"] is not None else None,
+                "warehouse_name": row["warehouse_name"],
+                "warehouse_source": str(row["warehouse_source"]),
                 "item_id": int(row["item_id"]),
+                "item_sku": row["item_sku"],
+                "item_name": row["item_name"],
                 "sku_id": row["sku_id"],
                 "title": row["title"],
                 "qty_sold": int(row["qty_sold"] or 0),

--- a/tests/api/test_finance_api_contract.py
+++ b/tests/api/test_finance_api_contract.py
@@ -134,6 +134,66 @@ async def _seed_finance_order_sales_line(db_session) -> str:
         {"order_id": order_id},
     )
 
+    warehouse_row = (
+        await db_session.execute(
+            text(
+                """
+                INSERT INTO warehouses (
+                  name,
+                  code,
+                  active
+                )
+                VALUES (
+                  :name,
+                  :code,
+                  TRUE
+                )
+                ON CONFLICT (code)
+                DO UPDATE SET
+                  name = EXCLUDED.name
+                RETURNING id
+                """
+            ),
+            {
+                "name": "FIN-订单销售测试仓库",
+                "code": f"FIN-WH-{uuid4().hex[:8]}",
+            },
+        )
+    ).mappings().one()
+
+    await db_session.execute(
+        text(
+            """
+            INSERT INTO order_fulfillment (
+              order_id,
+              planned_warehouse_id,
+              actual_warehouse_id,
+              fulfillment_status,
+              blocked_reasons,
+              updated_at
+            )
+            VALUES (
+              :order_id,
+              :warehouse_id,
+              NULL,
+              'SERVICE_ASSIGNED',
+              NULL,
+              now()
+            )
+            ON CONFLICT (order_id)
+            DO UPDATE SET
+              planned_warehouse_id = EXCLUDED.planned_warehouse_id,
+              actual_warehouse_id = EXCLUDED.actual_warehouse_id,
+              fulfillment_status = EXCLUDED.fulfillment_status,
+              updated_at = now()
+            """
+        ),
+        {
+            "order_id": order_id,
+            "warehouse_id": int(warehouse_row["id"]),
+        },
+    )
+
     await db_session.execute(
         text(
             """
@@ -238,6 +298,13 @@ async def test_finance_order_sales_contract(client):
     assert isinstance(body["by_store"], list)
     assert isinstance(body["by_item"], list)
     assert isinstance(body["items"], list)
+    if body["items"]:
+        first = body["items"][0]
+        assert "warehouse_id" in first
+        assert "warehouse_name" in first
+        assert "warehouse_source" in first
+        assert "item_sku" in first
+        assert "item_name" in first
     assert isinstance(body["total"], int)
     assert isinstance(body["limit"], int)
     assert isinstance(body["offset"], int)
@@ -269,7 +336,12 @@ async def test_finance_order_sales_reads_physical_sales_lines(client, session):
     assert item["receiver_province"] == "浙江省"
     assert item["receiver_city"] == "杭州市"
     assert item["receiver_district"] == "西湖区"
+    assert item["warehouse_id"] is not None
+    assert item["warehouse_name"] == "FIN-订单销售测试仓库"
+    assert item["warehouse_source"] == "planned"
     assert item["item_id"] == 1
+    assert item["item_sku"]
+    assert item["item_name"]
     assert item["sku_id"] == "FIN-SKU-1"
     assert item["title"] == "订单销售测试商品"
     assert item["qty_sold"] == 2


### PR DESCRIPTION
## Summary
- expose order sales display fields for finance order-sales read API
- keep finance read API backed by finance_order_sales_lines
- add API contract coverage for order sales display response

## Tests
- make test TESTS=tests/api/test_finance_api_contract.py

## Note
- This keeps the current finance display contract only.
- OMS platform order / FSKU sales fact modeling will continue separately.