### PR TITLE
feat(platform-order-ingestion): run pdd pull job pages

### DIFF
--- a/app/platform_order_ingestion/contracts_pull_jobs.py
+++ b/app/platform_order_ingestion/contracts_pull_jobs.py
@@ -64,6 +64,10 @@ class PlatformOrderPullJobRunCreateIn(BaseModel):
     page: int | None = Field(default=None, gt=0)
 
 
+class PlatformOrderPullJobRunPagesCreateIn(BaseModel):
+    max_pages: int = Field(default=10, gt=0, le=100)
+
+
 class PlatformOrderPullJobOut(BaseModel):
     id: int
     platform: str
@@ -137,6 +141,14 @@ class PlatformOrderPullJobRunDataOut(BaseModel):
     logs: list[PlatformOrderPullJobRunLogOut]
 
 
+class PlatformOrderPullJobRunPagesDataOut(BaseModel):
+    job: PlatformOrderPullJobOut
+    runs: list[PlatformOrderPullJobRunOut]
+    logs: list[PlatformOrderPullJobRunLogOut]
+    pages_executed: int
+    stopped_reason: str
+
+
 class PlatformOrderPullJobEnvelopeOut(BaseModel):
     ok: bool
     data: PlatformOrderPullJobOut
@@ -155,3 +167,8 @@ class PlatformOrderPullJobDetailEnvelopeOut(BaseModel):
 class PlatformOrderPullJobRunEnvelopeOut(BaseModel):
     ok: bool
     data: PlatformOrderPullJobRunDataOut
+
+
+class PlatformOrderPullJobRunPagesEnvelopeOut(BaseModel):
+    ok: bool
+    data: PlatformOrderPullJobRunPagesDataOut

--- a/app/platform_order_ingestion/router_pull_jobs.py
+++ b/app/platform_order_ingestion/router_pull_jobs.py
@@ -17,6 +17,9 @@ from app.platform_order_ingestion.contracts_pull_jobs import (
     PlatformOrderPullJobRunDataOut,
     PlatformOrderPullJobRunEnvelopeOut,
     PlatformOrderPullJobRunLogOut,
+    PlatformOrderPullJobRunPagesCreateIn,
+    PlatformOrderPullJobRunPagesDataOut,
+    PlatformOrderPullJobRunPagesEnvelopeOut,
     PlatformOrderPullJobRunOut,
 )
 from app.platform_order_ingestion.models.pull_job import (
@@ -204,5 +207,46 @@ async def run_platform_order_pull_job_once(
             job=_job_out(job),
             run=_run_out(run),
             logs=[_log_out(row) for row in logs],
+        ),
+    )
+
+@router.post(
+    "/platform-order-ingestion/pull-jobs/{job_id}/run-pages",
+    response_model=PlatformOrderPullJobRunPagesEnvelopeOut,
+    summary="连续执行平台订单采集任务页面",
+)
+async def run_platform_order_pull_job_pages(
+    job_id: int,
+    payload: PlatformOrderPullJobRunPagesCreateIn = Body(
+        default_factory=PlatformOrderPullJobRunPagesCreateIn
+    ),
+    session: AsyncSession = Depends(get_session),
+) -> PlatformOrderPullJobRunPagesEnvelopeOut:
+    try:
+        service = PlatformOrderPullJobService()
+        job, runs, logs, stopped_reason = await service.run_job_pages(
+            session,
+            job_id=job_id,
+            max_pages=payload.max_pages,
+        )
+        await session.commit()
+    except PlatformOrderPullJobServiceError as exc:
+        await session.rollback()
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:  # noqa: BLE001
+        await session.rollback()
+        raise HTTPException(
+            status_code=500,
+            detail=f"failed to run platform order pull job pages: {exc}",
+        ) from exc
+
+    return PlatformOrderPullJobRunPagesEnvelopeOut(
+        ok=True,
+        data=PlatformOrderPullJobRunPagesDataOut(
+            job=_job_out(job),
+            runs=[_run_out(row) for row in runs],
+            logs=[_log_out(row) for row in logs],
+            pages_executed=len(runs),
+            stopped_reason=stopped_reason,
         ),
     )

--- a/app/platform_order_ingestion/services/pull_jobs.py
+++ b/app/platform_order_ingestion/services/pull_jobs.py
@@ -271,6 +271,50 @@ class PlatformOrderPullJobService:
         logs = await get_pull_job_logs(session, job_id=job.id, run_id=run.id)
         return job, run, logs
 
+    async def run_job_pages(
+        self,
+        session: AsyncSession,
+        *,
+        job_id: int,
+        max_pages: int = 10,
+    ) -> tuple[
+        PlatformOrderPullJob,
+        list[PlatformOrderPullJobRun],
+        list[PlatformOrderPullJobRunLog],
+        str,
+    ]:
+        max_pages_int = int(max_pages)
+        if max_pages_int <= 0:
+            raise PlatformOrderPullJobServiceError("max_pages must be positive")
+        if max_pages_int > 100:
+            raise PlatformOrderPullJobServiceError("max_pages must be <= 100")
+
+        runs: list[PlatformOrderPullJobRun] = []
+        logs: list[PlatformOrderPullJobRunLog] = []
+        stopped_reason = "max_pages_reached"
+        job: PlatformOrderPullJob | None = None
+
+        for _ in range(max_pages_int):
+            job, run, run_logs = await self.run_job_once(
+                session,
+                job_id=job_id,
+                page=None,
+            )
+            runs.append(run)
+            logs.extend(run_logs)
+
+            if run.status == "failed":
+                stopped_reason = "failed"
+                break
+            if not run.has_more:
+                stopped_reason = "no_more"
+                break
+
+        if job is None:
+            raise PlatformOrderPullJobServiceError(f"platform order pull job not found: {job_id}")
+
+        return job, runs, logs, stopped_reason
+
     async def _run_pdd_job_page(
         self,
         *,

--- a/tests/api/test_platform_order_ingestion_store_status_contract.py
+++ b/tests/api/test_platform_order_ingestion_store_status_contract.py
@@ -47,6 +47,7 @@ async def _reset_store_status_state(session, *, store_id: int, platform: str) ->
         await session.execute(text("DELETE FROM taobao_app_configs"))
     elif platform_norm == "jd":
         await session.execute(text("DELETE FROM jd_app_configs"))
+    await session.execute(text("DELETE FROM store_warehouse WHERE store_id = :sid"), {"sid": store_id})
     await session.execute(text("DELETE FROM stores WHERE id = :sid"), {"sid": store_id})
     await session.commit()
 

--- a/tests/api/test_platform_order_pull_jobs_contract.py
+++ b/tests/api/test_platform_order_pull_jobs_contract.py
@@ -216,3 +216,134 @@ async def test_run_unsupported_platform_pull_job_fails_without_fake_success(clie
     assert data["run"]["error_message"] == "PLATFORM_PULL_JOB_NOT_IMPLEMENTED: taobao"
     assert data["logs"][-1]["event_type"] == "page_failed"
     assert data["logs"][-1]["level"] == "error"
+
+
+async def test_run_pdd_platform_order_pull_job_pages_stops_when_no_more(client, session, monkeypatch):
+    await _seed_store(session, store_id=7104, platform="PDD")
+
+    captured_pages = []
+
+    async def _fake_ingest_order_page(self, *, session, params):
+        captured_pages.append(params.page)
+        has_more = params.page == 1
+        return PddOrderIngestPageResult(
+            store_id=7104,
+            store_code="store-7104",
+            page=params.page,
+            page_size=params.page_size,
+            orders_count=1,
+            success_count=1,
+            failed_count=0,
+            has_more=has_more,
+            start_confirm_at=params.start_confirm_at,
+            end_confirm_at=params.end_confirm_at,
+            rows=[
+                PddOrderIngestRowResult(
+                    order_sn=f"PDD-JOB-ORDER-PAGE-{params.page}",
+                    pdd_order_id=9100 + params.page,
+                    status="OK",
+                    error=None,
+                )
+            ],
+        )
+
+    monkeypatch.setattr(
+        pdd_service_ingest.PddOrderIngestService,
+        "ingest_order_page",
+        _fake_ingest_order_page,
+    )
+
+    create_resp = await client.post(
+        "/oms/platform-order-ingestion/pull-jobs",
+        json={
+            "platform": "pdd",
+            "store_id": 7104,
+            "job_type": "manual",
+            "time_from": "2026-03-29 00:00:00",
+            "time_to": "2026-03-29 23:59:59",
+            "order_status": 1,
+            "page_size": 50,
+        },
+    )
+    assert create_resp.status_code == 200, create_resp.text
+    job_id = create_resp.json()["data"]["id"]
+
+    run_resp = await client.post(
+        f"/oms/platform-order-ingestion/pull-jobs/{job_id}/run-pages",
+        json={"max_pages": 5},
+    )
+    assert run_resp.status_code == 200, run_resp.text
+
+    data = run_resp.json()["data"]
+    assert captured_pages == [1, 2]
+    assert data["pages_executed"] == 2
+    assert data["stopped_reason"] == "no_more"
+    assert [run["page"] for run in data["runs"]] == [1, 2]
+    assert data["runs"][0]["has_more"] is True
+    assert data["runs"][1]["has_more"] is False
+    assert data["job"]["status"] == "success"
+    assert data["job"]["cursor_page"] == 2
+
+
+async def test_run_pdd_platform_order_pull_job_pages_respects_max_pages(client, session, monkeypatch):
+    await _seed_store(session, store_id=7105, platform="PDD")
+
+    captured_pages = []
+
+    async def _fake_ingest_order_page(self, *, session, params):
+        captured_pages.append(params.page)
+        return PddOrderIngestPageResult(
+            store_id=7105,
+            store_code="store-7105",
+            page=params.page,
+            page_size=params.page_size,
+            orders_count=1,
+            success_count=1,
+            failed_count=0,
+            has_more=True,
+            start_confirm_at=params.start_confirm_at,
+            end_confirm_at=params.end_confirm_at,
+            rows=[
+                PddOrderIngestRowResult(
+                    order_sn=f"PDD-JOB-MAX-PAGE-{params.page}",
+                    pdd_order_id=9200 + params.page,
+                    status="OK",
+                    error=None,
+                )
+            ],
+        )
+
+    monkeypatch.setattr(
+        pdd_service_ingest.PddOrderIngestService,
+        "ingest_order_page",
+        _fake_ingest_order_page,
+    )
+
+    create_resp = await client.post(
+        "/oms/platform-order-ingestion/pull-jobs",
+        json={
+            "platform": "pdd",
+            "store_id": 7105,
+            "job_type": "manual",
+            "time_from": "2026-03-29 00:00:00",
+            "time_to": "2026-03-29 23:59:59",
+            "order_status": 1,
+            "page_size": 50,
+        },
+    )
+    assert create_resp.status_code == 200, create_resp.text
+    job_id = create_resp.json()["data"]["id"]
+
+    run_resp = await client.post(
+        f"/oms/platform-order-ingestion/pull-jobs/{job_id}/run-pages",
+        json={"max_pages": 2},
+    )
+    assert run_resp.status_code == 200, run_resp.text
+
+    data = run_resp.json()["data"]
+    assert captured_pages == [1, 2]
+    assert data["pages_executed"] == 2
+    assert data["stopped_reason"] == "max_pages_reached"
+    assert [run["page"] for run in data["runs"]] == [1, 2]
+    assert all(run["has_more"] is True for run in data["runs"])
+    assert data["job"]["cursor_page"] == 3


### PR DESCRIPTION
## Summary
- add run-pages endpoint for platform order pull jobs
- repeatedly execute PDD pull job pages until has_more=false or max_pages is reached
- keep existing single-page run endpoint unchanged
- add contract tests for stop-on-no-more and max_pages guard
- fix store-status test cleanup to remove store_warehouse before deleting stores

## Boundary
- reuses existing PDD one-page job execution
- no scheduler or background worker
- no DB schema changes
- does not touch OMS order_facts, FSKU, internal orders, Finance, WMS or TMS

## Tests
- make test TESTS="tests/api/test_platform_order_pull_jobs_contract.py tests/api/test_platform_order_ingestion_store_status_contract.py tests/api/test_pdd_real_ingest_contract.py"