### PR TITLE
feat(platform-order-ingestion): run jd pull jobs

### DIFF
--- a/app/platform_order_ingestion/jd/pull_job_executor.py
+++ b/app/platform_order_ingestion/jd/pull_job_executor.py
@@ -1,0 +1,96 @@
+# Module split: JD owns its platform order pull-job executor implementation.
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.platform_order_ingestion.jd.service_ingest import JdOrderIngestService
+from app.platform_order_ingestion.jd.service_real_pull import JdRealPullParams
+from app.platform_order_ingestion.models.pull_job import PlatformOrderPullJob
+from app.platform_order_ingestion.services.pull_job_executor import (
+    PlatformOrderPullJobPageResult,
+    PlatformOrderPullJobPageRow,
+)
+
+
+class JdPullJobExecutor:
+    platform = "jd"
+
+    async def run_page(
+        self,
+        *,
+        session: AsyncSession,
+        job: PlatformOrderPullJob,
+        page: int,
+    ) -> PlatformOrderPullJobPageResult:
+        service = JdOrderIngestService()
+        result = await service.ingest_order_page(
+            session=session,
+            params=JdRealPullParams(
+                store_id=int(job.store_id),
+                start_time=self._format_platform_dt(job.time_from),
+                end_time=self._format_platform_dt(job.time_to),
+                page=int(page),
+                page_size=int(job.page_size),
+                order_state=self._resolve_order_state(job.request_payload),
+            ),
+        )
+
+        rows = [
+            PlatformOrderPullJobPageRow(
+                platform_order_no=row.order_id,
+                native_order_id=row.jd_order_id,
+                status=row.status,
+                error=row.error,
+            )
+            for row in result.rows
+        ]
+
+        result_payload = {
+            "platform": self.platform,
+            "store_id": result.store_id,
+            "store_code": result.store_code,
+            "page": result.page,
+            "page_size": result.page_size,
+            "orders_count": result.orders_count,
+            "success_count": result.success_count,
+            "failed_count": result.failed_count,
+            "has_more": result.has_more,
+            "start_time": result.start_time,
+            "end_time": result.end_time,
+            "rows": [
+                {
+                    "order_id": row.order_id,
+                    "jd_order_id": row.jd_order_id,
+                    "status": row.status,
+                    "error": row.error,
+                }
+                for row in result.rows
+            ],
+        }
+
+        return PlatformOrderPullJobPageResult(
+            platform=self.platform,
+            store_id=int(result.store_id),
+            page=int(result.page),
+            page_size=int(result.page_size),
+            orders_count=int(result.orders_count),
+            success_count=int(result.success_count),
+            failed_count=int(result.failed_count),
+            has_more=bool(result.has_more),
+            result_payload=result_payload,
+            rows=rows,
+        )
+
+    def _format_platform_dt(self, value) -> str | None:
+        if value is None:
+            return None
+        return value.strftime("%Y-%m-%d %H:%M:%S")
+
+    def _resolve_order_state(self, request_payload: dict[str, Any] | None) -> str | None:
+        if not isinstance(request_payload, dict):
+            return None
+        value = request_payload.get("order_state")
+        text = str(value or "").strip()
+        return text or None

--- a/app/platform_order_ingestion/services/pull_job_executor_registry.py
+++ b/app/platform_order_ingestion/services/pull_job_executor_registry.py
@@ -4,12 +4,14 @@
 # pull-job runner to platform-owned executor implementations.
 from __future__ import annotations
 
+from app.platform_order_ingestion.jd.pull_job_executor import JdPullJobExecutor
 from app.platform_order_ingestion.pdd.pull_job_executor import PddPullJobExecutor
 from app.platform_order_ingestion.services.pull_job_executor import PlatformOrderPullJobExecutor
 
 
 _EXECUTORS: dict[str, PlatformOrderPullJobExecutor] = {
     "pdd": PddPullJobExecutor(),
+    "jd": JdPullJobExecutor(),
 }
 
 

--- a/app/platform_order_ingestion/services/pull_jobs.py
+++ b/app/platform_order_ingestion/services/pull_jobs.py
@@ -202,7 +202,7 @@ class PlatformOrderPullJobService:
                     event_type="order_ingested",
                     platform_order_no=row.platform_order_no,
                     native_order_id=row.native_order_id,
-                    message="pdd order ingested",
+                    message=f"{result.platform} order ingested",
                     payload={"status": row.status},
                 )
             else:

--- a/tests/api/test_platform_order_pull_jobs_contract.py
+++ b/tests/api/test_platform_order_pull_jobs_contract.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 import pytest
 from sqlalchemy import text
 
+from app.platform_order_ingestion.jd import service_ingest as jd_service_ingest
+from app.platform_order_ingestion.jd.service_ingest import (
+    JdOrderIngestPageResult,
+    JdOrderIngestRowResult,
+)
 from app.platform_order_ingestion.pdd import service_ingest as pdd_service_ingest
 from app.platform_order_ingestion.pdd.service_ingest import (
     PddOrderIngestPageResult,
@@ -349,8 +354,51 @@ async def test_run_pdd_platform_order_pull_job_pages_respects_max_pages(client, 
     assert data["job"]["cursor_page"] == 3
 
 
-async def test_pull_job_service_keeps_unsupported_platform_explicit_after_executor_split(client, session):
+async def test_run_jd_platform_order_pull_job_records_run_and_logs_after_executor_registration(client, session, monkeypatch):
     await _seed_store(session, store_id=7106, platform="JD")
+
+    captured = {}
+
+    async def _fake_ingest_order_page(self, *, session, params):
+        captured["store_id"] = params.store_id
+        captured["start_time"] = params.start_time
+        captured["end_time"] = params.end_time
+        captured["order_state"] = params.order_state
+        captured["page"] = params.page
+        captured["page_size"] = params.page_size
+
+        return JdOrderIngestPageResult(
+            store_id=7106,
+            store_code="store-7106",
+            page=params.page,
+            page_size=params.page_size,
+            orders_count=2,
+            success_count=1,
+            failed_count=1,
+            has_more=True,
+            start_time=params.start_time,
+            end_time=params.end_time,
+            rows=[
+                JdOrderIngestRowResult(
+                    order_id="JD-JOB-ORDER-001",
+                    jd_order_id=9601,
+                    status="OK",
+                    error=None,
+                ),
+                JdOrderIngestRowResult(
+                    order_id="JD-JOB-ORDER-002",
+                    jd_order_id=None,
+                    status="FAILED",
+                    error="detail_failed: boom",
+                ),
+            ],
+        )
+
+    monkeypatch.setattr(
+        jd_service_ingest.JdOrderIngestService,
+        "ingest_order_page",
+        _fake_ingest_order_page,
+    )
 
     create_resp = await client.post(
         "/oms/platform-order-ingestion/pull-jobs",
@@ -361,17 +409,51 @@ async def test_pull_job_service_keeps_unsupported_platform_explicit_after_execut
             "time_from": "2026-03-29 00:00:00",
             "time_to": "2026-03-29 23:59:59",
             "page_size": 20,
+            "request_payload": {"order_state": "WAIT_SELLER_STOCK_OUT"},
         },
     )
     assert create_resp.status_code == 200, create_resp.text
     job_id = create_resp.json()["data"]["id"]
 
-    run_resp = await client.post(f"/oms/platform-order-ingestion/pull-jobs/{job_id}/runs")
+    run_resp = await client.post(
+        f"/oms/platform-order-ingestion/pull-jobs/{job_id}/runs",
+        json={"page": 1},
+    )
     assert run_resp.status_code == 200, run_resp.text
+
+    assert captured == {
+        "store_id": 7106,
+        "start_time": "2026-03-29 00:00:00",
+        "end_time": "2026-03-29 23:59:59",
+        "order_state": "WAIT_SELLER_STOCK_OUT",
+        "page": 1,
+        "page_size": 20,
+    }
 
     data = run_resp.json()["data"]
     assert data["job"]["platform"] == "jd"
-    assert data["job"]["status"] == "failed"
-    assert data["run"]["status"] == "failed"
-    assert data["run"]["error_message"] == "PLATFORM_PULL_JOB_NOT_IMPLEMENTED: jd"
-    assert data["logs"][-1]["event_type"] == "page_failed"
+    assert data["job"]["status"] == "partial_success"
+    assert data["job"]["cursor_page"] == 2
+
+    run = data["run"]
+    assert run["status"] == "partial_success"
+    assert run["page"] == 1
+    assert run["page_size"] == 20
+    assert run["has_more"] is True
+    assert run["orders_count"] == 2
+    assert run["success_count"] == 1
+    assert run["failed_count"] == 1
+    assert run["result_payload"]["rows"][0]["order_id"] == "JD-JOB-ORDER-001"
+    assert run["result_payload"]["rows"][0]["jd_order_id"] == 9601
+
+    logs = data["logs"]
+    assert [log["event_type"] for log in logs] == [
+        "page_started",
+        "order_ingested",
+        "order_failed",
+        "page_finished",
+    ]
+    assert logs[1]["platform_order_no"] == "JD-JOB-ORDER-001"
+    assert logs[1]["native_order_id"] == 9601
+    assert logs[1]["message"] == "jd order ingested"
+    assert logs[2]["level"] == "error"


### PR DESCRIPTION
## Summary
- add JD pull job executor
- register JD in the platform order pull job executor registry
- route platform_order_pull_jobs(platform=jd) through JdOrderIngestService
- keep Taobao explicitly unsupported until its native ingest is implemented
- make common pull-job log message platform-aware

## Boundary
- no DB schema changes
- writes only jd_orders / jd_order_items through existing JD native ingest service
- does not write platform_order_lines
- does not resolve FSKU or create internal orders
- does not touch Finance, WMS or TMS

## Tests
- make test TESTS="tests/api/test_platform_order_pull_jobs_contract.py tests/api/test_jd_real_ingest_contract.py tests/api/test_jd_orders_contract.py tests/unit/test_jd_pull_service.py"