### PR TITLE
feat(platform-order-ingestion): expose store ingestion status

### DIFF
--- a/app/platform_order_ingestion/contracts_status.py
+++ b/app/platform_order_ingestion/contracts_status.py
@@ -1,0 +1,94 @@
+# Module split: platform order ingestion store-level status API contracts.
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class PlatformOrderIngestionStoreOut(BaseModel):
+    id: int
+    platform: str
+    store_code: str
+    store_name: str
+    active: bool
+
+
+class PlatformOrderIngestionAppOut(BaseModel):
+    configured: bool
+    enabled_count: int
+    status: str
+
+
+class PlatformOrderIngestionCredentialOut(BaseModel):
+    present: bool
+    credential_type: str | None
+    credential_status: str
+    expires_at: str | None
+    expired: bool
+    scope: str | None
+    granted_identity_type: str | None
+    granted_identity_value: str | None
+    granted_identity_display: str | None
+
+
+class PlatformOrderIngestionConnectionOut(BaseModel):
+    present: bool
+    auth_source: str
+    connection_status: str
+    credential_status: str
+    reauth_required: bool
+    pull_ready: bool
+    status: str
+    status_reason: str | None
+    last_authorized_at: str | None
+    last_pull_checked_at: str | None
+    last_error_at: str | None
+
+
+class PlatformOrderIngestionLatestRunOut(BaseModel):
+    id: int
+    status: str
+    page: int
+    page_size: int
+    has_more: bool
+    orders_count: int
+    success_count: int
+    failed_count: int
+    started_at: str | None
+    finished_at: str | None
+    error_message: str | None
+
+
+class PlatformOrderIngestionLatestJobOut(BaseModel):
+    id: int
+    job_type: str
+    status: str
+    time_from: str | None
+    time_to: str | None
+    order_status: int | None
+    page_size: int
+    cursor_page: int
+    last_run_at: str | None
+    last_success_at: str | None
+    last_error_at: str | None
+    last_error_message: str | None
+    created_at: str | None
+    latest_run: PlatformOrderIngestionLatestRunOut | None = None
+
+
+class PlatformOrderIngestionStoreStatusDataOut(BaseModel):
+    platform: str
+    store: PlatformOrderIngestionStoreOut
+    app: PlatformOrderIngestionAppOut
+    credential: PlatformOrderIngestionCredentialOut
+    connection: PlatformOrderIngestionConnectionOut
+    latest_job: PlatformOrderIngestionLatestJobOut | None
+    pull_ready: bool
+    blocked_reasons: list[str]
+    meta: dict[str, Any] | None = None
+
+
+class PlatformOrderIngestionStoreStatusEnvelopeOut(BaseModel):
+    ok: bool
+    data: PlatformOrderIngestionStoreStatusDataOut

--- a/app/platform_order_ingestion/repos/status.py
+++ b/app/platform_order_ingestion/repos/status.py
@@ -1,0 +1,171 @@
+# Module split: platform order ingestion store-level status repository.
+from __future__ import annotations
+
+from typing import Mapping
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+_APP_TABLE_BY_PLATFORM = {
+    "pdd": "pdd_app_configs",
+    "taobao": "taobao_app_configs",
+    "jd": "jd_app_configs",
+}
+
+
+def normalize_platform(value: str) -> str:
+    return str(value or "").strip().lower()
+
+
+async def load_store_row(
+    session: AsyncSession,
+    *,
+    store_id: int,
+) -> Mapping | None:
+    result = await session.execute(
+        text(
+            """
+            SELECT id, platform, store_code, store_name, active
+              FROM stores
+             WHERE id = :store_id
+             LIMIT 1
+            """
+        ),
+        {"store_id": int(store_id)},
+    )
+    return result.mappings().first()
+
+
+async def count_enabled_app_configs(
+    session: AsyncSession,
+    *,
+    platform: str,
+) -> int:
+    platform_norm = normalize_platform(platform)
+    table = _APP_TABLE_BY_PLATFORM.get(platform_norm)
+    if table is None:
+        return 0
+
+    result = await session.execute(
+        text(f"SELECT count(*) FROM {table} WHERE is_enabled IS TRUE")
+    )
+    return int(result.scalar_one() or 0)
+
+
+async def load_connection_row(
+    session: AsyncSession,
+    *,
+    store_id: int,
+    platform: str,
+) -> Mapping | None:
+    result = await session.execute(
+        text(
+            """
+            SELECT
+              id,
+              store_id,
+              platform,
+              auth_source,
+              connection_status,
+              credential_status,
+              reauth_required,
+              pull_ready,
+              status,
+              status_reason,
+              last_authorized_at,
+              last_pull_checked_at,
+              last_error_at
+            FROM store_platform_connections
+            WHERE store_id = :store_id
+              AND platform = :platform
+            LIMIT 1
+            """
+        ),
+        {"store_id": int(store_id), "platform": normalize_platform(platform)},
+    )
+    return result.mappings().first()
+
+
+async def load_credential_row(
+    session: AsyncSession,
+    *,
+    store_id: int,
+    platform: str,
+) -> Mapping | None:
+    result = await session.execute(
+        text(
+            """
+            SELECT
+              id,
+              store_id,
+              platform,
+              credential_type,
+              expires_at,
+              scope,
+              granted_identity_type,
+              granted_identity_value,
+              granted_identity_display
+            FROM store_platform_credentials
+            WHERE store_id = :store_id
+              AND platform = :platform
+            LIMIT 1
+            """
+        ),
+        {"store_id": int(store_id), "platform": normalize_platform(platform)},
+    )
+    return result.mappings().first()
+
+
+async def load_latest_job_with_run(
+    session: AsyncSession,
+    *,
+    store_id: int,
+    platform: str,
+) -> Mapping | None:
+    result = await session.execute(
+        text(
+            """
+            SELECT
+              j.id AS job_id,
+              j.job_type,
+              j.status AS job_status,
+              j.time_from,
+              j.time_to,
+              j.order_status,
+              j.page_size AS job_page_size,
+              j.cursor_page,
+              j.last_run_at,
+              j.last_success_at,
+              j.last_error_at,
+              j.last_error_message,
+              j.created_at AS job_created_at,
+
+              r.id AS run_id,
+              r.status AS run_status,
+              r.page AS run_page,
+              r.page_size AS run_page_size,
+              r.has_more,
+              r.orders_count,
+              r.success_count,
+              r.failed_count,
+              r.started_at,
+              r.finished_at,
+              r.error_message AS run_error_message
+            FROM platform_order_pull_jobs j
+            LEFT JOIN LATERAL (
+              SELECT *
+              FROM platform_order_pull_job_runs r
+              WHERE r.job_id = j.id
+              ORDER BY r.id DESC
+              LIMIT 1
+            ) r ON TRUE
+            WHERE j.store_id = :store_id
+              AND j.platform = :platform
+            ORDER BY j.id DESC
+            LIMIT 1
+            """
+        ),
+        {"store_id": int(store_id), "platform": normalize_platform(platform)},
+    )
+    return result.mappings().first()

--- a/app/platform_order_ingestion/router.py
+++ b/app/platform_order_ingestion/router.py
@@ -2,6 +2,7 @@
 from fastapi import APIRouter
 
 from app.platform_order_ingestion.router_pull_jobs import router as platform_order_pull_jobs_router
+from app.platform_order_ingestion.router_status import router as platform_order_status_router
 
 from app.platform_order_ingestion.jd.router_app_config import router as jd_app_config_router
 from app.platform_order_ingestion.jd.router_auth import router as jd_auth_router
@@ -24,6 +25,7 @@ from app.platform_order_ingestion.taobao.router_pull import router as taobao_pul
 router = APIRouter(tags=["platform-order-ingestion"])
 
 router.include_router(platform_order_pull_jobs_router)
+router.include_router(platform_order_status_router)
 
 router.include_router(taobao_app_config_router)
 router.include_router(taobao_auth_router)

--- a/app/platform_order_ingestion/router_status.py
+++ b/app/platform_order_ingestion/router_status.py
@@ -1,0 +1,37 @@
+# Module split: platform order ingestion store-level status API routes.
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.deps import get_async_session as get_session
+from app.platform_order_ingestion.contracts_status import (
+    PlatformOrderIngestionStoreStatusEnvelopeOut,
+)
+from app.platform_order_ingestion.services.status import (
+    PlatformOrderIngestionStatusService,
+    PlatformOrderIngestionStatusServiceError,
+    PlatformOrderIngestionStoreNotFoundError,
+)
+
+router = APIRouter(tags=["platform-order-ingestion-status"])
+
+
+@router.get(
+    "/stores/{store_id}/platform-order-ingestion/status",
+    response_model=PlatformOrderIngestionStoreStatusEnvelopeOut,
+    summary="查询店铺平台订单采集状态",
+)
+async def get_store_platform_order_ingestion_status(
+    store_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> PlatformOrderIngestionStoreStatusEnvelopeOut:
+    try:
+        service = PlatformOrderIngestionStatusService()
+        data = await service.get_store_status(session, store_id=store_id)
+    except PlatformOrderIngestionStoreNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except PlatformOrderIngestionStatusServiceError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return PlatformOrderIngestionStoreStatusEnvelopeOut(ok=True, data=data)

--- a/app/platform_order_ingestion/services/status.py
+++ b/app/platform_order_ingestion/services/status.py
@@ -1,0 +1,242 @@
+# Module split: platform order ingestion store-level status service.
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.platform_order_ingestion.repos.status import (
+    count_enabled_app_configs,
+    load_connection_row,
+    load_credential_row,
+    load_latest_job_with_run,
+    load_store_row,
+    normalize_platform,
+)
+
+_SUPPORTED_PLATFORMS = {"pdd", "taobao", "jd"}
+
+
+class PlatformOrderIngestionStatusServiceError(Exception):
+    """平台订单采集状态服务异常。"""
+
+
+class PlatformOrderIngestionStoreNotFoundError(PlatformOrderIngestionStatusServiceError):
+    """店铺不存在。"""
+
+
+class PlatformOrderIngestionStatusService:
+    async def get_store_status(
+        self,
+        session: AsyncSession,
+        *,
+        store_id: int,
+    ) -> dict[str, Any]:
+        store = await load_store_row(session, store_id=store_id)
+        if store is None:
+            raise PlatformOrderIngestionStoreNotFoundError(f"store not found: {store_id}")
+
+        platform = normalize_platform(str(store["platform"]))
+        app_enabled_count = await count_enabled_app_configs(session, platform=platform)
+        credential = await load_credential_row(session, store_id=store_id, platform=platform)
+        connection = await load_connection_row(session, store_id=store_id, platform=platform)
+        latest_job = await load_latest_job_with_run(session, store_id=store_id, platform=platform)
+
+        app_status = self._app_status(platform=platform, enabled_count=app_enabled_count)
+        credential_status = self._credential_status(credential)
+        connection_out = self._connection_out(connection)
+        pull_ready = self._compute_pull_ready(
+            store_active=bool(store["active"]),
+            platform=platform,
+            app_status=app_status,
+            credential_status=credential_status["credential_status"],
+            connection_pull_ready=bool(connection_out["pull_ready"]),
+        )
+        blocked_reasons = self._blocked_reasons(
+            store_active=bool(store["active"]),
+            platform=platform,
+            app_status=app_status,
+            credential_status=credential_status["credential_status"],
+            connection_out=connection_out,
+        )
+
+        return {
+            "platform": platform,
+            "store": {
+                "id": int(store["id"]),
+                "platform": platform,
+                "store_code": str(store["store_code"]),
+                "store_name": str(store["store_name"]),
+                "active": bool(store["active"]),
+            },
+            "app": {
+                "configured": app_status == "ready",
+                "enabled_count": app_enabled_count,
+                "status": app_status,
+            },
+            "credential": credential_status,
+            "connection": connection_out,
+            "latest_job": self._latest_job_out(latest_job),
+            "pull_ready": pull_ready,
+            "blocked_reasons": blocked_reasons,
+            "meta": {
+                "source": "platform_order_ingestion_store_status",
+            },
+        }
+
+    def _app_status(self, *, platform: str, enabled_count: int) -> str:
+        if platform not in _SUPPORTED_PLATFORMS:
+            return "unsupported_platform"
+        if enabled_count <= 0:
+            return "not_configured"
+        if enabled_count > 1:
+            return "ambiguous"
+        return "ready"
+
+    def _credential_status(self, row: Mapping | None) -> dict[str, Any]:
+        if row is None:
+            return {
+                "present": False,
+                "credential_type": None,
+                "credential_status": "missing",
+                "expires_at": None,
+                "expired": False,
+                "scope": None,
+                "granted_identity_type": None,
+                "granted_identity_value": None,
+                "granted_identity_display": None,
+            }
+
+        expires_at = row["expires_at"]
+        expired = bool(expires_at and expires_at <= datetime.now(timezone.utc))
+        return {
+            "present": True,
+            "credential_type": row["credential_type"],
+            "credential_status": "expired" if expired else "valid",
+            "expires_at": self._dt(expires_at),
+            "expired": expired,
+            "scope": row["scope"],
+            "granted_identity_type": row["granted_identity_type"],
+            "granted_identity_value": row["granted_identity_value"],
+            "granted_identity_display": row["granted_identity_display"],
+        }
+
+    def _connection_out(self, row: Mapping | None) -> dict[str, Any]:
+        if row is None:
+            return {
+                "present": False,
+                "auth_source": "none",
+                "connection_status": "not_connected",
+                "credential_status": "missing",
+                "reauth_required": False,
+                "pull_ready": False,
+                "status": "not_connected",
+                "status_reason": "authorization_missing",
+                "last_authorized_at": None,
+                "last_pull_checked_at": None,
+                "last_error_at": None,
+            }
+
+        return {
+            "present": True,
+            "auth_source": row["auth_source"],
+            "connection_status": row["connection_status"],
+            "credential_status": row["credential_status"],
+            "reauth_required": bool(row["reauth_required"]),
+            "pull_ready": bool(row["pull_ready"]),
+            "status": row["status"],
+            "status_reason": row["status_reason"],
+            "last_authorized_at": self._dt(row["last_authorized_at"]),
+            "last_pull_checked_at": self._dt(row["last_pull_checked_at"]),
+            "last_error_at": self._dt(row["last_error_at"]),
+        }
+
+    def _compute_pull_ready(
+        self,
+        *,
+        store_active: bool,
+        platform: str,
+        app_status: str,
+        credential_status: str,
+        connection_pull_ready: bool,
+    ) -> bool:
+        return (
+            store_active
+            and platform in _SUPPORTED_PLATFORMS
+            and app_status == "ready"
+            and credential_status == "valid"
+            and connection_pull_ready
+        )
+
+    def _blocked_reasons(
+        self,
+        *,
+        store_active: bool,
+        platform: str,
+        app_status: str,
+        credential_status: str,
+        connection_out: dict[str, Any],
+    ) -> list[str]:
+        reasons: list[str] = []
+        if not store_active:
+            reasons.append("store_inactive")
+        if platform not in _SUPPORTED_PLATFORMS:
+            reasons.append("unsupported_platform")
+        if app_status == "not_configured":
+            reasons.append("platform_app_not_ready")
+        elif app_status == "ambiguous":
+            reasons.append("platform_app_ambiguous")
+        elif app_status == "unsupported_platform":
+            reasons.append("unsupported_platform")
+        if credential_status == "missing":
+            reasons.append("credential_missing")
+        elif credential_status == "expired":
+            reasons.append("credential_expired")
+        if not connection_out["pull_ready"]:
+            status_reason = connection_out.get("status_reason")
+            if status_reason and status_reason not in reasons:
+                reasons.append(str(status_reason))
+            elif "connection_not_ready" not in reasons:
+                reasons.append("connection_not_ready")
+        return reasons
+
+    def _latest_job_out(self, row: Mapping | None) -> dict[str, Any] | None:
+        if row is None:
+            return None
+
+        latest_run = None
+        if row["run_id"] is not None:
+            latest_run = {
+                "id": int(row["run_id"]),
+                "status": row["run_status"],
+                "page": int(row["run_page"]),
+                "page_size": int(row["run_page_size"]),
+                "has_more": bool(row["has_more"]),
+                "orders_count": int(row["orders_count"]),
+                "success_count": int(row["success_count"]),
+                "failed_count": int(row["failed_count"]),
+                "started_at": self._dt(row["started_at"]),
+                "finished_at": self._dt(row["finished_at"]),
+                "error_message": row["run_error_message"],
+            }
+
+        return {
+            "id": int(row["job_id"]),
+            "job_type": row["job_type"],
+            "status": row["job_status"],
+            "time_from": self._dt(row["time_from"]),
+            "time_to": self._dt(row["time_to"]),
+            "order_status": row["order_status"],
+            "page_size": int(row["job_page_size"]),
+            "cursor_page": int(row["cursor_page"]),
+            "last_run_at": self._dt(row["last_run_at"]),
+            "last_success_at": self._dt(row["last_success_at"]),
+            "last_error_at": self._dt(row["last_error_at"]),
+            "last_error_message": row["last_error_message"],
+            "created_at": self._dt(row["job_created_at"]),
+            "latest_run": latest_run,
+        }
+
+    def _dt(self, value: Any) -> str | None:
+        return value.isoformat() if value else None

--- a/tests/api/test_platform_order_ingestion_store_status_contract.py
+++ b/tests/api/test_platform_order_ingestion_store_status_contract.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import text
+
+from app.platform_order_ingestion.models.pdd_app_config import PddAppConfig
+from app.platform_order_ingestion.models.store_platform_connection import StorePlatformConnection
+from app.platform_order_ingestion.models.store_platform_credential import StorePlatformCredential
+from app.platform_order_ingestion.models.pull_job import (
+    PlatformOrderPullJob,
+    PlatformOrderPullJobRun,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _reset_store_status_state(session, *, store_id: int, platform: str) -> None:
+    platform_norm = platform.lower()
+    await session.execute(
+        text(
+            """
+            DELETE FROM platform_order_pull_job_run_logs
+             WHERE run_id IN (
+               SELECT id
+                 FROM platform_order_pull_job_runs
+                WHERE store_id = :sid
+             )
+            """
+        ),
+        {"sid": store_id},
+    )
+    await session.execute(text("DELETE FROM platform_order_pull_job_runs WHERE store_id = :sid"), {"sid": store_id})
+    await session.execute(text("DELETE FROM platform_order_pull_jobs WHERE store_id = :sid"), {"sid": store_id})
+    await session.execute(
+        text("DELETE FROM store_platform_connections WHERE store_id = :sid AND platform = :platform"),
+        {"sid": store_id, "platform": platform_norm},
+    )
+    await session.execute(
+        text("DELETE FROM store_platform_credentials WHERE store_id = :sid AND platform = :platform"),
+        {"sid": store_id, "platform": platform_norm},
+    )
+    if platform_norm == "pdd":
+        await session.execute(text("DELETE FROM pdd_app_configs"))
+    elif platform_norm == "taobao":
+        await session.execute(text("DELETE FROM taobao_app_configs"))
+    elif platform_norm == "jd":
+        await session.execute(text("DELETE FROM jd_app_configs"))
+    await session.execute(text("DELETE FROM stores WHERE id = :sid"), {"sid": store_id})
+    await session.commit()
+
+
+async def _seed_store(session, *, store_id: int, platform: str = "PDD", active: bool = True) -> None:
+    await session.execute(
+        text(
+            """
+            INSERT INTO stores (id, platform, store_code, store_name, active)
+            VALUES (:id, :platform, :store_code, :store_name, :active)
+            ON CONFLICT (id) DO UPDATE
+              SET platform = EXCLUDED.platform,
+                  store_code = EXCLUDED.store_code,
+                  store_name = EXCLUDED.store_name,
+                  active = EXCLUDED.active
+            """
+        ),
+        {
+            "id": store_id,
+            "platform": platform,
+            "store_code": f"store-{store_id}",
+            "store_name": f"store-{store_id}",
+            "active": active,
+        },
+    )
+    await session.commit()
+
+
+async def test_store_status_returns_not_ready_shell_when_no_app_or_auth(client, session):
+    store_id = 7301
+    await _reset_store_status_state(session, store_id=store_id, platform="pdd")
+    await _seed_store(session, store_id=store_id, platform="PDD")
+
+    resp = await client.get(f"/oms/stores/{store_id}/platform-order-ingestion/status")
+    assert resp.status_code == 200, resp.text
+
+    body = resp.json()
+    assert body["ok"] is True
+    data = body["data"]
+
+    assert data["platform"] == "pdd"
+    assert data["store"]["id"] == store_id
+    assert data["store"]["platform"] == "pdd"
+    assert data["store"]["store_code"] == f"store-{store_id}"
+    assert data["store"]["active"] is True
+
+    assert data["app"] == {
+        "configured": False,
+        "enabled_count": 0,
+        "status": "not_configured",
+    }
+    assert data["credential"]["present"] is False
+    assert data["credential"]["credential_status"] == "missing"
+
+    assert data["connection"]["present"] is False
+    assert data["connection"]["connection_status"] == "not_connected"
+    assert data["connection"]["credential_status"] == "missing"
+    assert data["connection"]["pull_ready"] is False
+    assert data["connection"]["status_reason"] == "authorization_missing"
+
+    assert data["latest_job"] is None
+    assert data["pull_ready"] is False
+    assert "platform_app_not_ready" in data["blocked_reasons"]
+    assert "credential_missing" in data["blocked_reasons"]
+    assert "authorization_missing" in data["blocked_reasons"]
+
+
+async def test_store_status_returns_ready_with_latest_job_and_run(client, session):
+    store_id = 7302
+    now = datetime.now(timezone.utc)
+    await _reset_store_status_state(session, store_id=store_id, platform="pdd")
+    await _seed_store(session, store_id=store_id, platform="PDD")
+
+    session.add(
+        PddAppConfig(
+            client_id="pdd-client-7302",
+            client_secret="pdd-secret-7302",
+            redirect_uri="http://127.0.0.1:8000/oms/pdd/oauth/callback",
+            api_base_url="https://gw-api.pinduoduo.com/api/router",
+            sign_method="md5",
+            is_enabled=True,
+        )
+    )
+    session.add(
+        StorePlatformCredential(
+            store_id=store_id,
+            platform="pdd",
+            credential_type="oauth",
+            access_token="access-token-7302",
+            refresh_token="refresh-token-7302",
+            expires_at=now + timedelta(days=1),
+            scope="pdd.order.list.get",
+            raw_payload_json={"source": "test"},
+            granted_identity_type="pdd_owner_id",
+            granted_identity_value="owner-7302",
+            granted_identity_display="store-7302",
+        )
+    )
+    session.add(
+        StorePlatformConnection(
+            store_id=store_id,
+            platform="pdd",
+            auth_source="oauth",
+            connection_status="connected",
+            credential_status="valid",
+            reauth_required=False,
+            pull_ready=True,
+            status="ready",
+            status_reason="real_pull_ok",
+            last_authorized_at=now,
+            last_pull_checked_at=now,
+        )
+    )
+    await session.flush()
+
+    job = PlatformOrderPullJob(
+        platform="pdd",
+        store_id=store_id,
+        job_type="manual",
+        status="success",
+        time_from=now - timedelta(hours=1),
+        time_to=now,
+        order_status=1,
+        page_size=50,
+        cursor_page=1,
+        last_run_at=now,
+        last_success_at=now,
+        created_at=now,
+        updated_at=now,
+    )
+    session.add(job)
+    await session.flush()
+
+    run = PlatformOrderPullJobRun(
+        job_id=job.id,
+        platform="pdd",
+        store_id=store_id,
+        status="success",
+        page=1,
+        page_size=50,
+        has_more=False,
+        started_at=now,
+        finished_at=now,
+        orders_count=2,
+        success_count=2,
+        failed_count=0,
+        request_payload={"page": 1},
+        result_payload={"ok": True},
+        created_at=now,
+    )
+    session.add(run)
+    await session.commit()
+
+    resp = await client.get(f"/oms/stores/{store_id}/platform-order-ingestion/status")
+    assert resp.status_code == 200, resp.text
+
+    data = resp.json()["data"]
+    assert data["app"]["configured"] is True
+    assert data["app"]["status"] == "ready"
+    assert data["credential"]["present"] is True
+    assert data["credential"]["credential_status"] == "valid"
+    assert data["credential"]["expired"] is False
+    assert data["credential"]["granted_identity_value"] == "owner-7302"
+    assert data["connection"]["present"] is True
+    assert data["connection"]["pull_ready"] is True
+    assert data["pull_ready"] is True
+    assert data["blocked_reasons"] == []
+
+    assert data["latest_job"]["id"] == job.id
+    assert data["latest_job"]["status"] == "success"
+    assert data["latest_job"]["latest_run"]["id"] == run.id
+    assert data["latest_job"]["latest_run"]["orders_count"] == 2
+    assert data["latest_job"]["latest_run"]["success_count"] == 2
+
+    assert "access-token-7302" not in resp.text
+    assert "refresh-token-7302" not in resp.text
+
+
+async def test_store_status_expired_credential_blocks_pull_ready_even_if_connection_is_stale_ready(client, session):
+    store_id = 7303
+    now = datetime.now(timezone.utc)
+    await _reset_store_status_state(session, store_id=store_id, platform="pdd")
+    await _seed_store(session, store_id=store_id, platform="PDD")
+
+    session.add(
+        PddAppConfig(
+            client_id="pdd-client-7303",
+            client_secret="pdd-secret-7303",
+            redirect_uri="http://127.0.0.1:8000/oms/pdd/oauth/callback",
+            api_base_url="https://gw-api.pinduoduo.com/api/router",
+            sign_method="md5",
+            is_enabled=True,
+        )
+    )
+    session.add(
+        StorePlatformCredential(
+            store_id=store_id,
+            platform="pdd",
+            credential_type="oauth",
+            access_token="expired-token-7303",
+            refresh_token="refresh-token-7303",
+            expires_at=now - timedelta(minutes=5),
+            scope="pdd.order.list.get",
+            raw_payload_json={"source": "test"},
+            granted_identity_type="pdd_owner_id",
+            granted_identity_value="owner-7303",
+            granted_identity_display="store-7303",
+        )
+    )
+    session.add(
+        StorePlatformConnection(
+            store_id=store_id,
+            platform="pdd",
+            auth_source="oauth",
+            connection_status="connected",
+            credential_status="valid",
+            reauth_required=False,
+            pull_ready=True,
+            status="ready",
+            status_reason="real_pull_ok",
+            last_authorized_at=now,
+            last_pull_checked_at=now,
+        )
+    )
+    await session.commit()
+
+    resp = await client.get(f"/oms/stores/{store_id}/platform-order-ingestion/status")
+    assert resp.status_code == 200, resp.text
+
+    data = resp.json()["data"]
+    assert data["app"]["status"] == "ready"
+    assert data["credential"]["credential_status"] == "expired"
+    assert data["credential"]["expired"] is True
+    assert data["connection"]["pull_ready"] is True
+    assert data["pull_ready"] is False
+    assert "credential_expired" in data["blocked_reasons"]
+
+
+async def test_store_status_returns_404_when_store_missing(client, session):
+    store_id = 7399
+    await _reset_store_status_state(session, store_id=store_id, platform="pdd")
+
+    resp = await client.get(f"/oms/stores/{store_id}/platform-order-ingestion/status")
+    assert resp.status_code == 404, resp.text
+    assert "store not found" in resp.text


### PR DESCRIPTION
## Summary
- add store-level platform order ingestion status endpoint
- aggregate store, platform app readiness, credential status, connection status and latest pull job/run
- compute effective pull_ready from store active, app readiness, credential validity and connection pull_ready
- do not expose access_token or refresh_token
- add API contract tests for not-ready, ready, expired credential and missing store cases

## Boundary
- read-only status aggregation only
- does not trigger test-pull or real pull
- does not mutate store_platform_connections
- does not touch OMS order_facts, FSKU, internal orders, Finance, WMS or TMS

## Tests
- make test TESTS="tests/api/test_platform_order_ingestion_store_status_contract.py tests/api/test_platform_order_pull_jobs_contract.py tests/api/test_pdd_connection_and_pull_contract.py tests/api/test_jd_connection_contract.py"