### PR TITLE
refactor(platform-order-ingestion): use page permissions

### DIFF
--- a/app/platform_order_ingestion/jd/router_app_config.py
+++ b/app/platform_order_ingestion/jd/router_app_config.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
 
 from app.db.deps import get_async_session as get_session
+from app.db.deps import get_db
+from app.platform_order_ingestion.permissions import (
+    require_platform_order_ingestion_read,
+    require_platform_order_ingestion_write,
+)
+from app.user.deps.auth import get_current_user
 
 from .repository import (
     JdAppConfigUpsertInput,
@@ -28,7 +35,11 @@ def _mask_secret(secret: str | None) -> str:
 @router.get("/jd/app-config/current")
 async def get_jd_app_config_current(
     session: AsyncSession = Depends(get_session),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
 ) -> dict:
+    require_platform_order_ingestion_read(db, current_user)
+
     row = await get_enabled_jd_app_config(session)
     if row is None:
         return {
@@ -68,7 +79,11 @@ async def get_jd_app_config_current(
 async def put_jd_app_config_current(
     payload: dict,
     session: AsyncSession = Depends(get_session),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
 ) -> dict:
+    require_platform_order_ingestion_write(db, current_user)
+
     """
     约定：
     - 若 client_secret 为空字符串，则沿用原 secret（已有记录时）

--- a/app/platform_order_ingestion/jd/router_connection.py
+++ b/app/platform_order_ingestion/jd/router_connection.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Path
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
 
 from app.db.deps import get_async_session as get_session
+from app.db.deps import get_db
+from app.platform_order_ingestion.permissions import require_platform_order_ingestion_read
+from app.user.deps.auth import get_current_user
 
 from .repository import (
     get_connection_by_store_platform,
@@ -19,7 +23,11 @@ router = APIRouter(tags=["oms-jd-connection"])
 async def get_store_jd_connection(
     store_id: int = Path(..., ge=1),
     session: AsyncSession = Depends(get_session),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
 ) -> dict:
+    require_platform_order_ingestion_read(db, current_user)
+
     try:
         credential = await get_credential_by_store_platform(
             session,

--- a/app/platform_order_ingestion/jd/router_ingest.py
+++ b/app/platform_order_ingestion/jd/router_ingest.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Body, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
 
 from app.db.deps import get_async_session as get_session
+from app.db.deps import get_db
+from app.platform_order_ingestion.permissions import require_platform_order_ingestion_write
+from app.user.deps.auth import get_current_user
 from app.platform_order_ingestion.jd.contracts_ingest import (
     JdOrderIngestDataOut,
     JdOrderIngestEnvelopeOut,
@@ -29,7 +33,11 @@ async def ingest_store_jd_orders(
     store_id: int,
     payload: JdOrderIngestRequest = Body(default_factory=JdOrderIngestRequest),
     session: AsyncSession = Depends(get_session),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
 ) -> JdOrderIngestEnvelopeOut:
+    require_platform_order_ingestion_write(db, current_user)
+
     try:
         service = JdOrderIngestService()
         result = await service.ingest_order_page(

--- a/app/platform_order_ingestion/jd/router_orders.py
+++ b/app/platform_order_ingestion/jd/router_orders.py
@@ -16,7 +16,7 @@ from app.platform_order_ingestion.jd.service_ledger import (
     get_jd_order_ledger_detail,
     list_jd_order_ledger_rows,
 )
-from app.oms.services.stores_helpers import check_perm
+from app.platform_order_ingestion.permissions import require_platform_order_ingestion_read
 
 router = APIRouter(tags=["oms-jd-orders"])
 
@@ -29,7 +29,7 @@ async def list_jd_orders_ledger(
     db: Session = Depends(get_db),
     current_user=Depends(get_current_user),
 ):
-    check_perm(db, current_user, ["operations.outbound"])
+    require_platform_order_ingestion_read(db, current_user)
 
     try:
         rows = await list_jd_order_ledger_rows(
@@ -53,7 +53,7 @@ async def get_jd_order_ledger(
     db: Session = Depends(get_db),
     current_user=Depends(get_current_user),
 ):
-    check_perm(db, current_user, ["operations.outbound"])
+    require_platform_order_ingestion_read(db, current_user)
 
     try:
         detail = await get_jd_order_ledger_detail(

--- a/app/platform_order_ingestion/jd/router_pull.py
+++ b/app/platform_order_ingestion/jd/router_pull.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Body, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
 
 from app.db.deps import get_async_session as get_session
+from app.db.deps import get_db
+from app.platform_order_ingestion.permissions import require_platform_order_ingestion_write
+from app.user.deps.auth import get_current_user
 
 from .service_pull import JdPullService, JdPullServiceError
 
@@ -17,7 +21,11 @@ async def test_store_jd_pull(
     store_id: int,
     payload: dict | None = Body(default=None),
     session: AsyncSession = Depends(get_session),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
 ) -> dict:
+    require_platform_order_ingestion_write(db, current_user)
+
     """
     京东 test-pull（第一版）。
 

--- a/app/platform_order_ingestion/pdd/router_app_config.py
+++ b/app/platform_order_ingestion/pdd/router_app_config.py
@@ -11,7 +11,10 @@ from sqlalchemy.orm import Session
 from app.user.deps.auth import get_current_user
 from app.db.deps import get_async_session as get_session
 from app.db.deps import get_db
-from app.oms.services.stores_helpers import check_perm
+from app.platform_order_ingestion.permissions import (
+    require_platform_order_ingestion_read,
+    require_platform_order_ingestion_write,
+)
 
 from .repository import (
     PddAppConfigUpsertInput,
@@ -44,7 +47,7 @@ async def get_current_pdd_app_config(
     """
     读取当前启用中的拼多多系统配置。
     """
-    check_perm(db, current_user, ["config.store.read"])
+    require_platform_order_ingestion_read(db, current_user)
 
     try:
         row = await get_enabled_pdd_app_config(session)
@@ -105,7 +108,7 @@ async def put_current_pdd_app_config(
     - 若当前已有启用配置，则原地更新
     - 若 client_secret 为空字符串，则沿用原 secret（已有记录时）
     """
-    check_perm(db, current_user, ["config.store.read"])
+    require_platform_order_ingestion_write(db, current_user)
 
     client_id = str(payload.get("client_id") or "").strip()
     client_secret_raw = payload.get("client_secret")

--- a/app/platform_order_ingestion/pdd/router_connection.py
+++ b/app/platform_order_ingestion/pdd/router_connection.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
 
 from app.db.deps import get_async_session as get_session
+from app.db.deps import get_db
+from app.platform_order_ingestion.permissions import require_platform_order_ingestion_read
+from app.user.deps.auth import get_current_user
 
 from .access_repository import (
     get_connection_by_store_platform,
@@ -19,7 +23,11 @@ router = APIRouter(tags=["oms-pdd-connection"])
 async def get_store_pdd_connection(
     store_id: int,
     session: AsyncSession = Depends(get_session),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
 ) -> dict:
+    require_platform_order_ingestion_read(db, current_user)
+
     """
     读取店铺 × 拼多多当前 connection 视图。
 

--- a/app/platform_order_ingestion/pdd/router_ingest.py
+++ b/app/platform_order_ingestion/pdd/router_ingest.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Body, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
 
 from app.db.deps import get_async_session as get_session
+from app.db.deps import get_db
+from app.platform_order_ingestion.permissions import require_platform_order_ingestion_write
+from app.user.deps.auth import get_current_user
 from app.platform_order_ingestion.pdd.contracts_ingest import (
     PddOrderIngestDataOut,
     PddOrderIngestEnvelopeOut,
@@ -29,7 +33,11 @@ async def ingest_store_pdd_orders(
     store_id: int,
     payload: PddOrderIngestRequest = Body(default_factory=PddOrderIngestRequest),
     session: AsyncSession = Depends(get_session),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
 ) -> PddOrderIngestEnvelopeOut:
+    require_platform_order_ingestion_write(db, current_user)
+
     """
     PDD 真实订单入库入口。
 

--- a/app/platform_order_ingestion/pdd/router_orders.py
+++ b/app/platform_order_ingestion/pdd/router_orders.py
@@ -16,7 +16,7 @@ from app.platform_order_ingestion.pdd.service_ledger import (
     get_pdd_order_ledger_detail,
     list_pdd_order_ledger_rows,
 )
-from app.oms.services.stores_helpers import check_perm
+from app.platform_order_ingestion.permissions import require_platform_order_ingestion_read
 
 router = APIRouter(tags=["oms-pdd-orders"])
 
@@ -29,7 +29,7 @@ async def list_pdd_orders_ledger(
     db: Session = Depends(get_db),
     current_user=Depends(get_current_user),
 ):
-    check_perm(db, current_user, ["operations.outbound"])
+    require_platform_order_ingestion_read(db, current_user)
 
     try:
         rows = await list_pdd_order_ledger_rows(
@@ -53,7 +53,7 @@ async def get_pdd_order_ledger(
     db: Session = Depends(get_db),
     current_user=Depends(get_current_user),
 ):
-    check_perm(db, current_user, ["operations.outbound"])
+    require_platform_order_ingestion_read(db, current_user)
 
     try:
         detail = await get_pdd_order_ledger_detail(

--- a/app/platform_order_ingestion/pdd/router_pull.py
+++ b/app/platform_order_ingestion/pdd/router_pull.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Body, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
 
 from app.db.deps import get_async_session as get_session
+from app.db.deps import get_db
+from app.platform_order_ingestion.permissions import require_platform_order_ingestion_write
+from app.user.deps.auth import get_current_user
 
 from .service_pull import PddPullService, PddPullServiceError
 
@@ -17,7 +21,11 @@ async def test_store_pdd_pull(
     store_id: int,
     payload: dict | None = Body(default=None),
     session: AsyncSession = Depends(get_session),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
 ) -> dict:
+    require_platform_order_ingestion_write(db, current_user)
+
     """
     拼多多 test-pull（第二版）。
 

--- a/app/platform_order_ingestion/permissions.py
+++ b/app/platform_order_ingestion/permissions.py
@@ -1,0 +1,37 @@
+# app/platform_order_ingestion/permissions.py
+# Module boundary: platform order ingestion uses its own page-scoped permissions.
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.user.services.user_service import AuthorizationError, UserService
+
+PLATFORM_ORDER_INGESTION_READ_PERMISSION = "page.platform_order_ingestion.read"
+PLATFORM_ORDER_INGESTION_WRITE_PERMISSION = "page.platform_order_ingestion.write"
+
+
+def _require_permission(db: Session, current_user: Any, permission_name: str) -> None:
+    svc = UserService(db)
+    try:
+        svc.check_permission(current_user, [permission_name])
+    except AuthorizationError:
+        raise HTTPException(status_code=403, detail="Not authorized.")
+
+
+def require_platform_order_ingestion_read(db: Session, current_user: Any) -> None:
+    _require_permission(db, current_user, PLATFORM_ORDER_INGESTION_READ_PERMISSION)
+
+
+def require_platform_order_ingestion_write(db: Session, current_user: Any) -> None:
+    _require_permission(db, current_user, PLATFORM_ORDER_INGESTION_WRITE_PERMISSION)
+
+
+__all__ = [
+    "PLATFORM_ORDER_INGESTION_READ_PERMISSION",
+    "PLATFORM_ORDER_INGESTION_WRITE_PERMISSION",
+    "require_platform_order_ingestion_read",
+    "require_platform_order_ingestion_write",
+]

--- a/app/platform_order_ingestion/router_mock.py
+++ b/app/platform_order_ingestion/router_mock.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Body, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
 
 from app.db.deps import get_async_session as get_session
+from app.db.deps import get_db
+from app.platform_order_ingestion.permissions import require_platform_order_ingestion_write
+from app.user.deps.auth import get_current_user
 from app.platform_order_ingestion.contracts_mock import (
     PlatformOrderIngestionMockAuthorizeRequest,
     PlatformOrderIngestionMockClearOrdersRequest,
@@ -23,7 +27,11 @@ async def authorize_store_mock(
     store_id: int,
     payload: PlatformOrderIngestionMockAuthorizeRequest = Body(...),
     session: AsyncSession = Depends(get_session),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
 ) -> dict:
+    require_platform_order_ingestion_write(db, current_user)
+
     try:
         service = PlatformOrderIngestionMockService()
         result = await service.mock_authorize_store(
@@ -68,7 +76,11 @@ async def ingest_store_orders_mock(
     store_id: int,
     payload: PlatformOrderIngestionMockIngestOrdersRequest = Body(...),
     session: AsyncSession = Depends(get_session),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
 ) -> dict:
+    require_platform_order_ingestion_write(db, current_user)
+
     try:
         service = PlatformOrderIngestionMockService()
         result = await service.mock_ingest_orders(
@@ -113,7 +125,11 @@ async def clear_store_orders_mock(
     store_id: int,
     payload: PlatformOrderIngestionMockClearOrdersRequest = Body(...),
     session: AsyncSession = Depends(get_session),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
 ) -> dict:
+    require_platform_order_ingestion_write(db, current_user)
+
     try:
         service = PlatformOrderIngestionMockService()
         result = await service.clear_mock_orders(

--- a/app/platform_order_ingestion/router_pull_jobs.py
+++ b/app/platform_order_ingestion/router_pull_jobs.py
@@ -3,8 +3,15 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
 
 from app.db.deps import get_async_session as get_session
+from app.db.deps import get_db
+from app.platform_order_ingestion.permissions import (
+    require_platform_order_ingestion_read,
+    require_platform_order_ingestion_write,
+)
+from app.user.deps.auth import get_current_user
 from app.platform_order_ingestion.contracts_pull_jobs import (
     PlatformOrderPullJobCreateIn,
     PlatformOrderPullJobDetailDataOut,
@@ -107,7 +114,11 @@ def _log_out(row: PlatformOrderPullJobRunLog) -> PlatformOrderPullJobRunLogOut:
 async def create_platform_order_pull_job(
     payload: PlatformOrderPullJobCreateIn = Body(...),
     session: AsyncSession = Depends(get_session),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
 ) -> PlatformOrderPullJobEnvelopeOut:
+    require_platform_order_ingestion_write(db, current_user)
+
     try:
         service = PlatformOrderPullJobService()
         job = await service.create_job(session, payload=payload)
@@ -134,7 +145,11 @@ async def list_platform_order_pull_jobs(
     limit: int = Query(default=50, gt=0, le=200),
     offset: int = Query(default=0, ge=0),
     session: AsyncSession = Depends(get_session),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
 ) -> PlatformOrderPullJobListEnvelopeOut:
+    require_platform_order_ingestion_read(db, current_user)
+
     service = PlatformOrderPullJobService()
     rows, total = await service.list_jobs(
         session,
@@ -163,7 +178,11 @@ async def list_platform_order_pull_jobs(
 async def get_platform_order_pull_job(
     job_id: int,
     session: AsyncSession = Depends(get_session),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
 ) -> PlatformOrderPullJobDetailEnvelopeOut:
+    require_platform_order_ingestion_read(db, current_user)
+
     try:
         service = PlatformOrderPullJobService()
         job, runs, logs = await service.get_job_detail(session, job_id=job_id)
@@ -189,7 +208,11 @@ async def run_platform_order_pull_job_once(
     job_id: int,
     payload: PlatformOrderPullJobRunCreateIn = Body(default_factory=PlatformOrderPullJobRunCreateIn),
     session: AsyncSession = Depends(get_session),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
 ) -> PlatformOrderPullJobRunEnvelopeOut:
+    require_platform_order_ingestion_write(db, current_user)
+
     try:
         service = PlatformOrderPullJobService()
         job, run, logs = await service.run_job_once(session, job_id=job_id, page=payload.page)
@@ -221,7 +244,11 @@ async def run_platform_order_pull_job_pages(
         default_factory=PlatformOrderPullJobRunPagesCreateIn
     ),
     session: AsyncSession = Depends(get_session),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
 ) -> PlatformOrderPullJobRunPagesEnvelopeOut:
+    require_platform_order_ingestion_write(db, current_user)
+
     try:
         service = PlatformOrderPullJobService()
         job, runs, logs, stopped_reason = await service.run_job_pages(

--- a/app/platform_order_ingestion/router_status.py
+++ b/app/platform_order_ingestion/router_status.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
 
 from app.db.deps import get_async_session as get_session
+from app.db.deps import get_db
+from app.platform_order_ingestion.permissions import require_platform_order_ingestion_read
+from app.user.deps.auth import get_current_user
 from app.platform_order_ingestion.contracts_status import (
     PlatformOrderIngestionStoreStatusEnvelopeOut,
 )
@@ -25,7 +29,11 @@ router = APIRouter(tags=["platform-order-ingestion-status"])
 async def get_store_platform_order_ingestion_status(
     store_id: int,
     session: AsyncSession = Depends(get_session),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
 ) -> PlatformOrderIngestionStoreStatusEnvelopeOut:
+    require_platform_order_ingestion_read(db, current_user)
+
     try:
         service = PlatformOrderIngestionStatusService()
         data = await service.get_store_status(session, store_id=store_id)

--- a/app/platform_order_ingestion/taobao/router_app_config.py
+++ b/app/platform_order_ingestion/taobao/router_app_config.py
@@ -11,7 +11,10 @@ from sqlalchemy.orm import Session
 from app.user.deps.auth import get_current_user
 from app.db.deps import get_async_session as get_session
 from app.db.deps import get_db
-from app.oms.services.stores_helpers import check_perm
+from app.platform_order_ingestion.permissions import (
+    require_platform_order_ingestion_read,
+    require_platform_order_ingestion_write,
+)
 
 from .repository import (
     TaobaoAppConfigUpsertInput,
@@ -44,7 +47,7 @@ async def get_current_taobao_app_config(
     """
     读取当前启用中的淘宝系统配置。
     """
-    check_perm(db, current_user, ["config.store.read"])
+    require_platform_order_ingestion_read(db, current_user)
 
     try:
         row = await get_enabled_taobao_app_config(session)
@@ -105,7 +108,7 @@ async def put_current_taobao_app_config(
     - 若当前已有启用配置，则原地更新
     - 若 app_secret 为空字符串，则沿用原 secret（已有记录时）
     """
-    check_perm(db, current_user, ["config.store.read"])
+    require_platform_order_ingestion_write(db, current_user)
 
     app_key = str(payload.get("app_key") or "").strip()
     app_secret_raw = payload.get("app_secret")

--- a/app/platform_order_ingestion/taobao/router_connection.py
+++ b/app/platform_order_ingestion/taobao/router_connection.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 from app.user.deps.auth import get_current_user
 from app.db.deps import get_async_session as get_session
 from app.db.deps import get_db
-from app.oms.services.stores_helpers import check_perm
+from app.platform_order_ingestion.permissions import require_platform_order_ingestion_read
 
 from .repository import (
     get_connection_by_store_platform,
@@ -38,7 +38,7 @@ async def get_store_taobao_connection(
     说明：
     - 第一版先直接读新两张表
     """
-    check_perm(db, current_user, ["config.store.read"])
+    require_platform_order_ingestion_read(db, current_user)
 
     platform = "taobao"
 

--- a/app/platform_order_ingestion/taobao/router_ingest.py
+++ b/app/platform_order_ingestion/taobao/router_ingest.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Body, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
 
 from app.db.deps import get_async_session as get_session
+from app.db.deps import get_db
+from app.platform_order_ingestion.permissions import require_platform_order_ingestion_write
+from app.user.deps.auth import get_current_user
 from app.platform_order_ingestion.taobao.contracts_ingest import (
     TaobaoOrderIngestDataOut,
     TaobaoOrderIngestEnvelopeOut,
@@ -29,7 +33,11 @@ async def ingest_store_taobao_orders(
     store_id: int,
     payload: TaobaoOrderIngestRequest = Body(default_factory=TaobaoOrderIngestRequest),
     session: AsyncSession = Depends(get_session),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
 ) -> TaobaoOrderIngestEnvelopeOut:
+    require_platform_order_ingestion_write(db, current_user)
+
     try:
         service = TaobaoOrderIngestService()
         result = await service.ingest_order_page(

--- a/app/platform_order_ingestion/taobao/router_orders.py
+++ b/app/platform_order_ingestion/taobao/router_orders.py
@@ -16,7 +16,7 @@ from app.platform_order_ingestion.taobao.service_ledger import (
     get_taobao_order_ledger_detail,
     list_taobao_order_ledger_rows,
 )
-from app.oms.services.stores_helpers import check_perm
+from app.platform_order_ingestion.permissions import require_platform_order_ingestion_read
 
 router = APIRouter(tags=["oms-taobao-orders"])
 
@@ -29,7 +29,7 @@ async def list_taobao_orders_ledger(
     db: Session = Depends(get_db),
     current_user=Depends(get_current_user),
 ):
-    check_perm(db, current_user, ["operations.outbound"])
+    require_platform_order_ingestion_read(db, current_user)
 
     try:
         rows = await list_taobao_order_ledger_rows(
@@ -53,7 +53,7 @@ async def get_taobao_order_ledger(
     db: Session = Depends(get_db),
     current_user=Depends(get_current_user),
 ):
-    check_perm(db, current_user, ["operations.outbound"])
+    require_platform_order_ingestion_read(db, current_user)
 
     try:
         detail = await get_taobao_order_ledger_detail(

--- a/app/platform_order_ingestion/taobao/router_pull.py
+++ b/app/platform_order_ingestion/taobao/router_pull.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 
 from app.db.deps import get_async_session as get_session
 from app.db.deps import get_db
-from app.oms.services.stores_helpers import check_perm
+from app.platform_order_ingestion.permissions import require_platform_order_ingestion_write
 from app.user.deps.auth import get_current_user
 
 from .repository import require_enabled_taobao_app_config
@@ -91,7 +91,7 @@ async def test_store_taobao_pull(
     - 更新 connection 状态；
     - 不写 taobao_orders / taobao_order_items。
     """
-    check_perm(db, current_user, ["config.store.read"])
+    require_platform_order_ingestion_write(db, current_user)
 
     payload = payload or {}
     start_time = payload.get("start_time")

--- a/tests/api/test_jd_app_config_contract.py
+++ b/tests/api/test_jd_app_config_contract.py
@@ -6,6 +6,29 @@ from sqlalchemy import text
 
 pytestmark = pytest.mark.asyncio
 
+from app.main import app
+from app.user.deps.auth import get_current_user
+
+
+class _PlatformOrderIngestionPermissionUser:
+    id: int = 999
+    username: str = "test-user"
+    is_active: bool = True
+    permissions = [
+        "page.platform_order_ingestion.read",
+        "page.platform_order_ingestion.write",
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _override_platform_order_ingestion_user():
+    app.dependency_overrides[get_current_user] = lambda: _PlatformOrderIngestionPermissionUser()
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
 
 async def _clear_jd_app_configs(session) -> None:
     await session.execute(text("DELETE FROM jd_app_configs"))

--- a/tests/api/test_jd_connection_contract.py
+++ b/tests/api/test_jd_connection_contract.py
@@ -11,6 +11,29 @@ from app.platform_order_ingestion.models.store_platform_credential import StoreP
 
 pytestmark = pytest.mark.asyncio
 
+from app.main import app
+from app.user.deps.auth import get_current_user
+
+
+class _PlatformOrderIngestionPermissionUser:
+    id: int = 999
+    username: str = "test-user"
+    is_active: bool = True
+    permissions = [
+        "page.platform_order_ingestion.read",
+        "page.platform_order_ingestion.write",
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _override_platform_order_ingestion_user():
+    app.dependency_overrides[get_current_user] = lambda: _PlatformOrderIngestionPermissionUser()
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
 
 def _store_row_sql(store_id: int) -> str:
     return f"""

--- a/tests/api/test_jd_orders_contract.py
+++ b/tests/api/test_jd_orders_contract.py
@@ -9,13 +9,13 @@ from sqlalchemy import text
 from app.user.deps.auth import get_current_user
 from app.main import app
 from app.platform_order_ingestion.models.jd_order import JdOrder, JdOrderItem
-import app.platform_order_ingestion.jd.router_orders as jd_router_orders
 
 
 class _TestUser:
     id: int = 999
     username: str = "test-user"
     is_active: bool = True
+    permissions = ["page.platform_order_ingestion.read", "page.platform_order_ingestion.write"]
 
 
 pytestmark = pytest.mark.asyncio
@@ -83,7 +83,6 @@ async def test_get_jd_orders_returns_list_rows(client, session, monkeypatch):
     await session.commit()
 
     app.dependency_overrides[get_current_user] = lambda: _TestUser()
-    monkeypatch.setattr(jd_router_orders, "check_perm", lambda db, current_user, required: None)
 
     try:
         resp = await client.get("/oms/jd/orders")
@@ -160,7 +159,6 @@ async def test_get_jd_order_detail_returns_header_and_items(client, session, mon
     await session.commit()
 
     app.dependency_overrides[get_current_user] = lambda: _TestUser()
-    monkeypatch.setattr(jd_router_orders, "check_perm", lambda db, current_user, required: None)
 
     try:
         resp = await client.get(f"/oms/jd/orders/{order.id}")
@@ -196,7 +194,6 @@ async def test_get_jd_order_detail_returns_404_when_missing(client, session, mon
     await _clear_jd_orders(session)
 
     app.dependency_overrides[get_current_user] = lambda: _TestUser()
-    monkeypatch.setattr(jd_router_orders, "check_perm", lambda db, current_user, required: None)
 
     try:
         resp = await client.get("/oms/jd/orders/999999")

--- a/tests/api/test_jd_real_ingest_contract.py
+++ b/tests/api/test_jd_real_ingest_contract.py
@@ -21,6 +21,29 @@ from app.platform_order_ingestion.jd.service_real_pull import (
 
 pytestmark = pytest.mark.asyncio
 
+from app.main import app
+from app.user.deps.auth import get_current_user
+
+
+class _PlatformOrderIngestionPermissionUser:
+    id: int = 999
+    username: str = "test-user"
+    is_active: bool = True
+    permissions = [
+        "page.platform_order_ingestion.read",
+        "page.platform_order_ingestion.write",
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _override_platform_order_ingestion_user():
+    app.dependency_overrides[get_current_user] = lambda: _PlatformOrderIngestionPermissionUser()
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
 
 async def _seed_jd_store(session, *, store_id: int = 8201) -> None:
     await session.execute(

--- a/tests/api/test_pdd_app_config_contract.py
+++ b/tests/api/test_pdd_app_config_contract.py
@@ -5,13 +5,13 @@ from sqlalchemy import text
 
 from app.user.deps.auth import get_current_user
 from app.main import app
-import app.platform_order_ingestion.pdd.router_app_config as pdd_router_app_config
 
 
 class _TestUser:
     id: int = 999
     username: str = "test-user"
     is_active: bool = True
+    permissions = ["page.platform_order_ingestion.read", "page.platform_order_ingestion.write"]
 
 
 pytestmark = pytest.mark.asyncio
@@ -27,7 +27,6 @@ async def test_get_current_pdd_app_config_returns_empty_shell_when_missing(clien
     await _clear_pdd_app_configs(session)
 
     app.dependency_overrides[get_current_user] = lambda: _TestUser()
-    monkeypatch.setattr(pdd_router_app_config, "check_perm", lambda db, current_user, required: None)
 
     try:
         resp = await client.get("/oms/pdd/app-config/current")
@@ -56,7 +55,6 @@ async def test_put_current_pdd_app_config_create_then_get_masked(client, session
     await _clear_pdd_app_configs(session)
 
     app.dependency_overrides[get_current_user] = lambda: _TestUser()
-    monkeypatch.setattr(pdd_router_app_config, "check_perm", lambda db, current_user, required: None)
 
     try:
         payload = {
@@ -110,7 +108,6 @@ async def test_put_current_pdd_app_config_blank_secret_keeps_existing_secret(cli
     await _clear_pdd_app_configs(session)
 
     app.dependency_overrides[get_current_user] = lambda: _TestUser()
-    monkeypatch.setattr(pdd_router_app_config, "check_perm", lambda db, current_user, required: None)
 
     try:
         create_payload = {
@@ -151,7 +148,6 @@ async def test_put_current_pdd_app_config_requires_secret_on_first_create(client
     await _clear_pdd_app_configs(session)
 
     app.dependency_overrides[get_current_user] = lambda: _TestUser()
-    monkeypatch.setattr(pdd_router_app_config, "check_perm", lambda db, current_user, required: None)
 
     try:
         payload = {

--- a/tests/api/test_pdd_connection_and_pull_contract.py
+++ b/tests/api/test_pdd_connection_and_pull_contract.py
@@ -16,6 +16,7 @@ class _TestUser:
     id: int = 999
     username: str = "test-user"
     is_active: bool = True
+    permissions = ["page.platform_order_ingestion.read", "page.platform_order_ingestion.write"]
 
 
 pytestmark = pytest.mark.asyncio

--- a/tests/api/test_pdd_real_ingest_contract.py
+++ b/tests/api/test_pdd_real_ingest_contract.py
@@ -10,6 +10,29 @@ from app.platform_order_ingestion.pdd.service_ingest import (
 
 pytestmark = pytest.mark.asyncio
 
+from app.main import app
+from app.user.deps.auth import get_current_user
+
+
+class _PlatformOrderIngestionPermissionUser:
+    id: int = 999
+    username: str = "test-user"
+    is_active: bool = True
+    permissions = [
+        "page.platform_order_ingestion.read",
+        "page.platform_order_ingestion.write",
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _override_platform_order_ingestion_user():
+    app.dependency_overrides[get_current_user] = lambda: _PlatformOrderIngestionPermissionUser()
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
 
 async def test_post_store_pdd_orders_ingest_returns_page_result(client, session, monkeypatch):
     captured = {}

--- a/tests/api/test_pdd_real_pull_contract.py
+++ b/tests/api/test_pdd_real_pull_contract.py
@@ -15,6 +15,7 @@ class _TestUser:
     id: int = 999
     username: str = "test-user"
     is_active: bool = True
+    permissions = ["page.platform_order_ingestion.read", "page.platform_order_ingestion.write"]
 
 
 pytestmark = pytest.mark.asyncio

--- a/tests/api/test_platform_order_ingestion_permission_contract.py
+++ b/tests/api/test_platform_order_ingestion_permission_contract.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import pytest
+
+from app.main import app
+from app.user.deps.auth import get_current_user
+
+pytestmark = pytest.mark.asyncio
+
+
+class _NoPlatformOrderIngestionPermissionUser:
+    id: int = 999
+    username: str = "no-platform-order-ingestion-permission"
+    is_active: bool = True
+    permissions: list[str] = []
+
+
+class _ReadOnlyPlatformOrderIngestionUser:
+    id: int = 998
+    username: str = "platform-order-ingestion-read-only"
+    is_active: bool = True
+    permissions = ["page.platform_order_ingestion.read"]
+
+
+async def test_pull_job_list_requires_platform_order_ingestion_read(client):
+    app.dependency_overrides[get_current_user] = lambda: _NoPlatformOrderIngestionPermissionUser()
+    try:
+        resp = await client.get("/oms/platform-order-ingestion/pull-jobs")
+        assert resp.status_code == 403, resp.text
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+async def test_pull_job_create_requires_platform_order_ingestion_write(client):
+    app.dependency_overrides[get_current_user] = lambda: _ReadOnlyPlatformOrderIngestionUser()
+    try:
+        resp = await client.post(
+            "/oms/platform-order-ingestion/pull-jobs",
+            json={
+                "platform": "pdd",
+                "store_id": 1,
+                "job_type": "manual",
+                "page_size": 50,
+            },
+        )
+        assert resp.status_code == 403, resp.text
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+async def test_mock_authorize_requires_platform_order_ingestion_write(client):
+    app.dependency_overrides[get_current_user] = lambda: _ReadOnlyPlatformOrderIngestionUser()
+    try:
+        resp = await client.post(
+            "/oms/platform-order-ingestion/mock/stores/1/authorize",
+            json={
+                "platform": "pdd",
+                "expires_in_days": 365,
+                "pull_ready": True,
+            },
+        )
+        assert resp.status_code == 403, resp.text
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)

--- a/tests/api/test_platform_order_ingestion_store_status_contract.py
+++ b/tests/api/test_platform_order_ingestion_store_status_contract.py
@@ -15,6 +15,29 @@ from app.platform_order_ingestion.models.pull_job import (
 
 pytestmark = pytest.mark.asyncio
 
+from app.main import app
+from app.user.deps.auth import get_current_user
+
+
+class _PlatformOrderIngestionPermissionUser:
+    id: int = 999
+    username: str = "test-user"
+    is_active: bool = True
+    permissions = [
+        "page.platform_order_ingestion.read",
+        "page.platform_order_ingestion.write",
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _override_platform_order_ingestion_user():
+    app.dependency_overrides[get_current_user] = lambda: _PlatformOrderIngestionPermissionUser()
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
 
 async def _reset_store_status_state(session, *, store_id: int, platform: str) -> None:
     platform_norm = platform.lower()

--- a/tests/api/test_platform_order_ingestion_unified_mock_contract.py
+++ b/tests/api/test_platform_order_ingestion_unified_mock_contract.py
@@ -5,6 +5,29 @@ from sqlalchemy import text
 
 pytestmark = pytest.mark.asyncio
 
+from app.main import app
+from app.user.deps.auth import get_current_user
+
+
+class _PlatformOrderIngestionPermissionUser:
+    id: int = 999
+    username: str = "test-user"
+    is_active: bool = True
+    permissions = [
+        "page.platform_order_ingestion.read",
+        "page.platform_order_ingestion.write",
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _override_platform_order_ingestion_user():
+    app.dependency_overrides[get_current_user] = lambda: _PlatformOrderIngestionPermissionUser()
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
 
 async def _seed_store(session, *, store_id: int, platform: str) -> None:
     await session.execute(

--- a/tests/api/test_platform_order_pull_jobs_contract.py
+++ b/tests/api/test_platform_order_pull_jobs_contract.py
@@ -21,6 +21,29 @@ from app.platform_order_ingestion.pdd.service_ingest import (
 
 pytestmark = pytest.mark.asyncio
 
+from app.main import app
+from app.user.deps.auth import get_current_user
+
+
+class _PlatformOrderIngestionPermissionUser:
+    id: int = 999
+    username: str = "test-user"
+    is_active: bool = True
+    permissions = [
+        "page.platform_order_ingestion.read",
+        "page.platform_order_ingestion.write",
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _override_platform_order_ingestion_user():
+    app.dependency_overrides[get_current_user] = lambda: _PlatformOrderIngestionPermissionUser()
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
 
 async def _seed_store(session, *, store_id: int = 7101, platform: str = "PDD") -> None:
     await session.execute(

--- a/tests/api/test_taobao_app_config_contract.py
+++ b/tests/api/test_taobao_app_config_contract.py
@@ -5,13 +5,13 @@ from sqlalchemy import text
 
 from app.user.deps.auth import get_current_user
 from app.main import app
-import app.platform_order_ingestion.taobao.router_app_config as taobao_router_app_config
 
 
 class _TestUser:
     id: int = 999
     username: str = "test-user"
     is_active: bool = True
+    permissions = ["page.platform_order_ingestion.read", "page.platform_order_ingestion.write"]
 
 
 pytestmark = pytest.mark.asyncio
@@ -27,7 +27,6 @@ async def test_get_current_taobao_app_config_returns_empty_shell_when_missing(cl
     await _clear_taobao_app_configs(session)
 
     app.dependency_overrides[get_current_user] = lambda: _TestUser()
-    monkeypatch.setattr(taobao_router_app_config, "check_perm", lambda db, current_user, required: None)
 
     try:
         resp = await client.get("/oms/taobao/app-config/current")
@@ -56,7 +55,6 @@ async def test_put_current_taobao_app_config_create_then_get_masked(client, sess
     await _clear_taobao_app_configs(session)
 
     app.dependency_overrides[get_current_user] = lambda: _TestUser()
-    monkeypatch.setattr(taobao_router_app_config, "check_perm", lambda db, current_user, required: None)
 
     try:
         payload = {
@@ -110,7 +108,6 @@ async def test_put_current_taobao_app_config_blank_secret_keeps_existing_secret(
     await _clear_taobao_app_configs(session)
 
     app.dependency_overrides[get_current_user] = lambda: _TestUser()
-    monkeypatch.setattr(taobao_router_app_config, "check_perm", lambda db, current_user, required: None)
 
     try:
         create_payload = {
@@ -151,7 +148,6 @@ async def test_put_current_taobao_app_config_requires_secret_on_first_create(cli
     await _clear_taobao_app_configs(session)
 
     app.dependency_overrides[get_current_user] = lambda: _TestUser()
-    monkeypatch.setattr(taobao_router_app_config, "check_perm", lambda db, current_user, required: None)
 
     try:
         payload = {

--- a/tests/api/test_taobao_real_ingest_contract.py
+++ b/tests/api/test_taobao_real_ingest_contract.py
@@ -21,6 +21,29 @@ from app.platform_order_ingestion.taobao.service_real_pull import (
 
 pytestmark = pytest.mark.asyncio
 
+from app.main import app
+from app.user.deps.auth import get_current_user
+
+
+class _PlatformOrderIngestionPermissionUser:
+    id: int = 999
+    username: str = "test-user"
+    is_active: bool = True
+    permissions = [
+        "page.platform_order_ingestion.read",
+        "page.platform_order_ingestion.write",
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _override_platform_order_ingestion_user():
+    app.dependency_overrides[get_current_user] = lambda: _PlatformOrderIngestionPermissionUser()
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
 
 async def _seed_taobao_store(session, *, store_id: int = 8601) -> None:
     await session.execute(


### PR DESCRIPTION
## Summary

- add platform-order-ingestion-owned permission helper
- require page.platform_order_ingestion.read for read endpoints
- require page.platform_order_ingestion.write for write endpoints
- remove direct dependency on legacy OMS store permission helper from platform_order_ingestion routers
- update platform order ingestion API tests for the independent page permission contract
- add explicit permission contract tests

## Validation

- python3 -m compileall app/platform_order_ingestion tests/api/test_platform_order_ingestion_permission_contract.py
- make test TESTS="tests/api/test_platform_order_ingestion_permission_contract.py tests/api/test_platform_order_ingestion_store_status_contract.py tests/api/test_platform_order_ingestion_unified_mock_contract.py tests/api/test_platform_order_pull_jobs_contract.py tests/api/test_pdd_app_config_contract.py tests/api/test_pdd_connection_and_pull_contract.py tests/api/test_pdd_real_ingest_contract.py tests/api/test_pdd_real_pull_contract.py tests/api/test_jd_app_config_contract.py tests/api/test_jd_connection_contract.py tests/api/test_jd_orders_contract.py tests/api/test_jd_real_ingest_contract.py tests/api/test_taobao_app_config_contract.py tests/api/test_taobao_real_ingest_contract.py"
- rg scan confirmed no legacy config.store / operations.outbound permission literals remain under app/platform_order_ingestion