### PR TITLE
feat(platform-order-ingestion): ingest taobao native orders

### DIFF
--- a/app/platform_order_ingestion/router.py
+++ b/app/platform_order_ingestion/router.py
@@ -20,6 +20,7 @@ from app.platform_order_ingestion.pdd.router_pull import router as pdd_pull_rout
 from app.platform_order_ingestion.taobao.router_app_config import router as taobao_app_config_router
 from app.platform_order_ingestion.taobao.router_auth import router as taobao_auth_router
 from app.platform_order_ingestion.taobao.router_connection import router as taobao_connection_router
+from app.platform_order_ingestion.taobao.router_ingest import router as taobao_ingest_router
 from app.platform_order_ingestion.taobao.router_orders import router as taobao_orders_router
 from app.platform_order_ingestion.taobao.router_pull import router as taobao_pull_router
 
@@ -32,6 +33,7 @@ router.include_router(taobao_app_config_router)
 router.include_router(taobao_auth_router)
 router.include_router(taobao_connection_router)
 router.include_router(taobao_pull_router)
+router.include_router(taobao_ingest_router)
 router.include_router(taobao_orders_router)
 
 router.include_router(pdd_app_config_router)

--- a/app/platform_order_ingestion/taobao/contracts_ingest.py
+++ b/app/platform_order_ingestion/taobao/contracts_ingest.py
@@ -1,0 +1,41 @@
+# Module split: Taobao platform order native ingest API contracts.
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class TaobaoOrderIngestRequest(BaseModel):
+    start_time: Optional[str] = Field(default=None)
+    end_time: Optional[str] = Field(default=None)
+    status: Optional[str] = Field(default=None)
+    page: int = Field(default=1, ge=1)
+    page_size: int = Field(default=50, ge=1, le=100)
+
+
+class TaobaoOrderIngestRowOut(BaseModel):
+    tid: str
+    taobao_order_id: Optional[int] = None
+    status: str
+    error: Optional[str] = None
+
+
+class TaobaoOrderIngestDataOut(BaseModel):
+    platform: str
+    store_id: int
+    store_code: str
+    page: int
+    page_size: int
+    orders_count: int
+    success_count: int
+    failed_count: int
+    has_more: bool
+    start_time: Optional[str] = None
+    end_time: Optional[str] = None
+    rows: List[TaobaoOrderIngestRowOut]
+
+
+class TaobaoOrderIngestEnvelopeOut(BaseModel):
+    ok: bool
+    data: TaobaoOrderIngestDataOut

--- a/app/platform_order_ingestion/taobao/repo_orders.py
+++ b/app/platform_order_ingestion/taobao/repo_orders.py
@@ -1,11 +1,16 @@
 # Module split: platform order ingestion now owns platform app config, auth, connection checks, native pull/ingest, and native order ledgers; no legacy alias is kept.
 from __future__ import annotations
 
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.platform_order_ingestion.models.taobao_order import TaobaoOrder
+from app.platform_order_ingestion.models.taobao_order import TaobaoOrder, TaobaoOrderItem
+from app.platform_order_ingestion.taobao.service_order_detail import TaobaoOrderDetail
+from app.platform_order_ingestion.taobao.service_real_pull import TaobaoOrderSummary
 
 
 async def list_taobao_orders(
@@ -40,3 +45,185 @@ async def get_taobao_order_with_items(
     )
     result = await session.execute(stmt)
     return result.scalar_one_or_none()
+
+_MONEY_QUANT = Decimal("0.01")
+
+
+def _money(raw: object) -> Decimal | None:
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    if not text:
+        return None
+    try:
+        return Decimal(text).quantize(_MONEY_QUANT)
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _parse_optional_dt(value: str | None) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+
+    for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S"):
+        try:
+            return datetime.strptime(text, fmt).replace(tzinfo=timezone.utc)
+        except ValueError:
+            pass
+
+    try:
+        normalized = text.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+async def load_store_code_by_store_id_for_taobao(
+    session: AsyncSession,
+    *,
+    store_id: int,
+) -> str:
+    row = (
+        await session.execute(
+            sa.text(
+                """
+                SELECT store_code
+                  FROM stores
+                 WHERE id = :store_id
+                   AND lower(platform) = 'taobao'
+                 LIMIT 1
+                """
+            ),
+            {"store_id": int(store_id)},
+        )
+    ).mappings().first()
+
+    store_code = row.get("store_code") if row else None
+    if not store_code:
+        raise LookupError(f"taobao store not found: store_id={int(store_id)}")
+
+    return str(store_code)
+
+
+async def get_taobao_order_by_store_and_tid(
+    session: AsyncSession,
+    *,
+    store_id: int,
+    tid: str,
+) -> TaobaoOrder | None:
+    stmt = (
+        sa.select(TaobaoOrder)
+        .where(
+            TaobaoOrder.store_id == int(store_id),
+            TaobaoOrder.tid == str(tid).strip(),
+        )
+        .limit(1)
+    )
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def upsert_taobao_order(
+    session: AsyncSession,
+    *,
+    store_id: int,
+    summary: TaobaoOrderSummary,
+    detail: TaobaoOrderDetail,
+) -> TaobaoOrder:
+    tid = str(detail.tid or summary.tid or "").strip()
+    if not tid:
+        raise ValueError("detail.tid is required")
+
+    existing = await get_taobao_order_by_store_and_tid(
+        session,
+        store_id=int(store_id),
+        tid=tid,
+    )
+
+    values = {
+        "store_id": int(store_id),
+        "tid": tid,
+        "status": detail.status or summary.status,
+        "type": detail.type or summary.type,
+        "buyer_nick": detail.buyer_nick or summary.buyer_nick,
+        "buyer_open_uid": detail.buyer_open_uid or summary.buyer_open_uid,
+        "receiver_name": detail.receiver_name or summary.receiver_name,
+        "receiver_mobile": detail.receiver_mobile or summary.receiver_mobile,
+        "receiver_phone": detail.receiver_phone or summary.receiver_phone,
+        "receiver_state": detail.receiver_state or summary.receiver_state,
+        "receiver_city": detail.receiver_city or summary.receiver_city,
+        "receiver_district": detail.receiver_district or summary.receiver_district,
+        "receiver_town": detail.receiver_town or summary.receiver_town,
+        "receiver_address": detail.receiver_address or summary.receiver_address,
+        "receiver_zip": detail.receiver_zip or summary.receiver_zip,
+        "buyer_memo": detail.buyer_memo or summary.buyer_memo,
+        "buyer_message": detail.buyer_message or summary.buyer_message,
+        "seller_memo": detail.seller_memo or summary.seller_memo,
+        "seller_flag": detail.seller_flag if detail.seller_flag is not None else summary.seller_flag,
+        "payment": _money(detail.payment or summary.payment),
+        "total_fee": _money(detail.total_fee or summary.total_fee),
+        "post_fee": _money(detail.post_fee or summary.post_fee),
+        "coupon_fee": _money(detail.coupon_fee),
+        "created": _parse_optional_dt(detail.created or summary.created),
+        "pay_time": _parse_optional_dt(detail.pay_time or summary.pay_time),
+        "modified": _parse_optional_dt(detail.modified or summary.modified),
+        "raw_summary_payload": summary.raw_order,
+        "raw_detail_payload": detail.raw_payload,
+    }
+
+    if existing is None:
+        obj = TaobaoOrder(**values)
+        session.add(obj)
+        await session.flush()
+        return obj
+
+    for key, value in values.items():
+        setattr(existing, key, value)
+
+    await session.flush()
+    return existing
+
+
+async def replace_taobao_order_items(
+    session: AsyncSession,
+    *,
+    taobao_order_id: int,
+    tid: str,
+    detail: TaobaoOrderDetail,
+) -> list[TaobaoOrderItem]:
+    await session.execute(
+        sa.delete(TaobaoOrderItem).where(TaobaoOrderItem.taobao_order_id == int(taobao_order_id))
+    )
+
+    created: list[TaobaoOrderItem] = []
+    for item in detail.items or []:
+        oid = str(item.oid or "").strip()
+        if not oid:
+            continue
+
+        obj = TaobaoOrderItem(
+            taobao_order_id=int(taobao_order_id),
+            tid=str(tid).strip(),
+            oid=oid,
+            num_iid=item.num_iid,
+            sku_id=item.sku_id,
+            outer_iid=item.outer_iid,
+            outer_sku_id=item.outer_sku_id,
+            title=item.title,
+            price=_money(item.price),
+            num=int(item.num or 0),
+            payment=_money(item.payment),
+            total_fee=_money(item.total_fee),
+            sku_properties_name=item.sku_properties_name,
+            raw_item_payload=item.raw_item,
+        )
+        session.add(obj)
+        created.append(obj)
+
+    await session.flush()
+    return created

--- a/app/platform_order_ingestion/taobao/router_ingest.py
+++ b/app/platform_order_ingestion/taobao/router_ingest.py
@@ -1,0 +1,81 @@
+# Module split: Taobao platform order native ingest API routes.
+from __future__ import annotations
+
+from fastapi import APIRouter, Body, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.deps import get_async_session as get_session
+from app.platform_order_ingestion.taobao.contracts_ingest import (
+    TaobaoOrderIngestDataOut,
+    TaobaoOrderIngestEnvelopeOut,
+    TaobaoOrderIngestRequest,
+    TaobaoOrderIngestRowOut,
+)
+from app.platform_order_ingestion.taobao.service_ingest import (
+    TaobaoOrderIngestService,
+    TaobaoOrderIngestServiceError,
+)
+from app.platform_order_ingestion.taobao.service_real_pull import TaobaoRealPullParams
+
+router = APIRouter(tags=["oms-taobao-ingest"])
+
+
+@router.post(
+    "/stores/{store_id}/taobao/orders/ingest",
+    response_model=TaobaoOrderIngestEnvelopeOut,
+    summary="淘宝真实拉单入平台原生订单表",
+)
+async def ingest_store_taobao_orders(
+    store_id: int,
+    payload: TaobaoOrderIngestRequest = Body(default_factory=TaobaoOrderIngestRequest),
+    session: AsyncSession = Depends(get_session),
+) -> TaobaoOrderIngestEnvelopeOut:
+    try:
+        service = TaobaoOrderIngestService()
+        result = await service.ingest_order_page(
+            session=session,
+            params=TaobaoRealPullParams(
+                store_id=int(store_id),
+                start_time=payload.start_time,
+                end_time=payload.end_time,
+                status=payload.status,
+                page=int(payload.page),
+                page_size=int(payload.page_size),
+            ),
+        )
+        await session.commit()
+    except (ValueError, LookupError, TaobaoOrderIngestServiceError) as exc:
+        await session.rollback()
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:  # noqa: BLE001
+        await session.rollback()
+        raise HTTPException(
+            status_code=500,
+            detail=f"failed to ingest taobao orders: {exc}",
+        ) from exc
+
+    return TaobaoOrderIngestEnvelopeOut(
+        ok=True,
+        data=TaobaoOrderIngestDataOut(
+            platform="taobao",
+            store_id=int(result.store_id),
+            store_code=str(result.store_code),
+            page=int(result.page),
+            page_size=int(result.page_size),
+            orders_count=int(result.orders_count),
+            success_count=int(result.success_count),
+            failed_count=int(result.failed_count),
+            has_more=bool(result.has_more),
+            start_time=result.start_time,
+            end_time=result.end_time,
+            rows=[
+                TaobaoOrderIngestRowOut(
+                    tid=row.tid,
+                    taobao_order_id=row.taobao_order_id,
+                    status=row.status,
+                    error=row.error,
+                )
+                for row in result.rows
+            ],
+        ),
+    )

--- a/app/platform_order_ingestion/taobao/service_ingest.py
+++ b/app/platform_order_ingestion/taobao/service_ingest.py
@@ -1,0 +1,191 @@
+# Module split: Taobao platform order native ingest service.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.platform_order_ingestion.models.taobao_order import TaobaoOrder
+from app.platform_order_ingestion.taobao.repo_orders import (
+    load_store_code_by_store_id_for_taobao,
+    replace_taobao_order_items,
+    upsert_taobao_order,
+)
+from app.platform_order_ingestion.taobao.service_order_detail import (
+    TaobaoOrderDetailService,
+    TaobaoOrderDetailServiceError,
+)
+from app.platform_order_ingestion.taobao.service_real_pull import (
+    TaobaoOrderSummary,
+    TaobaoRealPullParams,
+    TaobaoRealPullService,
+    TaobaoRealPullServiceError,
+)
+
+
+class TaobaoOrderIngestServiceError(Exception):
+    """淘宝平台订单入库服务异常。"""
+
+
+@dataclass(frozen=True)
+class TaobaoOrderIngestRowResult:
+    tid: str
+    taobao_order_id: Optional[int]
+    status: str
+    error: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class TaobaoOrderIngestPageResult:
+    store_id: int
+    store_code: str
+    page: int
+    page_size: int
+    orders_count: int
+    success_count: int
+    failed_count: int
+    has_more: bool
+    start_time: Optional[str]
+    end_time: Optional[str]
+    rows: list[TaobaoOrderIngestRowResult]
+
+
+class TaobaoOrderIngestService:
+    """
+    淘宝专表入库服务。
+
+    职责：
+    - 拉淘宝订单摘要页；
+    - 逐单补详情；
+    - 写入 taobao_orders / taobao_order_items。
+
+    不负责：
+    - OMS 地址校验；
+    - OMS 商品映射；
+    - 写 platform_order_lines；
+    - 建内部 orders/order_items；
+    - 触碰 finance。
+    """
+
+    def __init__(
+        self,
+        *,
+        pull_service: TaobaoRealPullService | None = None,
+        detail_service: TaobaoOrderDetailService | None = None,
+    ) -> None:
+        self.pull_service = pull_service or TaobaoRealPullService()
+        self.detail_service = detail_service or TaobaoOrderDetailService()
+
+    async def ingest_order_page(
+        self,
+        *,
+        session: AsyncSession,
+        params: TaobaoRealPullParams,
+    ) -> TaobaoOrderIngestPageResult:
+        store_id = int(params.store_id)
+        if store_id <= 0:
+            raise TaobaoOrderIngestServiceError("store_id must be positive")
+
+        try:
+            store_code = await load_store_code_by_store_id_for_taobao(
+                session,
+                store_id=store_id,
+            )
+        except Exception as exc:
+            raise TaobaoOrderIngestServiceError(
+                f"failed to load taobao store_code by store_id={store_id}: {exc}"
+            ) from exc
+
+        try:
+            page_result = await self.pull_service.fetch_order_page(
+                session=session,
+                params=params,
+            )
+        except TaobaoRealPullServiceError as exc:
+            raise TaobaoOrderIngestServiceError(f"taobao pull failed: {exc}") from exc
+
+        rows: list[TaobaoOrderIngestRowResult] = []
+        success_count = 0
+        failed_count = 0
+
+        for summary in page_result.orders:
+            row = await self._ingest_one_summary(
+                session=session,
+                store_id=store_id,
+                summary=summary,
+            )
+            rows.append(row)
+            if row.status == "OK":
+                success_count += 1
+            else:
+                failed_count += 1
+
+        return TaobaoOrderIngestPageResult(
+            store_id=store_id,
+            store_code=store_code,
+            page=int(page_result.page),
+            page_size=int(page_result.page_size),
+            orders_count=int(page_result.orders_count),
+            success_count=success_count,
+            failed_count=failed_count,
+            has_more=bool(page_result.has_more),
+            start_time=page_result.start_time,
+            end_time=page_result.end_time,
+            rows=rows,
+        )
+
+    async def _ingest_one_summary(
+        self,
+        *,
+        session: AsyncSession,
+        store_id: int,
+        summary: TaobaoOrderSummary,
+    ) -> TaobaoOrderIngestRowResult:
+        tid = str(summary.tid or "").strip()
+        if not tid:
+            return TaobaoOrderIngestRowResult(
+                tid="",
+                taobao_order_id=None,
+                status="FAILED",
+                error="empty tid",
+            )
+
+        try:
+            detail = await self.detail_service.fetch_order_detail(
+                session=session,
+                store_id=store_id,
+                tid=tid,
+            )
+            taobao_order: TaobaoOrder = await upsert_taobao_order(
+                session,
+                store_id=store_id,
+                summary=summary,
+                detail=detail,
+            )
+            await replace_taobao_order_items(
+                session,
+                taobao_order_id=int(taobao_order.id),
+                tid=tid,
+                detail=detail,
+            )
+            return TaobaoOrderIngestRowResult(
+                tid=tid,
+                taobao_order_id=int(taobao_order.id),
+                status="OK",
+                error=None,
+            )
+        except TaobaoOrderDetailServiceError as exc:
+            return TaobaoOrderIngestRowResult(
+                tid=tid,
+                taobao_order_id=None,
+                status="FAILED",
+                error=f"detail_failed: {exc}",
+            )
+        except Exception as exc:
+            return TaobaoOrderIngestRowResult(
+                tid=tid,
+                taobao_order_id=None,
+                status="FAILED",
+                error=str(exc),
+            )

--- a/tests/api/test_taobao_real_ingest_contract.py
+++ b/tests/api/test_taobao_real_ingest_contract.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+
+from app.platform_order_ingestion.taobao import router_ingest as taobao_router_ingest
+from app.platform_order_ingestion.taobao.service_ingest import (
+    TaobaoOrderIngestPageResult,
+    TaobaoOrderIngestRowResult,
+    TaobaoOrderIngestService,
+)
+from app.platform_order_ingestion.taobao.service_order_detail import (
+    TaobaoOrderDetail,
+    TaobaoOrderDetailItem,
+)
+from app.platform_order_ingestion.taobao.service_real_pull import (
+    TaobaoOrderPageResult,
+    TaobaoOrderSummary,
+    TaobaoRealPullParams,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_taobao_store(session, *, store_id: int = 8601) -> None:
+    await session.execute(
+        text(
+            """
+            INSERT INTO stores (id, platform, store_code, store_name, active)
+            VALUES (:id, 'taobao', :store_code, :store_name, TRUE)
+            ON CONFLICT (id) DO UPDATE
+              SET platform = 'taobao',
+                  store_code = EXCLUDED.store_code,
+                  store_name = EXCLUDED.store_name,
+                  active = TRUE
+            """
+        ),
+        {
+            "id": store_id,
+            "store_code": f"store-{store_id}",
+            "store_name": f"store-{store_id}",
+        },
+    )
+    await session.commit()
+
+
+async def test_post_store_taobao_orders_ingest_returns_page_result(client, monkeypatch):
+    async def _fake_ingest_order_page(self, *, session, params):
+        assert params.store_id == 123
+        assert params.start_time == "2026-03-29 00:00:00"
+        assert params.end_time == "2026-03-29 23:59:59"
+        assert params.status == "WAIT_SELLER_SEND_GOODS"
+        assert params.page == 1
+        assert params.page_size == 50
+        return TaobaoOrderIngestPageResult(
+            store_id=123,
+            store_code="TAOBAO-STORE-123",
+            page=1,
+            page_size=50,
+            orders_count=2,
+            success_count=1,
+            failed_count=1,
+            has_more=False,
+            start_time=params.start_time,
+            end_time=params.end_time,
+            rows=[
+                TaobaoOrderIngestRowResult(
+                    tid="TB-ORDER-001",
+                    taobao_order_id=9001,
+                    status="OK",
+                    error=None,
+                ),
+                TaobaoOrderIngestRowResult(
+                    tid="TB-ORDER-002",
+                    taobao_order_id=None,
+                    status="FAILED",
+                    error="detail_failed: boom",
+                ),
+            ],
+        )
+
+    monkeypatch.setattr(
+        taobao_router_ingest.TaobaoOrderIngestService,
+        "ingest_order_page",
+        _fake_ingest_order_page,
+    )
+
+    resp = await client.post(
+        "/oms/stores/123/taobao/orders/ingest",
+        json={
+            "start_time": "2026-03-29 00:00:00",
+            "end_time": "2026-03-29 23:59:59",
+            "status": "WAIT_SELLER_SEND_GOODS",
+            "page": 1,
+            "page_size": 50,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    body = resp.json()
+    assert body["ok"] is True
+    data = body["data"]
+    assert data["platform"] == "taobao"
+    assert data["store_id"] == 123
+    assert data["store_code"] == "TAOBAO-STORE-123"
+    assert data["orders_count"] == 2
+    assert data["success_count"] == 1
+    assert data["failed_count"] == 1
+    assert data["rows"][0]["tid"] == "TB-ORDER-001"
+    assert data["rows"][0]["taobao_order_id"] == 9001
+    assert data["rows"][1]["status"] == "FAILED"
+
+
+async def test_taobao_order_ingest_service_persists_order_and_replaces_items(session, monkeypatch):
+    store_id = 8601
+    await _seed_taobao_store(session, store_id=store_id)
+    await session.execute(text("DELETE FROM taobao_order_items"))
+    await session.execute(text("DELETE FROM taobao_orders WHERE store_id = :sid"), {"sid": store_id})
+    await session.commit()
+
+    async def _fake_fetch_order_page(self, *, session, params):
+        assert params.store_id == store_id
+        return TaobaoOrderPageResult(
+            page=params.page,
+            page_size=params.page_size,
+            orders_count=1,
+            has_more=False,
+            start_time=params.start_time or "2026-03-29 00:00:00",
+            end_time=params.end_time or "2026-03-29 23:59:59",
+            orders=[
+                TaobaoOrderSummary(
+                    tid="TB-INGEST-8601",
+                    status="WAIT_SELLER_SEND_GOODS",
+                    type="fixed",
+                    buyer_nick="buyer-8601",
+                    buyer_open_uid="ou-8601",
+                    receiver_name="张三",
+                    receiver_mobile="13800138000",
+                    receiver_state="上海",
+                    receiver_city="上海市",
+                    receiver_district="浦东新区",
+                    receiver_town="张江镇",
+                    receiver_address="测试路 1 号",
+                    payment="99.00",
+                    total_fee="109.00",
+                    post_fee="10.00",
+                    created="2026-03-29 12:00:00",
+                    pay_time="2026-03-29 12:05:00",
+                    modified="2026-03-29 12:10:00",
+                    items_count=1,
+                    raw_order={"tid": "TB-INGEST-8601"},
+                )
+            ],
+            raw_payload={"page": params.page},
+        )
+
+    async def _fake_fetch_order_detail(self, *, session, store_id: int, tid: str):
+        assert tid == "TB-INGEST-8601"
+        return TaobaoOrderDetail(
+            tid="TB-INGEST-8601",
+            status="WAIT_SELLER_SEND_GOODS",
+            type="fixed",
+            buyer_nick="buyer-8601",
+            buyer_open_uid="ou-8601",
+            receiver_name="张三",
+            receiver_mobile="13800138000",
+            receiver_phone=None,
+            receiver_state="上海",
+            receiver_city="上海市",
+            receiver_district="浦东新区",
+            receiver_town="张江镇",
+            receiver_address="测试路 1 号",
+            receiver_zip=None,
+            buyer_memo="请尽快发货",
+            buyer_message=None,
+            seller_memo="测试备注",
+            seller_flag=1,
+            payment="99.00",
+            total_fee="109.00",
+            post_fee="10.00",
+            coupon_fee="0.00",
+            created="2026-03-29 12:00:00",
+            pay_time="2026-03-29 12:05:00",
+            modified="2026-03-29 12:10:00",
+            items=[
+                TaobaoOrderDetailItem(
+                    oid="TB-OID-8601",
+                    num_iid="NUMIID8601",
+                    sku_id="SKUID8601",
+                    outer_iid="OUTER-ITEM-8601",
+                    outer_sku_id="OUTER-SKU-8601",
+                    title="淘宝测试商品",
+                    price="99.00",
+                    num=2,
+                    payment="99.00",
+                    total_fee="99.00",
+                    sku_properties_name="颜色:黑色",
+                    raw_item={"oid": "TB-OID-8601"},
+                )
+            ],
+            raw_payload={"tid": "TB-INGEST-8601"},
+        )
+
+    monkeypatch.setattr(
+        "app.platform_order_ingestion.taobao.service_ingest.TaobaoRealPullService.fetch_order_page",
+        _fake_fetch_order_page,
+    )
+    monkeypatch.setattr(
+        "app.platform_order_ingestion.taobao.service_ingest.TaobaoOrderDetailService.fetch_order_detail",
+        _fake_fetch_order_detail,
+    )
+
+    service = TaobaoOrderIngestService()
+    result = await service.ingest_order_page(
+        session=session,
+        params=TaobaoRealPullParams(
+            store_id=store_id,
+            start_time="2026-03-29 00:00:00",
+            end_time="2026-03-29 23:59:59",
+            page=1,
+            page_size=50,
+            status="WAIT_SELLER_SEND_GOODS",
+        ),
+    )
+    await session.commit()
+
+    assert result.store_id == store_id
+    assert result.store_code == f"store-{store_id}"
+    assert result.orders_count == 1
+    assert result.success_count == 1
+    assert result.failed_count == 0
+    assert result.rows[0].status == "OK"
+    assert result.rows[0].taobao_order_id is not None
+
+    rows = (
+        await session.execute(
+            text(
+                """
+                SELECT o.tid, o.status, o.payment, i.oid, i.outer_sku_id, i.num
+                  FROM taobao_orders o
+                  JOIN taobao_order_items i ON i.taobao_order_id = o.id
+                 WHERE o.store_id = :sid
+                   AND o.tid = 'TB-INGEST-8601'
+                """
+            ),
+            {"sid": store_id},
+        )
+    ).mappings().all()
+
+    assert len(rows) == 1
+    assert rows[0]["tid"] == "TB-INGEST-8601"
+    assert rows[0]["status"] == "WAIT_SELLER_SEND_GOODS"
+    assert str(rows[0]["payment"]) == "99.00"
+    assert rows[0]["oid"] == "TB-OID-8601"
+    assert rows[0]["outer_sku_id"] == "OUTER-SKU-8601"
+    assert rows[0]["num"] == 2
+
+
+async def test_post_store_taobao_orders_ingest_returns_400_on_service_error(client, monkeypatch):
+    async def _fake_ingest_order_page(self, *, session, params):
+        raise taobao_router_ingest.TaobaoOrderIngestServiceError("taobao pull failed: credential expired")
+
+    monkeypatch.setattr(
+        taobao_router_ingest.TaobaoOrderIngestService,
+        "ingest_order_page",
+        _fake_ingest_order_page,
+    )
+
+    resp = await client.post(
+        "/oms/stores/123/taobao/orders/ingest",
+        json={
+            "start_time": "2026-03-29 00:00:00",
+            "end_time": "2026-03-29 23:59:59",
+            "page": 1,
+            "page_size": 50,
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    assert "credential expired" in resp.text
+
+
+async def test_post_store_taobao_orders_ingest_rejects_invalid_page_size(client):
+    resp = await client.post(
+        "/oms/stores/123/taobao/orders/ingest",
+        json={"page_size": 0},
+    )
+    assert resp.status_code == 422, resp.text


### PR DESCRIPTION
## Summary
- add Taobao native order ingest contracts, service and router
- upsert taobao_orders by store_id + tid
- replace taobao_order_items from latest Taobao detail payload
- mount POST /oms/stores/{store_id}/taobao/orders/ingest
- add API/service contract tests for Taobao native ingest

## Boundary
- writes only taobao_orders / taobao_order_items
- does not write platform_order_lines
- does not resolve FSKU or create internal orders
- does not touch Finance, WMS or TMS
- does not yet register Taobao pull-job executor

## Tests
- make test TESTS="tests/api/test_taobao_real_ingest_contract.py tests/unit/test_taobao_pull_service.py tests/unit/test_taobao_real_pull_service.py tests/api/test_taobao_app_config_contract.py tests/api/test_platform_order_pull_jobs_contract.py"