### PR TITLE
feat(platform-order-ingestion): add taobao real pull services

### DIFF
--- a/app/platform_order_ingestion/taobao/service_order_detail.py
+++ b/app/platform_order_ingestion/taobao/service_order_detail.py
@@ -1,0 +1,282 @@
+# Module split: Taobao platform order detail service.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Any, Mapping
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.platform_order_ingestion.taobao.contracts import TaobaoTopRequest
+from app.platform_order_ingestion.taobao.errors import TaobaoTopError
+from app.platform_order_ingestion.taobao.repository import (
+    get_credential_by_store_platform,
+    require_enabled_taobao_app_config,
+)
+from app.platform_order_ingestion.taobao.settings import build_taobao_top_config_from_model
+from app.platform_order_ingestion.taobao.top_client import TaobaoTopClient
+
+
+TAOBAO_PLATFORM = "taobao"
+TAOBAO_TRADE_FULLINFO_GET_METHOD = "taobao.trade.fullinfo.get"
+
+TAOBAO_TRADE_DETAIL_FIELDS = ",".join(
+    [
+        "tid",
+        "status",
+        "type",
+        "buyer_nick",
+        "buyer_open_uid",
+        "receiver_name",
+        "receiver_mobile",
+        "receiver_phone",
+        "receiver_state",
+        "receiver_city",
+        "receiver_district",
+        "receiver_town",
+        "receiver_address",
+        "receiver_zip",
+        "buyer_memo",
+        "buyer_message",
+        "seller_memo",
+        "seller_flag",
+        "payment",
+        "total_fee",
+        "post_fee",
+        "coupon_fee",
+        "created",
+        "pay_time",
+        "modified",
+        "orders",
+    ]
+)
+
+
+class TaobaoOrderDetailServiceError(Exception):
+    """淘宝订单详情服务异常。"""
+
+
+@dataclass(frozen=True)
+class TaobaoOrderDetailItem:
+    oid: str
+    num_iid: str | None = None
+    sku_id: str | None = None
+    outer_iid: str | None = None
+    outer_sku_id: str | None = None
+    title: str | None = None
+    price: str | None = None
+    num: int = 0
+    payment: str | None = None
+    total_fee: str | None = None
+    sku_properties_name: str | None = None
+    raw_item: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class TaobaoOrderDetail:
+    tid: str
+    status: str | None = None
+    type: str | None = None
+    buyer_nick: str | None = None
+    buyer_open_uid: str | None = None
+    receiver_name: str | None = None
+    receiver_mobile: str | None = None
+    receiver_phone: str | None = None
+    receiver_state: str | None = None
+    receiver_city: str | None = None
+    receiver_district: str | None = None
+    receiver_town: str | None = None
+    receiver_address: str | None = None
+    receiver_zip: str | None = None
+    buyer_memo: str | None = None
+    buyer_message: str | None = None
+    seller_memo: str | None = None
+    seller_flag: int | None = None
+    payment: str | None = None
+    total_fee: str | None = None
+    post_fee: str | None = None
+    coupon_fee: str | None = None
+    created: str | None = None
+    pay_time: str | None = None
+    modified: str | None = None
+    items: list[TaobaoOrderDetailItem] | None = None
+    raw_payload: dict[str, Any] | None = None
+
+
+class TaobaoOrderDetailService:
+    """
+    淘宝订单详情补全服务。
+
+    职责：
+    - 使用 tid 调用 taobao.trade.fullinfo.get；
+    - 提取订单头和子订单原生字段；
+    - 不写 taobao_orders / taobao_order_items；
+    - 不写 platform_order_lines；
+    - 不做 FSKU / SKU 映射。
+    """
+
+    async def fetch_order_detail(
+        self,
+        *,
+        session: AsyncSession,
+        store_id: int,
+        tid: str,
+    ) -> TaobaoOrderDetail:
+        store_id_int = int(store_id)
+        tid_text = str(tid or "").strip()
+
+        if store_id_int <= 0:
+            raise TaobaoOrderDetailServiceError("store_id must be positive")
+        if not tid_text:
+            raise TaobaoOrderDetailServiceError("tid is required")
+
+        app_config = await require_enabled_taobao_app_config(session)
+        config = build_taobao_top_config_from_model(app_config)
+
+        credential = await get_credential_by_store_platform(
+            session,
+            store_id=store_id_int,
+            platform=TAOBAO_PLATFORM,
+        )
+        if credential is None:
+            raise TaobaoOrderDetailServiceError("taobao credential not found")
+
+        request = TaobaoTopRequest(
+            method=TAOBAO_TRADE_FULLINFO_GET_METHOD,
+            session=credential.access_token,
+            biz_params={
+                "fields": TAOBAO_TRADE_DETAIL_FIELDS,
+                "tid": tid_text,
+            },
+        )
+
+        client = TaobaoTopClient(config=config)
+        try:
+            response = await client.call(request)
+        except TaobaoTopError as exc:
+            raise TaobaoOrderDetailServiceError(f"taobao trade detail request failed: {exc}") from exc
+
+        trade = self._parse_trade_info(response.body)
+        return self._parse_detail(trade)
+
+    def _parse_trade_info(self, body: Mapping[str, Any]) -> Mapping[str, Any]:
+        candidates = [
+            body.get("trade"),
+            body.get("trade_fullinfo_get_response"),
+            body,
+        ]
+        for item in candidates:
+            if isinstance(item, Mapping):
+                trade = item.get("trade") if "trade" in item else item
+                if isinstance(trade, Mapping):
+                    tid = self._first_non_empty_str(trade, "tid", "trade_id")
+                    if tid:
+                        return trade
+
+        raise TaobaoOrderDetailServiceError(f"taobao trade detail missing tid: {body}")
+
+    def _parse_detail(self, trade: Mapping[str, Any]) -> TaobaoOrderDetail:
+        tid = self._first_non_empty_str(trade, "tid", "trade_id") or ""
+        items = self._parse_items(trade)
+
+        return TaobaoOrderDetail(
+            tid=tid,
+            status=self._first_non_empty_str(trade, "status", "trade_status"),
+            type=self._first_non_empty_str(trade, "type"),
+            buyer_nick=self._first_non_empty_str(trade, "buyer_nick"),
+            buyer_open_uid=self._first_non_empty_str(trade, "buyer_open_uid"),
+            receiver_name=self._first_non_empty_str(trade, "receiver_name"),
+            receiver_mobile=self._first_non_empty_str(trade, "receiver_mobile"),
+            receiver_phone=self._first_non_empty_str(trade, "receiver_phone"),
+            receiver_state=self._first_non_empty_str(trade, "receiver_state"),
+            receiver_city=self._first_non_empty_str(trade, "receiver_city"),
+            receiver_district=self._first_non_empty_str(trade, "receiver_district"),
+            receiver_town=self._first_non_empty_str(trade, "receiver_town"),
+            receiver_address=self._first_non_empty_str(trade, "receiver_address"),
+            receiver_zip=self._first_non_empty_str(trade, "receiver_zip"),
+            buyer_memo=self._first_non_empty_str(trade, "buyer_memo"),
+            buyer_message=self._first_non_empty_str(trade, "buyer_message"),
+            seller_memo=self._first_non_empty_str(trade, "seller_memo"),
+            seller_flag=self._optional_int(trade.get("seller_flag")),
+            payment=self._money_text(trade.get("payment")),
+            total_fee=self._money_text(trade.get("total_fee")),
+            post_fee=self._money_text(trade.get("post_fee")),
+            coupon_fee=self._money_text(trade.get("coupon_fee")),
+            created=self._first_non_empty_str(trade, "created"),
+            pay_time=self._first_non_empty_str(trade, "pay_time"),
+            modified=self._first_non_empty_str(trade, "modified"),
+            items=items,
+            raw_payload=dict(trade),
+        )
+
+    def _parse_items(self, trade: Mapping[str, Any]) -> list[TaobaoOrderDetailItem]:
+        raw_items = self._extract_orders_list(trade)
+        rows: list[TaobaoOrderDetailItem] = []
+
+        for item in raw_items:
+            if not isinstance(item, Mapping):
+                continue
+
+            oid = self._first_non_empty_str(item, "oid", "order_id")
+            if not oid:
+                continue
+
+            rows.append(
+                TaobaoOrderDetailItem(
+                    oid=oid,
+                    num_iid=self._first_non_empty_str(item, "num_iid"),
+                    sku_id=self._first_non_empty_str(item, "sku_id"),
+                    outer_iid=self._first_non_empty_str(item, "outer_iid"),
+                    outer_sku_id=self._first_non_empty_str(item, "outer_sku_id"),
+                    title=self._first_non_empty_str(item, "title"),
+                    price=self._money_text(item.get("price")),
+                    num=int(self._optional_int(item.get("num")) or 0),
+                    payment=self._money_text(item.get("payment")),
+                    total_fee=self._money_text(item.get("total_fee")),
+                    sku_properties_name=self._first_non_empty_str(item, "sku_properties_name"),
+                    raw_item=dict(item),
+                )
+            )
+
+        return rows
+
+    def _extract_orders_list(self, trade: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+        orders = trade.get("orders")
+        if isinstance(orders, list):
+            return [x for x in orders if isinstance(x, Mapping)]
+        if isinstance(orders, Mapping):
+            nested = orders.get("order")
+            if isinstance(nested, list):
+                return [x for x in nested if isinstance(x, Mapping)]
+            if isinstance(nested, Mapping):
+                return [nested]
+        return []
+
+    def _optional_int(self, value: Any) -> int | None:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _money_text(self, value: Any) -> str | None:
+        if value is None:
+            return None
+        text = str(value).strip()
+        if not text:
+            return None
+        try:
+            return str(Decimal(text).quantize(Decimal("0.01")))
+        except (InvalidOperation, ValueError):
+            return text
+
+    def _first_non_empty_str(self, data: Mapping[str, Any], *keys: str) -> str | None:
+        for key in keys:
+            value = data.get(key)
+            if value is None:
+                continue
+            text = str(value).strip()
+            if text:
+                return text
+        return None

--- a/app/platform_order_ingestion/taobao/service_real_pull.py
+++ b/app/platform_order_ingestion/taobao/service_real_pull.py
@@ -1,0 +1,400 @@
+# Module split: Taobao platform order real-pull service.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal, InvalidOperation
+from typing import Any, Mapping, Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.platform_order_ingestion.taobao.contracts import TaobaoTopRequest
+from app.platform_order_ingestion.taobao.errors import TaobaoTopError
+from app.platform_order_ingestion.taobao.repository import (
+    get_credential_by_store_platform,
+    require_enabled_taobao_app_config,
+)
+from app.platform_order_ingestion.taobao.settings import build_taobao_top_config_from_model
+from app.platform_order_ingestion.taobao.top_client import TaobaoTopClient
+
+
+TAOBAO_PLATFORM = "taobao"
+TAOBAO_TRADES_SOLD_GET_METHOD = "taobao.trades.sold.get"
+
+DEFAULT_TAOBAO_PAGE = 1
+DEFAULT_TAOBAO_PAGE_SIZE = 50
+MAX_TAOBAO_PAGE_SIZE = 100
+DEFAULT_TAOBAO_WINDOW_MINUTES = 30
+DEFAULT_TAOBAO_SAFETY_BUFFER_SECONDS = 60
+MAX_TAOBAO_WINDOW_DAYS = 30
+
+TAOBAO_TRADE_SUMMARY_FIELDS = ",".join(
+    [
+        "tid",
+        "status",
+        "type",
+        "buyer_nick",
+        "buyer_open_uid",
+        "created",
+        "pay_time",
+        "modified",
+        "payment",
+        "total_fee",
+        "post_fee",
+        "receiver_name",
+        "receiver_mobile",
+        "receiver_phone",
+        "receiver_state",
+        "receiver_city",
+        "receiver_district",
+        "receiver_town",
+        "receiver_address",
+        "receiver_zip",
+        "buyer_memo",
+        "buyer_message",
+        "seller_memo",
+        "seller_flag",
+        "orders",
+    ]
+)
+
+
+class TaobaoRealPullServiceError(Exception):
+    """淘宝真实拉单异常。"""
+
+
+@dataclass(frozen=True)
+class TaobaoOrderSummary:
+    tid: str
+    status: str | None = None
+    type: str | None = None
+    buyer_nick: str | None = None
+    buyer_open_uid: str | None = None
+    receiver_name: str | None = None
+    receiver_mobile: str | None = None
+    receiver_phone: str | None = None
+    receiver_state: str | None = None
+    receiver_city: str | None = None
+    receiver_district: str | None = None
+    receiver_town: str | None = None
+    receiver_address: str | None = None
+    receiver_zip: str | None = None
+    buyer_memo: str | None = None
+    buyer_message: str | None = None
+    seller_memo: str | None = None
+    seller_flag: int | None = None
+    payment: str | None = None
+    total_fee: str | None = None
+    post_fee: str | None = None
+    created: str | None = None
+    pay_time: str | None = None
+    modified: str | None = None
+    items_count: int = 0
+    raw_order: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class TaobaoOrderPageResult:
+    page: int
+    page_size: int
+    orders_count: int
+    has_more: bool
+    start_time: str
+    end_time: str
+    orders: list[TaobaoOrderSummary]
+    raw_payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class TaobaoRealPullParams:
+    store_id: int
+    start_time: Optional[str] = None
+    end_time: Optional[str] = None
+    status: Optional[str] = None
+    page: int = DEFAULT_TAOBAO_PAGE
+    page_size: int = DEFAULT_TAOBAO_PAGE_SIZE
+
+
+class TaobaoRealPullService:
+    """
+    淘宝真实订单摘要拉取服务。
+
+    职责：
+    - 使用当前店铺 access_token 调用 taobao.trades.sold.get；
+    - 按时间窗口拉取订单摘要；
+    - 解析为平台原生摘要 DTO；
+    - 不写 taobao_orders / taobao_order_items；
+    - 不写 platform_order_lines；
+    - 不做 FSKU / SKU 映射。
+    """
+
+    async def fetch_order_page(
+        self,
+        *,
+        session: AsyncSession,
+        params: TaobaoRealPullParams,
+    ) -> TaobaoOrderPageResult:
+        if params.store_id <= 0:
+            raise TaobaoRealPullServiceError("store_id must be positive")
+        if params.page <= 0:
+            raise TaobaoRealPullServiceError("page must be positive")
+        if params.page_size <= 0:
+            raise TaobaoRealPullServiceError("page_size must be positive")
+        if params.page_size > MAX_TAOBAO_PAGE_SIZE:
+            raise TaobaoRealPullServiceError(f"page_size must be <= {MAX_TAOBAO_PAGE_SIZE}")
+
+        start_text, end_text = self._resolve_time_window(
+            start_time=params.start_time,
+            end_time=params.end_time,
+        )
+
+        app_config = await require_enabled_taobao_app_config(session)
+        config = build_taobao_top_config_from_model(app_config)
+
+        credential = await get_credential_by_store_platform(
+            session,
+            store_id=params.store_id,
+            platform=TAOBAO_PLATFORM,
+        )
+        if credential is None:
+            raise TaobaoRealPullServiceError("taobao credential not found")
+        if credential.expires_at <= datetime.now(timezone.utc):
+            raise TaobaoRealPullServiceError("taobao credential expired")
+
+        request = TaobaoTopRequest(
+            method=TAOBAO_TRADES_SOLD_GET_METHOD,
+            session=credential.access_token,
+            biz_params=self._build_trades_sold_params(
+                start_time=start_text,
+                end_time=end_text,
+                status=params.status,
+                page=params.page,
+                page_size=params.page_size,
+            ),
+        )
+
+        client = TaobaoTopClient(config=config)
+        try:
+            response = await client.call(request)
+        except TaobaoTopError as exc:
+            raise TaobaoRealPullServiceError(f"taobao trades sold request failed: {exc}") from exc
+
+        orders, has_more = self._parse_order_page(
+            response.body,
+            page=params.page,
+            page_size=params.page_size,
+        )
+
+        return TaobaoOrderPageResult(
+            page=int(params.page),
+            page_size=int(params.page_size),
+            orders_count=len(orders),
+            has_more=bool(has_more),
+            start_time=start_text,
+            end_time=end_text,
+            orders=orders,
+            raw_payload=response.raw,
+        )
+
+    def _build_trades_sold_params(
+        self,
+        *,
+        start_time: str,
+        end_time: str,
+        status: str | None,
+        page: int,
+        page_size: int,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "fields": TAOBAO_TRADE_SUMMARY_FIELDS,
+            "start_created": start_time,
+            "end_created": end_time,
+            "page_no": int(page),
+            "page_size": int(page_size),
+            "use_has_next": True,
+        }
+        if status:
+            payload["status"] = str(status).strip()
+        return payload
+
+    def _resolve_time_window(
+        self,
+        *,
+        start_time: Optional[str],
+        end_time: Optional[str],
+    ) -> tuple[str, str]:
+        now = datetime.now(timezone.utc)
+
+        if not start_time and not end_time:
+            end_dt = now
+            start_dt = end_dt - timedelta(
+                minutes=DEFAULT_TAOBAO_WINDOW_MINUTES,
+                seconds=DEFAULT_TAOBAO_SAFETY_BUFFER_SECONDS,
+            )
+            return self._format_dt(start_dt), self._format_dt(end_dt)
+
+        if not start_time or not end_time:
+            raise TaobaoRealPullServiceError("start_time and end_time must be both provided")
+
+        start_dt = self._parse_dt(start_time)
+        end_dt = self._parse_dt(end_time)
+
+        if end_dt <= start_dt:
+            raise TaobaoRealPullServiceError("end_time must be greater than start_time")
+        if (end_dt - start_dt) > timedelta(days=MAX_TAOBAO_WINDOW_DAYS):
+            raise TaobaoRealPullServiceError("time window must be <= 30 days")
+
+        safe_start_dt = start_dt - timedelta(seconds=DEFAULT_TAOBAO_SAFETY_BUFFER_SECONDS)
+        return self._format_dt(safe_start_dt), self._format_dt(end_dt)
+
+    def _parse_order_page(
+        self,
+        body: Mapping[str, Any],
+        *,
+        page: int,
+        page_size: int,
+    ) -> tuple[list[TaobaoOrderSummary], bool]:
+        trades_raw = self._extract_trades_list(body)
+        orders: list[TaobaoOrderSummary] = []
+
+        for trade in trades_raw:
+            if not isinstance(trade, Mapping):
+                continue
+
+            tid = self._first_non_empty_str(trade, "tid", "trade_id")
+            if not tid:
+                continue
+
+            seller_flag = self._optional_int(trade.get("seller_flag"))
+            orders.append(
+                TaobaoOrderSummary(
+                    tid=tid,
+                    status=self._first_non_empty_str(trade, "status", "trade_status"),
+                    type=self._first_non_empty_str(trade, "type"),
+                    buyer_nick=self._first_non_empty_str(trade, "buyer_nick"),
+                    buyer_open_uid=self._first_non_empty_str(trade, "buyer_open_uid"),
+                    receiver_name=self._first_non_empty_str(trade, "receiver_name"),
+                    receiver_mobile=self._first_non_empty_str(trade, "receiver_mobile"),
+                    receiver_phone=self._first_non_empty_str(trade, "receiver_phone"),
+                    receiver_state=self._first_non_empty_str(trade, "receiver_state"),
+                    receiver_city=self._first_non_empty_str(trade, "receiver_city"),
+                    receiver_district=self._first_non_empty_str(trade, "receiver_district"),
+                    receiver_town=self._first_non_empty_str(trade, "receiver_town"),
+                    receiver_address=self._first_non_empty_str(trade, "receiver_address"),
+                    receiver_zip=self._first_non_empty_str(trade, "receiver_zip"),
+                    buyer_memo=self._first_non_empty_str(trade, "buyer_memo"),
+                    buyer_message=self._first_non_empty_str(trade, "buyer_message"),
+                    seller_memo=self._first_non_empty_str(trade, "seller_memo"),
+                    seller_flag=seller_flag,
+                    payment=self._money_text(trade.get("payment")),
+                    total_fee=self._money_text(trade.get("total_fee")),
+                    post_fee=self._money_text(trade.get("post_fee")),
+                    created=self._first_non_empty_str(trade, "created"),
+                    pay_time=self._first_non_empty_str(trade, "pay_time"),
+                    modified=self._first_non_empty_str(trade, "modified"),
+                    items_count=self._extract_items_count(trade),
+                    raw_order=dict(trade),
+                )
+            )
+
+        return orders, self._extract_has_more(body, count=len(orders), page=page, page_size=page_size)
+
+    def _extract_trades_list(self, body: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+        candidates: list[Any] = [
+            body.get("trades"),
+            body.get("trade"),
+            body.get("trade_list"),
+        ]
+        for item in candidates:
+            if isinstance(item, list):
+                return [x for x in item if isinstance(x, Mapping)]
+            if isinstance(item, Mapping):
+                for key in ("trade", "trades", "trade_list"):
+                    nested = item.get(key)
+                    if isinstance(nested, list):
+                        return [x for x in nested if isinstance(x, Mapping)]
+        return []
+
+    def _extract_items_count(self, trade: Mapping[str, Any]) -> int:
+        orders = trade.get("orders")
+        if isinstance(orders, list):
+            return len(orders)
+        if isinstance(orders, Mapping):
+            nested = orders.get("order")
+            if isinstance(nested, list):
+                return len(nested)
+        return 0
+
+    def _extract_has_more(
+        self,
+        body: Mapping[str, Any],
+        *,
+        count: int,
+        page: int,
+        page_size: int,
+    ) -> bool:
+        for key in ("has_next", "has_more", "has_next_page"):
+            raw = body.get(key)
+            if isinstance(raw, bool):
+                return raw
+            if isinstance(raw, int):
+                return raw != 0
+            if isinstance(raw, str):
+                text = raw.strip().lower()
+                if text in {"true", "1", "yes"}:
+                    return True
+                if text in {"false", "0", "no"}:
+                    return False
+
+        total = body.get("total_results") or body.get("total")
+        try:
+            if total is not None:
+                return int(total) > int(page) * int(page_size)
+        except (TypeError, ValueError):
+            pass
+
+        return count >= page_size
+
+    def _parse_dt(self, value: str) -> datetime:
+        text = str(value or "").strip()
+        if not text:
+            raise TaobaoRealPullServiceError("time value is required")
+        try:
+            dt = datetime.strptime(text, "%Y-%m-%d %H:%M:%S")
+        except ValueError as exc:
+            raise TaobaoRealPullServiceError(
+                f"invalid datetime format: {text!r}, expected yyyy-MM-dd HH:mm:ss"
+            ) from exc
+        return dt.replace(tzinfo=timezone.utc)
+
+    def _format_dt(self, value: datetime) -> str:
+        return value.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+    def _optional_int(self, value: Any) -> int | None:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _money_text(self, value: Any) -> str | None:
+        if value is None:
+            return None
+        text = str(value).strip()
+        if not text:
+            return None
+        try:
+            return str(Decimal(text).quantize(Decimal("0.01")))
+        except (InvalidOperation, ValueError):
+            return text
+
+    def _first_non_empty_str(self, data: Mapping[str, Any], *keys: str) -> str | None:
+        for key in keys:
+            value = data.get(key)
+            if value is None:
+                continue
+            text = str(value).strip()
+            if text:
+                return text
+        return None

--- a/tests/unit/test_taobao_real_pull_service.py
+++ b/tests/unit/test_taobao_real_pull_service.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import text
+
+from app.platform_order_ingestion.models.store_platform_credential import StorePlatformCredential
+from app.platform_order_ingestion.models.taobao_app_config import TaobaoAppConfig
+from app.platform_order_ingestion.taobao.contracts import TaobaoTopResponse
+from app.platform_order_ingestion.taobao import service_order_detail as detail_module
+from app.platform_order_ingestion.taobao import service_real_pull as real_pull_module
+from app.platform_order_ingestion.taobao.service_order_detail import TaobaoOrderDetailService
+from app.platform_order_ingestion.taobao.service_real_pull import (
+    TaobaoRealPullParams,
+    TaobaoRealPullService,
+    TaobaoRealPullServiceError,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_store(session, *, store_id: int = 8401) -> None:
+    await session.execute(
+        text(
+            """
+            INSERT INTO stores (id, platform, store_code, store_name, active)
+            VALUES (:id, 'taobao', :store_code, :store_name, TRUE)
+            ON CONFLICT (id) DO UPDATE
+              SET platform = 'taobao',
+                  store_code = EXCLUDED.store_code,
+                  store_name = EXCLUDED.store_name,
+                  active = TRUE
+            """
+        ),
+        {
+            "id": store_id,
+            "store_code": f"store-{store_id}",
+            "store_name": f"store-{store_id}",
+        },
+    )
+    await session.commit()
+
+
+async def _clear_taobao_state(session) -> None:
+    await session.execute(text("DELETE FROM store_platform_connections WHERE platform = 'taobao'"))
+    await session.execute(text("DELETE FROM store_platform_credentials WHERE platform = 'taobao'"))
+    await session.execute(text("DELETE FROM taobao_app_configs"))
+    await session.commit()
+
+
+async def _seed_app_and_credential(session, *, store_id: int = 8401) -> None:
+    now = datetime.now(timezone.utc)
+    await _seed_store(session, store_id=store_id)
+    session.add(
+        TaobaoAppConfig(
+            app_key="taobao-app-key",
+            app_secret="taobao-app-secret",
+            callback_url="http://127.0.0.1:8000/oms/taobao/oauth/callback",
+            api_base_url="https://eco.taobao.com/router/rest",
+            sign_method="md5",
+            is_enabled=True,
+        )
+    )
+    session.add(
+        StorePlatformCredential(
+            store_id=store_id,
+            platform="taobao",
+            credential_type="oauth",
+            access_token="taobao-session-token",
+            refresh_token="taobao-refresh-token",
+            expires_at=now + timedelta(days=1),
+            scope="taobao.trades.sold.get,taobao.trade.fullinfo.get",
+            raw_payload_json={"source": "test"},
+            granted_identity_type="taobao_user_id",
+            granted_identity_value="tb-user-8401",
+            granted_identity_display="tb-shop-8401",
+        )
+    )
+    await session.commit()
+
+
+async def test_fetch_order_page_requires_both_time_values(session):
+    service = TaobaoRealPullService()
+
+    with pytest.raises(TaobaoRealPullServiceError, match="both provided"):
+        await service.fetch_order_page(
+            session=session,
+            params=TaobaoRealPullParams(
+                store_id=8401,
+                start_time="2026-03-29 00:00:00",
+                end_time=None,
+            ),
+        )
+
+
+async def test_fetch_order_page_rejects_window_too_large(session):
+    service = TaobaoRealPullService()
+
+    with pytest.raises(TaobaoRealPullServiceError, match="<= 30 days"):
+        await service.fetch_order_page(
+            session=session,
+            params=TaobaoRealPullParams(
+                store_id=8401,
+                start_time="2026-01-01 00:00:00",
+                end_time="2026-03-01 00:00:00",
+            ),
+        )
+
+
+async def test_fetch_order_page_rejects_missing_credential(session):
+    await _clear_taobao_state(session)
+    await _seed_store(session, store_id=8402)
+    session.add(
+        TaobaoAppConfig(
+            app_key="taobao-app-key",
+            app_secret="taobao-app-secret",
+            callback_url="http://127.0.0.1:8000/oms/taobao/oauth/callback",
+            api_base_url="https://eco.taobao.com/router/rest",
+            sign_method="md5",
+            is_enabled=True,
+        )
+    )
+    await session.commit()
+
+    service = TaobaoRealPullService()
+    with pytest.raises(TaobaoRealPullServiceError, match="credential not found"):
+        await service.fetch_order_page(
+            session=session,
+            params=TaobaoRealPullParams(
+                store_id=8402,
+                start_time="2026-03-29 00:00:00",
+                end_time="2026-03-29 23:59:59",
+            ),
+        )
+
+
+async def test_fetch_order_page_success_parses_trades(session, monkeypatch):
+    await _clear_taobao_state(session)
+    await _seed_app_and_credential(session, store_id=8403)
+
+    captured = {}
+
+    class _FakeTopClient:
+        def __init__(self, *, config):
+            captured["config_app_key"] = config.app_key
+
+        async def call(self, request):
+            captured["method"] = request.method
+            captured["session"] = request.session
+            captured["biz_params"] = dict(request.biz_params)
+
+            return TaobaoTopResponse(
+                raw={"taobao_trades_sold_get_response": {"ok": True}},
+                body={
+                    "total_results": 1,
+                    "has_next": False,
+                    "trades": {
+                        "trade": [
+                            {
+                                "tid": "TB-ORDER-8403",
+                                "status": "WAIT_SELLER_SEND_GOODS",
+                                "type": "fixed",
+                                "buyer_nick": "buyer-demo",
+                                "buyer_open_uid": "ou-demo",
+                                "receiver_name": "张三",
+                                "receiver_mobile": "13800138000",
+                                "receiver_state": "上海",
+                                "receiver_city": "上海市",
+                                "receiver_district": "浦东新区",
+                                "receiver_town": "张江镇",
+                                "receiver_address": "科苑路 88 号",
+                                "payment": "99",
+                                "total_fee": "109.00",
+                                "post_fee": "10",
+                                "seller_flag": "1",
+                                "created": "2026-03-29 12:00:00",
+                                "pay_time": "2026-03-29 12:05:00",
+                                "modified": "2026-03-29 12:10:00",
+                                "orders": {
+                                    "order": [
+                                        {
+                                            "oid": "TB-OID-8403",
+                                            "outer_sku_id": "OUTER-SKU-8403",
+                                        }
+                                    ]
+                                },
+                            }
+                        ]
+                    },
+                },
+            )
+
+    monkeypatch.setattr(real_pull_module, "TaobaoTopClient", _FakeTopClient)
+
+    service = TaobaoRealPullService()
+    result = await service.fetch_order_page(
+        session=session,
+        params=TaobaoRealPullParams(
+            store_id=8403,
+            start_time="2026-03-29 00:00:00",
+            end_time="2026-03-29 23:59:59",
+            status="WAIT_SELLER_SEND_GOODS",
+            page=2,
+            page_size=50,
+        ),
+    )
+
+    assert captured["config_app_key"] == "taobao-app-key"
+    assert captured["method"] == "taobao.trades.sold.get"
+    assert captured["session"] == "taobao-session-token"
+    assert captured["biz_params"]["start_created"] == "2026-03-28 23:59:00"
+    assert captured["biz_params"]["end_created"] == "2026-03-29 23:59:59"
+    assert captured["biz_params"]["status"] == "WAIT_SELLER_SEND_GOODS"
+    assert captured["biz_params"]["page_no"] == 2
+    assert captured["biz_params"]["page_size"] == 50
+    assert "fields" in captured["biz_params"]
+
+    assert result.page == 2
+    assert result.page_size == 50
+    assert result.orders_count == 1
+    assert result.has_more is False
+    assert result.orders[0].tid == "TB-ORDER-8403"
+    assert result.orders[0].status == "WAIT_SELLER_SEND_GOODS"
+    assert result.orders[0].payment == "99.00"
+    assert result.orders[0].seller_flag == 1
+    assert result.orders[0].items_count == 1
+
+
+async def test_fetch_order_detail_success_parses_items(session, monkeypatch):
+    await _clear_taobao_state(session)
+    await _seed_app_and_credential(session, store_id=8404)
+
+    captured = {}
+
+    class _FakeTopClient:
+        def __init__(self, *, config):
+            captured["config_app_key"] = config.app_key
+
+        async def call(self, request):
+            captured["method"] = request.method
+            captured["session"] = request.session
+            captured["biz_params"] = dict(request.biz_params)
+
+            return TaobaoTopResponse(
+                raw={"taobao_trade_fullinfo_get_response": {"ok": True}},
+                body={
+                    "trade": {
+                        "tid": "TB-DETAIL-8404",
+                        "status": "WAIT_SELLER_SEND_GOODS",
+                        "type": "fixed",
+                        "buyer_nick": "buyer-demo",
+                        "buyer_open_uid": "ou-demo",
+                        "receiver_name": "李四",
+                        "receiver_mobile": "13900139000",
+                        "receiver_phone": "021-12345678",
+                        "receiver_state": "浙江",
+                        "receiver_city": "杭州市",
+                        "receiver_district": "西湖区",
+                        "receiver_town": "转塘街道",
+                        "receiver_address": "云栖小镇 18 号",
+                        "receiver_zip": "310000",
+                        "buyer_memo": "请尽快发货",
+                        "buyer_message": "晚上可收件",
+                        "seller_memo": "测试备注",
+                        "seller_flag": "2",
+                        "payment": "99",
+                        "total_fee": "109",
+                        "post_fee": "10",
+                        "coupon_fee": "5",
+                        "created": "2026-03-29 12:00:00",
+                        "pay_time": "2026-03-29 12:05:00",
+                        "modified": "2026-03-29 12:10:00",
+                        "orders": {
+                            "order": [
+                                {
+                                    "oid": "TB-OID-8404",
+                                    "num_iid": "NUMIID8404",
+                                    "sku_id": "SKUID8404",
+                                    "outer_iid": "OUTER-ITEM-8404",
+                                    "outer_sku_id": "OUTER-SKU-8404",
+                                    "title": "淘宝测试商品",
+                                    "price": "99",
+                                    "num": "1",
+                                    "payment": "99",
+                                    "total_fee": "99",
+                                    "sku_properties_name": "颜色:黑色;尺寸:XL",
+                                }
+                            ]
+                        },
+                    }
+                },
+            )
+
+    monkeypatch.setattr(detail_module, "TaobaoTopClient", _FakeTopClient)
+
+    service = TaobaoOrderDetailService()
+    result = await service.fetch_order_detail(
+        session=session,
+        store_id=8404,
+        tid="TB-DETAIL-8404",
+    )
+
+    assert captured["method"] == "taobao.trade.fullinfo.get"
+    assert captured["session"] == "taobao-session-token"
+    assert captured["biz_params"]["tid"] == "TB-DETAIL-8404"
+    assert "fields" in captured["biz_params"]
+
+    assert result.tid == "TB-DETAIL-8404"
+    assert result.status == "WAIT_SELLER_SEND_GOODS"
+    assert result.receiver_name == "李四"
+    assert result.payment == "99.00"
+    assert result.total_fee == "109.00"
+    assert result.post_fee == "10.00"
+    assert result.coupon_fee == "5.00"
+    assert result.seller_flag == 2
+    assert result.items is not None
+    assert len(result.items) == 1
+    assert result.items[0].oid == "TB-OID-8404"
+    assert result.items[0].outer_sku_id == "OUTER-SKU-8404"
+    assert result.items[0].price == "99.00"
+    assert result.items[0].num == 1
+    assert result.items[0].payment == "99.00"


### PR DESCRIPTION
## Summary
- add Taobao real order page pull service using taobao.trades.sold.get
- add Taobao order detail service using taobao.trade.fullinfo.get
- parse native Taobao trade and order-item fields into DTOs
- add unit tests for validation, credential checks, page parsing and detail parsing

## Boundary
- does not write taobao_orders / taobao_order_items
- does not register Taobao pull-job executor
- does not write platform_order_lines
- does not resolve FSKU or create internal orders
- does not touch Finance, WMS or TMS

## Tests
- make test TESTS="tests/unit/test_taobao_real_pull_service.py tests/unit/test_taobao_settings_resolution.py tests/api/test_taobao_app_config_contract.py"