### PR TITLE
feat(oms): import platform order mirrors from collector

### DIFF
--- a/app/oms/order_facts/contracts/collector_import.py
+++ b/app/oms/order_facts/contracts/collector_import.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class ImportPlatformOrderMirrorFromCollectorIn(BaseModel):
+    collector_order_id: int = Field(..., ge=1)
+
+
+class ImportPlatformOrderMirrorFromCollectorOut(BaseModel):
+    ok: bool = True
+    imported: bool = True
+    platform: str
+    collector_order_id: int
+    mirror_id: int

--- a/app/oms/order_facts/router_platform_order_mirrors.py
+++ b/app/oms/order_facts/router_platform_order_mirrors.py
@@ -4,10 +4,22 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.deps import get_async_session
+from app.oms.order_facts.contracts.collector_import import (
+    ImportPlatformOrderMirrorFromCollectorIn,
+    ImportPlatformOrderMirrorFromCollectorOut,
+)
 from app.oms.order_facts.contracts.platform_order_mirror import (
     PlatformOrderMirrorEnvelopeOut,
     PlatformOrderMirrorImportIn,
     PlatformOrderMirrorListOut,
+)
+from app.oms.order_facts.services.collector_export_client import (
+    CollectorExportError,
+    CollectorExportNotFound,
+    CollectorExportUpstreamError,
+)
+from app.oms.order_facts.services.collector_import_service import (
+    import_platform_order_mirror_from_collector,
 )
 from app.oms.order_facts.services.platform_order_mirror_service import (
     get_platform_order_mirror_detail,
@@ -38,6 +50,37 @@ def _register_platform_routes(platform: str) -> None:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
 
         return PlatformOrderMirrorEnvelopeOut(ok=True, data=data)
+
+    @router.post(
+        f"/{platform}/platform-order-mirrors/import-from-collector",
+        response_model=ImportPlatformOrderMirrorFromCollectorOut,
+    )
+    async def import_platform_order_mirror_from_collector_route(
+        payload: ImportPlatformOrderMirrorFromCollectorIn = Body(...),
+        session: AsyncSession = Depends(get_async_session),
+    ) -> ImportPlatformOrderMirrorFromCollectorOut:
+        try:
+            data = await import_platform_order_mirror_from_collector(
+                session,
+                platform=platform,
+                collector_order_id=payload.collector_order_id,
+            )
+        except CollectorExportNotFound as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except CollectorExportUpstreamError as exc:
+            raise HTTPException(status_code=502, detail=str(exc)) from exc
+        except CollectorExportError as exc:
+            raise HTTPException(status_code=502, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+        return ImportPlatformOrderMirrorFromCollectorOut(
+            ok=True,
+            imported=True,
+            platform=platform,
+            collector_order_id=int(payload.collector_order_id),
+            mirror_id=int(data.id),
+        )
 
     @router.get(
         f"/{platform}/platform-order-mirrors",

--- a/app/oms/order_facts/services/collector_export_client.py
+++ b/app/oms/order_facts/services/collector_export_client.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+
+class CollectorExportError(RuntimeError):
+    pass
+
+
+class CollectorExportNotFound(CollectorExportError):
+    pass
+
+
+class CollectorExportUpstreamError(CollectorExportError):
+    pass
+
+
+def _collector_base_url() -> str:
+    return (os.getenv("COLLECTOR_API_BASE_URL") or "http://127.0.0.1:8001").rstrip("/")
+
+
+def _collector_token() -> str | None:
+    token = (os.getenv("COLLECTOR_API_TOKEN") or "").strip()
+    return token or None
+
+
+def _collector_timeout_seconds() -> float:
+    raw = (os.getenv("COLLECTOR_API_TIMEOUT_SECONDS") or "10").strip()
+    try:
+        value = float(raw)
+    except ValueError:
+        return 10.0
+    return value if value > 0 else 10.0
+
+
+async def fetch_collector_export_order(
+    *,
+    platform: str,
+    collector_order_id: int,
+) -> dict[str, Any]:
+    plat = (platform or "").strip().lower()
+    if plat not in {"pdd", "taobao", "jd"}:
+        raise CollectorExportError(f"unsupported platform: {platform!r}")
+
+    url = f"{_collector_base_url()}/collector/export/{plat}/orders/{int(collector_order_id)}"
+
+    headers: dict[str, str] = {}
+    token = _collector_token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    try:
+        async with httpx.AsyncClient(timeout=_collector_timeout_seconds()) as client:
+            resp = await client.get(url, headers=headers)
+    except httpx.RequestError as exc:
+        raise CollectorExportUpstreamError(f"collector request failed: {exc}") from exc
+
+    if resp.status_code == 404:
+        raise CollectorExportNotFound(f"collector export order not found: platform={plat} id={int(collector_order_id)}")
+
+    if resp.status_code >= 400:
+        raise CollectorExportUpstreamError(
+            f"collector export request failed: status={resp.status_code} body={resp.text}"
+        )
+
+    body = resp.json()
+    data = body.get("data") if isinstance(body, dict) else None
+    if not isinstance(data, dict):
+        raise CollectorExportUpstreamError("collector export response missing data object")
+
+    return data

--- a/app/oms/order_facts/services/collector_import_service.py
+++ b/app/oms/order_facts/services/collector_import_service.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.oms.order_facts.contracts.platform_order_mirror import (
+    PlatformOrderMirrorImportIn,
+    PlatformOrderMirrorLineImportIn,
+    PlatformOrderMirrorOut,
+)
+from app.oms.order_facts.services.collector_export_client import fetch_collector_export_order
+from app.oms.order_facts.services.platform_order_mirror_service import upsert_platform_order_mirror
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _line_from_collector(line: dict[str, Any]) -> PlatformOrderMirrorLineImportIn:
+    return PlatformOrderMirrorLineImportIn(
+        collector_line_id=int(line["collector_line_id"]),
+        collector_order_id=int(line["collector_order_id"]),
+        platform_order_no=str(line["platform_order_no"]),
+        merchant_sku=line.get("merchant_sku"),
+        platform_item_id=line.get("platform_item_id"),
+        platform_sku_id=line.get("platform_sku_id"),
+        title=line.get("title"),
+        quantity=line.get("quantity") or 0,
+        unit_price=line.get("unit_price"),
+        line_amount=line.get("line_amount"),
+        platform_fields=_dict(line.get("platform_fields")),
+        raw_item_payload=line.get("raw_item_payload"),
+    )
+
+
+def _payload_from_collector(data: dict[str, Any]) -> PlatformOrderMirrorImportIn:
+    lines = [
+        _line_from_collector(line)
+        for line in _list(data.get("lines"))
+        if isinstance(line, dict)
+    ]
+
+    return PlatformOrderMirrorImportIn(
+        collector_order_id=int(data["collector_order_id"]),
+        collector_store_id=int(data["collector_store_id"]),
+        collector_store_code=str(data["collector_store_code"]),
+        collector_store_name=str(data["collector_store_name"]),
+        platform=str(data["platform"]).lower(),  # type: ignore[arg-type]
+        platform_order_no=str(data["platform_order_no"]),
+        platform_status=data.get("platform_status"),
+        source_updated_at=data.get("source_updated_at"),
+        pulled_at=data.get("pulled_at"),
+        last_synced_at=data.get("last_synced_at") or data.get("collector_last_synced_at"),
+        receiver=_dict(data.get("receiver")),
+        amounts=_dict(data.get("amounts")),
+        platform_fields=_dict(data.get("platform_fields")),
+        raw_refs=_dict(data.get("raw_refs")),
+        lines=lines,
+    )
+
+
+async def import_platform_order_mirror_from_collector(
+    session: AsyncSession,
+    *,
+    platform: str,
+    collector_order_id: int,
+) -> PlatformOrderMirrorOut:
+    plat = (platform or "").strip().lower()
+    data = await fetch_collector_export_order(
+        platform=plat,
+        collector_order_id=int(collector_order_id),
+    )
+
+    payload = _payload_from_collector(data)
+    if payload.platform != plat:
+        raise ValueError(f"collector payload platform mismatch: path={plat} payload={payload.platform}")
+
+    return await upsert_platform_order_mirror(
+        session,
+        platform=plat,
+        payload=payload,
+    )

--- a/tests/api/test_oms_import_mirrors_from_collector_api.py
+++ b/tests/api/test_oms_import_mirrors_from_collector_api.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+
+from app.oms.order_facts.services import collector_import_service
+from app.oms.order_facts.services.collector_export_client import (
+    CollectorExportNotFound,
+    CollectorExportUpstreamError,
+)
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _clear_mirrors(session) -> None:
+    await session.execute(text("DELETE FROM oms_pdd_order_mirror_lines"))
+    await session.execute(text("DELETE FROM oms_taobao_order_mirror_lines"))
+    await session.execute(text("DELETE FROM oms_jd_order_mirror_lines"))
+    await session.execute(text("DELETE FROM oms_pdd_order_mirrors"))
+    await session.execute(text("DELETE FROM oms_taobao_order_mirrors"))
+    await session.execute(text("DELETE FROM oms_jd_order_mirrors"))
+    await session.commit()
+
+
+async def _ensure_store(session, *, platform: str, store_code: str) -> int:
+    row = (
+        await session.execute(
+            text(
+                """
+                INSERT INTO stores (
+                  platform,
+                  store_code,
+                  store_name,
+                  active
+                )
+                VALUES (
+                  :platform,
+                  :store_code,
+                  :store_name,
+                  true
+                )
+                ON CONFLICT (platform, store_code) DO UPDATE
+                SET
+                  store_name = EXCLUDED.store_name,
+                  active = EXCLUDED.active
+                RETURNING id
+                """
+            ),
+            {
+                "platform": platform,
+                "store_code": store_code,
+                "store_name": f"{platform}-{store_code}",
+            },
+        )
+    ).mappings().one()
+    await session.commit()
+    return int(row["id"])
+
+
+def _collector_payload(
+    *,
+    platform: str,
+    collector_order_id: int,
+    collector_store_code: str,
+    platform_order_no: str,
+    merchant_sku: str,
+) -> dict[str, Any]:
+    return {
+        "collector_order_id": collector_order_id,
+        "collector_store_id": collector_order_id + 1000,
+        "collector_store_code": collector_store_code,
+        "collector_store_name": f"{platform}-collector-store",
+        "platform": platform,
+        "platform_order_no": platform_order_no,
+        "platform_status": "WAIT_SELLER_SEND_GOODS",
+        "source_updated_at": "2026-04-28T08:00:00+00:00",
+        "pulled_at": "2026-04-28T08:01:00+00:00",
+        "last_synced_at": "2026-04-28T08:02:00+00:00",
+        "receiver": {"name": "张三", "phone": "13800138000"},
+        "amounts": {"pay_amount": "86.00"},
+        "platform_fields": {"source": "collector-export"},
+        "raw_refs": {"detail": {"ok": True}},
+        "lines": [
+            {
+                "collector_line_id": collector_order_id + 2000,
+                "collector_order_id": collector_order_id,
+                "platform_order_no": platform_order_no,
+                "merchant_sku": merchant_sku,
+                "platform_item_id": f"{platform}-ITEM-1",
+                "platform_sku_id": f"{platform}-SKU-1",
+                "title": f"{platform} 测试商品",
+                "quantity": 2,
+                "unit_price": "43.00",
+                "line_amount": "86.00",
+                "platform_fields": {"line_source": "collector-export"},
+                "raw_item_payload": {"merchant_sku": merchant_sku},
+            }
+        ],
+    }
+
+
+async def test_pdd_import_from_collector_writes_platform_order_mirror(
+    client,
+    session,
+    monkeypatch,
+) -> None:
+    await _clear_mirrors(session)
+
+    suffix = uuid4().hex[:8]
+    store_code = f"PDD-COLLECTOR-{suffix}"
+    wms_store_id = await _ensure_store(session, platform="pdd", store_code=store_code)
+
+    async def fake_fetch_collector_export_order(*, platform: str, collector_order_id: int) -> dict[str, Any]:
+        assert platform == "pdd"
+        assert collector_order_id == 990001
+        return _collector_payload(
+            platform="pdd",
+            collector_order_id=collector_order_id,
+            collector_store_code=store_code,
+            platform_order_no=f"PDD-COLLECTOR-ORDER-{suffix}",
+            merchant_sku="PDD-FSKU-COLLECTOR",
+        )
+
+    monkeypatch.setattr(
+        collector_import_service,
+        "fetch_collector_export_order",
+        fake_fetch_collector_export_order,
+    )
+
+    resp = await client.post(
+        "/oms/pdd/platform-order-mirrors/import-from-collector",
+        json={"collector_order_id": 990001},
+    )
+    assert resp.status_code == 200, resp.text
+
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["imported"] is True
+    assert body["platform"] == "pdd"
+    mirror_id = int(body["mirror_id"])
+
+    detail = await client.get(f"/oms/pdd/platform-order-mirrors/{mirror_id}")
+    assert detail.status_code == 200, detail.text
+
+    data = detail.json()["data"]
+    assert data["collector_order_id"] == 990001
+    assert data["wms_store_id"] == wms_store_id
+    assert data["receiver"]["name"] == "张三"
+    assert data["lines"][0]["merchant_sku"] == "PDD-FSKU-COLLECTOR"
+
+
+async def test_taobao_import_from_collector_uses_platform_separated_endpoint(
+    client,
+    session,
+    monkeypatch,
+) -> None:
+    await _clear_mirrors(session)
+
+    suffix = uuid4().hex[:8]
+    store_code = f"TAOBAO-COLLECTOR-{suffix}"
+    await _ensure_store(session, platform="taobao", store_code=store_code)
+
+    async def fake_fetch_collector_export_order(*, platform: str, collector_order_id: int) -> dict[str, Any]:
+        assert platform == "taobao"
+        return _collector_payload(
+            platform="taobao",
+            collector_order_id=collector_order_id,
+            collector_store_code=store_code,
+            platform_order_no=f"TB-COLLECTOR-ORDER-{suffix}",
+            merchant_sku="TB-FSKU-COLLECTOR",
+        )
+
+    monkeypatch.setattr(
+        collector_import_service,
+        "fetch_collector_export_order",
+        fake_fetch_collector_export_order,
+    )
+
+    resp = await client.post(
+        "/oms/taobao/platform-order-mirrors/import-from-collector",
+        json={"collector_order_id": 990002},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["platform"] == "taobao"
+
+
+async def test_import_from_collector_maps_not_found_to_404(
+    client,
+    monkeypatch,
+) -> None:
+    async def fake_fetch_collector_export_order(*, platform: str, collector_order_id: int) -> dict[str, Any]:
+        raise CollectorExportNotFound("collector export order not found")
+
+    monkeypatch.setattr(
+        collector_import_service,
+        "fetch_collector_export_order",
+        fake_fetch_collector_export_order,
+    )
+
+    resp = await client.post(
+        "/oms/jd/platform-order-mirrors/import-from-collector",
+        json={"collector_order_id": 999999},
+    )
+    assert resp.status_code == 404, resp.text
+    assert "collector export order not found" in resp.text
+
+
+async def test_import_from_collector_maps_upstream_error_to_502(
+    client,
+    monkeypatch,
+) -> None:
+    async def fake_fetch_collector_export_order(*, platform: str, collector_order_id: int) -> dict[str, Any]:
+        raise CollectorExportUpstreamError("collector unavailable")
+
+    monkeypatch.setattr(
+        collector_import_service,
+        "fetch_collector_export_order",
+        fake_fetch_collector_export_order,
+    )
+
+    resp = await client.post(
+        "/oms/pdd/platform-order-mirrors/import-from-collector",
+        json={"collector_order_id": 990003},
+    )
+    assert resp.status_code == 502, resp.text
+    assert "collector unavailable" in resp.text


### PR DESCRIPTION
## Summary
- add WMS Collector Export client for platform order mirrors
- add platform-separated import-from-collector endpoints for PDD / Taobao / JD
- reuse OMS-owned platform order mirror upsert service
- keep 商品映射 and 履约订单转化 out of this PR

## Routes
- POST /oms/pdd/platform-order-mirrors/import-from-collector
- POST /oms/taobao/platform-order-mirrors/import-from-collector
- POST /oms/jd/platform-order-mirrors/import-from-collector

## Environment
- COLLECTOR_API_BASE_URL, default http://127.0.0.1:8001
- COLLECTOR_API_TOKEN, optional Bearer token
- COLLECTOR_API_TIMEOUT_SECONDS, default 10

## Verification
- python3 -m compileall app/oms/order_facts/contracts app/oms/order_facts/services app/oms/order_facts/router_platform_order_mirrors.py tests/api/test_oms_import_mirrors_from_collector_api.py
- make test TESTS="tests/api/test_oms_platform_order_mirrors_api.py tests/api/test_oms_import_mirrors_from_collector_api.py"
- route registration check for three import-from-collector endpoints
