### PR TITLE
fix(oms): remove retired pdd fact bridge import

### DIFF
--- a/app/oms/order_facts/router.py
+++ b/app/oms/order_facts/router.py
@@ -4,4 +4,4 @@ from fastapi import APIRouter
 router = APIRouter()
 
 # Collector 分离后，OMS 不再保留旧平台采集事实桥接。
-# 后续 Collector -> OMS 导入合同落地后，再在本模块下挂接新的平台订单镜像 / 履约订单转化路由。
+# 后续 Collector -> OMS 导入合同落地后，再在本模块挂接新的平台订单镜像 / 履约订单转化路由。


### PR DESCRIPTION
## Summary
- remove stale import of retired PDD fact bridge from OMS order facts router
- keep OMS order facts router mounted as an empty extension point for future Collector -> OMS contracts

## Verification
- python3 -m compileall app/oms/order_facts/router.py app/main.py
- app import check passed
- runtime old platform ingestion route check passed
- targeted tests passed
