### PR TITLE
feat(platform-order-ingestion): run taobao pull jobs

### DIFF
--- a/app/platform_order_ingestion/services/pull_job_executor_registry.py
+++ b/app/platform_order_ingestion/services/pull_job_executor_registry.py
@@ -6,12 +6,14 @@ from __future__ import annotations
 
 from app.platform_order_ingestion.jd.pull_job_executor import JdPullJobExecutor
 from app.platform_order_ingestion.pdd.pull_job_executor import PddPullJobExecutor
+from app.platform_order_ingestion.taobao.pull_job_executor import TaobaoPullJobExecutor
 from app.platform_order_ingestion.services.pull_job_executor import PlatformOrderPullJobExecutor
 
 
 _EXECUTORS: dict[str, PlatformOrderPullJobExecutor] = {
     "pdd": PddPullJobExecutor(),
     "jd": JdPullJobExecutor(),
+    "taobao": TaobaoPullJobExecutor(),
 }
 
 

--- a/app/platform_order_ingestion/taobao/pull_job_executor.py
+++ b/app/platform_order_ingestion/taobao/pull_job_executor.py
@@ -1,0 +1,96 @@
+# Module split: Taobao owns its platform order pull-job executor implementation.
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.platform_order_ingestion.models.pull_job import PlatformOrderPullJob
+from app.platform_order_ingestion.services.pull_job_executor import (
+    PlatformOrderPullJobPageResult,
+    PlatformOrderPullJobPageRow,
+)
+from app.platform_order_ingestion.taobao.service_ingest import TaobaoOrderIngestService
+from app.platform_order_ingestion.taobao.service_real_pull import TaobaoRealPullParams
+
+
+class TaobaoPullJobExecutor:
+    platform = "taobao"
+
+    async def run_page(
+        self,
+        *,
+        session: AsyncSession,
+        job: PlatformOrderPullJob,
+        page: int,
+    ) -> PlatformOrderPullJobPageResult:
+        service = TaobaoOrderIngestService()
+        result = await service.ingest_order_page(
+            session=session,
+            params=TaobaoRealPullParams(
+                store_id=int(job.store_id),
+                start_time=self._format_platform_dt(job.time_from),
+                end_time=self._format_platform_dt(job.time_to),
+                status=self._resolve_status(job.request_payload),
+                page=int(page),
+                page_size=int(job.page_size),
+            ),
+        )
+
+        rows = [
+            PlatformOrderPullJobPageRow(
+                platform_order_no=row.tid,
+                native_order_id=row.taobao_order_id,
+                status=row.status,
+                error=row.error,
+            )
+            for row in result.rows
+        ]
+
+        result_payload = {
+            "platform": self.platform,
+            "store_id": result.store_id,
+            "store_code": result.store_code,
+            "page": result.page,
+            "page_size": result.page_size,
+            "orders_count": result.orders_count,
+            "success_count": result.success_count,
+            "failed_count": result.failed_count,
+            "has_more": result.has_more,
+            "start_time": result.start_time,
+            "end_time": result.end_time,
+            "rows": [
+                {
+                    "tid": row.tid,
+                    "taobao_order_id": row.taobao_order_id,
+                    "status": row.status,
+                    "error": row.error,
+                }
+                for row in result.rows
+            ],
+        }
+
+        return PlatformOrderPullJobPageResult(
+            platform=self.platform,
+            store_id=int(result.store_id),
+            page=int(result.page),
+            page_size=int(result.page_size),
+            orders_count=int(result.orders_count),
+            success_count=int(result.success_count),
+            failed_count=int(result.failed_count),
+            has_more=bool(result.has_more),
+            result_payload=result_payload,
+            rows=rows,
+        )
+
+    def _format_platform_dt(self, value) -> str | None:
+        if value is None:
+            return None
+        return value.strftime("%Y-%m-%d %H:%M:%S")
+
+    def _resolve_status(self, request_payload: dict[str, Any] | None) -> str | None:
+        if not isinstance(request_payload, dict):
+            return None
+        value = request_payload.get("status")
+        text = str(value or "").strip()
+        return text or None

--- a/tests/api/test_platform_order_pull_jobs_contract.py
+++ b/tests/api/test_platform_order_pull_jobs_contract.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 import pytest
 from sqlalchemy import text
 
+from app.platform_order_ingestion.taobao import service_ingest as taobao_service_ingest
+from app.platform_order_ingestion.taobao.service_ingest import (
+    TaobaoOrderIngestPageResult,
+    TaobaoOrderIngestRowResult,
+)
 from app.platform_order_ingestion.jd import service_ingest as jd_service_ingest
 from app.platform_order_ingestion.jd.service_ingest import (
     JdOrderIngestPageResult,
@@ -195,8 +200,51 @@ async def test_run_pdd_platform_order_pull_job_records_run_and_logs(client, sess
     assert len(detail["logs"]) == 4
 
 
-async def test_run_unsupported_platform_pull_job_fails_without_fake_success(client, session):
+async def test_run_taobao_platform_order_pull_job_records_run_and_logs_after_executor_registration(client, session, monkeypatch):
     await _seed_store(session, store_id=7103, platform="TAOBAO")
+
+    captured = {}
+
+    async def _fake_ingest_order_page(self, *, session, params):
+        captured["store_id"] = params.store_id
+        captured["start_time"] = params.start_time
+        captured["end_time"] = params.end_time
+        captured["status"] = params.status
+        captured["page"] = params.page
+        captured["page_size"] = params.page_size
+
+        return TaobaoOrderIngestPageResult(
+            store_id=7103,
+            store_code="store-7103",
+            page=params.page,
+            page_size=params.page_size,
+            orders_count=2,
+            success_count=1,
+            failed_count=1,
+            has_more=True,
+            start_time=params.start_time,
+            end_time=params.end_time,
+            rows=[
+                TaobaoOrderIngestRowResult(
+                    tid="TB-JOB-ORDER-001",
+                    taobao_order_id=9701,
+                    status="OK",
+                    error=None,
+                ),
+                TaobaoOrderIngestRowResult(
+                    tid="TB-JOB-ORDER-002",
+                    taobao_order_id=None,
+                    status="FAILED",
+                    error="detail_failed: boom",
+                ),
+            ],
+        )
+
+    monkeypatch.setattr(
+        taobao_service_ingest.TaobaoOrderIngestService,
+        "ingest_order_page",
+        _fake_ingest_order_page,
+    )
 
     create_resp = await client.post(
         "/oms/platform-order-ingestion/pull-jobs",
@@ -207,20 +255,54 @@ async def test_run_unsupported_platform_pull_job_fails_without_fake_success(clie
             "time_from": "2026-03-29 00:00:00",
             "time_to": "2026-03-29 23:59:59",
             "page_size": 50,
+            "request_payload": {"status": "WAIT_SELLER_SEND_GOODS"},
         },
     )
     assert create_resp.status_code == 200, create_resp.text
     job_id = create_resp.json()["data"]["id"]
 
-    run_resp = await client.post(f"/oms/platform-order-ingestion/pull-jobs/{job_id}/runs")
+    run_resp = await client.post(
+        f"/oms/platform-order-ingestion/pull-jobs/{job_id}/runs",
+        json={"page": 1},
+    )
     assert run_resp.status_code == 200, run_resp.text
 
+    assert captured == {
+        "store_id": 7103,
+        "start_time": "2026-03-29 00:00:00",
+        "end_time": "2026-03-29 23:59:59",
+        "status": "WAIT_SELLER_SEND_GOODS",
+        "page": 1,
+        "page_size": 50,
+    }
+
     data = run_resp.json()["data"]
-    assert data["job"]["status"] == "failed"
-    assert data["run"]["status"] == "failed"
-    assert data["run"]["error_message"] == "PLATFORM_PULL_JOB_NOT_IMPLEMENTED: taobao"
-    assert data["logs"][-1]["event_type"] == "page_failed"
-    assert data["logs"][-1]["level"] == "error"
+    assert data["job"]["platform"] == "taobao"
+    assert data["job"]["status"] == "partial_success"
+    assert data["job"]["cursor_page"] == 2
+
+    run = data["run"]
+    assert run["status"] == "partial_success"
+    assert run["page"] == 1
+    assert run["page_size"] == 50
+    assert run["has_more"] is True
+    assert run["orders_count"] == 2
+    assert run["success_count"] == 1
+    assert run["failed_count"] == 1
+    assert run["result_payload"]["rows"][0]["tid"] == "TB-JOB-ORDER-001"
+    assert run["result_payload"]["rows"][0]["taobao_order_id"] == 9701
+
+    logs = data["logs"]
+    assert [log["event_type"] for log in logs] == [
+        "page_started",
+        "order_ingested",
+        "order_failed",
+        "page_finished",
+    ]
+    assert logs[1]["platform_order_no"] == "TB-JOB-ORDER-001"
+    assert logs[1]["native_order_id"] == 9701
+    assert logs[1]["message"] == "taobao order ingested"
+    assert logs[2]["level"] == "error"
 
 
 async def test_run_pdd_platform_order_pull_job_pages_stops_when_no_more(client, session, monkeypatch):


### PR DESCRIPTION
## Summary
- add Taobao pull job executor
- register Taobao in the platform order pull job executor registry
- route platform_order_pull_jobs(platform=taobao) through TaobaoOrderIngestService
- pass Taobao order status through job request_payload.status
- add pull-job contract test for Taobao execution logs and result payload

## Boundary
- no DB schema changes
- writes only taobao_orders / taobao_order_items through existing Taobao native ingest service
- does not write platform_order_lines
- does not resolve FSKU or create internal orders
- does not touch Finance, WMS or TMS

## Tests
- make test TESTS="tests/api/test_platform_order_pull_jobs_contract.py tests/api/test_taobao_real_ingest_contract.py tests/unit/test_taobao_pull_service.py tests/unit/test_taobao_real_pull_service.py"