### PR TITLE
feat(oms): add platform order resolve preview

### DIFF
--- a/app/oms/contracts/platform_orders_resolve_preview.py
+++ b/app/oms/contracts/platform_orders_resolve_preview.py
@@ -1,0 +1,52 @@
+# app/oms/contracts/platform_orders_resolve_preview.py
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class PlatformOrderResolvePreviewIn(BaseModel):
+    platform: str = Field(..., min_length=1, max_length=50)
+    store_id: int = Field(..., ge=1)
+    ext_order_no: str = Field(..., min_length=1, max_length=128)
+
+
+class PlatformOrderResolvePreviewFactLineOut(BaseModel):
+    line_no: int
+    line_key: str
+    locator_kind: Optional[str] = None
+    locator_value: Optional[str] = None
+    filled_code: Optional[str] = None
+    qty: int
+    title: Optional[str] = None
+    spec: Optional[str] = None
+    extras: Optional[Dict[str, Any]] = None
+
+
+class PlatformOrderResolvePreviewResolvedLineOut(BaseModel):
+    filled_code: str
+    qty: int
+    fsku_id: int
+    expanded_items: List[Dict[str, Any]]
+
+
+class PlatformOrderResolvePreviewItemQtyOut(BaseModel):
+    item_id: int
+    qty: int
+    sku: Optional[str] = None
+    name: Optional[str] = None
+
+
+class PlatformOrderResolvePreviewOut(BaseModel):
+    status: str
+    ref: str
+    platform: str
+    store_id: int
+    ext_order_no: str
+    facts_n: int
+    fact_lines: List[PlatformOrderResolvePreviewFactLineOut]
+    resolved: List[PlatformOrderResolvePreviewResolvedLineOut]
+    unresolved: List[Dict[str, Any]]
+    item_qty_map: Dict[str, int]
+    item_qty_items: List[PlatformOrderResolvePreviewItemQtyOut]

--- a/app/oms/router.py
+++ b/app/oms/router.py
@@ -23,6 +23,7 @@ from app.oms.routers.platform_orders_confirm_create import router as platform_or
 from app.oms.routers.platform_orders_ingest_routes import router as platform_orders_ingest_router
 from app.oms.routers.platform_orders_manual_decisions import router as platform_orders_manual_decisions_router
 from app.oms.routers.platform_orders_replay import router as platform_orders_replay_router
+from app.oms.routers.platform_orders_resolve_preview import router as platform_orders_resolve_preview_router
 from app.oms.routers.stores import router as stores_router
 from app.oms.orders.routers.order_outbound_options import router as order_outbound_options_router
 from app.oms.orders.routers.order_outbound_view import router as order_outbound_view_router
@@ -32,6 +33,7 @@ router = APIRouter(prefix="/oms", tags=["OMS"])
 router.include_router(platform_orders_ingest_router)
 router.include_router(platform_orders_confirm_create_router)
 router.include_router(platform_orders_replay_router)
+router.include_router(platform_orders_resolve_preview_router)
 router.include_router(platform_orders_manual_decisions_router)
 router.include_router(stores_router)
 router.include_router(fsku_router)

--- a/app/oms/routers/platform_orders_resolve_preview.py
+++ b/app/oms/routers/platform_orders_resolve_preview.py
@@ -1,0 +1,172 @@
+# app/oms/routers/platform_orders_resolve_preview.py
+from __future__ import annotations
+
+from fastapi import APIRouter, Body, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.problem import make_problem
+from app.db.deps import get_async_session as get_session
+from app.oms.contracts.platform_orders_resolve_preview import (
+    PlatformOrderResolvePreviewFactLineOut,
+    PlatformOrderResolvePreviewIn,
+    PlatformOrderResolvePreviewItemQtyOut,
+    PlatformOrderResolvePreviewOut,
+    PlatformOrderResolvePreviewResolvedLineOut,
+)
+from app.oms.repos.platform_orders_fact import (
+    load_fact_lines_for_order,
+    load_store_code_by_store_id,
+)
+from app.oms.services.platform_order_ingest_flow import PlatformOrderIngestFlow
+from app.oms.services.platform_order_resolve_service import (
+    load_items_brief,
+    norm_platform,
+)
+
+router = APIRouter(tags=["platform-orders"])
+
+
+def _preview_status(*, resolved_count: int, unresolved_count: int, item_qty_count: int) -> str:
+    if item_qty_count > 0 and unresolved_count == 0:
+        return "OK"
+    if item_qty_count > 0 and unresolved_count > 0:
+        return "PARTIAL"
+    if resolved_count > 0 and unresolved_count == 0:
+        return "OK"
+    return "UNRESOLVED"
+
+
+@router.post(
+    "/platform-orders/resolve-preview",
+    response_model=PlatformOrderResolvePreviewOut,
+    summary="平台订单事实只读解析预览：读取 platform_order_lines 并展开到 FSKU/SKU，不建单",
+)
+async def preview_platform_order_resolve(
+    payload: PlatformOrderResolvePreviewIn = Body(...),
+    session: AsyncSession = Depends(get_session),
+) -> PlatformOrderResolvePreviewOut:
+    """
+    只读解析预览。
+
+    边界：
+    - 读取 platform_order_lines；
+    - 复用 resolver 展开 FSKU / item；
+    - 返回 resolved / unresolved / item_qty_map；
+    - 不写 platform_order_lines；
+    - 不建 orders/order_items；
+    - 不触碰 finance。
+    """
+    plat = norm_platform(payload.platform)
+    store_id = int(payload.store_id)
+    ext = str(payload.ext_order_no or "").strip()
+    if not ext:
+        raise HTTPException(
+            status_code=422,
+            detail=make_problem(
+                status_code=422,
+                error_code="request_validation_error",
+                message="ext_order_no 不能为空",
+                context={"platform": plat, "store_id": store_id},
+            ),
+        )
+
+    try:
+        store_code = await load_store_code_by_store_id(session, store_id=store_id)
+    except LookupError:
+        raise HTTPException(
+            status_code=404,
+            detail=make_problem(
+                status_code=404,
+                error_code="not_found",
+                message="store_id 不存在",
+                context={"platform": plat, "store_id": store_id, "ext_order_no": ext},
+            ),
+        )
+
+    fact_lines = await load_fact_lines_for_order(
+        session,
+        platform=plat,
+        store_id=store_id,
+        ext_order_no=ext,
+    )
+
+    if not fact_lines:
+        return PlatformOrderResolvePreviewOut(
+            status="NOT_FOUND",
+            ref=f"ORD:{plat}:{store_code}:{ext}",
+            platform=plat,
+            store_id=store_id,
+            ext_order_no=ext,
+            facts_n=0,
+            fact_lines=[],
+            resolved=[],
+            unresolved=[
+                {
+                    "reason": "FACTS_NOT_FOUND",
+                    "hint": "未找到该订单的事实行（platform/store_id/ext_order_no）",
+                }
+            ],
+            item_qty_map={},
+            item_qty_items=[],
+        )
+
+    resolved_lines, unresolved, item_qty_map = await PlatformOrderIngestFlow.resolve_fact_lines(
+        session,
+        platform=plat,
+        store_id=store_id,
+        lines=fact_lines,
+    )
+
+    items_brief = await load_items_brief(
+        session,
+        item_ids=sorted(int(x) for x in item_qty_map.keys()),
+    )
+
+    item_qty_items = [
+        PlatformOrderResolvePreviewItemQtyOut(
+            item_id=int(item_id),
+            qty=int(item_qty_map[item_id]),
+            sku=(items_brief.get(int(item_id)) or {}).get("sku"),
+            name=(items_brief.get(int(item_id)) or {}).get("name"),
+        )
+        for item_id in sorted(item_qty_map.keys())
+    ]
+
+    return PlatformOrderResolvePreviewOut(
+        status=_preview_status(
+            resolved_count=len(resolved_lines),
+            unresolved_count=len(unresolved),
+            item_qty_count=len(item_qty_map),
+        ),
+        ref=f"ORD:{plat}:{store_code}:{ext}",
+        platform=plat,
+        store_id=store_id,
+        ext_order_no=ext,
+        facts_n=len(fact_lines),
+        fact_lines=[
+            PlatformOrderResolvePreviewFactLineOut(
+                line_no=int(line.get("line_no") or 0),
+                line_key=str(line.get("line_key") or ""),
+                locator_kind=line.get("locator_kind"),
+                locator_value=line.get("locator_value"),
+                filled_code=line.get("filled_code"),
+                qty=int(line.get("qty") or 1),
+                title=line.get("title"),
+                spec=line.get("spec"),
+                extras=line.get("extras") or {},
+            )
+            for line in fact_lines
+        ],
+        resolved=[
+            PlatformOrderResolvePreviewResolvedLineOut(
+                filled_code=str(line.filled_code),
+                qty=int(line.qty),
+                fsku_id=int(line.fsku_id),
+                expanded_items=list(line.expanded_items or []),
+            )
+            for line in resolved_lines
+        ],
+        unresolved=list(unresolved or []),
+        item_qty_map={str(int(k)): int(v) for k, v in item_qty_map.items()},
+        item_qty_items=item_qty_items,
+    )

--- a/tests/api/test_platform_orders_resolve_preview_contract.py
+++ b/tests/api/test_platform_orders_resolve_preview_contract.py
@@ -1,0 +1,328 @@
+# tests/api/test_platform_orders_resolve_preview_contract.py
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Optional, Tuple
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _ensure_store(session: AsyncSession, *, platform: str, store_code: str, name: str) -> int:
+    plat = platform.strip().upper()
+    sid = store_code.strip()
+    await session.execute(
+        text(
+            """
+            INSERT INTO stores(platform, store_code, store_name, active, created_at, updated_at)
+            VALUES (:p, :s, :n, true, now(), now())
+            ON CONFLICT (platform, store_code) DO UPDATE
+              SET store_name = EXCLUDED.store_name,
+                  active = true,
+                  updated_at = now()
+            """
+        ),
+        {"p": plat, "s": sid, "n": name},
+    )
+    row = (
+        await session.execute(
+            text("SELECT id FROM stores WHERE platform=:p AND store_code=:s LIMIT 1"),
+            {"p": plat, "s": sid},
+        )
+    ).mappings().first()
+    assert row and row.get("id") is not None
+    return int(row["id"])
+
+
+def _locator_from_fact(*, filled_code: Optional[str], line_no: int) -> Tuple[str, str]:
+    fc = (filled_code or "").strip()
+    if fc:
+        return "FILLED_CODE", fc
+    return "LINE_NO", str(int(line_no))
+
+
+async def _insert_fact_line(
+    session: AsyncSession,
+    *,
+    platform: str,
+    store_code: str,
+    store_id: int,
+    ext_order_no: str,
+    line_no: int,
+    line_key: str,
+    filled_code: Optional[str],
+    qty: int,
+    title: str,
+    spec: str,
+) -> None:
+    locator_kind, locator_value = _locator_from_fact(
+        filled_code=filled_code,
+        line_no=int(line_no),
+    )
+    await session.execute(
+        text(
+            """
+            INSERT INTO platform_order_lines(
+              platform, store_code, store_id, ext_order_no,
+              line_no, line_key,
+              locator_kind, locator_value,
+              filled_code, qty, title, spec,
+              extras, raw_payload,
+              created_at, updated_at
+            ) VALUES (
+              :platform, :store_code, :store_id, :ext_order_no,
+              :line_no, :line_key,
+              :locator_kind, :locator_value,
+              :filled_code, :qty, :title, :spec,
+              (:extras)::jsonb, (:raw_payload)::jsonb,
+              now(), now()
+            )
+            ON CONFLICT (platform, store_code, ext_order_no, line_key)
+            DO UPDATE SET
+              store_id=EXCLUDED.store_id,
+              locator_kind=EXCLUDED.locator_kind,
+              locator_value=EXCLUDED.locator_value,
+              filled_code=EXCLUDED.filled_code,
+              qty=EXCLUDED.qty,
+              title=EXCLUDED.title,
+              spec=EXCLUDED.spec,
+              extras=EXCLUDED.extras,
+              raw_payload=EXCLUDED.raw_payload,
+              updated_at=now()
+            """
+        ),
+        {
+            "platform": platform,
+            "store_code": store_code,
+            "store_id": int(store_id),
+            "ext_order_no": ext_order_no,
+            "line_no": int(line_no),
+            "line_key": line_key,
+            "locator_kind": locator_kind,
+            "locator_value": locator_value,
+            "filled_code": filled_code,
+            "qty": int(qty),
+            "title": title,
+            "spec": spec,
+            "extras": json.dumps({"source": "resolve-preview-test"}, ensure_ascii=False),
+            "raw_payload": json.dumps({"source": "resolve-preview-test"}, ensure_ascii=False),
+        },
+    )
+
+
+async def _create_published_fsku_with_component(
+    session: AsyncSession,
+    *,
+    item_id: int,
+    component_qty: int = 1,
+) -> tuple[int, str]:
+    uniq = uuid.uuid4().hex[:10]
+    code = f"UT-PREVIEW-{uniq}"
+    name = f"UT-PREVIEW-FSKU-{uniq}"
+
+    row = (
+        await session.execute(
+            text(
+                """
+                INSERT INTO fskus(name, code, shape, status, published_at, created_at, updated_at)
+                VALUES (:name, :code, 'bundle', 'published', now(), now(), now())
+                RETURNING id
+                """
+            ),
+            {"name": name, "code": code},
+        )
+    ).mappings().first()
+    assert row and row.get("id") is not None
+    fsku_id = int(row["id"])
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO fsku_components(fsku_id, item_id, qty, role, created_at, updated_at)
+            VALUES (:fid, :item_id, :qty, 'main', now(), now())
+            """
+        ),
+        {"fid": fsku_id, "item_id": int(item_id), "qty": int(component_qty)},
+    )
+    return fsku_id, code
+
+
+async def _orders_count(session: AsyncSession, *, platform: str, store_code: str, ext_order_no: str) -> int:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT count(*) AS n
+                  FROM orders
+                 WHERE platform = :p
+                   AND store_code = :s
+                   AND ext_order_no = :e
+                """
+            ),
+            {"p": platform, "s": store_code, "e": ext_order_no},
+        )
+    ).mappings().first()
+    return int(row["n"] if row and row.get("n") is not None else 0)
+
+
+async def test_platform_orders_resolve_preview_expands_fsku_without_creating_order(client, session):
+    platform = "PDD"
+    store_code = "UT-PREVIEW-PDD"
+    store_id = await _ensure_store(
+        session,
+        platform=platform,
+        store_code=store_code,
+        name="UT Preview PDD",
+    )
+    ext = f"UT-PREVIEW-OK-{uuid.uuid4().hex[:8]}"
+
+    fsku_id, fsku_code = await _create_published_fsku_with_component(
+        session,
+        item_id=1,
+        component_qty=2,
+    )
+    assert fsku_id > 0
+
+    await _insert_fact_line(
+        session,
+        platform=platform,
+        store_code=store_code,
+        store_id=store_id,
+        ext_order_no=ext,
+        line_no=1,
+        line_key=f"PSKU:{fsku_code}",
+        filled_code=fsku_code,
+        qty=3,
+        title="只读解析预览商品",
+        spec="默认规格",
+    )
+    await session.commit()
+
+    before = await _orders_count(
+        session,
+        platform=platform,
+        store_code=store_code,
+        ext_order_no=ext,
+    )
+
+    resp = await client.post(
+        "/oms/platform-orders/resolve-preview",
+        json={"platform": platform, "store_id": store_id, "ext_order_no": ext},
+    )
+    assert resp.status_code == 200, resp.text
+
+    data = resp.json()
+    assert data["status"] == "OK"
+    assert data["platform"] == platform
+    assert data["store_id"] == store_id
+    assert data["ext_order_no"] == ext
+    assert data["facts_n"] == 1
+    assert len(data["fact_lines"]) == 1
+    assert data["fact_lines"][0]["filled_code"] == fsku_code
+    assert data["fact_lines"][0]["qty"] == 3
+
+    assert len(data["resolved"]) == 1
+    resolved = data["resolved"][0]
+    assert resolved["filled_code"] == fsku_code
+    assert resolved["qty"] == 3
+    assert int(resolved["fsku_id"]) == int(fsku_id)
+    assert resolved["expanded_items"] == [
+        {
+            "item_id": 1,
+            "component_qty": 2,
+            "need_qty": 6,
+            "role": "main",
+        }
+    ]
+
+    assert data["unresolved"] == []
+    assert data["item_qty_map"] == {"1": 6}
+    assert data["item_qty_items"][0]["item_id"] == 1
+    assert data["item_qty_items"][0]["qty"] == 6
+    assert isinstance(data["item_qty_items"][0]["sku"], str)
+    assert isinstance(data["item_qty_items"][0]["name"], str)
+
+    after = await _orders_count(
+        session,
+        platform=platform,
+        store_code=store_code,
+        ext_order_no=ext,
+    )
+    assert after == before
+
+
+async def test_platform_orders_resolve_preview_returns_unresolved_for_missing_filled_code(client, session):
+    platform = "PDD"
+    store_code = "UT-PREVIEW-PDD-MISSING"
+    store_id = await _ensure_store(
+        session,
+        platform=platform,
+        store_code=store_code,
+        name="UT Preview Missing",
+    )
+    ext = f"UT-PREVIEW-MISSING-{uuid.uuid4().hex[:8]}"
+
+    await _insert_fact_line(
+        session,
+        platform=platform,
+        store_code=store_code,
+        store_id=store_id,
+        ext_order_no=ext,
+        line_no=1,
+        line_key="NO_PSKU:1",
+        filled_code=None,
+        qty=1,
+        title="缺填写码商品",
+        spec="默认规格",
+    )
+    await session.commit()
+
+    resp = await client.post(
+        "/oms/platform-orders/resolve-preview",
+        json={"platform": platform, "store_id": store_id, "ext_order_no": ext},
+    )
+    assert resp.status_code == 200, resp.text
+
+    data = resp.json()
+    assert data["status"] == "UNRESOLVED"
+    assert data["facts_n"] == 1
+    assert data["resolved"] == []
+    assert data["item_qty_map"] == {}
+    assert data["item_qty_items"] == []
+    assert len(data["unresolved"]) == 1
+    assert data["unresolved"][0]["reason"] == "MISSING_FILLED_CODE"
+
+
+async def test_platform_orders_resolve_preview_returns_not_found(client, session):
+    platform = "PDD"
+    store_code = "UT-PREVIEW-PDD-NOTFOUND"
+    store_id = await _ensure_store(
+        session,
+        platform=platform,
+        store_code=store_code,
+        name="UT Preview NotFound",
+    )
+    await session.commit()
+
+    resp = await client.post(
+        "/oms/platform-orders/resolve-preview",
+        json={
+            "platform": platform,
+            "store_id": store_id,
+            "ext_order_no": f"UT-PREVIEW-NOTFOUND-{uuid.uuid4().hex[:8]}",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    data = resp.json()
+    assert data["status"] == "NOT_FOUND"
+    assert data["facts_n"] == 0
+    assert data["fact_lines"] == []
+    assert data["resolved"] == []
+    assert data["item_qty_map"] == {}
+    assert data["item_qty_items"] == []
+    assert data["unresolved"][0]["reason"] == "FACTS_NOT_FOUND"


### PR DESCRIPTION
## Summary
- add read-only platform order resolve preview endpoint
- read platform_order_lines and reuse existing resolver to preview FSKU/SKU expansion
- return fact lines, resolved lines, unresolved reasons, item_qty_map and item_qty_items
- do not create internal orders, do not write finance data

## Tests
- make test TESTS="tests/api/test_platform_orders_resolve_preview_contract.py tests/api/test_platform_orders_replay_contract.py tests/api/test_pdd_fact_bridge_contract.py"