### PR TITLE
feat(platform-order-ingestion): ingest jd native orders

### DIFF
--- a/app/platform_order_ingestion/jd/contracts_ingest.py
+++ b/app/platform_order_ingestion/jd/contracts_ingest.py
@@ -1,0 +1,41 @@
+# Module split: JD platform order native ingest API contracts.
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class JdOrderIngestRequest(BaseModel):
+    start_time: Optional[str] = Field(default=None)
+    end_time: Optional[str] = Field(default=None)
+    order_state: Optional[str] = Field(default=None)
+    page: int = Field(default=1, ge=1)
+    page_size: int = Field(default=20, ge=1, le=100)
+
+
+class JdOrderIngestRowOut(BaseModel):
+    order_id: str
+    jd_order_id: Optional[int] = None
+    status: str
+    error: Optional[str] = None
+
+
+class JdOrderIngestDataOut(BaseModel):
+    platform: str
+    store_id: int
+    store_code: str
+    page: int
+    page_size: int
+    orders_count: int
+    success_count: int
+    failed_count: int
+    has_more: bool
+    start_time: Optional[str] = None
+    end_time: Optional[str] = None
+    rows: List[JdOrderIngestRowOut]
+
+
+class JdOrderIngestEnvelopeOut(BaseModel):
+    ok: bool
+    data: JdOrderIngestDataOut

--- a/app/platform_order_ingestion/jd/repo_orders.py
+++ b/app/platform_order_ingestion/jd/repo_orders.py
@@ -1,11 +1,16 @@
 # Module split: platform order ingestion now owns platform app config, auth, connection checks, native pull/ingest, and native order ledgers; no legacy alias is kept.
 from __future__ import annotations
 
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.platform_order_ingestion.models.jd_order import JdOrder
+from app.platform_order_ingestion.models.jd_order import JdOrder, JdOrderItem
+from app.platform_order_ingestion.jd.service_order_detail import JdOrderDetail
+from app.platform_order_ingestion.jd.service_real_pull import JdOrderSummary
 
 
 async def list_jd_orders(
@@ -37,3 +42,175 @@ async def get_jd_order_with_items(
     )
     result = await session.execute(stmt)
     return result.scalar_one_or_none()
+
+_MONEY_QUANT = Decimal("0.01")
+
+
+def _money(raw: object) -> Decimal | None:
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    if not text:
+        return None
+    try:
+        return Decimal(text).quantize(_MONEY_QUANT)
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _parse_optional_dt(value: str | None) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+
+    for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S"):
+        try:
+            return datetime.strptime(text, fmt).replace(tzinfo=timezone.utc)
+        except ValueError:
+            pass
+
+    try:
+        normalized = text.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+async def load_store_code_by_store_id_for_jd(
+    session: AsyncSession,
+    *,
+    store_id: int,
+) -> str:
+    row = (
+        await session.execute(
+            sa.text(
+                """
+                SELECT store_code
+                  FROM stores
+                 WHERE id = :store_id
+                   AND lower(platform) = 'jd'
+                 LIMIT 1
+                """
+            ),
+            {"store_id": int(store_id)},
+        )
+    ).mappings().first()
+
+    store_code = row.get("store_code") if row else None
+    if not store_code:
+        raise LookupError(f"jd store not found: store_id={int(store_id)}")
+
+    return str(store_code)
+
+
+async def get_jd_order_by_store_and_order_id(
+    session: AsyncSession,
+    *,
+    store_id: int,
+    order_id: str,
+) -> JdOrder | None:
+    stmt = (
+        sa.select(JdOrder)
+        .where(
+            JdOrder.store_id == int(store_id),
+            JdOrder.order_id == str(order_id).strip(),
+        )
+        .limit(1)
+    )
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def upsert_jd_order(
+    session: AsyncSession,
+    *,
+    store_id: int,
+    summary: JdOrderSummary,
+    detail: JdOrderDetail,
+) -> JdOrder:
+    order_id = str(detail.order_id or summary.platform_order_id or "").strip()
+    if not order_id:
+        raise ValueError("detail.order_id is required")
+
+    existing = await get_jd_order_by_store_and_order_id(
+        session,
+        store_id=int(store_id),
+        order_id=order_id,
+    )
+
+    values = {
+        "store_id": int(store_id),
+        "order_id": order_id,
+        "vender_id": detail.vender_id,
+        "order_type": detail.order_type or summary.order_type,
+        "order_state": detail.order_state or summary.order_state,
+        "buyer_pin": detail.buyer_pin,
+        "consignee_name": detail.consignee_name or summary.consignee_name_masked,
+        "consignee_mobile": detail.consignee_mobile or summary.consignee_mobile_masked,
+        "consignee_phone": detail.consignee_phone,
+        "consignee_province": detail.consignee_province,
+        "consignee_city": detail.consignee_city,
+        "consignee_county": detail.consignee_county,
+        "consignee_town": detail.consignee_town,
+        "consignee_address": detail.consignee_address or summary.consignee_address_summary_masked,
+        "order_remark": detail.order_remark or summary.order_remark,
+        "seller_remark": detail.seller_remark,
+        "order_total_price": _money(detail.order_total_price or summary.order_total_price),
+        "order_seller_price": _money(detail.order_seller_price),
+        "freight_price": _money(detail.freight_price),
+        "payment_confirm": detail.payment_confirm,
+        "order_start_time": _parse_optional_dt(detail.order_start_time or summary.order_start_time),
+        "order_end_time": _parse_optional_dt(detail.order_end_time),
+        "modified": _parse_optional_dt(detail.modified or summary.modified),
+        "raw_summary_payload": summary.raw_order,
+        "raw_detail_payload": detail.raw_payload,
+    }
+
+    if existing is None:
+        obj = JdOrder(**values)
+        session.add(obj)
+        await session.flush()
+        return obj
+
+    for key, value in values.items():
+        setattr(existing, key, value)
+
+    await session.flush()
+    return existing
+
+
+async def replace_jd_order_items(
+    session: AsyncSession,
+    *,
+    jd_order_id: int,
+    order_id: str,
+    detail: JdOrderDetail,
+) -> list[JdOrderItem]:
+    await session.execute(
+        sa.delete(JdOrderItem).where(JdOrderItem.jd_order_id == int(jd_order_id))
+    )
+
+    created: list[JdOrderItem] = []
+    for item in detail.items or []:
+        obj = JdOrderItem(
+            jd_order_id=int(jd_order_id),
+            order_id=str(order_id).strip(),
+            sku_id=item.sku_id,
+            outer_sku_id=item.outer_sku_id,
+            ware_id=item.ware_id,
+            item_name=item.item_name,
+            item_total=int(item.item_total or 0),
+            item_price=_money(item.item_price),
+            sku_name=item.sku_name,
+            gift_point=item.gift_point,
+            raw_item_payload=item.raw_item,
+        )
+        session.add(obj)
+        created.append(obj)
+
+    await session.flush()
+    return created

--- a/app/platform_order_ingestion/jd/router_ingest.py
+++ b/app/platform_order_ingestion/jd/router_ingest.py
@@ -1,0 +1,81 @@
+# Module split: JD platform order native ingest API routes.
+from __future__ import annotations
+
+from fastapi import APIRouter, Body, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.deps import get_async_session as get_session
+from app.platform_order_ingestion.jd.contracts_ingest import (
+    JdOrderIngestDataOut,
+    JdOrderIngestEnvelopeOut,
+    JdOrderIngestRequest,
+    JdOrderIngestRowOut,
+)
+from app.platform_order_ingestion.jd.service_ingest import (
+    JdOrderIngestService,
+    JdOrderIngestServiceError,
+)
+from app.platform_order_ingestion.jd.service_real_pull import JdRealPullParams
+
+router = APIRouter(tags=["oms-jd-ingest"])
+
+
+@router.post(
+    "/stores/{store_id}/jd/orders/ingest",
+    response_model=JdOrderIngestEnvelopeOut,
+    summary="JD 真实拉单入平台原生订单表",
+)
+async def ingest_store_jd_orders(
+    store_id: int,
+    payload: JdOrderIngestRequest = Body(default_factory=JdOrderIngestRequest),
+    session: AsyncSession = Depends(get_session),
+) -> JdOrderIngestEnvelopeOut:
+    try:
+        service = JdOrderIngestService()
+        result = await service.ingest_order_page(
+            session=session,
+            params=JdRealPullParams(
+                store_id=int(store_id),
+                start_time=payload.start_time,
+                end_time=payload.end_time,
+                page=int(payload.page),
+                page_size=int(payload.page_size),
+                order_state=payload.order_state,
+            ),
+        )
+        await session.commit()
+    except (ValueError, LookupError, JdOrderIngestServiceError) as exc:
+        await session.rollback()
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:  # noqa: BLE001
+        await session.rollback()
+        raise HTTPException(
+            status_code=500,
+            detail=f"failed to ingest jd orders: {exc}",
+        ) from exc
+
+    return JdOrderIngestEnvelopeOut(
+        ok=True,
+        data=JdOrderIngestDataOut(
+            platform="jd",
+            store_id=int(result.store_id),
+            store_code=str(result.store_code),
+            page=int(result.page),
+            page_size=int(result.page_size),
+            orders_count=int(result.orders_count),
+            success_count=int(result.success_count),
+            failed_count=int(result.failed_count),
+            has_more=bool(result.has_more),
+            start_time=result.start_time,
+            end_time=result.end_time,
+            rows=[
+                JdOrderIngestRowOut(
+                    order_id=row.order_id,
+                    jd_order_id=row.jd_order_id,
+                    status=row.status,
+                    error=row.error,
+                )
+                for row in result.rows
+            ],
+        ),
+    )

--- a/app/platform_order_ingestion/jd/service_ingest.py
+++ b/app/platform_order_ingestion/jd/service_ingest.py
@@ -1,0 +1,191 @@
+# Module split: JD platform order native ingest service.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.platform_order_ingestion.models.jd_order import JdOrder
+from app.platform_order_ingestion.jd.repo_orders import (
+    load_store_code_by_store_id_for_jd,
+    replace_jd_order_items,
+    upsert_jd_order,
+)
+from app.platform_order_ingestion.jd.service_order_detail import (
+    JdOrderDetailService,
+    JdOrderDetailServiceError,
+)
+from app.platform_order_ingestion.jd.service_real_pull import (
+    JdRealPullParams,
+    JdRealPullService,
+    JdRealPullServiceError,
+    JdOrderSummary,
+)
+
+
+class JdOrderIngestServiceError(Exception):
+    """JD 平台订单入库服务异常。"""
+
+
+@dataclass(frozen=True)
+class JdOrderIngestRowResult:
+    order_id: str
+    jd_order_id: Optional[int]
+    status: str
+    error: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class JdOrderIngestPageResult:
+    store_id: int
+    store_code: str
+    page: int
+    page_size: int
+    orders_count: int
+    success_count: int
+    failed_count: int
+    has_more: bool
+    start_time: Optional[str]
+    end_time: Optional[str]
+    rows: list[JdOrderIngestRowResult]
+
+
+class JdOrderIngestService:
+    """
+    JD 专表入库服务。
+
+    职责：
+    - 拉 JD 订单摘要页；
+    - 逐单补详情；
+    - 写入 jd_orders / jd_order_items。
+
+    不负责：
+    - OMS 地址校验；
+    - OMS 商品映射；
+    - 写 platform_order_lines；
+    - 建内部 orders/order_items；
+    - 触碰 finance。
+    """
+
+    def __init__(
+        self,
+        *,
+        pull_service: JdRealPullService | None = None,
+        detail_service: JdOrderDetailService | None = None,
+    ) -> None:
+        self.pull_service = pull_service or JdRealPullService()
+        self.detail_service = detail_service or JdOrderDetailService()
+
+    async def ingest_order_page(
+        self,
+        *,
+        session: AsyncSession,
+        params: JdRealPullParams,
+    ) -> JdOrderIngestPageResult:
+        store_id = int(params.store_id)
+        if store_id <= 0:
+            raise JdOrderIngestServiceError("store_id must be positive")
+
+        try:
+            store_code = await load_store_code_by_store_id_for_jd(
+                session,
+                store_id=store_id,
+            )
+        except Exception as exc:
+            raise JdOrderIngestServiceError(
+                f"failed to load jd store_code by store_id={store_id}: {exc}"
+            ) from exc
+
+        try:
+            page_result = await self.pull_service.fetch_order_page(
+                session=session,
+                params=params,
+            )
+        except JdRealPullServiceError as exc:
+            raise JdOrderIngestServiceError(f"jd pull failed: {exc}") from exc
+
+        rows: list[JdOrderIngestRowResult] = []
+        success_count = 0
+        failed_count = 0
+
+        for summary in page_result.orders:
+            row = await self._ingest_one_summary(
+                session=session,
+                store_id=store_id,
+                summary=summary,
+            )
+            rows.append(row)
+            if row.status == "OK":
+                success_count += 1
+            else:
+                failed_count += 1
+
+        return JdOrderIngestPageResult(
+            store_id=store_id,
+            store_code=store_code,
+            page=int(page_result.page),
+            page_size=int(page_result.page_size),
+            orders_count=int(page_result.orders_count),
+            success_count=success_count,
+            failed_count=failed_count,
+            has_more=bool(page_result.has_more),
+            start_time=page_result.start_time,
+            end_time=page_result.end_time,
+            rows=rows,
+        )
+
+    async def _ingest_one_summary(
+        self,
+        *,
+        session: AsyncSession,
+        store_id: int,
+        summary: JdOrderSummary,
+    ) -> JdOrderIngestRowResult:
+        order_id = str(summary.platform_order_id or "").strip()
+        if not order_id:
+            return JdOrderIngestRowResult(
+                order_id="",
+                jd_order_id=None,
+                status="FAILED",
+                error="empty platform_order_id",
+            )
+
+        try:
+            detail = await self.detail_service.fetch_order_detail(
+                session=session,
+                store_id=store_id,
+                order_id=order_id,
+            )
+            jd_order: JdOrder = await upsert_jd_order(
+                session,
+                store_id=store_id,
+                summary=summary,
+                detail=detail,
+            )
+            await replace_jd_order_items(
+                session,
+                jd_order_id=int(jd_order.id),
+                order_id=order_id,
+                detail=detail,
+            )
+            return JdOrderIngestRowResult(
+                order_id=order_id,
+                jd_order_id=int(jd_order.id),
+                status="OK",
+                error=None,
+            )
+        except JdOrderDetailServiceError as exc:
+            return JdOrderIngestRowResult(
+                order_id=order_id,
+                jd_order_id=None,
+                status="FAILED",
+                error=f"detail_failed: {exc}",
+            )
+        except Exception as exc:
+            return JdOrderIngestRowResult(
+                order_id=order_id,
+                jd_order_id=None,
+                status="FAILED",
+                error=str(exc),
+            )

--- a/app/platform_order_ingestion/router.py
+++ b/app/platform_order_ingestion/router.py
@@ -7,6 +7,7 @@ from app.platform_order_ingestion.router_status import router as platform_order_
 from app.platform_order_ingestion.jd.router_app_config import router as jd_app_config_router
 from app.platform_order_ingestion.jd.router_auth import router as jd_auth_router
 from app.platform_order_ingestion.jd.router_connection import router as jd_connection_router
+from app.platform_order_ingestion.jd.router_ingest import router as jd_ingest_router
 from app.platform_order_ingestion.jd.router_orders import router as jd_orders_router
 from app.platform_order_ingestion.jd.router_pull import router as jd_pull_router
 from app.platform_order_ingestion.pdd.router_app_config import router as pdd_app_config_router
@@ -45,4 +46,5 @@ router.include_router(jd_app_config_router)
 router.include_router(jd_auth_router)
 router.include_router(jd_connection_router)
 router.include_router(jd_pull_router)
+router.include_router(jd_ingest_router)
 router.include_router(jd_orders_router)

--- a/tests/api/test_jd_real_ingest_contract.py
+++ b/tests/api/test_jd_real_ingest_contract.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+from sqlalchemy import text
+import pytest
+
+from app.platform_order_ingestion.jd import router_ingest as jd_router_ingest
+from app.platform_order_ingestion.jd.service_ingest import (
+    JdOrderIngestPageResult,
+    JdOrderIngestRowResult,
+    JdOrderIngestService,
+)
+from app.platform_order_ingestion.jd.service_order_detail import (
+    JdOrderDetail,
+    JdOrderDetailItem,
+)
+from app.platform_order_ingestion.jd.service_real_pull import (
+    JdOrderPageResult,
+    JdOrderSummary,
+    JdRealPullParams,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_jd_store(session, *, store_id: int = 8201) -> None:
+    await session.execute(
+        text(
+            """
+            INSERT INTO stores (id, platform, store_code, store_name, active)
+            VALUES (:id, 'jd', :store_code, :store_name, TRUE)
+            ON CONFLICT (id) DO UPDATE
+              SET platform = 'jd',
+                  store_code = EXCLUDED.store_code,
+                  store_name = EXCLUDED.store_name,
+                  active = TRUE
+            """
+        ),
+        {
+            "id": store_id,
+            "store_code": f"store-{store_id}",
+            "store_name": f"store-{store_id}",
+        },
+    )
+    await session.commit()
+
+
+async def test_post_store_jd_orders_ingest_returns_page_result(client, monkeypatch):
+    async def _fake_ingest_order_page(self, *, session, params):
+        assert params.store_id == 123
+        assert params.start_time == "2026-03-29 00:00:00"
+        assert params.end_time == "2026-03-29 23:59:59"
+        assert params.page == 1
+        assert params.page_size == 20
+        assert params.order_state == "WAIT_SELLER_STOCK_OUT"
+        return JdOrderIngestPageResult(
+            store_id=123,
+            store_code="JD-STORE-123",
+            page=1,
+            page_size=20,
+            orders_count=2,
+            success_count=1,
+            failed_count=1,
+            has_more=False,
+            start_time=params.start_time,
+            end_time=params.end_time,
+            rows=[
+                JdOrderIngestRowResult(
+                    order_id="JD-ORDER-001",
+                    jd_order_id=9001,
+                    status="OK",
+                    error=None,
+                ),
+                JdOrderIngestRowResult(
+                    order_id="JD-ORDER-002",
+                    jd_order_id=None,
+                    status="FAILED",
+                    error="detail_failed: boom",
+                ),
+            ],
+        )
+
+    monkeypatch.setattr(
+        jd_router_ingest.JdOrderIngestService,
+        "ingest_order_page",
+        _fake_ingest_order_page,
+    )
+
+    resp = await client.post(
+        "/oms/stores/123/jd/orders/ingest",
+        json={
+            "start_time": "2026-03-29 00:00:00",
+            "end_time": "2026-03-29 23:59:59",
+            "order_state": "WAIT_SELLER_STOCK_OUT",
+            "page": 1,
+            "page_size": 20,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    body = resp.json()
+    assert body["ok"] is True
+    data = body["data"]
+    assert data["platform"] == "jd"
+    assert data["store_id"] == 123
+    assert data["store_code"] == "JD-STORE-123"
+    assert data["orders_count"] == 2
+    assert data["success_count"] == 1
+    assert data["failed_count"] == 1
+    assert data["rows"][0]["order_id"] == "JD-ORDER-001"
+    assert data["rows"][0]["jd_order_id"] == 9001
+    assert data["rows"][1]["status"] == "FAILED"
+
+
+async def test_jd_order_ingest_service_persists_order_and_replaces_items(session, monkeypatch):
+    store_id = 8201
+    await _seed_jd_store(session, store_id=store_id)
+    await session.execute(text("DELETE FROM jd_order_items"))
+    await session.execute(text("DELETE FROM jd_orders WHERE store_id = :sid"), {"sid": store_id})
+    await session.commit()
+
+    async def _fake_fetch_order_page(self, *, session, params):
+        assert params.store_id == store_id
+        return JdOrderPageResult(
+            page=params.page,
+            page_size=params.page_size,
+            orders_count=1,
+            has_more=False,
+            start_time=params.start_time or "2026-03-29 00:00:00",
+            end_time=params.end_time or "2026-03-29 23:59:59",
+            orders=[
+                JdOrderSummary(
+                    platform_order_id="JD-INGEST-8201",
+                    order_state="WAIT_SELLER_STOCK_OUT",
+                    order_type="SOP",
+                    order_start_time="2026-03-29 12:00:00",
+                    modified="2026-03-29 12:10:00",
+                    consignee_name_masked="张三",
+                    consignee_mobile_masked="13800138000",
+                    consignee_address_summary_masked="上海市浦东新区测试路 1 号",
+                    order_remark="请尽快发货",
+                    order_total_price="128.50",
+                    items_count=1,
+                    raw_order={"order_id": "JD-INGEST-8201"},
+                )
+            ],
+            raw_payload={"page": params.page},
+        )
+
+    async def _fake_fetch_order_detail(self, *, session, store_id: int, order_id: str):
+        assert order_id == "JD-INGEST-8201"
+        return JdOrderDetail(
+            order_id="JD-INGEST-8201",
+            vender_id="VENDER-8201",
+            order_type="SOP",
+            order_state="WAIT_SELLER_STOCK_OUT",
+            buyer_pin="buyer-8201",
+            consignee_name="张三",
+            consignee_mobile="13800138000",
+            consignee_phone=None,
+            consignee_province="上海市",
+            consignee_city="上海市",
+            consignee_county="浦东新区",
+            consignee_town="张江镇",
+            consignee_address="测试路 1 号",
+            order_remark="请尽快发货",
+            seller_remark="测试备注",
+            order_total_price="128.50",
+            order_seller_price="120.00",
+            freight_price="8.50",
+            payment_confirm="true",
+            order_start_time="2026-03-29 12:00:00",
+            order_end_time=None,
+            modified="2026-03-29 12:10:00",
+            items=[
+                JdOrderDetailItem(
+                    sku_id="SKU-JD-8201",
+                    outer_sku_id="OUTER-SKU-8201",
+                    ware_id="WARE-8201",
+                    item_name="京东测试商品A",
+                    item_total=2,
+                    item_price="39.90",
+                    sku_name="颜色:黑;尺码:M",
+                    gift_point=0,
+                    raw_item={"sku_id": "SKU-JD-8201"},
+                )
+            ],
+            raw_payload={"order_id": "JD-INGEST-8201"},
+        )
+
+    monkeypatch.setattr(
+        "app.platform_order_ingestion.jd.service_ingest.JdRealPullService.fetch_order_page",
+        _fake_fetch_order_page,
+    )
+    monkeypatch.setattr(
+        "app.platform_order_ingestion.jd.service_ingest.JdOrderDetailService.fetch_order_detail",
+        _fake_fetch_order_detail,
+    )
+
+    service = JdOrderIngestService()
+    result = await service.ingest_order_page(
+        session=session,
+        params=JdRealPullParams(
+            store_id=store_id,
+            start_time="2026-03-29 00:00:00",
+            end_time="2026-03-29 23:59:59",
+            page=1,
+            page_size=20,
+            order_state="WAIT_SELLER_STOCK_OUT",
+        ),
+    )
+    await session.commit()
+
+    assert result.store_id == store_id
+    assert result.store_code == f"store-{store_id}"
+    assert result.orders_count == 1
+    assert result.success_count == 1
+    assert result.failed_count == 0
+    assert result.rows[0].status == "OK"
+    assert result.rows[0].jd_order_id is not None
+
+    rows = (
+        await session.execute(
+            text(
+                """
+                SELECT o.order_id, o.order_state, o.order_total_price, i.sku_id, i.outer_sku_id, i.item_total
+                  FROM jd_orders o
+                  JOIN jd_order_items i ON i.jd_order_id = o.id
+                 WHERE o.store_id = :sid
+                   AND o.order_id = 'JD-INGEST-8201'
+                """
+            ),
+            {"sid": store_id},
+        )
+    ).mappings().all()
+
+    assert len(rows) == 1
+    assert rows[0]["order_id"] == "JD-INGEST-8201"
+    assert rows[0]["order_state"] == "WAIT_SELLER_STOCK_OUT"
+    assert str(rows[0]["order_total_price"]) == "128.50"
+    assert rows[0]["sku_id"] == "SKU-JD-8201"
+    assert rows[0]["outer_sku_id"] == "OUTER-SKU-8201"
+    assert rows[0]["item_total"] == 2
+
+
+async def test_post_store_jd_orders_ingest_returns_400_on_service_error(client, monkeypatch):
+    async def _fake_ingest_order_page(self, *, session, params):
+        raise jd_router_ingest.JdOrderIngestServiceError("jd pull failed: credential expired")
+
+    monkeypatch.setattr(
+        jd_router_ingest.JdOrderIngestService,
+        "ingest_order_page",
+        _fake_ingest_order_page,
+    )
+
+    resp = await client.post(
+        "/oms/stores/123/jd/orders/ingest",
+        json={
+            "start_time": "2026-03-29 00:00:00",
+            "end_time": "2026-03-29 23:59:59",
+            "page": 1,
+            "page_size": 20,
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    assert "credential expired" in resp.text
+
+
+async def test_post_store_jd_orders_ingest_rejects_invalid_page_size(client):
+    resp = await client.post(
+        "/oms/stores/123/jd/orders/ingest",
+        json={"page_size": 0},
+    )
+    assert resp.status_code == 422, resp.text


### PR DESCRIPTION
## Summary
- add JD native order ingest contracts, service and router
- upsert jd_orders by store_id + order_id
- replace jd_order_items from latest JD detail payload
- mount POST /oms/stores/{store_id}/jd/orders/ingest
- add API/service contract tests for JD native ingest

## Boundary
- writes only jd_orders / jd_order_items
- does not write platform_order_lines
- does not resolve FSKU or create internal orders
- does not touch Finance, WMS or TMS
- does not yet register JD pull-job executor

## Tests
- make test TESTS="tests/api/test_jd_real_ingest_contract.py tests/api/test_jd_orders_contract.py tests/unit/test_jd_pull_service.py tests/unit/test_jd_ledger_service.py tests/api/test_platform_order_pull_jobs_contract.py"