### PR TITLE
feat(oms): add platform order mirror tables and APIs

### DIFF
--- a/alembic/versions/202604281620_oms_platform_order_mirrors.py
+++ b/alembic/versions/202604281620_oms_platform_order_mirrors.py
@@ -1,0 +1,131 @@
+"""oms_platform_order_mirrors
+
+Revision ID: 202604281620
+Revises: 202604281430
+Create Date: 2026-04-28 16:20:00.000000
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "202604281620"
+down_revision: Union[str, Sequence[str], None] = "202604281430"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _create_platform_tables(platform: str) -> None:
+    op.execute(
+        f"""
+        CREATE TABLE oms_{platform}_order_mirrors (
+          id BIGSERIAL PRIMARY KEY,
+
+          collector_order_id BIGINT NOT NULL,
+          collector_store_id BIGINT NOT NULL,
+          collector_store_code VARCHAR(128) NOT NULL,
+          collector_store_name VARCHAR(255) NOT NULL,
+
+          wms_store_id BIGINT NULL REFERENCES stores(id) ON DELETE SET NULL,
+
+          platform_order_no VARCHAR(128) NOT NULL,
+          platform_status VARCHAR(64) NULL,
+
+          import_status VARCHAR(32) NOT NULL DEFAULT 'imported',
+          mirror_status VARCHAR(32) NOT NULL DEFAULT 'active',
+
+          source_updated_at TIMESTAMPTZ NULL,
+          pulled_at TIMESTAMPTZ NULL,
+          collector_last_synced_at TIMESTAMPTZ NULL,
+
+          receiver_json JSONB NOT NULL DEFAULT '{{}}'::jsonb,
+          amounts_json JSONB NOT NULL DEFAULT '{{}}'::jsonb,
+          platform_fields_json JSONB NOT NULL DEFAULT '{{}}'::jsonb,
+          raw_refs_json JSONB NOT NULL DEFAULT '{{}}'::jsonb,
+
+          imported_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+          last_synced_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+          created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+          updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+          CONSTRAINT uq_oms_{platform}_order_mirrors_collector_order
+            UNIQUE (collector_order_id),
+          CONSTRAINT uq_oms_{platform}_order_mirrors_collector_store_order
+            UNIQUE (collector_store_id, platform_order_no),
+          CONSTRAINT ck_oms_{platform}_order_mirrors_import_status
+            CHECK (import_status IN ('imported', 'rejected', 'superseded')),
+          CONSTRAINT ck_oms_{platform}_order_mirrors_mirror_status
+            CHECK (mirror_status IN ('active', 'archived'))
+        )
+        """
+    )
+
+    op.execute(
+        f"""
+        CREATE TABLE oms_{platform}_order_mirror_lines (
+          id BIGSERIAL PRIMARY KEY,
+
+          mirror_id BIGINT NOT NULL REFERENCES oms_{platform}_order_mirrors(id) ON DELETE CASCADE,
+          collector_line_id BIGINT NOT NULL,
+          collector_order_id BIGINT NOT NULL,
+          platform_order_no VARCHAR(128) NOT NULL,
+
+          merchant_sku VARCHAR(128) NULL,
+          platform_item_id VARCHAR(128) NULL,
+          platform_sku_id VARCHAR(128) NULL,
+          title VARCHAR(255) NULL,
+
+          quantity NUMERIC(14, 4) NOT NULL DEFAULT 0,
+          unit_price NUMERIC(14, 2) NULL,
+          line_amount NUMERIC(14, 2) NULL,
+
+          platform_fields_json JSONB NOT NULL DEFAULT '{{}}'::jsonb,
+          raw_item_payload_json JSONB NULL,
+
+          created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+          updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+          CONSTRAINT uq_oms_{platform}_order_mirror_lines_line
+            UNIQUE (mirror_id, collector_line_id)
+        )
+        """
+    )
+
+    op.execute(
+        f"CREATE INDEX ix_oms_{platform}_order_mirrors_order_no "
+        f"ON oms_{platform}_order_mirrors(platform_order_no)"
+    )
+    op.execute(
+        f"CREATE INDEX ix_oms_{platform}_order_mirrors_status "
+        f"ON oms_{platform}_order_mirrors(platform_status)"
+    )
+    op.execute(
+        f"CREATE INDEX ix_oms_{platform}_order_mirrors_wms_store "
+        f"ON oms_{platform}_order_mirrors(wms_store_id)"
+    )
+    op.execute(
+        f"CREATE INDEX ix_oms_{platform}_order_mirror_lines_mirror "
+        f"ON oms_{platform}_order_mirror_lines(mirror_id)"
+    )
+    op.execute(
+        f"CREATE INDEX ix_oms_{platform}_order_mirror_lines_merchant_sku "
+        f"ON oms_{platform}_order_mirror_lines(merchant_sku)"
+    )
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+
+    for platform in ("pdd", "taobao", "jd"):
+        _create_platform_tables(platform)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+
+    for platform in ("jd", "taobao", "pdd"):
+        op.execute(f"DROP TABLE IF EXISTS oms_{platform}_order_mirror_lines")
+        op.execute(f"DROP TABLE IF EXISTS oms_{platform}_order_mirrors")

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -124,6 +124,7 @@ def init_models(
         "app.oms.orders.models.order_logistics",
         "app.oms.orders.models.order_fulfillment",
         "app.oms.stores.models.store",
+        "app.oms.order_facts.models.platform_order_mirror",
         "app.wms.warehouses.models.warehouse",
     ]
     for mod in [m for m in explicit_chain if m and m not in ex]:
@@ -142,6 +143,7 @@ def init_models(
         "app.shipping_assist.records.models",
         "app.shipping_assist.billing.models",
         "app.oms.fsku.models",
+        "app.oms.order_facts.models",
         "app.shipping_assist.pricing.templates.models",
         "app.shipping_assist.providers.models",
         "app.shipping_assist.shipment.models",

--- a/app/oms/order_facts/contracts/__init__.py
+++ b/app/oms/order_facts/contracts/__init__.py
@@ -1,0 +1,1 @@
+# Contracts for OMS order facts.

--- a/app/oms/order_facts/contracts/platform_order_mirror.py
+++ b/app/oms/order_facts/contracts/platform_order_mirror.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+OmsMirrorPlatform = Literal["pdd", "taobao", "jd"]
+
+
+class PlatformOrderMirrorLineImportIn(BaseModel):
+    collector_line_id: int = Field(..., ge=1)
+    collector_order_id: int = Field(..., ge=1)
+    platform_order_no: str = Field(..., min_length=1, max_length=128)
+
+    merchant_sku: Optional[str] = Field(None, max_length=128)
+    platform_item_id: Optional[str] = Field(None, max_length=128)
+    platform_sku_id: Optional[str] = Field(None, max_length=128)
+    title: Optional[str] = Field(None, max_length=255)
+
+    quantity: Decimal = Decimal("0")
+    unit_price: Optional[Decimal] = None
+    line_amount: Optional[Decimal] = None
+
+    platform_fields: dict[str, Any] = Field(default_factory=dict)
+    raw_item_payload: Any = None
+
+
+class PlatformOrderMirrorImportIn(BaseModel):
+    collector_order_id: int = Field(..., ge=1)
+    collector_store_id: int = Field(..., ge=1)
+    collector_store_code: str = Field(..., min_length=1, max_length=128)
+    collector_store_name: str = Field(..., min_length=1, max_length=255)
+
+    platform: OmsMirrorPlatform
+    platform_order_no: str = Field(..., min_length=1, max_length=128)
+    platform_status: Optional[str] = Field(None, max_length=64)
+
+    source_updated_at: Optional[str] = None
+    pulled_at: Optional[str] = None
+    last_synced_at: Optional[str] = None
+
+    receiver: dict[str, Any] = Field(default_factory=dict)
+    amounts: dict[str, Any] = Field(default_factory=dict)
+    platform_fields: dict[str, Any] = Field(default_factory=dict)
+    raw_refs: dict[str, Any] = Field(default_factory=dict)
+
+    lines: list[PlatformOrderMirrorLineImportIn] = Field(default_factory=list)
+
+
+class PlatformOrderMirrorLineOut(BaseModel):
+    id: int
+    collector_line_id: int
+    collector_order_id: int
+    platform_order_no: str
+
+    merchant_sku: Optional[str] = None
+    platform_item_id: Optional[str] = None
+    platform_sku_id: Optional[str] = None
+    title: Optional[str] = None
+
+    quantity: str
+    unit_price: Optional[str] = None
+    line_amount: Optional[str] = None
+
+    platform_fields: dict[str, Any] = Field(default_factory=dict)
+    raw_item_payload: Any = None
+
+
+class PlatformOrderMirrorOut(BaseModel):
+    id: int
+    collector_order_id: int
+    collector_store_id: int
+    collector_store_code: str
+    collector_store_name: str
+
+    wms_store_id: Optional[int] = None
+
+    platform: OmsMirrorPlatform
+    platform_order_no: str
+    platform_status: Optional[str] = None
+
+    import_status: str
+    mirror_status: str
+
+    source_updated_at: Optional[str] = None
+    pulled_at: Optional[str] = None
+    collector_last_synced_at: Optional[str] = None
+    imported_at: Optional[str] = None
+    last_synced_at: Optional[str] = None
+
+    receiver: dict[str, Any] = Field(default_factory=dict)
+    amounts: dict[str, Any] = Field(default_factory=dict)
+    platform_fields: dict[str, Any] = Field(default_factory=dict)
+    raw_refs: dict[str, Any] = Field(default_factory=dict)
+
+    lines: list[PlatformOrderMirrorLineOut] = Field(default_factory=list)
+
+
+class PlatformOrderMirrorListOut(BaseModel):
+    ok: bool = True
+    data: list[PlatformOrderMirrorOut]
+
+
+class PlatformOrderMirrorEnvelopeOut(BaseModel):
+    ok: bool = True
+    data: PlatformOrderMirrorOut

--- a/app/oms/order_facts/models/__init__.py
+++ b/app/oms/order_facts/models/__init__.py
@@ -1,0 +1,1 @@
+# Domain-owned ORM models for OMS order facts.

--- a/app/oms/order_facts/models/platform_order_mirror.py
+++ b/app/oms/order_facts/models/platform_order_mirror.py
@@ -1,0 +1,194 @@
+# app/oms/order_facts/models/platform_order_mirror.py
+# Domain model: OMS-owned platform order mirrors imported from Collector export contracts.
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class _MirrorMixin:
+    id: Mapped[int] = mapped_column(sa.BigInteger, primary_key=True, autoincrement=True)
+
+    collector_order_id: Mapped[int] = mapped_column(sa.BigInteger, nullable=False)
+    collector_store_id: Mapped[int] = mapped_column(sa.BigInteger, nullable=False)
+    collector_store_code: Mapped[str] = mapped_column(sa.String(128), nullable=False)
+    collector_store_name: Mapped[str] = mapped_column(sa.String(255), nullable=False)
+
+    wms_store_id: Mapped[int | None] = mapped_column(
+        sa.BigInteger,
+        sa.ForeignKey("stores.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    platform_order_no: Mapped[str] = mapped_column(sa.String(128), nullable=False)
+    platform_status: Mapped[str | None] = mapped_column(sa.String(64), nullable=True)
+
+    import_status: Mapped[str] = mapped_column(sa.String(32), nullable=False, server_default="imported")
+    mirror_status: Mapped[str] = mapped_column(sa.String(32), nullable=False, server_default="active")
+
+    source_updated_at: Mapped[datetime | None] = mapped_column(sa.DateTime(timezone=True), nullable=True)
+    pulled_at: Mapped[datetime | None] = mapped_column(sa.DateTime(timezone=True), nullable=True)
+    collector_last_synced_at: Mapped[datetime | None] = mapped_column(sa.DateTime(timezone=True), nullable=True)
+
+    receiver_json: Mapped[dict] = mapped_column(JSONB, nullable=False, server_default=sa.text("'{}'::jsonb"))
+    amounts_json: Mapped[dict] = mapped_column(JSONB, nullable=False, server_default=sa.text("'{}'::jsonb"))
+    platform_fields_json: Mapped[dict] = mapped_column(JSONB, nullable=False, server_default=sa.text("'{}'::jsonb"))
+    raw_refs_json: Mapped[dict] = mapped_column(JSONB, nullable=False, server_default=sa.text("'{}'::jsonb"))
+
+    imported_at: Mapped[datetime] = mapped_column(sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now())
+    last_synced_at: Mapped[datetime] = mapped_column(sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now())
+    created_at: Mapped[datetime] = mapped_column(sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+        onupdate=sa.func.now(),
+    )
+
+
+class _MirrorLineMixin:
+    id: Mapped[int] = mapped_column(sa.BigInteger, primary_key=True, autoincrement=True)
+
+    collector_line_id: Mapped[int] = mapped_column(sa.BigInteger, nullable=False)
+    collector_order_id: Mapped[int] = mapped_column(sa.BigInteger, nullable=False)
+    platform_order_no: Mapped[str] = mapped_column(sa.String(128), nullable=False)
+
+    merchant_sku: Mapped[str | None] = mapped_column(sa.String(128), nullable=True)
+    platform_item_id: Mapped[str | None] = mapped_column(sa.String(128), nullable=True)
+    platform_sku_id: Mapped[str | None] = mapped_column(sa.String(128), nullable=True)
+    title: Mapped[str | None] = mapped_column(sa.String(255), nullable=True)
+
+    quantity: Mapped[Decimal] = mapped_column(sa.Numeric(14, 4), nullable=False, server_default="0")
+    unit_price: Mapped[Decimal | None] = mapped_column(sa.Numeric(14, 2), nullable=True)
+    line_amount: Mapped[Decimal | None] = mapped_column(sa.Numeric(14, 2), nullable=True)
+
+    platform_fields_json: Mapped[dict] = mapped_column(JSONB, nullable=False, server_default=sa.text("'{}'::jsonb"))
+    raw_item_payload_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+        onupdate=sa.func.now(),
+    )
+
+
+class OmsPddOrderMirror(_MirrorMixin, Base):
+    __tablename__ = "oms_pdd_order_mirrors"
+    __table_args__ = (
+        sa.UniqueConstraint("collector_order_id", name="uq_oms_pdd_order_mirrors_collector_order"),
+        sa.UniqueConstraint(
+            "collector_store_id",
+            "platform_order_no",
+            name="uq_oms_pdd_order_mirrors_collector_store_order",
+        ),
+        sa.CheckConstraint(
+            "import_status IN ('imported', 'rejected', 'superseded')",
+            name="ck_oms_pdd_order_mirrors_import_status",
+        ),
+        sa.CheckConstraint(
+            "mirror_status IN ('active', 'archived')",
+            name="ck_oms_pdd_order_mirrors_mirror_status",
+        ),
+        sa.Index("ix_oms_pdd_order_mirrors_order_no", "platform_order_no"),
+        sa.Index("ix_oms_pdd_order_mirrors_status", "platform_status"),
+        sa.Index("ix_oms_pdd_order_mirrors_wms_store", "wms_store_id"),
+    )
+
+
+class OmsPddOrderMirrorLine(_MirrorLineMixin, Base):
+    __tablename__ = "oms_pdd_order_mirror_lines"
+    __table_args__ = (
+        sa.UniqueConstraint("mirror_id", "collector_line_id", name="uq_oms_pdd_order_mirror_lines_line"),
+        sa.Index("ix_oms_pdd_order_mirror_lines_mirror", "mirror_id"),
+        sa.Index("ix_oms_pdd_order_mirror_lines_merchant_sku", "merchant_sku"),
+    )
+
+    mirror_id: Mapped[int] = mapped_column(
+        sa.BigInteger,
+        sa.ForeignKey("oms_pdd_order_mirrors.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+
+class OmsTaobaoOrderMirror(_MirrorMixin, Base):
+    __tablename__ = "oms_taobao_order_mirrors"
+    __table_args__ = (
+        sa.UniqueConstraint("collector_order_id", name="uq_oms_taobao_order_mirrors_collector_order"),
+        sa.UniqueConstraint(
+            "collector_store_id",
+            "platform_order_no",
+            name="uq_oms_taobao_order_mirrors_collector_store_order",
+        ),
+        sa.CheckConstraint(
+            "import_status IN ('imported', 'rejected', 'superseded')",
+            name="ck_oms_taobao_order_mirrors_import_status",
+        ),
+        sa.CheckConstraint(
+            "mirror_status IN ('active', 'archived')",
+            name="ck_oms_taobao_order_mirrors_mirror_status",
+        ),
+        sa.Index("ix_oms_taobao_order_mirrors_order_no", "platform_order_no"),
+        sa.Index("ix_oms_taobao_order_mirrors_status", "platform_status"),
+        sa.Index("ix_oms_taobao_order_mirrors_wms_store", "wms_store_id"),
+    )
+
+
+class OmsTaobaoOrderMirrorLine(_MirrorLineMixin, Base):
+    __tablename__ = "oms_taobao_order_mirror_lines"
+    __table_args__ = (
+        sa.UniqueConstraint("mirror_id", "collector_line_id", name="uq_oms_taobao_order_mirror_lines_line"),
+        sa.Index("ix_oms_taobao_order_mirror_lines_mirror", "mirror_id"),
+        sa.Index("ix_oms_taobao_order_mirror_lines_merchant_sku", "merchant_sku"),
+    )
+
+    mirror_id: Mapped[int] = mapped_column(
+        sa.BigInteger,
+        sa.ForeignKey("oms_taobao_order_mirrors.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+
+class OmsJdOrderMirror(_MirrorMixin, Base):
+    __tablename__ = "oms_jd_order_mirrors"
+    __table_args__ = (
+        sa.UniqueConstraint("collector_order_id", name="uq_oms_jd_order_mirrors_collector_order"),
+        sa.UniqueConstraint(
+            "collector_store_id",
+            "platform_order_no",
+            name="uq_oms_jd_order_mirrors_collector_store_order",
+        ),
+        sa.CheckConstraint(
+            "import_status IN ('imported', 'rejected', 'superseded')",
+            name="ck_oms_jd_order_mirrors_import_status",
+        ),
+        sa.CheckConstraint(
+            "mirror_status IN ('active', 'archived')",
+            name="ck_oms_jd_order_mirrors_mirror_status",
+        ),
+        sa.Index("ix_oms_jd_order_mirrors_order_no", "platform_order_no"),
+        sa.Index("ix_oms_jd_order_mirrors_status", "platform_status"),
+        sa.Index("ix_oms_jd_order_mirrors_wms_store", "wms_store_id"),
+    )
+
+
+class OmsJdOrderMirrorLine(_MirrorLineMixin, Base):
+    __tablename__ = "oms_jd_order_mirror_lines"
+    __table_args__ = (
+        sa.UniqueConstraint("mirror_id", "collector_line_id", name="uq_oms_jd_order_mirror_lines_line"),
+        sa.Index("ix_oms_jd_order_mirror_lines_mirror", "mirror_id"),
+        sa.Index("ix_oms_jd_order_mirror_lines_merchant_sku", "merchant_sku"),
+    )
+
+    mirror_id: Mapped[int] = mapped_column(
+        sa.BigInteger,
+        sa.ForeignKey("oms_jd_order_mirrors.id", ondelete="CASCADE"),
+        nullable=False,
+    )

--- a/app/oms/order_facts/router.py
+++ b/app/oms/order_facts/router.py
@@ -1,7 +1,12 @@
 from fastapi import APIRouter
 
+from app.oms.order_facts.router_platform_order_mirrors import (
+    router as platform_order_mirrors_router,
+)
+
 
 router = APIRouter()
 
 # Collector 分离后，OMS 不再保留旧平台采集事实桥接。
-# 后续 Collector -> OMS 导入合同落地后，再在本模块挂接新的平台订单镜像 / 履约订单转化路由。
+# 当前模块承载 OMS 自有的平台订单镜像与后续履约订单转化入口。
+router.include_router(platform_order_mirrors_router)

--- a/app/oms/order_facts/router_platform_order_mirrors.py
+++ b/app/oms/order_facts/router_platform_order_mirrors.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.deps import get_async_session
+from app.oms.order_facts.contracts.platform_order_mirror import (
+    PlatformOrderMirrorEnvelopeOut,
+    PlatformOrderMirrorImportIn,
+    PlatformOrderMirrorListOut,
+)
+from app.oms.order_facts.services.platform_order_mirror_service import (
+    get_platform_order_mirror_detail,
+    list_platform_order_mirrors,
+    upsert_platform_order_mirror,
+)
+
+
+router = APIRouter(tags=["oms-platform-order-mirrors"])
+
+
+def _register_platform_routes(platform: str) -> None:
+    @router.post(
+        f"/{platform}/platform-order-mirrors/import",
+        response_model=PlatformOrderMirrorEnvelopeOut,
+    )
+    async def import_platform_order_mirror(
+        payload: PlatformOrderMirrorImportIn = Body(...),
+        session: AsyncSession = Depends(get_async_session),
+    ) -> PlatformOrderMirrorEnvelopeOut:
+        try:
+            data = await upsert_platform_order_mirror(
+                session,
+                platform=platform,
+                payload=payload,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+        return PlatformOrderMirrorEnvelopeOut(ok=True, data=data)
+
+    @router.get(
+        f"/{platform}/platform-order-mirrors",
+        response_model=PlatformOrderMirrorListOut,
+    )
+    async def list_platform_order_mirror_rows(
+        limit: int = Query(200, ge=1, le=1000),
+        offset: int = Query(0, ge=0),
+        session: AsyncSession = Depends(get_async_session),
+    ) -> PlatformOrderMirrorListOut:
+        rows = await list_platform_order_mirrors(
+            session,
+            platform=platform,
+            limit=limit,
+            offset=offset,
+        )
+        return PlatformOrderMirrorListOut(ok=True, data=rows)
+
+    @router.get(
+        f"/{platform}/platform-order-mirrors/{{mirror_id}}",
+        response_model=PlatformOrderMirrorEnvelopeOut,
+    )
+    async def get_platform_order_mirror_row(
+        mirror_id: int = Path(..., ge=1),
+        session: AsyncSession = Depends(get_async_session),
+    ) -> PlatformOrderMirrorEnvelopeOut:
+        data = await get_platform_order_mirror_detail(
+            session,
+            platform=platform,
+            mirror_id=mirror_id,
+        )
+        if data is None:
+            raise HTTPException(status_code=404, detail=f"{platform} platform order mirror not found")
+        return PlatformOrderMirrorEnvelopeOut(ok=True, data=data)
+
+
+for _platform in ("pdd", "taobao", "jd"):
+    _register_platform_routes(_platform)

--- a/app/oms/order_facts/services/__init__.py
+++ b/app/oms/order_facts/services/__init__.py
@@ -1,0 +1,1 @@
+# Services for OMS order facts.

--- a/app/oms/order_facts/services/platform_order_mirror_service.py
+++ b/app/oms/order_facts/services/platform_order_mirror_service.py
@@ -1,0 +1,459 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Mapping
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.oms.order_facts.contracts.platform_order_mirror import (
+    PlatformOrderMirrorImportIn,
+    PlatformOrderMirrorLineOut,
+    PlatformOrderMirrorOut,
+)
+
+
+_PLATFORM_TABLES = {
+    "pdd": ("oms_pdd_order_mirrors", "oms_pdd_order_mirror_lines"),
+    "taobao": ("oms_taobao_order_mirrors", "oms_taobao_order_mirror_lines"),
+    "jd": ("oms_jd_order_mirrors", "oms_jd_order_mirror_lines"),
+}
+
+
+def _tables(platform: str) -> tuple[str, str]:
+    key = (platform or "").strip().lower()
+    if key not in _PLATFORM_TABLES:
+        raise ValueError(f"unsupported platform: {platform!r}")
+    return _PLATFORM_TABLES[key]
+
+
+def _dt(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    text_value = str(value).strip()
+    if not text_value:
+        return None
+
+    try:
+        normalized = text_value.replace("Z", "+00:00")
+        return datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+
+
+def _json(value: Any) -> str:
+    if value is None:
+        value = {}
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
+def _fmt_dt(value: Any) -> str | None:
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
+def _fmt_dec(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _row_dict(row: Mapping[str, Any]) -> dict[str, Any]:
+    return dict(row)
+
+
+async def _resolve_wms_store_id(
+    session: AsyncSession,
+    *,
+    platform: str,
+    collector_store_code: str,
+) -> int | None:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT id
+                  FROM stores
+                 WHERE lower(platform) = :platform
+                   AND store_code = :store_code
+                 LIMIT 1
+                """
+            ),
+            {
+                "platform": platform.lower(),
+                "store_code": str(collector_store_code),
+            },
+        )
+    ).mappings().first()
+
+    if row is None or row.get("id") is None:
+        return None
+    return int(row["id"])
+
+
+async def upsert_platform_order_mirror(
+    session: AsyncSession,
+    *,
+    platform: str,
+    payload: PlatformOrderMirrorImportIn,
+) -> PlatformOrderMirrorOut:
+    plat = platform.strip().lower()
+    if payload.platform != plat:
+        raise ValueError(f"payload platform mismatch: path={plat} payload={payload.platform}")
+
+    header_table, line_table = _tables(plat)
+
+    wms_store_id = await _resolve_wms_store_id(
+        session,
+        platform=plat,
+        collector_store_code=payload.collector_store_code,
+    )
+
+    header = (
+        await session.execute(
+            text(
+                f"""
+                INSERT INTO {header_table} (
+                  collector_order_id,
+                  collector_store_id,
+                  collector_store_code,
+                  collector_store_name,
+                  wms_store_id,
+                  platform_order_no,
+                  platform_status,
+                  import_status,
+                  mirror_status,
+                  source_updated_at,
+                  pulled_at,
+                  collector_last_synced_at,
+                  receiver_json,
+                  amounts_json,
+                  platform_fields_json,
+                  raw_refs_json,
+                  imported_at,
+                  last_synced_at,
+                  updated_at
+                )
+                VALUES (
+                  :collector_order_id,
+                  :collector_store_id,
+                  :collector_store_code,
+                  :collector_store_name,
+                  :wms_store_id,
+                  :platform_order_no,
+                  :platform_status,
+                  'imported',
+                  'active',
+                  :source_updated_at,
+                  :pulled_at,
+                  :collector_last_synced_at,
+                  CAST(:receiver_json AS jsonb),
+                  CAST(:amounts_json AS jsonb),
+                  CAST(:platform_fields_json AS jsonb),
+                  CAST(:raw_refs_json AS jsonb),
+                  now(),
+                  now(),
+                  now()
+                )
+                ON CONFLICT (collector_order_id) DO UPDATE
+                SET
+                  collector_store_id = EXCLUDED.collector_store_id,
+                  collector_store_code = EXCLUDED.collector_store_code,
+                  collector_store_name = EXCLUDED.collector_store_name,
+                  wms_store_id = EXCLUDED.wms_store_id,
+                  platform_order_no = EXCLUDED.platform_order_no,
+                  platform_status = EXCLUDED.platform_status,
+                  import_status = 'imported',
+                  mirror_status = 'active',
+                  source_updated_at = EXCLUDED.source_updated_at,
+                  pulled_at = EXCLUDED.pulled_at,
+                  collector_last_synced_at = EXCLUDED.collector_last_synced_at,
+                  receiver_json = EXCLUDED.receiver_json,
+                  amounts_json = EXCLUDED.amounts_json,
+                  platform_fields_json = EXCLUDED.platform_fields_json,
+                  raw_refs_json = EXCLUDED.raw_refs_json,
+                  last_synced_at = now(),
+                  updated_at = now()
+                RETURNING
+                  id,
+                  collector_order_id,
+                  collector_store_id,
+                  collector_store_code,
+                  collector_store_name,
+                  wms_store_id,
+                  platform_order_no,
+                  platform_status,
+                  import_status,
+                  mirror_status,
+                  source_updated_at,
+                  pulled_at,
+                  collector_last_synced_at,
+                  imported_at,
+                  last_synced_at,
+                  receiver_json,
+                  amounts_json,
+                  platform_fields_json,
+                  raw_refs_json
+                """
+            ),
+            {
+                "collector_order_id": int(payload.collector_order_id),
+                "collector_store_id": int(payload.collector_store_id),
+                "collector_store_code": str(payload.collector_store_code),
+                "collector_store_name": str(payload.collector_store_name),
+                "wms_store_id": wms_store_id,
+                "platform_order_no": str(payload.platform_order_no),
+                "platform_status": payload.platform_status,
+                "source_updated_at": _dt(payload.source_updated_at),
+                "pulled_at": _dt(payload.pulled_at),
+                "collector_last_synced_at": _dt(payload.last_synced_at),
+                "receiver_json": _json(payload.receiver),
+                "amounts_json": _json(payload.amounts),
+                "platform_fields_json": _json(payload.platform_fields),
+                "raw_refs_json": _json(payload.raw_refs),
+            },
+        )
+    ).mappings().one()
+
+    mirror_id = int(header["id"])
+
+    await session.execute(
+        text(f"DELETE FROM {line_table} WHERE mirror_id = :mirror_id"),
+        {"mirror_id": mirror_id},
+    )
+
+    for line in payload.lines:
+        await session.execute(
+            text(
+                f"""
+                INSERT INTO {line_table} (
+                  mirror_id,
+                  collector_line_id,
+                  collector_order_id,
+                  platform_order_no,
+                  merchant_sku,
+                  platform_item_id,
+                  platform_sku_id,
+                  title,
+                  quantity,
+                  unit_price,
+                  line_amount,
+                  platform_fields_json,
+                  raw_item_payload_json,
+                  updated_at
+                )
+                VALUES (
+                  :mirror_id,
+                  :collector_line_id,
+                  :collector_order_id,
+                  :platform_order_no,
+                  :merchant_sku,
+                  :platform_item_id,
+                  :platform_sku_id,
+                  :title,
+                  :quantity,
+                  :unit_price,
+                  :line_amount,
+                  CAST(:platform_fields_json AS jsonb),
+                  CAST(:raw_item_payload_json AS jsonb),
+                  now()
+                )
+                """
+            ),
+            {
+                "mirror_id": mirror_id,
+                "collector_line_id": int(line.collector_line_id),
+                "collector_order_id": int(line.collector_order_id),
+                "platform_order_no": str(line.platform_order_no),
+                "merchant_sku": line.merchant_sku,
+                "platform_item_id": line.platform_item_id,
+                "platform_sku_id": line.platform_sku_id,
+                "title": line.title,
+                "quantity": Decimal(line.quantity),
+                "unit_price": line.unit_price,
+                "line_amount": line.line_amount,
+                "platform_fields_json": _json(line.platform_fields),
+                "raw_item_payload_json": _json(line.raw_item_payload),
+            },
+        )
+
+    await session.commit()
+
+    out = await get_platform_order_mirror_detail(session, platform=plat, mirror_id=mirror_id)
+    if out is None:
+        raise RuntimeError(f"mirror not found after upsert: platform={plat} id={mirror_id}")
+    return out
+
+
+async def list_platform_order_mirrors(
+    session: AsyncSession,
+    *,
+    platform: str,
+    limit: int,
+    offset: int,
+) -> list[PlatformOrderMirrorOut]:
+    header_table, _line_table = _tables(platform)
+
+    rows = (
+        await session.execute(
+            text(
+                f"""
+                SELECT
+                  id,
+                  collector_order_id,
+                  collector_store_id,
+                  collector_store_code,
+                  collector_store_name,
+                  wms_store_id,
+                  platform_order_no,
+                  platform_status,
+                  import_status,
+                  mirror_status,
+                  source_updated_at,
+                  pulled_at,
+                  collector_last_synced_at,
+                  imported_at,
+                  last_synced_at,
+                  receiver_json,
+                  amounts_json,
+                  platform_fields_json,
+                  raw_refs_json
+                FROM {header_table}
+                ORDER BY last_synced_at DESC, id DESC
+                LIMIT :limit OFFSET :offset
+                """
+            ),
+            {"limit": int(limit), "offset": int(offset)},
+        )
+    ).mappings().all()
+
+    return [_mirror_out(platform=platform, row=_row_dict(row), lines=[]) for row in rows]
+
+
+async def get_platform_order_mirror_detail(
+    session: AsyncSession,
+    *,
+    platform: str,
+    mirror_id: int,
+) -> PlatformOrderMirrorOut | None:
+    header_table, line_table = _tables(platform)
+
+    header = (
+        await session.execute(
+            text(
+                f"""
+                SELECT
+                  id,
+                  collector_order_id,
+                  collector_store_id,
+                  collector_store_code,
+                  collector_store_name,
+                  wms_store_id,
+                  platform_order_no,
+                  platform_status,
+                  import_status,
+                  mirror_status,
+                  source_updated_at,
+                  pulled_at,
+                  collector_last_synced_at,
+                  imported_at,
+                  last_synced_at,
+                  receiver_json,
+                  amounts_json,
+                  platform_fields_json,
+                  raw_refs_json
+                FROM {header_table}
+                WHERE id = :mirror_id
+                LIMIT 1
+                """
+            ),
+            {"mirror_id": int(mirror_id)},
+        )
+    ).mappings().first()
+
+    if header is None:
+        return None
+
+    line_rows = (
+        await session.execute(
+            text(
+                f"""
+                SELECT
+                  id,
+                  collector_line_id,
+                  collector_order_id,
+                  platform_order_no,
+                  merchant_sku,
+                  platform_item_id,
+                  platform_sku_id,
+                  title,
+                  quantity,
+                  unit_price,
+                  line_amount,
+                  platform_fields_json,
+                  raw_item_payload_json
+                FROM {line_table}
+                WHERE mirror_id = :mirror_id
+                ORDER BY id ASC
+                """
+            ),
+            {"mirror_id": int(mirror_id)},
+        )
+    ).mappings().all()
+
+    lines = [_line_out(_row_dict(line)) for line in line_rows]
+    return _mirror_out(platform=platform, row=_row_dict(header), lines=lines)
+
+
+def _mirror_out(
+    *,
+    platform: str,
+    row: Mapping[str, Any],
+    lines: list[PlatformOrderMirrorLineOut],
+) -> PlatformOrderMirrorOut:
+    return PlatformOrderMirrorOut(
+        id=int(row["id"]),
+        collector_order_id=int(row["collector_order_id"]),
+        collector_store_id=int(row["collector_store_id"]),
+        collector_store_code=str(row["collector_store_code"]),
+        collector_store_name=str(row["collector_store_name"]),
+        wms_store_id=int(row["wms_store_id"]) if row.get("wms_store_id") is not None else None,
+        platform=platform,  # type: ignore[arg-type]
+        platform_order_no=str(row["platform_order_no"]),
+        platform_status=row.get("platform_status"),
+        import_status=str(row["import_status"]),
+        mirror_status=str(row["mirror_status"]),
+        source_updated_at=_fmt_dt(row.get("source_updated_at")),
+        pulled_at=_fmt_dt(row.get("pulled_at")),
+        collector_last_synced_at=_fmt_dt(row.get("collector_last_synced_at")),
+        imported_at=_fmt_dt(row.get("imported_at")),
+        last_synced_at=_fmt_dt(row.get("last_synced_at")),
+        receiver=row.get("receiver_json") or {},
+        amounts=row.get("amounts_json") or {},
+        platform_fields=row.get("platform_fields_json") or {},
+        raw_refs=row.get("raw_refs_json") or {},
+        lines=lines,
+    )
+
+
+def _line_out(row: Mapping[str, Any]) -> PlatformOrderMirrorLineOut:
+    return PlatformOrderMirrorLineOut(
+        id=int(row["id"]),
+        collector_line_id=int(row["collector_line_id"]),
+        collector_order_id=int(row["collector_order_id"]),
+        platform_order_no=str(row["platform_order_no"]),
+        merchant_sku=row.get("merchant_sku"),
+        platform_item_id=row.get("platform_item_id"),
+        platform_sku_id=row.get("platform_sku_id"),
+        title=row.get("title"),
+        quantity=str(row.get("quantity") or "0"),
+        unit_price=_fmt_dec(row.get("unit_price")),
+        line_amount=_fmt_dec(row.get("line_amount")),
+        platform_fields=row.get("platform_fields_json") or {},
+        raw_item_payload=row.get("raw_item_payload_json"),
+    )

--- a/tests/api/test_oms_platform_order_mirrors_api.py
+++ b/tests/api/test_oms_platform_order_mirrors_api.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _clear_mirrors(session) -> None:
+    await session.execute(text("DELETE FROM oms_pdd_order_mirror_lines"))
+    await session.execute(text("DELETE FROM oms_taobao_order_mirror_lines"))
+    await session.execute(text("DELETE FROM oms_jd_order_mirror_lines"))
+    await session.execute(text("DELETE FROM oms_pdd_order_mirrors"))
+    await session.execute(text("DELETE FROM oms_taobao_order_mirrors"))
+    await session.execute(text("DELETE FROM oms_jd_order_mirrors"))
+    await session.commit()
+
+
+async def _ensure_store(session, *, platform: str, store_code: str, store_name: str) -> int:
+    row = (
+        await session.execute(
+            text(
+                """
+                INSERT INTO stores (
+                  platform,
+                  store_code,
+                  store_name,
+                  active
+                )
+                VALUES (
+                  :platform,
+                  :store_code,
+                  :store_name,
+                  true
+                )
+                ON CONFLICT (platform, store_code) DO UPDATE
+                SET
+                  store_name = EXCLUDED.store_name,
+                  active = EXCLUDED.active
+                RETURNING id
+                """
+            ),
+            {
+                "platform": platform,
+                "store_code": store_code,
+                "store_name": store_name,
+            },
+        )
+    ).mappings().one()
+    await session.commit()
+    return int(row["id"])
+
+
+def _payload(
+    *,
+    platform: str,
+    collector_order_id: int,
+    collector_line_id: int,
+    collector_store_code: str,
+    platform_order_no: str,
+    merchant_sku: str,
+) -> dict:
+    return {
+        "collector_order_id": collector_order_id,
+        "collector_store_id": collector_order_id + 1000,
+        "collector_store_code": collector_store_code,
+        "collector_store_name": f"{platform}-collector-store",
+        "platform": platform,
+        "platform_order_no": platform_order_no,
+        "platform_status": "WAIT_SELLER_SEND_GOODS",
+        "source_updated_at": "2026-04-28T08:00:00+00:00",
+        "pulled_at": "2026-04-28T08:01:00+00:00",
+        "last_synced_at": "2026-04-28T08:02:00+00:00",
+        "receiver": {
+            "name": "张三",
+            "phone": "13800138000",
+            "province": "浙江省",
+            "city": "杭州市",
+            "address": "文三路 1 号",
+        },
+        "amounts": {
+            "pay_amount": "86.00",
+        },
+        "platform_fields": {
+            "source": "collector-export-contract",
+        },
+        "raw_refs": {
+            "summary": {"platform_order_no": platform_order_no},
+        },
+        "lines": [
+            {
+                "collector_line_id": collector_line_id,
+                "collector_order_id": collector_order_id,
+                "platform_order_no": platform_order_no,
+                "merchant_sku": merchant_sku,
+                "platform_item_id": f"{platform}-ITEM-1",
+                "platform_sku_id": f"{platform}-SKU-1",
+                "title": f"{platform} 测试商品",
+                "quantity": "2",
+                "unit_price": "43.00",
+                "line_amount": "86.00",
+                "platform_fields": {
+                    "line_source": "collector-export-contract",
+                },
+                "raw_item_payload": {
+                    "merchant_sku": merchant_sku,
+                },
+            }
+        ],
+    }
+
+
+async def test_import_pdd_platform_order_mirror_is_idempotent(client, session) -> None:
+    await _clear_mirrors(session)
+
+    suffix = uuid4().hex[:8]
+    store_code = f"PDD-MIRROR-{suffix}"
+    wms_store_id = await _ensure_store(
+        session,
+        platform="pdd",
+        store_code=store_code,
+        store_name="PDD 镜像测试店铺",
+    )
+
+    payload = _payload(
+        platform="pdd",
+        collector_order_id=910001,
+        collector_line_id=920001,
+        collector_store_code=store_code,
+        platform_order_no=f"PDD-MIRROR-ORDER-{suffix}",
+        merchant_sku="PDD-FSKU-1",
+    )
+
+    first = await client.post("/oms/pdd/platform-order-mirrors/import", json=payload)
+    assert first.status_code == 200, first.text
+
+    body = first.json()
+    assert body["ok"] is True
+    data = body["data"]
+    assert data["platform"] == "pdd"
+    assert data["collector_order_id"] == 910001
+    assert data["wms_store_id"] == wms_store_id
+    assert data["platform_order_no"] == payload["platform_order_no"]
+    assert data["receiver"]["name"] == "张三"
+    assert data["amounts"]["pay_amount"] == "86.00"
+    assert len(data["lines"]) == 1
+    assert data["lines"][0]["merchant_sku"] == "PDD-FSKU-1"
+
+    mirror_id = int(data["id"])
+
+    payload["platform_status"] = "UPDATED"
+    payload["lines"][0]["title"] = "PDD 测试商品 - 已更新"
+
+    second = await client.post("/oms/pdd/platform-order-mirrors/import", json=payload)
+    assert second.status_code == 200, second.text
+    data2 = second.json()["data"]
+
+    assert int(data2["id"]) == mirror_id
+    assert data2["platform_status"] == "UPDATED"
+    assert len(data2["lines"]) == 1
+    assert data2["lines"][0]["title"] == "PDD 测试商品 - 已更新"
+
+    detail = await client.get(f"/oms/pdd/platform-order-mirrors/{mirror_id}")
+    assert detail.status_code == 200, detail.text
+    assert detail.json()["data"]["id"] == mirror_id
+
+    listing = await client.get("/oms/pdd/platform-order-mirrors")
+    assert listing.status_code == 200, listing.text
+    assert any(int(row["id"]) == mirror_id for row in listing.json()["data"])
+
+
+async def test_import_taobao_platform_order_mirror(client, session) -> None:
+    await _clear_mirrors(session)
+
+    suffix = uuid4().hex[:8]
+    store_code = f"TAOBAO-MIRROR-{suffix}"
+    await _ensure_store(
+        session,
+        platform="taobao",
+        store_code=store_code,
+        store_name="淘宝镜像测试店铺",
+    )
+
+    payload = _payload(
+        platform="taobao",
+        collector_order_id=910002,
+        collector_line_id=920002,
+        collector_store_code=store_code,
+        platform_order_no=f"TB-MIRROR-ORDER-{suffix}",
+        merchant_sku="TB-FSKU-1",
+    )
+
+    resp = await client.post("/oms/taobao/platform-order-mirrors/import", json=payload)
+    assert resp.status_code == 200, resp.text
+
+    data = resp.json()["data"]
+    assert data["platform"] == "taobao"
+    assert data["lines"][0]["merchant_sku"] == "TB-FSKU-1"
+
+
+async def test_import_jd_platform_order_mirror(client, session) -> None:
+    await _clear_mirrors(session)
+
+    suffix = uuid4().hex[:8]
+    store_code = f"JD-MIRROR-{suffix}"
+    await _ensure_store(
+        session,
+        platform="jd",
+        store_code=store_code,
+        store_name="京东镜像测试店铺",
+    )
+
+    payload = _payload(
+        platform="jd",
+        collector_order_id=910003,
+        collector_line_id=920003,
+        collector_store_code=store_code,
+        platform_order_no=f"JD-MIRROR-ORDER-{suffix}",
+        merchant_sku="JD-FSKU-1",
+    )
+
+    resp = await client.post("/oms/jd/platform-order-mirrors/import", json=payload)
+    assert resp.status_code == 200, resp.text
+
+    data = resp.json()["data"]
+    assert data["platform"] == "jd"
+    assert data["lines"][0]["merchant_sku"] == "JD-FSKU-1"
+
+
+async def test_import_rejects_path_payload_platform_mismatch(client, session) -> None:
+    await _clear_mirrors(session)
+
+    payload = _payload(
+        platform="taobao",
+        collector_order_id=910004,
+        collector_line_id=920004,
+        collector_store_code="MISMATCH-STORE",
+        platform_order_no="MISMATCH-ORDER",
+        merchant_sku="MISMATCH-FSKU",
+    )
+
+    resp = await client.post("/oms/pdd/platform-order-mirrors/import", json=payload)
+    assert resp.status_code == 422, resp.text
+    assert "payload platform mismatch" in resp.text


### PR DESCRIPTION
## Summary
- add OMS-owned platform order mirror tables for PDD / Taobao / JD
- add platform-separated mirror import/list/detail APIs
- register mirror ORM metadata
- keep Collector HTTP pull, 商品映射, and 履约订单转化 out of this PR

## Routes
- POST /oms/pdd/platform-order-mirrors/import
- GET /oms/pdd/platform-order-mirrors
- GET /oms/pdd/platform-order-mirrors/{mirror_id}
- POST /oms/taobao/platform-order-mirrors/import
- GET /oms/taobao/platform-order-mirrors
- GET /oms/taobao/platform-order-mirrors/{mirror_id}
- POST /oms/jd/platform-order-mirrors/import
- GET /oms/jd/platform-order-mirrors
- GET /oms/jd/platform-order-mirrors/{mirror_id}

## Verification
- python3 -m compileall app/oms/order_facts/contracts app/oms/order_facts/services app/oms/order_facts/router.py app/oms/order_facts/router_platform_order_mirrors.py tests/api/test_oms_platform_order_mirrors_api.py
- make test TESTS=tests/api/test_oms_platform_order_mirrors_api.py
- make upgrade-dev
- make alembic-check
- route registration check for all nine OMS platform order mirror endpoints
