### PR TITLE
feat(oms): add fsku mapping candidate APIs

### DIFF
--- a/app/oms/order_facts/contracts/fsku_mapping_candidate.py
+++ b/app/oms/order_facts/contracts/fsku_mapping_candidate.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+MappingStatus = Literal["bound", "unbound", "missing_merchant_code"]
+
+
+class FskuMappingCandidateOut(BaseModel):
+    platform: str
+
+    mirror_id: int
+    line_id: int
+    collector_order_id: int
+    collector_line_id: int
+
+    store_code: str
+    collector_store_id: int
+    collector_store_name: str
+
+    platform_order_no: str
+    merchant_code: Optional[str] = None
+    platform_item_id: Optional[str] = None
+    platform_sku_id: Optional[str] = None
+    title: Optional[str] = None
+    quantity: str
+    line_amount: Optional[str] = None
+
+    is_bound: bool
+    mapping_status: MappingStatus
+
+    binding_id: Optional[int] = None
+    fsku_id: Optional[int] = None
+    fsku_code: Optional[str] = None
+    fsku_name: Optional[str] = None
+    fsku_status: Optional[str] = None
+    binding_reason: Optional[str] = None
+    binding_updated_at: Optional[str] = None
+
+
+class FskuMappingCandidateListDataOut(BaseModel):
+    items: list[FskuMappingCandidateOut] = Field(default_factory=list)
+    total: int
+    limit: int
+    offset: int
+
+
+class FskuMappingCandidateListOut(BaseModel):
+    ok: bool = True
+    data: FskuMappingCandidateListDataOut

--- a/app/oms/order_facts/router.py
+++ b/app/oms/order_facts/router.py
@@ -1,5 +1,8 @@
 from fastapi import APIRouter
 
+from app.oms.order_facts.router_fsku_mapping_candidates import (
+    router as fsku_mapping_candidates_router,
+)
 from app.oms.order_facts.router_platform_order_mirrors import (
     router as platform_order_mirrors_router,
 )
@@ -8,5 +11,6 @@ from app.oms.order_facts.router_platform_order_mirrors import (
 router = APIRouter()
 
 # Collector 分离后，OMS 不再保留旧平台采集事实桥接。
-# 当前模块承载 OMS 自有的平台订单镜像与后续履约订单转化入口。
+# 当前模块承载 OMS 自有的平台订单镜像、商品映射候选与后续履约订单转化入口。
 router.include_router(platform_order_mirrors_router)
+router.include_router(fsku_mapping_candidates_router)

--- a/app/oms/order_facts/router_fsku_mapping_candidates.py
+++ b/app/oms/order_facts/router_fsku_mapping_candidates.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.deps import get_async_session
+from app.oms.order_facts.contracts.fsku_mapping_candidate import (
+    FskuMappingCandidateListOut,
+)
+from app.oms.order_facts.services.fsku_mapping_candidate_service import (
+    list_fsku_mapping_candidates,
+)
+
+
+router = APIRouter(tags=["oms-fsku-mapping-candidates"])
+
+
+def _register_platform_routes(platform: str) -> None:
+    @router.get(
+        f"/{platform}/fsku-mapping/candidates",
+        response_model=FskuMappingCandidateListOut,
+    )
+    async def list_platform_fsku_mapping_candidates(
+        store_code: str | None = Query(None, min_length=1, max_length=128),
+        merchant_code: str | None = Query(None, min_length=1, max_length=128),
+        only_unbound: bool = Query(False),
+        limit: int = Query(200, ge=1, le=1000),
+        offset: int = Query(0, ge=0),
+        session: AsyncSession = Depends(get_async_session),
+    ) -> FskuMappingCandidateListOut:
+        try:
+            data = await list_fsku_mapping_candidates(
+                session,
+                platform=platform,
+                store_code=store_code,
+                merchant_code=merchant_code,
+                only_unbound=only_unbound,
+                limit=limit,
+                offset=offset,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+        return FskuMappingCandidateListOut(ok=True, data=data)
+
+
+for _platform in ("pdd", "taobao", "jd"):
+    _register_platform_routes(_platform)

--- a/app/oms/order_facts/services/fsku_mapping_candidate_service.py
+++ b/app/oms/order_facts/services/fsku_mapping_candidate_service.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.oms.order_facts.contracts.fsku_mapping_candidate import (
+    FskuMappingCandidateListDataOut,
+    FskuMappingCandidateOut,
+)
+
+
+_PLATFORM_TABLES = {
+    "pdd": ("oms_pdd_order_mirrors", "oms_pdd_order_mirror_lines"),
+    "taobao": ("oms_taobao_order_mirrors", "oms_taobao_order_mirror_lines"),
+    "jd": ("oms_jd_order_mirrors", "oms_jd_order_mirror_lines"),
+}
+
+
+def _tables(platform: str) -> tuple[str, str]:
+    key = (platform or "").strip().lower()
+    if key not in _PLATFORM_TABLES:
+        raise ValueError(f"unsupported platform: {platform!r}")
+    return _PLATFORM_TABLES[key]
+
+
+def _fmt(value: Any) -> str | None:
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
+def _mapping_status(*, merchant_code: str | None, binding_id: int | None) -> str:
+    if not merchant_code:
+        return "missing_merchant_code"
+    if binding_id is not None:
+        return "bound"
+    return "unbound"
+
+
+def _candidate_out(platform: str, row: Mapping[str, Any]) -> FskuMappingCandidateOut:
+    merchant_code = row.get("merchant_code")
+    merchant_code_text = str(merchant_code).strip() if merchant_code is not None else None
+    if merchant_code_text == "":
+        merchant_code_text = None
+
+    binding_id = row.get("binding_id")
+    binding_id_int = int(binding_id) if binding_id is not None else None
+
+    return FskuMappingCandidateOut(
+        platform=platform,
+        mirror_id=int(row["mirror_id"]),
+        line_id=int(row["line_id"]),
+        collector_order_id=int(row["collector_order_id"]),
+        collector_line_id=int(row["collector_line_id"]),
+        store_code=str(row["store_code"]),
+        collector_store_id=int(row["collector_store_id"]),
+        collector_store_name=str(row["collector_store_name"]),
+        platform_order_no=str(row["platform_order_no"]),
+        merchant_code=merchant_code_text,
+        platform_item_id=row.get("platform_item_id"),
+        platform_sku_id=row.get("platform_sku_id"),
+        title=row.get("title"),
+        quantity=str(row.get("quantity") or "0"),
+        line_amount=_fmt(row.get("line_amount")),
+        is_bound=binding_id_int is not None,
+        mapping_status=_mapping_status(
+            merchant_code=merchant_code_text,
+            binding_id=binding_id_int,
+        ),  # type: ignore[arg-type]
+        binding_id=binding_id_int,
+        fsku_id=int(row["fsku_id"]) if row.get("fsku_id") is not None else None,
+        fsku_code=row.get("fsku_code"),
+        fsku_name=row.get("fsku_name"),
+        fsku_status=row.get("fsku_status"),
+        binding_reason=row.get("binding_reason"),
+        binding_updated_at=_fmt(row.get("binding_updated_at")),
+    )
+
+
+async def list_fsku_mapping_candidates(
+    session: AsyncSession,
+    *,
+    platform: str,
+    store_code: str | None,
+    merchant_code: str | None,
+    only_unbound: bool,
+    limit: int,
+    offset: int,
+) -> FskuMappingCandidateListDataOut:
+    plat = (platform or "").strip().lower()
+    mirror_table, line_table = _tables(plat)
+
+    clauses: list[str] = ["1 = 1"]
+    params: dict[str, Any] = {
+        "platform": plat,
+        "limit": int(limit),
+        "offset": int(offset),
+    }
+
+    if store_code and store_code.strip():
+        clauses.append("m.collector_store_code = :store_code")
+        params["store_code"] = store_code.strip()
+
+    if merchant_code and merchant_code.strip():
+        clauses.append("l.merchant_sku ILIKE :merchant_code_like")
+        params["merchant_code_like"] = f"%{merchant_code.strip()}%"
+
+    if only_unbound:
+        clauses.append("b.id IS NULL")
+
+    where_sql = " AND ".join(clauses)
+
+    count_row = (
+        await session.execute(
+            text(
+                f"""
+                SELECT count(*) AS total
+                  FROM {line_table} l
+                  JOIN {mirror_table} m ON m.id = l.mirror_id
+                  LEFT JOIN merchant_code_fsku_bindings b
+                    ON b.platform = :platform
+                   AND b.store_code = m.collector_store_code
+                   AND b.merchant_code = l.merchant_sku
+                  LEFT JOIN fskus f ON f.id = b.fsku_id
+                 WHERE {where_sql}
+                """
+            ),
+            params,
+        )
+    ).mappings().one()
+
+    rows = (
+        await session.execute(
+            text(
+                f"""
+                SELECT
+                  m.id AS mirror_id,
+                  l.id AS line_id,
+                  l.collector_order_id,
+                  l.collector_line_id,
+
+                  m.collector_store_code AS store_code,
+                  m.collector_store_id,
+                  m.collector_store_name,
+
+                  l.platform_order_no,
+                  l.merchant_sku AS merchant_code,
+                  l.platform_item_id,
+                  l.platform_sku_id,
+                  l.title,
+                  l.quantity,
+                  l.line_amount,
+
+                  b.id AS binding_id,
+                  b.fsku_id,
+                  b.reason AS binding_reason,
+                  b.updated_at AS binding_updated_at,
+
+                  f.code AS fsku_code,
+                  f.name AS fsku_name,
+                  f.status AS fsku_status
+                FROM {line_table} l
+                JOIN {mirror_table} m ON m.id = l.mirror_id
+                LEFT JOIN merchant_code_fsku_bindings b
+                  ON b.platform = :platform
+                 AND b.store_code = m.collector_store_code
+                 AND b.merchant_code = l.merchant_sku
+                LEFT JOIN fskus f ON f.id = b.fsku_id
+                WHERE {where_sql}
+                ORDER BY m.last_synced_at DESC, m.id DESC, l.id ASC
+                LIMIT :limit OFFSET :offset
+                """
+            ),
+            params,
+        )
+    ).mappings().all()
+
+    return FskuMappingCandidateListDataOut(
+        items=[_candidate_out(plat, row) for row in rows],
+        total=int(count_row["total"]),
+        limit=int(limit),
+        offset=int(offset),
+    )

--- a/tests/api/test_oms_fsku_mapping_candidates_api.py
+++ b/tests/api/test_oms_fsku_mapping_candidates_api.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _clear_rows(session) -> None:
+    await session.execute(text("DELETE FROM merchant_code_fsku_bindings"))
+    await session.execute(text("DELETE FROM oms_pdd_order_mirror_lines"))
+    await session.execute(text("DELETE FROM oms_taobao_order_mirror_lines"))
+    await session.execute(text("DELETE FROM oms_jd_order_mirror_lines"))
+    await session.execute(text("DELETE FROM oms_pdd_order_mirrors"))
+    await session.execute(text("DELETE FROM oms_taobao_order_mirrors"))
+    await session.execute(text("DELETE FROM oms_jd_order_mirrors"))
+    await session.commit()
+
+
+async def _ensure_store(session, *, platform: str, store_code: str) -> int:
+    row = (
+        await session.execute(
+            text(
+                """
+                INSERT INTO stores (
+                  platform,
+                  store_code,
+                  store_name,
+                  active
+                )
+                VALUES (
+                  :platform,
+                  :store_code,
+                  :store_name,
+                  true
+                )
+                ON CONFLICT (platform, store_code) DO UPDATE
+                SET
+                  store_name = EXCLUDED.store_name,
+                  active = EXCLUDED.active
+                RETURNING id
+                """
+            ),
+            {
+                "platform": platform,
+                "store_code": store_code,
+                "store_name": f"{platform}-{store_code}",
+            },
+        )
+    ).mappings().one()
+    await session.commit()
+    return int(row["id"])
+
+
+async def _create_published_fsku(session, *, code: str, name: str) -> int:
+    row = (
+        await session.execute(
+            text(
+                """
+                INSERT INTO fskus (
+                  code,
+                  name,
+                  shape,
+                  status,
+                  published_at,
+                  created_at,
+                  updated_at
+                )
+                VALUES (
+                  :code,
+                  :name,
+                  'single',
+                  'published',
+                  now(),
+                  now(),
+                  now()
+                )
+                RETURNING id
+                """
+            ),
+            {"code": code, "name": name},
+        )
+    ).mappings().one()
+    await session.commit()
+    return int(row["id"])
+
+
+async def _create_pdd_mirror_with_lines(
+    session,
+    *,
+    store_code: str,
+    order_no: str,
+    bound_code: str,
+    unbound_code: str,
+) -> None:
+    mirror = (
+        await session.execute(
+            text(
+                """
+                INSERT INTO oms_pdd_order_mirrors (
+                  collector_order_id,
+                  collector_store_id,
+                  collector_store_code,
+                  collector_store_name,
+                  platform_order_no,
+                  platform_status
+                )
+                VALUES (
+                  810001,
+                  820001,
+                  :store_code,
+                  'PDD 候选测试店铺',
+                  :order_no,
+                  'WAIT_SELLER_SEND_GOODS'
+                )
+                RETURNING id
+                """
+            ),
+            {"store_code": store_code, "order_no": order_no},
+        )
+    ).mappings().one()
+
+    mirror_id = int(mirror["id"])
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO oms_pdd_order_mirror_lines (
+              mirror_id,
+              collector_line_id,
+              collector_order_id,
+              platform_order_no,
+              merchant_sku,
+              platform_item_id,
+              platform_sku_id,
+              title,
+              quantity,
+              line_amount
+            )
+            VALUES
+              (:mirror_id, 910001, 810001, :order_no, :bound_code, 'PDD-ITEM-1', 'PDD-SKU-1', '已绑定商品', 2, 86.00),
+              (:mirror_id, 910002, 810001, :order_no, :unbound_code, 'PDD-ITEM-2', 'PDD-SKU-2', '未绑定商品', 1, 43.00),
+              (:mirror_id, 910003, 810001, :order_no, NULL, 'PDD-ITEM-3', 'PDD-SKU-3', '缺少商家编码商品', 1, 12.00)
+            """
+        ),
+        {
+            "mirror_id": mirror_id,
+            "order_no": order_no,
+            "bound_code": bound_code,
+            "unbound_code": unbound_code,
+        },
+    )
+
+    await session.commit()
+
+
+async def test_pdd_fsku_mapping_candidates_return_binding_status(client, session) -> None:
+    await _clear_rows(session)
+
+    suffix = uuid4().hex[:8]
+    store_code = f"PDD-FSKU-MAP-{suffix}"
+    bound_code = f"PDD-BOUND-{suffix}"
+    unbound_code = f"PDD-UNBOUND-{suffix}"
+
+    await _ensure_store(session, platform="pdd", store_code=store_code)
+    fsku_id = await _create_published_fsku(
+        session,
+        code=f"FSKU-CANDIDATE-{suffix}",
+        name="候选测试 FSKU",
+    )
+
+    await _create_pdd_mirror_with_lines(
+        session,
+        store_code=store_code,
+        order_no=f"PDD-FSKU-MAP-ORDER-{suffix}",
+        bound_code=bound_code,
+        unbound_code=unbound_code,
+    )
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO merchant_code_fsku_bindings (
+              platform,
+              store_code,
+              merchant_code,
+              fsku_id,
+              reason,
+              created_at,
+              updated_at
+            )
+            VALUES (
+              'pdd',
+              :store_code,
+              :merchant_code,
+              :fsku_id,
+              'candidate test',
+              now(),
+              now()
+            )
+            """
+        ),
+        {
+            "store_code": store_code,
+            "merchant_code": bound_code,
+            "fsku_id": fsku_id,
+        },
+    )
+    await session.commit()
+
+    resp = await client.get(
+        "/oms/pdd/fsku-mapping/candidates",
+        params={"store_code": store_code},
+    )
+    assert resp.status_code == 200, resp.text
+
+    body = resp.json()
+    assert body["ok"] is True
+    data = body["data"]
+    assert data["total"] == 3
+
+    by_code = {row["merchant_code"]: row for row in data["items"]}
+
+    bound = by_code[bound_code]
+    assert bound["is_bound"] is True
+    assert bound["mapping_status"] == "bound"
+    assert bound["fsku_id"] == fsku_id
+    assert bound["fsku_code"] == f"FSKU-CANDIDATE-{suffix}"
+    assert bound["fsku_name"] == "候选测试 FSKU"
+
+    unbound = by_code[unbound_code]
+    assert unbound["is_bound"] is False
+    assert unbound["mapping_status"] == "unbound"
+
+    missing = by_code[None]
+    assert missing["is_bound"] is False
+    assert missing["mapping_status"] == "missing_merchant_code"
+
+
+async def test_pdd_fsku_mapping_candidates_can_filter_only_unbound(client, session) -> None:
+    await _clear_rows(session)
+
+    suffix = uuid4().hex[:8]
+    store_code = f"PDD-FSKU-MAP-FILTER-{suffix}"
+    bound_code = f"PDD-BOUND-FILTER-{suffix}"
+    unbound_code = f"PDD-UNBOUND-FILTER-{suffix}"
+
+    await _ensure_store(session, platform="pdd", store_code=store_code)
+    fsku_id = await _create_published_fsku(
+        session,
+        code=f"FSKU-CANDIDATE-FILTER-{suffix}",
+        name="候选过滤 FSKU",
+    )
+    await _create_pdd_mirror_with_lines(
+        session,
+        store_code=store_code,
+        order_no=f"PDD-FSKU-MAP-FILTER-ORDER-{suffix}",
+        bound_code=bound_code,
+        unbound_code=unbound_code,
+    )
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO merchant_code_fsku_bindings (
+              platform,
+              store_code,
+              merchant_code,
+              fsku_id,
+              reason,
+              created_at,
+              updated_at
+            )
+            VALUES (
+              'pdd',
+              :store_code,
+              :merchant_code,
+              :fsku_id,
+              'candidate test',
+              now(),
+              now()
+            )
+            """
+        ),
+        {
+            "store_code": store_code,
+            "merchant_code": bound_code,
+            "fsku_id": fsku_id,
+        },
+    )
+    await session.commit()
+
+    resp = await client.get(
+        "/oms/pdd/fsku-mapping/candidates",
+        params={"store_code": store_code, "only_unbound": "true"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    items = resp.json()["data"]["items"]
+    statuses = {row["mapping_status"] for row in items}
+
+    assert "bound" not in statuses
+    assert "unbound" in statuses
+    assert "missing_merchant_code" in statuses
+
+
+async def test_fsku_mapping_candidate_routes_are_platform_separated(client, session) -> None:
+    await _clear_rows(session)
+
+    suffix = uuid4().hex[:8]
+    store_code = f"PDD-FSKU-MAP-ISO-{suffix}"
+    await _ensure_store(session, platform="pdd", store_code=store_code)
+    await _create_pdd_mirror_with_lines(
+        session,
+        store_code=store_code,
+        order_no=f"PDD-FSKU-MAP-ISO-ORDER-{suffix}",
+        bound_code=f"PDD-BOUND-ISO-{suffix}",
+        unbound_code=f"PDD-UNBOUND-ISO-{suffix}",
+    )
+
+    pdd_resp = await client.get(
+        "/oms/pdd/fsku-mapping/candidates",
+        params={"store_code": store_code},
+    )
+    assert pdd_resp.status_code == 200, pdd_resp.text
+    assert pdd_resp.json()["data"]["total"] == 3
+
+    taobao_resp = await client.get(
+        "/oms/taobao/fsku-mapping/candidates",
+        params={"store_code": store_code},
+    )
+    assert taobao_resp.status_code == 200, taobao_resp.text
+    assert taobao_resp.json()["data"]["total"] == 0


### PR DESCRIPTION
## Summary
- add platform-separated OMS FSKU mapping candidate APIs
- expose mirror line candidates with current merchant_code -> FSKU binding status
- keep binding writes on existing merchant-code-bindings APIs
- keep PDD / Taobao / JD candidate reads separated

## Routes
- GET /oms/pdd/fsku-mapping/candidates
- GET /oms/taobao/fsku-mapping/candidates
- GET /oms/jd/fsku-mapping/candidates

## Verification
- python3 -m compileall app/oms/order_facts/contracts/fsku_mapping_candidate.py app/oms/order_facts/services/fsku_mapping_candidate_service.py app/oms/order_facts/router_fsku_mapping_candidates.py app/oms/order_facts/router.py tests/api/test_oms_fsku_mapping_candidates_api.py
- make test TESTS=tests/api/test_oms_fsku_mapping_candidates_api.py
- make test TESTS="tests/api/test_oms_fsku_mapping_candidates_api.py tests/api/test_oms_platform_order_mirrors_api.py tests/api/test_oms_import_mirrors_from_collector_api.py"
- make alembic-check
- route registration check for three FSKU mapping candidate endpoints
