### PR TITLE
feat(platform-order-ingestion): enable taobao real test pull

### DIFF
--- a/app/platform_order_ingestion/taobao/router_pull.py
+++ b/app/platform_order_ingestion/taobao/router_pull.py
@@ -2,35 +2,103 @@
 # app/platform_order_ingestion/taobao/router_pull.py
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Path, Query, HTTPException
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
-from app.user.deps.auth import get_current_user
 from app.db.deps import get_async_session as get_session
 from app.db.deps import get_db
 from app.oms.services.stores_helpers import check_perm
+from app.user.deps.auth import get_current_user
 
 from .repository import require_enabled_taobao_app_config
-from .service_pull import TaobaoPullService, TaobaoPullServiceError
+from .service_pull import TaobaoPullOrderResult, TaobaoPullService, TaobaoPullServiceError
 from .settings import build_taobao_top_config_from_model
 
 
 router = APIRouter(tags=["oms-taobao-pull"])
 
 
+def _detail_out(order: TaobaoPullOrderResult) -> dict | None:
+    if order.detail is None:
+        return None
+
+    return {
+        "tid": order.detail.tid,
+        "status": order.detail.status,
+        "type": order.detail.type,
+        "buyer_nick": order.detail.buyer_nick,
+        "buyer_open_uid": order.detail.buyer_open_uid,
+        "receiver_name": order.detail.receiver_name,
+        "receiver_mobile": order.detail.receiver_mobile,
+        "receiver_phone": order.detail.receiver_phone,
+        "receiver_state": order.detail.receiver_state,
+        "receiver_city": order.detail.receiver_city,
+        "receiver_district": order.detail.receiver_district,
+        "receiver_town": order.detail.receiver_town,
+        "receiver_address": order.detail.receiver_address,
+        "receiver_zip": order.detail.receiver_zip,
+        "buyer_memo": order.detail.buyer_memo,
+        "buyer_message": order.detail.buyer_message,
+        "seller_memo": order.detail.seller_memo,
+        "seller_flag": order.detail.seller_flag,
+        "payment": order.detail.payment,
+        "total_fee": order.detail.total_fee,
+        "post_fee": order.detail.post_fee,
+        "coupon_fee": order.detail.coupon_fee,
+        "created": order.detail.created,
+        "pay_time": order.detail.pay_time,
+        "modified": order.detail.modified,
+        "items": [
+            {
+                "oid": item.oid,
+                "num_iid": item.num_iid,
+                "sku_id": item.sku_id,
+                "outer_iid": item.outer_iid,
+                "outer_sku_id": item.outer_sku_id,
+                "title": item.title,
+                "price": item.price,
+                "num": item.num,
+                "payment": item.payment,
+                "total_fee": item.total_fee,
+                "sku_properties_name": item.sku_properties_name,
+                "raw_item": item.raw_item,
+            }
+            for item in (order.detail.items or [])
+        ],
+        "raw_payload": order.detail.raw_payload,
+    }
+
+
 @router.post("/stores/{store_id}/taobao/test-pull")
 async def test_store_taobao_pull(
     store_id: int = Path(..., ge=1),
     allow_real_request: bool = Query(False),
+    payload: dict | None = Body(default=None),
     session: AsyncSession = Depends(get_session),
     db: Session = Depends(get_db),
     current_user=Depends(get_current_user),
 ) -> dict:
     """
-    淘宝 test-pull（第一版）。
+    淘宝 test-pull。
+
+    allow_real_request=False:
+    - 只检查配置和授权，不发真实订单请求。
+
+    allow_real_request=True:
+    - 调用 taobao.trades.sold.get 拉一页摘要；
+    - 逐单调用 taobao.trade.fullinfo.get 补详情；
+    - 更新 connection 状态；
+    - 不写 taobao_orders / taobao_order_items。
     """
     check_perm(db, current_user, ["config.store.read"])
+
+    payload = payload or {}
+    start_time = payload.get("start_time")
+    end_time = payload.get("end_time")
+    status = payload.get("status")
+    page = int(payload.get("page") or 1)
+    page_size = int(payload.get("page_size") or 50)
 
     try:
         app_config = await require_enabled_taobao_app_config(session)
@@ -41,6 +109,11 @@ async def test_store_taobao_pull(
         result = await service.check_pull_ready(
             store_id=store_id,
             allow_real_request=allow_real_request,
+            start_time=start_time,
+            end_time=end_time,
+            page=page,
+            page_size=page_size,
+            status=status,
         )
     except (TaobaoPullServiceError, ValueError) as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -59,5 +132,31 @@ async def test_store_taobao_pull(
             "pull_ready": result.pull_ready,
             "status": result.status,
             "status_reason": result.status_reason,
+            "orders_count": result.orders_count,
+            "detailed_orders_count": result.detailed_orders_count,
+            "page": result.page,
+            "page_size": result.page_size,
+            "has_more": result.has_more,
+            "start_time": result.start_time,
+            "end_time": result.end_time,
+            "orders": [
+                {
+                    "tid": order.tid,
+                    "status": order.status,
+                    "type": order.type,
+                    "created": order.created,
+                    "pay_time": order.pay_time,
+                    "modified": order.modified,
+                    "receiver_name": order.receiver_name,
+                    "receiver_mobile": order.receiver_mobile,
+                    "receiver_address_summary": order.receiver_address_summary,
+                    "payment": order.payment,
+                    "total_fee": order.total_fee,
+                    "items_count": order.items_count,
+                    "detail_loaded": order.detail_loaded,
+                    "detail": _detail_out(order),
+                }
+                for order in result.orders
+            ],
         },
     }

--- a/app/platform_order_ingestion/taobao/service_pull.py
+++ b/app/platform_order_ingestion/taobao/service_pull.py
@@ -2,7 +2,7 @@
 # app/platform_order_ingestion/taobao/service_pull.py
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -13,14 +13,41 @@ from .repository import (
     get_credential_by_store_platform,
     upsert_connection_by_store_platform,
 )
+from .service_order_detail import (
+    TaobaoOrderDetail,
+    TaobaoOrderDetailService,
+    TaobaoOrderDetailServiceError,
+)
+from .service_real_pull import (
+    TAOBAO_PLATFORM,
+    TaobaoOrderSummary,
+    TaobaoRealPullParams,
+    TaobaoRealPullService,
+    TaobaoRealPullServiceError,
+)
 from .settings import TaobaoTopConfig
-
-
-TAOBAO_PLATFORM = "taobao"
 
 
 class TaobaoPullServiceError(Exception):
     """OMS 淘宝 test-pull 服务异常。"""
+
+
+@dataclass(frozen=True)
+class TaobaoPullOrderResult:
+    tid: str
+    status: str | None = None
+    type: str | None = None
+    created: str | None = None
+    pay_time: str | None = None
+    modified: str | None = None
+    receiver_name: str | None = None
+    receiver_mobile: str | None = None
+    receiver_address_summary: str | None = None
+    payment: str | None = None
+    total_fee: str | None = None
+    items_count: int = 0
+    detail_loaded: bool = False
+    detail: TaobaoOrderDetail | None = None
 
 
 @dataclass(frozen=True)
@@ -31,21 +58,31 @@ class TaobaoPullCheckResult:
     pull_ready: bool
     status: str
     status_reason: Optional[str]
+    orders_count: int = 0
+    detailed_orders_count: int = 0
+    page: int = 1
+    page_size: int = 50
+    has_more: bool = False
+    start_time: str | None = None
+    end_time: str | None = None
+    orders: list[TaobaoPullOrderResult] = field(default_factory=list)
 
 
 class TaobaoPullService:
     """
     OMS / 淘宝 test-pull 服务。
 
-    当前阶段职责：
-    - 校验是否具备真实拉单前提
-    - 推进 store_platform_connections 状态
-    - 默认不发真实请求
+    职责：
+    - 校验是否具备真实拉单前提；
+    - allow_real_request=False 时只更新连接状态，不发真实请求；
+    - allow_real_request=True 时拉取一页淘宝订单摘要并逐单补详情；
+    - 推进 store_platform_connections 状态。
 
-    当前阶段不负责：
-    - 真实订单读取接口调用
-    - 真实拉单结果解析
-    - 前端 contract 拼装
+    不负责：
+    - 写 taobao_orders / taobao_order_items；
+    - 写 platform_order_lines；
+    - FSKU / SKU 映射；
+    - 内部订单创建。
     """
 
     def __init__(
@@ -62,6 +99,11 @@ class TaobaoPullService:
         *,
         store_id: int,
         allow_real_request: bool = False,
+        start_time: str | None = None,
+        end_time: str | None = None,
+        page: int = 1,
+        page_size: int = 50,
+        status: str | None = None,
     ) -> TaobaoPullCheckResult:
         if store_id <= 0:
             raise TaobaoPullServiceError("store_id must be > 0")
@@ -69,30 +111,36 @@ class TaobaoPullService:
         now = datetime.now(timezone.utc)
         platform = TAOBAO_PLATFORM
 
-        # 1) 平台应用配置是否齐备
         if self.config is None:
             await upsert_connection_by_store_platform(
                 self.session,
                 data=ConnectionUpsertInput(
                     store_id=store_id,
                     platform=platform,
+                    auth_source="none",
+                    connection_status="not_connected",
+                    credential_status="missing",
+                    reauth_required=False,
                     pull_ready=False,
                     status="error",
                     status_reason="platform_app_not_ready",
+                    last_pull_checked_at=now,
                     last_error_at=now,
                 ),
             )
             await self.session.commit()
-            return TaobaoPullCheckResult(
+            return self._to_result(
                 store_id=store_id,
-                platform=platform,
                 executed_real_pull=False,
                 pull_ready=False,
                 status="error",
                 status_reason="platform_app_not_ready",
+                page=page,
+                page_size=page_size,
+                start_time=start_time,
+                end_time=end_time,
             )
 
-        # 2) credentials 是否存在
         credential = await get_credential_by_store_platform(
             self.session,
             store_id=store_id,
@@ -104,56 +152,68 @@ class TaobaoPullService:
                 data=ConnectionUpsertInput(
                     store_id=store_id,
                     platform=platform,
+                    auth_source="none",
+                    connection_status="not_connected",
                     credential_status="missing",
                     reauth_required=False,
                     pull_ready=False,
                     status="auth_pending",
                     status_reason="credential_missing",
+                    last_pull_checked_at=now,
                     last_error_at=now,
                 ),
             )
             await self.session.commit()
-            return TaobaoPullCheckResult(
+            return self._to_result(
                 store_id=store_id,
-                platform=platform,
                 executed_real_pull=False,
                 pull_ready=False,
                 status="auth_pending",
                 status_reason="credential_missing",
+                page=page,
+                page_size=page_size,
+                start_time=start_time,
+                end_time=end_time,
             )
 
-        # 3) credentials 是否过期
         if credential.expires_at <= now:
             await upsert_connection_by_store_platform(
                 self.session,
                 data=ConnectionUpsertInput(
                     store_id=store_id,
                     platform=platform,
+                    auth_source="oauth",
+                    connection_status="connected",
                     credential_status="expired",
                     reauth_required=True,
                     pull_ready=False,
                     status="auth_pending",
                     status_reason="credential_expired",
+                    last_pull_checked_at=now,
                     last_error_at=now,
                 ),
             )
             await self.session.commit()
-            return TaobaoPullCheckResult(
+            return self._to_result(
                 store_id=store_id,
-                platform=platform,
                 executed_real_pull=False,
                 pull_ready=False,
                 status="auth_pending",
                 status_reason="credential_expired",
+                page=page,
+                page_size=page_size,
+                start_time=start_time,
+                end_time=end_time,
             )
 
-        # 4) 当前阶段默认不发真实请求
         if not allow_real_request:
             await upsert_connection_by_store_platform(
                 self.session,
                 data=ConnectionUpsertInput(
                     store_id=store_id,
                     platform=platform,
+                    auth_source="oauth",
+                    connection_status="connected",
                     credential_status="valid",
                     reauth_required=False,
                     pull_ready=False,
@@ -164,37 +224,183 @@ class TaobaoPullService:
                 ),
             )
             await self.session.commit()
-            return TaobaoPullCheckResult(
+            return self._to_result(
                 store_id=store_id,
-                platform=platform,
                 executed_real_pull=False,
                 pull_ready=False,
                 status="error",
                 status_reason="real_pull_disabled",
+                page=page,
+                page_size=page_size,
+                start_time=start_time,
+                end_time=end_time,
             )
 
-        # 5) 预留：未来真实订单相关最小读取接口验证
-        # 当前先不实现真实调用，避免在未正式接入平台时伪造成功结果
+        real_pull_service = TaobaoRealPullService()
+        try:
+            page_result = await real_pull_service.fetch_order_page(
+                session=self.session,
+                params=TaobaoRealPullParams(
+                    store_id=store_id,
+                    start_time=start_time,
+                    end_time=end_time,
+                    status=status,
+                    page=page,
+                    page_size=page_size,
+                ),
+            )
+        except TaobaoRealPullServiceError:
+            await upsert_connection_by_store_platform(
+                self.session,
+                data=ConnectionUpsertInput(
+                    store_id=store_id,
+                    platform=platform,
+                    auth_source="oauth",
+                    connection_status="connected",
+                    credential_status="valid",
+                    reauth_required=False,
+                    pull_ready=False,
+                    status="error",
+                    status_reason="real_pull_failed",
+                    last_pull_checked_at=now,
+                    last_error_at=now,
+                ),
+            )
+            await self.session.commit()
+            return self._to_result(
+                store_id=store_id,
+                executed_real_pull=True,
+                pull_ready=False,
+                status="error",
+                status_reason="real_pull_failed",
+                page=page,
+                page_size=page_size,
+                start_time=start_time,
+                end_time=end_time,
+            )
+
+        detail_service = TaobaoOrderDetailService()
+        orders: list[TaobaoPullOrderResult] = []
+        detailed_orders_count = 0
+
+        for summary in page_result.orders:
+            detail_loaded = False
+            detail: TaobaoOrderDetail | None = None
+
+            try:
+                detail = await detail_service.fetch_order_detail(
+                    session=self.session,
+                    store_id=store_id,
+                    tid=summary.tid,
+                )
+                detail_loaded = True
+                detailed_orders_count += 1
+            except TaobaoOrderDetailServiceError:
+                detail_loaded = False
+                detail = None
+
+            orders.append(
+                self._merge_summary_and_detail(
+                    summary=summary,
+                    detail_loaded=detail_loaded,
+                    detail=detail,
+                )
+            )
+
+        status_reason = "real_pull_empty" if page_result.orders_count == 0 else "real_pull_ok"
+
         await upsert_connection_by_store_platform(
             self.session,
             data=ConnectionUpsertInput(
                 store_id=store_id,
                 platform=platform,
+                auth_source="oauth",
+                connection_status="connected",
                 credential_status="valid",
                 reauth_required=False,
-                pull_ready=False,
-                status="error",
-                status_reason="real_pull_not_implemented",
+                pull_ready=True,
+                status="ready",
+                status_reason=status_reason,
                 last_pull_checked_at=now,
-                last_error_at=now,
             ),
         )
         await self.session.commit()
+
+        return self._to_result(
+            store_id=store_id,
+            executed_real_pull=True,
+            pull_ready=True,
+            status="ready",
+            status_reason=status_reason,
+            orders_count=page_result.orders_count,
+            detailed_orders_count=detailed_orders_count,
+            page=page_result.page,
+            page_size=page_result.page_size,
+            has_more=page_result.has_more,
+            start_time=page_result.start_time,
+            end_time=page_result.end_time,
+            orders=orders,
+        )
+
+    def _merge_summary_and_detail(
+        self,
+        *,
+        summary: TaobaoOrderSummary,
+        detail_loaded: bool,
+        detail: TaobaoOrderDetail | None,
+    ) -> TaobaoPullOrderResult:
+        detail_items_count = len(detail.items or []) if detail else 0
+        return TaobaoPullOrderResult(
+            tid=summary.tid,
+            status=detail.status if detail and detail.status else summary.status,
+            type=detail.type if detail and detail.type else summary.type,
+            created=detail.created if detail and detail.created else summary.created,
+            pay_time=detail.pay_time if detail and detail.pay_time else summary.pay_time,
+            modified=detail.modified if detail and detail.modified else summary.modified,
+            receiver_name=detail.receiver_name if detail and detail.receiver_name else summary.receiver_name,
+            receiver_mobile=detail.receiver_mobile if detail and detail.receiver_mobile else summary.receiver_mobile,
+            receiver_address_summary=(
+                detail.receiver_address
+                if detail and detail.receiver_address
+                else summary.receiver_address
+            ),
+            payment=detail.payment if detail and detail.payment else summary.payment,
+            total_fee=detail.total_fee if detail and detail.total_fee else summary.total_fee,
+            items_count=detail_items_count if detail_loaded else summary.items_count,
+            detail_loaded=detail_loaded,
+            detail=detail,
+        )
+
+    def _to_result(
+        self,
+        *,
+        store_id: int,
+        executed_real_pull: bool,
+        pull_ready: bool,
+        status: str,
+        status_reason: str | None,
+        orders_count: int = 0,
+        detailed_orders_count: int = 0,
+        page: int = 1,
+        page_size: int = 50,
+        has_more: bool = False,
+        start_time: str | None = None,
+        end_time: str | None = None,
+        orders: list[TaobaoPullOrderResult] | None = None,
+    ) -> TaobaoPullCheckResult:
         return TaobaoPullCheckResult(
             store_id=store_id,
-            platform=platform,
-            executed_real_pull=False,
-            pull_ready=False,
-            status="error",
-            status_reason="real_pull_not_implemented",
+            platform=TAOBAO_PLATFORM,
+            executed_real_pull=executed_real_pull,
+            pull_ready=pull_ready,
+            status=status,
+            status_reason=status_reason,
+            orders_count=orders_count,
+            detailed_orders_count=detailed_orders_count,
+            page=page,
+            page_size=page_size,
+            has_more=has_more,
+            start_time=start_time,
+            end_time=end_time,
+            orders=orders or [],
         )

--- a/tests/unit/test_taobao_pull_service.py
+++ b/tests/unit/test_taobao_pull_service.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import text
+
+from app.platform_order_ingestion.models.store_platform_credential import StorePlatformCredential
+from app.platform_order_ingestion.taobao import service_pull as taobao_pull_module
+from app.platform_order_ingestion.taobao.service_order_detail import (
+    TaobaoOrderDetail,
+    TaobaoOrderDetailItem,
+)
+from app.platform_order_ingestion.taobao.service_pull import TaobaoPullService
+from app.platform_order_ingestion.taobao.service_real_pull import (
+    TaobaoOrderPageResult,
+    TaobaoOrderSummary,
+    TaobaoRealPullServiceError,
+)
+from app.platform_order_ingestion.taobao.settings import TaobaoTopConfig
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_store(session, *, store_id: int = 8501) -> None:
+    await session.execute(
+        text(
+            """
+            INSERT INTO stores (id, platform, store_code, store_name, active)
+            VALUES (:id, 'taobao', :store_code, :store_name, TRUE)
+            ON CONFLICT (id) DO UPDATE
+              SET platform = 'taobao',
+                  store_code = EXCLUDED.store_code,
+                  store_name = EXCLUDED.store_name,
+                  active = TRUE
+            """
+        ),
+        {
+            "id": store_id,
+            "store_code": f"store-{store_id}",
+            "store_name": f"store-{store_id}",
+        },
+    )
+    await session.commit()
+
+
+async def _clear_taobao_state(session) -> None:
+    await session.execute(text("DELETE FROM store_platform_connections WHERE platform = 'taobao'"))
+    await session.execute(text("DELETE FROM store_platform_credentials WHERE platform = 'taobao'"))
+    await session.commit()
+
+
+async def _seed_credential(session, *, store_id: int = 8501, expired: bool = False) -> None:
+    now = datetime.now(timezone.utc)
+    await _seed_store(session, store_id=store_id)
+    session.add(
+        StorePlatformCredential(
+            store_id=store_id,
+            platform="taobao",
+            credential_type="oauth",
+            access_token="taobao-session-token",
+            refresh_token="taobao-refresh-token",
+            expires_at=now - timedelta(minutes=5) if expired else now + timedelta(days=1),
+            scope="taobao.trades.sold.get,taobao.trade.fullinfo.get",
+            raw_payload_json={"source": "test"},
+            granted_identity_type="taobao_user_id",
+            granted_identity_value=f"tb-user-{store_id}",
+            granted_identity_display=f"tb-shop-{store_id}",
+        )
+    )
+    await session.commit()
+
+
+def _config() -> TaobaoTopConfig:
+    return TaobaoTopConfig(
+        app_key="taobao-app-key",
+        app_secret="taobao-app-secret",
+        api_base_url="https://eco.taobao.com/router/rest",
+        sign_method="md5",
+    )
+
+
+async def test_check_pull_ready_returns_credential_missing_when_no_credential(session):
+    await _clear_taobao_state(session)
+    await _seed_store(session, store_id=8501)
+
+    service = TaobaoPullService(session, config=_config())
+    store_id = 8501
+    result = await service.check_pull_ready(store_id=store_id)
+
+    assert result.store_id == store_id
+    assert result.platform == "taobao"
+    assert result.executed_real_pull is False
+    assert result.pull_ready is False
+    assert result.status == "auth_pending"
+    assert result.status_reason == "credential_missing"
+
+
+async def test_check_pull_ready_returns_real_pull_disabled_when_not_allowed(session):
+    await _clear_taobao_state(session)
+    await _seed_credential(session, store_id=8502)
+
+    service = TaobaoPullService(session, config=_config())
+    result = await service.check_pull_ready(store_id=8502, allow_real_request=False)
+
+    assert result.store_id == 8502
+    assert result.executed_real_pull is False
+    assert result.pull_ready is False
+    assert result.status == "error"
+    assert result.status_reason == "real_pull_disabled"
+
+
+async def test_check_pull_ready_returns_real_pull_ok_when_summary_and_detail_loaded(session, monkeypatch):
+    await _clear_taobao_state(session)
+    await _seed_credential(session, store_id=8503)
+
+    async def _fake_fetch_order_page(self, *, session, params):
+        assert params.store_id == 8503
+        assert params.start_time == "2026-03-29 00:00:00"
+        assert params.end_time == "2026-03-29 23:59:59"
+        assert params.status == "WAIT_SELLER_SEND_GOODS"
+        assert params.page == 2
+        assert params.page_size == 50
+
+        return TaobaoOrderPageResult(
+            page=2,
+            page_size=50,
+            orders_count=1,
+            has_more=False,
+            start_time="2026-03-28 23:59:00",
+            end_time="2026-03-29 23:59:59",
+            orders=[
+                TaobaoOrderSummary(
+                    tid="TB-PULL-8503",
+                    status="WAIT_SELLER_SEND_GOODS",
+                    type="fixed",
+                    created="2026-03-29 12:00:00",
+                    pay_time="2026-03-29 12:05:00",
+                    modified="2026-03-29 12:10:00",
+                    receiver_name="张三",
+                    receiver_mobile="13800138000",
+                    receiver_address="测试路 1 号",
+                    payment="99.00",
+                    total_fee="109.00",
+                    items_count=1,
+                    raw_order={},
+                )
+            ],
+            raw_payload={},
+        )
+
+    async def _fake_fetch_order_detail(self, *, session, store_id: int, tid: str):
+        assert store_id == 8503
+        assert tid == "TB-PULL-8503"
+
+        return TaobaoOrderDetail(
+            tid="TB-PULL-8503",
+            status="WAIT_SELLER_SEND_GOODS",
+            type="fixed",
+            buyer_nick="buyer-demo",
+            buyer_open_uid="ou-demo",
+            receiver_name="张三",
+            receiver_mobile="13800138000",
+            receiver_phone=None,
+            receiver_state="上海",
+            receiver_city="上海市",
+            receiver_district="浦东新区",
+            receiver_town="张江镇",
+            receiver_address="测试路 1 号",
+            receiver_zip=None,
+            buyer_memo="请尽快发货",
+            buyer_message=None,
+            seller_memo="测试备注",
+            seller_flag=1,
+            payment="99.00",
+            total_fee="109.00",
+            post_fee="10.00",
+            coupon_fee="0.00",
+            created="2026-03-29 12:00:00",
+            pay_time="2026-03-29 12:05:00",
+            modified="2026-03-29 12:10:00",
+            items=[
+                TaobaoOrderDetailItem(
+                    oid="TB-OID-8503",
+                    num_iid="NUMIID8503",
+                    sku_id="SKUID8503",
+                    outer_iid="OUTER-ITEM-8503",
+                    outer_sku_id="OUTER-SKU-8503",
+                    title="淘宝测试商品",
+                    price="99.00",
+                    num=1,
+                    payment="99.00",
+                    total_fee="99.00",
+                    sku_properties_name="颜色:黑色",
+                    raw_item={},
+                )
+            ],
+            raw_payload={},
+        )
+
+    monkeypatch.setattr(
+        taobao_pull_module.TaobaoRealPullService,
+        "fetch_order_page",
+        _fake_fetch_order_page,
+    )
+    monkeypatch.setattr(
+        taobao_pull_module.TaobaoOrderDetailService,
+        "fetch_order_detail",
+        _fake_fetch_order_detail,
+    )
+
+    service = TaobaoPullService(session, config=_config())
+    result = await service.check_pull_ready(
+        store_id=8503,
+        allow_real_request=True,
+        start_time="2026-03-29 00:00:00",
+        end_time="2026-03-29 23:59:59",
+        status="WAIT_SELLER_SEND_GOODS",
+        page=2,
+        page_size=50,
+    )
+
+    assert result.store_id == 8503
+    assert result.executed_real_pull is True
+    assert result.pull_ready is True
+    assert result.status == "ready"
+    assert result.status_reason == "real_pull_ok"
+    assert result.orders_count == 1
+    assert result.detailed_orders_count == 1
+    assert result.page == 2
+    assert result.page_size == 50
+    assert result.has_more is False
+    assert result.start_time == "2026-03-28 23:59:00"
+    assert result.end_time == "2026-03-29 23:59:59"
+    assert len(result.orders) == 1
+    assert result.orders[0].tid == "TB-PULL-8503"
+    assert result.orders[0].detail_loaded is True
+    assert result.orders[0].detail is not None
+    assert result.orders[0].detail.items is not None
+    assert result.orders[0].detail.items[0].outer_sku_id == "OUTER-SKU-8503"
+
+
+async def test_check_pull_ready_returns_real_pull_failed_when_pull_errors(session, monkeypatch):
+    await _clear_taobao_state(session)
+    await _seed_credential(session, store_id=8504)
+
+    async def _fake_fetch_order_page(self, *, session, params):
+        raise TaobaoRealPullServiceError("boom")
+
+    monkeypatch.setattr(
+        taobao_pull_module.TaobaoRealPullService,
+        "fetch_order_page",
+        _fake_fetch_order_page,
+    )
+
+    service = TaobaoPullService(session, config=_config())
+    result = await service.check_pull_ready(
+        store_id=8504,
+        allow_real_request=True,
+        start_time="2026-03-29 00:00:00",
+        end_time="2026-03-29 23:59:59",
+    )
+
+    assert result.store_id == 8504
+    assert result.executed_real_pull is True
+    assert result.pull_ready is False
+    assert result.status == "error"
+    assert result.status_reason == "real_pull_failed"
+    assert result.orders_count == 0
+    assert result.orders == []


### PR DESCRIPTION
## Summary
- wire TaobaoPullService allow_real_request=true to TaobaoRealPullService
- load Taobao order details through TaobaoOrderDetailService
- update store_platform_connections with real_pull_ok / real_pull_empty / real_pull_failed
- expand taobao test-pull response with page, has_more, order summary and detail preview
- add unit tests for missing credential, disabled real pull, successful real pull, and real pull failure

## Boundary
- does not write taobao_orders / taobao_order_items
- does not register Taobao pull-job executor
- does not write platform_order_lines
- does not resolve FSKU or create internal orders
- does not touch Finance, WMS or TMS

## Tests
- make test TESTS="tests/unit/test_taobao_pull_service.py tests/unit/test_taobao_real_pull_service.py tests/unit/test_taobao_settings_resolution.py tests/api/test_taobao_app_config_contract.py"