### PR TITLE
refactor(platform-order-ingestion): extract pull job executors

### DIFF
--- a/app/platform_order_ingestion/pdd/pull_job_executor.py
+++ b/app/platform_order_ingestion/pdd/pull_job_executor.py
@@ -1,0 +1,87 @@
+# Module split: PDD owns its platform order pull-job executor implementation.
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.platform_order_ingestion.models.pull_job import PlatformOrderPullJob
+from app.platform_order_ingestion.pdd.service_ingest import PddOrderIngestService
+from app.platform_order_ingestion.pdd.service_real_pull import PddRealPullParams
+from app.platform_order_ingestion.services.pull_job_executor import (
+    PlatformOrderPullJobPageResult,
+    PlatformOrderPullJobPageRow,
+)
+
+
+class PddPullJobExecutor:
+    platform = "pdd"
+
+    async def run_page(
+        self,
+        *,
+        session: AsyncSession,
+        job: PlatformOrderPullJob,
+        page: int,
+    ) -> PlatformOrderPullJobPageResult:
+        service = PddOrderIngestService()
+        result = await service.ingest_order_page(
+            session=session,
+            params=PddRealPullParams(
+                store_id=int(job.store_id),
+                start_confirm_at=self._format_platform_dt(job.time_from),
+                end_confirm_at=self._format_platform_dt(job.time_to),
+                order_status=int(job.order_status or 1),
+                page=int(page),
+                page_size=int(job.page_size),
+            ),
+        )
+
+        rows = [
+            PlatformOrderPullJobPageRow(
+                platform_order_no=row.order_sn,
+                native_order_id=row.pdd_order_id,
+                status=row.status,
+                error=row.error,
+            )
+            for row in result.rows
+        ]
+
+        result_payload = {
+            "platform": self.platform,
+            "store_id": result.store_id,
+            "store_code": result.store_code,
+            "page": result.page,
+            "page_size": result.page_size,
+            "orders_count": result.orders_count,
+            "success_count": result.success_count,
+            "failed_count": result.failed_count,
+            "has_more": result.has_more,
+            "start_confirm_at": result.start_confirm_at,
+            "end_confirm_at": result.end_confirm_at,
+            "rows": [
+                {
+                    "order_sn": row.order_sn,
+                    "pdd_order_id": row.pdd_order_id,
+                    "status": row.status,
+                    "error": row.error,
+                }
+                for row in result.rows
+            ],
+        }
+
+        return PlatformOrderPullJobPageResult(
+            platform=self.platform,
+            store_id=int(result.store_id),
+            page=int(result.page),
+            page_size=int(result.page_size),
+            orders_count=int(result.orders_count),
+            success_count=int(result.success_count),
+            failed_count=int(result.failed_count),
+            has_more=bool(result.has_more),
+            result_payload=result_payload,
+            rows=rows,
+        )
+
+    def _format_platform_dt(self, value) -> str | None:
+        if value is None:
+            return None
+        return value.strftime("%Y-%m-%d %H:%M:%S")

--- a/app/platform_order_ingestion/services/pull_job_executor.py
+++ b/app/platform_order_ingestion/services/pull_job_executor.py
@@ -1,0 +1,44 @@
+# Module split: platform order ingestion pull-job executor contract.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.platform_order_ingestion.models.pull_job import PlatformOrderPullJob
+
+
+@dataclass(frozen=True)
+class PlatformOrderPullJobPageRow:
+    platform_order_no: str
+    native_order_id: int | None
+    status: str
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class PlatformOrderPullJobPageResult:
+    platform: str
+    store_id: int
+    page: int
+    page_size: int
+    orders_count: int
+    success_count: int
+    failed_count: int
+    has_more: bool
+    result_payload: dict[str, Any]
+    rows: list[PlatformOrderPullJobPageRow]
+
+
+class PlatformOrderPullJobExecutor(Protocol):
+    platform: str
+
+    async def run_page(
+        self,
+        *,
+        session: AsyncSession,
+        job: PlatformOrderPullJob,
+        page: int,
+    ) -> PlatformOrderPullJobPageResult:
+        ...

--- a/app/platform_order_ingestion/services/pull_job_executor_registry.py
+++ b/app/platform_order_ingestion/services/pull_job_executor_registry.py
@@ -1,0 +1,17 @@
+# Module split: platform order ingestion pull-job executor registry.
+#
+# This is not a cross-platform business adapter. It only dispatches the common
+# pull-job runner to platform-owned executor implementations.
+from __future__ import annotations
+
+from app.platform_order_ingestion.pdd.pull_job_executor import PddPullJobExecutor
+from app.platform_order_ingestion.services.pull_job_executor import PlatformOrderPullJobExecutor
+
+
+_EXECUTORS: dict[str, PlatformOrderPullJobExecutor] = {
+    "pdd": PddPullJobExecutor(),
+}
+
+
+def get_pull_job_executor(platform: str) -> PlatformOrderPullJobExecutor | None:
+    return _EXECUTORS.get(str(platform or "").strip().lower())

--- a/app/platform_order_ingestion/services/pull_jobs.py
+++ b/app/platform_order_ingestion/services/pull_jobs.py
@@ -12,11 +12,9 @@ from app.platform_order_ingestion.models.pull_job import (
     PlatformOrderPullJobRun,
     PlatformOrderPullJobRunLog,
 )
-from app.platform_order_ingestion.pdd.service_ingest import (
-    PddOrderIngestPageResult,
-    PddOrderIngestService,
+from app.platform_order_ingestion.services.pull_job_executor_registry import (
+    get_pull_job_executor,
 )
-from app.platform_order_ingestion.pdd.service_real_pull import PddRealPullParams
 from app.platform_order_ingestion.repos.pull_jobs import (
     create_pull_job,
     create_pull_job_run,
@@ -135,7 +133,8 @@ class PlatformOrderPullJobService:
             payload=request_payload,
         )
 
-        if job.platform != "pdd":
+        executor = get_pull_job_executor(job.platform)
+        if executor is None:
             message = f"PLATFORM_PULL_JOB_NOT_IMPLEMENTED: {job.platform}"
             await create_pull_job_run_log(
                 session,
@@ -162,7 +161,7 @@ class PlatformOrderPullJobService:
             return job, run, logs
 
         try:
-            result = await self._run_pdd_job_page(
+            result = await executor.run_page(
                 session=session,
                 job=job,
                 page=run_page,
@@ -201,8 +200,8 @@ class PlatformOrderPullJobService:
                     run_id=run.id,
                     level="info",
                     event_type="order_ingested",
-                    platform_order_no=row.order_sn,
-                    native_order_id=row.pdd_order_id,
+                    platform_order_no=row.platform_order_no,
+                    native_order_id=row.native_order_id,
                     message="pdd order ingested",
                     payload={"status": row.status},
                 )
@@ -213,8 +212,8 @@ class PlatformOrderPullJobService:
                     run_id=run.id,
                     level="error",
                     event_type="order_failed",
-                    platform_order_no=row.order_sn,
-                    native_order_id=row.pdd_order_id,
+                    platform_order_no=row.platform_order_no,
+                    native_order_id=row.native_order_id,
                     message=row.error,
                     payload={"status": row.status, "error": row.error},
                 )
@@ -224,28 +223,7 @@ class PlatformOrderPullJobService:
             success_count=result.success_count,
             failed_count=result.failed_count,
         )
-        result_payload = {
-            "platform": "pdd",
-            "store_id": result.store_id,
-            "store_code": result.store_code,
-            "page": result.page,
-            "page_size": result.page_size,
-            "orders_count": result.orders_count,
-            "success_count": result.success_count,
-            "failed_count": result.failed_count,
-            "has_more": result.has_more,
-            "start_confirm_at": result.start_confirm_at,
-            "end_confirm_at": result.end_confirm_at,
-            "rows": [
-                {
-                    "order_sn": row.order_sn,
-                    "pdd_order_id": row.pdd_order_id,
-                    "status": row.status,
-                    "error": row.error,
-                }
-                for row in result.rows
-            ],
-        }
+        result_payload = result.result_payload
 
         await create_pull_job_run_log(
             session,
@@ -314,26 +292,6 @@ class PlatformOrderPullJobService:
             raise PlatformOrderPullJobServiceError(f"platform order pull job not found: {job_id}")
 
         return job, runs, logs, stopped_reason
-
-    async def _run_pdd_job_page(
-        self,
-        *,
-        session: AsyncSession,
-        job: PlatformOrderPullJob,
-        page: int,
-    ) -> PddOrderIngestPageResult:
-        service = PddOrderIngestService()
-        return await service.ingest_order_page(
-            session=session,
-            params=PddRealPullParams(
-                store_id=int(job.store_id),
-                start_confirm_at=self._format_platform_dt(job.time_from),
-                end_confirm_at=self._format_platform_dt(job.time_to),
-                order_status=int(job.order_status or 1),
-                page=int(page),
-                page_size=int(job.page_size),
-            ),
-        )
 
     def _resolve_run_status(
         self,

--- a/tests/api/test_platform_order_pull_jobs_contract.py
+++ b/tests/api/test_platform_order_pull_jobs_contract.py
@@ -347,3 +347,31 @@ async def test_run_pdd_platform_order_pull_job_pages_respects_max_pages(client, 
     assert [run["page"] for run in data["runs"]] == [1, 2]
     assert all(run["has_more"] is True for run in data["runs"])
     assert data["job"]["cursor_page"] == 3
+
+
+async def test_pull_job_service_keeps_unsupported_platform_explicit_after_executor_split(client, session):
+    await _seed_store(session, store_id=7106, platform="JD")
+
+    create_resp = await client.post(
+        "/oms/platform-order-ingestion/pull-jobs",
+        json={
+            "platform": "jd",
+            "store_id": 7106,
+            "job_type": "manual",
+            "time_from": "2026-03-29 00:00:00",
+            "time_to": "2026-03-29 23:59:59",
+            "page_size": 20,
+        },
+    )
+    assert create_resp.status_code == 200, create_resp.text
+    job_id = create_resp.json()["data"]["id"]
+
+    run_resp = await client.post(f"/oms/platform-order-ingestion/pull-jobs/{job_id}/runs")
+    assert run_resp.status_code == 200, run_resp.text
+
+    data = run_resp.json()["data"]
+    assert data["job"]["platform"] == "jd"
+    assert data["job"]["status"] == "failed"
+    assert data["run"]["status"] == "failed"
+    assert data["run"]["error_message"] == "PLATFORM_PULL_JOB_NOT_IMPLEMENTED: jd"
+    assert data["logs"][-1]["event_type"] == "page_failed"


### PR DESCRIPTION
## Summary
- add pull job executor contract and registry
- move PDD pull-job page execution into a PDD-owned executor
- keep public pull job service platform-neutral
- keep JD/Taobao explicitly unsupported until their native ingest executors are implemented

## Boundary
- no DB schema changes
- PDD behavior unchanged
- no unified platform adapter / no cross-platform field normalization
- does not touch OMS order_facts, FSKU, internal orders, Finance, WMS or TMS

## Tests
- make test TESTS="tests/api/test_platform_order_pull_jobs_contract.py tests/api/test_platform_order_ingestion_store_status_contract.py tests/api/test_pdd_real_ingest_contract.py"