### PR TITLE
feat(oms): convert platform mirrors to fulfillment orders

### DIFF
--- a/app/oms/order_facts/contracts/fulfillment_conversion.py
+++ b/app/oms/order_facts/contracts/fulfillment_conversion.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class FulfillmentOrderConversionIn(BaseModel):
+    mirror_id: int = Field(..., ge=1)
+
+
+class FulfillmentOrderConversionOut(BaseModel):
+    ok: bool = True
+
+    platform: str
+    mirror_id: int
+    order_id: int | None
+    ref: str
+    status: str
+
+    store_id: int
+    store_code: str
+    ext_order_no: str
+
+    lines_count: int
+    item_lines_count: int
+
+    fulfillment_status: str | None = None
+    blocked_reasons: Any = None
+    risk_flags: list[str] = Field(default_factory=list)

--- a/app/oms/order_facts/router.py
+++ b/app/oms/order_facts/router.py
@@ -3,6 +3,9 @@ from fastapi import APIRouter
 from app.oms.order_facts.router_fsku_mapping_candidates import (
     router as fsku_mapping_candidates_router,
 )
+from app.oms.order_facts.router_fulfillment_conversion import (
+    router as fulfillment_conversion_router,
+)
 from app.oms.order_facts.router_platform_order_mirrors import (
     router as platform_order_mirrors_router,
 )
@@ -11,6 +14,7 @@ from app.oms.order_facts.router_platform_order_mirrors import (
 router = APIRouter()
 
 # Collector 分离后，OMS 不再保留旧平台采集事实桥接。
-# 当前模块承载 OMS 自有的平台订单镜像、商品映射候选与后续履约订单转化入口。
+# 当前模块承载 OMS 自有的平台订单镜像、商品映射候选与履约订单转化入口。
 router.include_router(platform_order_mirrors_router)
 router.include_router(fsku_mapping_candidates_router)
+router.include_router(fulfillment_conversion_router)

--- a/app/oms/order_facts/router_fulfillment_conversion.py
+++ b/app/oms/order_facts/router_fulfillment_conversion.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Body, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.deps import get_async_session
+from app.oms.order_facts.contracts.fulfillment_conversion import (
+    FulfillmentOrderConversionIn,
+    FulfillmentOrderConversionOut,
+)
+from app.oms.order_facts.services.fulfillment_conversion_service import (
+    FulfillmentConversionNotFound,
+    FulfillmentConversionValidationError,
+    convert_platform_order_mirror_to_fulfillment_order,
+)
+
+
+router = APIRouter(tags=["oms-fulfillment-order-conversion"])
+
+
+def _register_platform_routes(platform: str) -> None:
+    @router.post(
+        f"/{platform}/fulfillment-order-conversion/convert",
+        response_model=FulfillmentOrderConversionOut,
+    )
+    async def convert_platform_fulfillment_order(
+        payload: FulfillmentOrderConversionIn = Body(...),
+        session: AsyncSession = Depends(get_async_session),
+    ) -> FulfillmentOrderConversionOut:
+        try:
+            return await convert_platform_order_mirror_to_fulfillment_order(
+                session,
+                platform=platform,
+                mirror_id=int(payload.mirror_id),
+            )
+        except FulfillmentConversionNotFound as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except FulfillmentConversionValidationError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+for _platform in ("pdd", "taobao", "jd"):
+    _register_platform_routes(_platform)

--- a/app/oms/order_facts/services/fulfillment_conversion_service.py
+++ b/app/oms/order_facts/services/fulfillment_conversion_service.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+from typing import Any, Mapping
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.audit import new_trace
+from app.oms.order_facts.contracts.fulfillment_conversion import (
+    FulfillmentOrderConversionOut,
+)
+from app.oms.services.platform_order_ingest_flow import PlatformOrderIngestFlow
+
+
+_PLATFORM_TABLES = {
+    "pdd": ("oms_pdd_order_mirrors", "oms_pdd_order_mirror_lines"),
+    "taobao": ("oms_taobao_order_mirrors", "oms_taobao_order_mirror_lines"),
+    "jd": ("oms_jd_order_mirrors", "oms_jd_order_mirror_lines"),
+}
+
+
+class FulfillmentConversionNotFound(Exception):
+    pass
+
+
+class FulfillmentConversionValidationError(Exception):
+    pass
+
+
+def _tables(platform: str) -> tuple[str, str]:
+    key = (platform or "").strip().lower()
+    if key not in _PLATFORM_TABLES:
+        raise FulfillmentConversionValidationError(f"unsupported platform: {platform!r}")
+    return _PLATFORM_TABLES[key]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _str_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    s = str(value).strip()
+    return s or None
+
+
+def _as_positive_integral_decimal(value: Any, *, label: str) -> Decimal:
+    try:
+        d = Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise FulfillmentConversionValidationError(f"{label} 非法：{value!r}") from exc
+
+    if d <= 0:
+        raise FulfillmentConversionValidationError(f"{label} 必须大于 0：{value!r}")
+
+    if d != d.to_integral_value():
+        raise FulfillmentConversionValidationError(f"{label} 必须为整数：{value!r}")
+
+    return d
+
+
+def _address_from_receiver(receiver: Mapping[str, Any]) -> dict[str, str]:
+    name = _str_or_none(receiver.get("receiver_name")) or _str_or_none(receiver.get("name"))
+    phone = (
+        _str_or_none(receiver.get("receiver_phone"))
+        or _str_or_none(receiver.get("phone"))
+        or _str_or_none(receiver.get("mobile"))
+    )
+    province = (
+        _str_or_none(receiver.get("province"))
+        or _str_or_none(receiver.get("state"))
+        or _str_or_none(receiver.get("receiver_state"))
+    )
+    city = _str_or_none(receiver.get("city"))
+    district = (
+        _str_or_none(receiver.get("district"))
+        or _str_or_none(receiver.get("county"))
+    )
+    detail = (
+        _str_or_none(receiver.get("detail"))
+        or _str_or_none(receiver.get("address"))
+        or _str_or_none(receiver.get("receiver_address"))
+    )
+    zipcode = _str_or_none(receiver.get("zipcode")) or _str_or_none(receiver.get("zip"))
+
+    out = {
+        "receiver_name": name,
+        "receiver_phone": phone,
+        "province": province,
+        "city": city,
+        "district": district,
+        "detail": detail,
+        "zipcode": zipcode,
+    }
+    return {k: v for k, v in out.items() if v is not None}
+
+
+async def _load_header(
+    session: AsyncSession,
+    *,
+    platform: str,
+    mirror_id: int,
+) -> dict[str, Any]:
+    mirror_table, _line_table = _tables(platform)
+
+    row = (
+        await session.execute(
+            text(
+                f"""
+                SELECT
+                  id,
+                  collector_order_id,
+                  collector_store_id,
+                  collector_store_code,
+                  collector_store_name,
+                  wms_store_id,
+                  platform_order_no,
+                  platform_status,
+                  source_updated_at,
+                  receiver_json,
+                  amounts_json,
+                  platform_fields_json,
+                  raw_refs_json
+                FROM {mirror_table}
+                WHERE id = :mirror_id
+                LIMIT 1
+                """
+            ),
+            {"mirror_id": int(mirror_id)},
+        )
+    ).mappings().first()
+
+    if row is None:
+        raise FulfillmentConversionNotFound(f"{platform} platform order mirror not found: {int(mirror_id)}")
+
+    data = dict(row)
+    if data.get("wms_store_id") is None:
+        raise FulfillmentConversionValidationError(
+            f"平台订单镜像未匹配 WMS 店铺：platform={platform} mirror_id={int(mirror_id)}"
+        )
+
+    return data
+
+
+async def _load_line_component_rows(
+    session: AsyncSession,
+    *,
+    platform: str,
+    mirror_id: int,
+) -> list[dict[str, Any]]:
+    _mirror_table, line_table = _tables(platform)
+
+    rows = (
+        await session.execute(
+            text(
+                f"""
+                SELECT
+                  l.id AS line_id,
+                  l.collector_line_id,
+                  l.collector_order_id,
+                  l.platform_order_no,
+                  l.merchant_sku,
+                  l.platform_item_id,
+                  l.platform_sku_id,
+                  l.title,
+                  l.quantity AS line_quantity,
+                  l.line_amount,
+
+                  b.id AS binding_id,
+                  b.fsku_id,
+
+                  f.code AS fsku_code,
+                  f.name AS fsku_name,
+                  f.status AS fsku_status,
+
+                  c.id AS component_id,
+                  c.item_id AS component_item_id,
+                  c.qty AS component_qty,
+                  c.role AS component_role
+                FROM {line_table} l
+                LEFT JOIN merchant_code_fsku_bindings b
+                  ON b.platform = :platform
+                 AND b.store_code = (
+                   SELECT m.collector_store_code
+                   FROM {_tables(platform)[0]} m
+                   WHERE m.id = l.mirror_id
+                   LIMIT 1
+                 )
+                 AND b.merchant_code = l.merchant_sku
+                LEFT JOIN fskus f
+                  ON f.id = b.fsku_id
+                LEFT JOIN fsku_components c
+                  ON c.fsku_id = f.id
+                WHERE l.mirror_id = :mirror_id
+                ORDER BY l.id ASC, c.id ASC
+                """
+            ),
+            {"platform": platform, "mirror_id": int(mirror_id)},
+        )
+    ).mappings().all()
+
+    return [dict(row) for row in rows]
+
+
+def _build_item_qty_map(rows: list[dict[str, Any]]) -> tuple[dict[int, int], list[dict[str, Any]], int]:
+    if not rows:
+        raise FulfillmentConversionValidationError("平台订单镜像没有订单行，不能转化为履约订单")
+
+    item_qty_map: dict[int, int] = {}
+    resolved: list[dict[str, Any]] = []
+    errors: list[str] = []
+    seen_lines: set[int] = set()
+
+    for row in rows:
+        line_id = int(row["line_id"])
+
+        merchant_code = _str_or_none(row.get("merchant_sku"))
+        if not merchant_code:
+            if line_id not in seen_lines:
+                errors.append(f"line_id={line_id} 缺少 merchant_code")
+                seen_lines.add(line_id)
+            continue
+
+        binding_id = row.get("binding_id")
+        if binding_id is None:
+            if line_id not in seen_lines:
+                errors.append(f"line_id={line_id} merchant_code={merchant_code} 未绑定 FSKU")
+                seen_lines.add(line_id)
+            continue
+
+        fsku_status = _str_or_none(row.get("fsku_status"))
+        if fsku_status != "published":
+            if line_id not in seen_lines:
+                errors.append(f"line_id={line_id} merchant_code={merchant_code} 绑定的 FSKU 不是 published")
+                seen_lines.add(line_id)
+            continue
+
+        component_item_id = row.get("component_item_id")
+        component_qty = row.get("component_qty")
+        if component_item_id is None or component_qty is None:
+            if line_id not in seen_lines:
+                errors.append(f"line_id={line_id} merchant_code={merchant_code} 对应 FSKU 没有 components")
+                seen_lines.add(line_id)
+            continue
+
+        line_qty = _as_positive_integral_decimal(row.get("line_quantity"), label=f"line_id={line_id}.quantity")
+        component_qty_dec = _as_positive_integral_decimal(
+            component_qty,
+            label=f"line_id={line_id}.component_qty",
+        )
+        final_qty_dec = line_qty * component_qty_dec
+
+        if final_qty_dec != final_qty_dec.to_integral_value():
+            errors.append(f"line_id={line_id} 展开后数量不是整数：{final_qty_dec}")
+            continue
+
+        item_id = int(component_item_id)
+        final_qty = int(final_qty_dec)
+        item_qty_map[item_id] = int(item_qty_map.get(item_id, 0)) + final_qty
+
+        resolved.append(
+            {
+                "line_id": line_id,
+                "collector_line_id": int(row["collector_line_id"]),
+                "merchant_code": merchant_code,
+                "fsku_id": int(row["fsku_id"]),
+                "fsku_code": row.get("fsku_code"),
+                "component_item_id": item_id,
+                "qty": final_qty,
+                "title": row.get("title"),
+            }
+        )
+
+    if errors:
+        raise FulfillmentConversionValidationError("；".join(errors[:10]))
+
+    if not item_qty_map:
+        raise FulfillmentConversionValidationError("没有可转化的商品行")
+
+    lines_count = len({int(row["line_id"]) for row in rows})
+    return item_qty_map, resolved, lines_count
+
+
+async def convert_platform_order_mirror_to_fulfillment_order(
+    session: AsyncSession,
+    *,
+    platform: str,
+    mirror_id: int,
+) -> FulfillmentOrderConversionOut:
+    plat = (platform or "").strip().lower()
+    header = await _load_header(session, platform=plat, mirror_id=int(mirror_id))
+    rows = await _load_line_component_rows(session, platform=plat, mirror_id=int(mirror_id))
+
+    item_qty_map, resolved, lines_count = _build_item_qty_map(rows)
+
+    store_id = int(header["wms_store_id"])
+    store_code = str(header["collector_store_code"])
+    ext_order_no = str(header["platform_order_no"])
+
+    receiver = _dict(header.get("receiver_json"))
+    address = _address_from_receiver(receiver)
+    buyer_name = address.get("receiver_name")
+    buyer_phone = address.get("receiver_phone")
+
+    trace = new_trace(f"oms:{plat}:fulfillment-order-conversion")
+
+    items_payload = await PlatformOrderIngestFlow.build_items_payload_from_item_qty_map(
+        session,
+        store_id=store_id,
+        item_qty_map=item_qty_map,
+        source="oms/fulfillment-order-conversion",
+        extras={
+            "platform_order_mirror_id": int(mirror_id),
+            "collector_order_id": int(header["collector_order_id"]),
+            "platform_order_no": ext_order_no,
+        },
+    )
+
+    try:
+        out = await PlatformOrderIngestFlow.run_tail_from_items_payload(
+            session,
+            platform=plat,
+            store_code=store_code,
+            store_id=store_id,
+            ext_order_no=ext_order_no,
+            occurred_at=None,
+            buyer_name=buyer_name,
+            buyer_phone=buyer_phone,
+            address=address or None,
+            items_payload=items_payload,
+            trace_id=trace.trace_id,
+            source="oms/fulfillment-order-conversion",
+            extras={
+                "platform_order_mirror_id": int(mirror_id),
+                "collector_order_id": int(header["collector_order_id"]),
+                "platform_order_no": ext_order_no,
+            },
+            resolved=resolved,
+            unresolved=[],
+            facts_written=0,
+            allow_manual_continue=False,
+            risk_flags=[],
+            risk_level=None,
+            risk_reason=None,
+        )
+        await session.commit()
+    except Exception:
+        await session.rollback()
+        raise
+
+    return FulfillmentOrderConversionOut(
+        ok=True,
+        platform=plat,
+        mirror_id=int(mirror_id),
+        order_id=int(out["id"]) if out.get("id") is not None else None,
+        ref=str(out.get("ref") or f"ORD:{plat}:{store_code}:{ext_order_no}"),
+        status=str(out.get("status") or "OK"),
+        store_id=store_id,
+        store_code=store_code,
+        ext_order_no=ext_order_no,
+        lines_count=lines_count,
+        item_lines_count=len(item_qty_map),
+        fulfillment_status=out.get("fulfillment_status"),
+        blocked_reasons=out.get("blocked_reasons"),
+        risk_flags=[str(x) for x in out.get("risk_flags") or []],
+    )

--- a/tests/api/test_oms_fulfillment_order_conversion_api.py
+++ b/tests/api/test_oms_fulfillment_order_conversion_api.py
@@ -1,0 +1,415 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _clear_rows(session) -> None:
+    await session.execute(text("DELETE FROM merchant_code_fsku_bindings"))
+    await session.execute(text("DELETE FROM oms_pdd_order_mirror_lines"))
+    await session.execute(text("DELETE FROM oms_taobao_order_mirror_lines"))
+    await session.execute(text("DELETE FROM oms_jd_order_mirror_lines"))
+    await session.execute(text("DELETE FROM oms_pdd_order_mirrors"))
+    await session.execute(text("DELETE FROM oms_taobao_order_mirrors"))
+    await session.execute(text("DELETE FROM oms_jd_order_mirrors"))
+    await session.commit()
+
+
+async def _pick_any_item_id(session) -> int:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT id
+                FROM items
+                ORDER BY id ASC
+                LIMIT 1
+                """
+            )
+        )
+    ).first()
+    assert row is not None, "expected at least one baseline item"
+    return int(row[0])
+
+
+async def _ensure_store(session, *, platform: str, store_code: str) -> int:
+    row = (
+        await session.execute(
+            text(
+                """
+                INSERT INTO stores (
+                  platform,
+                  store_code,
+                  store_name,
+                  active
+                )
+                VALUES (
+                  upper(:platform),
+                  :store_code,
+                  :store_name,
+                  true
+                )
+                ON CONFLICT (platform, store_code) DO UPDATE
+                SET
+                  store_name = EXCLUDED.store_name,
+                  active = EXCLUDED.active
+                RETURNING id
+                """
+            ),
+            {
+                "platform": platform,
+                "store_code": store_code,
+                "store_name": f"{platform}-{store_code}",
+            },
+        )
+    ).mappings().one()
+    await session.commit()
+    return int(row["id"])
+
+
+async def _create_published_fsku_with_component(
+    session,
+    *,
+    item_id: int,
+    code: str,
+    name: str,
+    component_qty: int = 1,
+) -> int:
+    row = (
+        await session.execute(
+            text(
+                """
+                INSERT INTO fskus (
+                  code,
+                  name,
+                  shape,
+                  status,
+                  published_at,
+                  created_at,
+                  updated_at
+                )
+                VALUES (
+                  :code,
+                  :name,
+                  'single',
+                  'published',
+                  now(),
+                  now(),
+                  now()
+                )
+                RETURNING id
+                """
+            ),
+            {"code": code, "name": name},
+        )
+    ).mappings().one()
+
+    fsku_id = int(row["id"])
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO fsku_components (
+              fsku_id,
+              item_id,
+              qty,
+              role,
+              created_at,
+              updated_at
+            )
+            VALUES (
+              :fsku_id,
+              :item_id,
+              :qty,
+              'primary',
+              now(),
+              now()
+            )
+            """
+        ),
+        {
+            "fsku_id": fsku_id,
+            "item_id": int(item_id),
+            "qty": int(component_qty),
+        },
+    )
+
+    await session.commit()
+    return fsku_id
+
+
+async def _create_pdd_mirror(
+    session,
+    *,
+    store_id: int,
+    store_code: str,
+    order_no: str,
+    merchant_code: str,
+) -> int:
+    row = (
+        await session.execute(
+            text(
+                """
+                INSERT INTO oms_pdd_order_mirrors (
+                  collector_order_id,
+                  collector_store_id,
+                  collector_store_code,
+                  collector_store_name,
+                  wms_store_id,
+                  platform_order_no,
+                  platform_status,
+                  receiver_json,
+                  amounts_json
+                )
+                VALUES (
+                  :collector_order_id,
+                  :collector_store_id,
+                  :store_code,
+                  'PDD 履约转化测试店铺',
+                  :store_id,
+                  :order_no,
+                  'WAIT_SELLER_SEND_GOODS',
+                  jsonb_build_object(
+                    'name', '张三',
+                    'phone', '13800000000',
+                    'province', '浙江省',
+                    'city', '杭州市',
+                    'district', '西湖区',
+                    'address', '文三路 1 号'
+                  ),
+                  jsonb_build_object('pay_amount', '86.00')
+                )
+                RETURNING id
+                """
+            ),
+            {
+                "collector_order_id": abs(hash(order_no)) % 1000000000,
+                "collector_store_id": 880001,
+                "store_code": store_code,
+                "store_id": int(store_id),
+                "order_no": order_no,
+            },
+        )
+    ).mappings().one()
+
+    mirror_id = int(row["id"])
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO oms_pdd_order_mirror_lines (
+              mirror_id,
+              collector_line_id,
+              collector_order_id,
+              platform_order_no,
+              merchant_sku,
+              platform_item_id,
+              platform_sku_id,
+              title,
+              quantity,
+              unit_price,
+              line_amount
+            )
+            VALUES (
+              :mirror_id,
+              :collector_line_id,
+              880001,
+              :order_no,
+              :merchant_code,
+              'PDD-ITEM-1',
+              'PDD-SKU-1',
+              'PDD 履约转化测试商品',
+              2,
+              43.00,
+              86.00
+            )
+            """
+        ),
+        {
+            "mirror_id": mirror_id,
+            "collector_line_id": mirror_id + 1000,
+            "order_no": order_no,
+            "merchant_code": merchant_code,
+        },
+    )
+
+    await session.commit()
+    return mirror_id
+
+
+async def test_pdd_fulfillment_order_conversion_creates_oms_order(
+    client,
+    session,
+    monkeypatch,
+) -> None:
+    await _clear_rows(session)
+
+    suffix = uuid4().hex[:8]
+    store_code = f"PDD-FULFILL-{suffix}"
+    merchant_code = f"PDD-FSKU-FULFILL-{suffix}"
+    order_no = f"PDD-FULFILL-ORDER-{suffix}"
+
+    monkeypatch.setenv("TEST_STORE_ID", store_code)
+
+    item_id = await _pick_any_item_id(session)
+    store_id = await _ensure_store(session, platform="pdd", store_code=store_code)
+    fsku_id = await _create_published_fsku_with_component(
+        session,
+        item_id=item_id,
+        code=f"FSKU-FULFILL-{suffix}",
+        name="履约转化 FSKU",
+        component_qty=1,
+    )
+    mirror_id = await _create_pdd_mirror(
+        session,
+        store_id=store_id,
+        store_code=store_code,
+        order_no=order_no,
+        merchant_code=merchant_code,
+    )
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO merchant_code_fsku_bindings (
+              platform,
+              store_code,
+              merchant_code,
+              fsku_id,
+              reason,
+              created_at,
+              updated_at
+            )
+            VALUES (
+              'pdd',
+              :store_code,
+              :merchant_code,
+              :fsku_id,
+              'fulfillment conversion test',
+              now(),
+              now()
+            )
+            """
+        ),
+        {
+            "store_code": store_code,
+            "merchant_code": merchant_code,
+            "fsku_id": fsku_id,
+        },
+    )
+    await session.commit()
+
+    resp = await client.post(
+        "/oms/pdd/fulfillment-order-conversion/convert",
+        json={"mirror_id": mirror_id},
+    )
+    assert resp.status_code == 200, resp.text
+
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["platform"] == "pdd"
+    assert data["mirror_id"] == mirror_id
+    assert data["store_id"] == store_id
+    assert data["store_code"] == store_code
+    assert data["ext_order_no"] == order_no
+    assert data["lines_count"] == 1
+    assert data["item_lines_count"] == 1
+
+    order_id = int(data["order_id"])
+    assert order_id > 0
+
+    head = (
+        await session.execute(
+            text(
+                """
+                SELECT platform, store_code, ext_order_no, store_id, buyer_name, buyer_phone
+                FROM orders
+                WHERE id = :order_id
+                LIMIT 1
+                """
+            ),
+            {"order_id": order_id},
+        )
+    ).mappings().one()
+
+    assert head["platform"] == "PDD"
+    assert head["store_code"] == store_code
+    assert head["ext_order_no"] == order_no
+    assert int(head["store_id"]) == store_id
+    assert head["buyer_name"] == "张三"
+
+    line = (
+        await session.execute(
+            text(
+                """
+                SELECT item_id, req_qty
+                FROM order_lines
+                WHERE order_id = :order_id
+                ORDER BY id ASC
+                LIMIT 1
+                """
+            ),
+            {"order_id": order_id},
+        )
+    ).mappings().one()
+
+    assert int(line["item_id"]) == item_id
+    assert int(line["req_qty"]) == 2
+
+    second = await client.post(
+        "/oms/pdd/fulfillment-order-conversion/convert",
+        json={"mirror_id": mirror_id},
+    )
+    assert second.status_code == 200, second.text
+    assert int(second.json()["order_id"]) == order_id
+
+
+async def test_pdd_fulfillment_order_conversion_rejects_unbound_merchant_code(
+    client,
+    session,
+    monkeypatch,
+) -> None:
+    await _clear_rows(session)
+
+    suffix = uuid4().hex[:8]
+    store_code = f"PDD-FULFILL-UNBOUND-{suffix}"
+    order_no = f"PDD-FULFILL-UNBOUND-ORDER-{suffix}"
+
+    monkeypatch.setenv("TEST_STORE_ID", store_code)
+
+    store_id = await _ensure_store(session, platform="pdd", store_code=store_code)
+    mirror_id = await _create_pdd_mirror(
+        session,
+        store_id=store_id,
+        store_code=store_code,
+        order_no=order_no,
+        merchant_code=f"PDD-UNBOUND-{suffix}",
+    )
+
+    resp = await client.post(
+        "/oms/pdd/fulfillment-order-conversion/convert",
+        json={"mirror_id": mirror_id},
+    )
+
+    assert resp.status_code == 422, resp.text
+    assert "未绑定 FSKU" in resp.text
+
+
+async def test_fulfillment_order_conversion_routes_are_platform_separated(
+    client,
+    session,
+) -> None:
+    await _clear_rows(session)
+
+    resp = await client.post(
+        "/oms/taobao/fulfillment-order-conversion/convert",
+        json={"mirror_id": 999999},
+    )
+
+    assert resp.status_code == 404, resp.text
+    assert "taobao platform order mirror not found" in resp.text


### PR DESCRIPTION
## Summary
- add platform-separated fulfillment order conversion APIs
- convert OMS platform order mirrors into OMS orders through existing OrderService tail flow
- resolve merchant_code -> published FSKU and expand FSKU components into item quantities
- keep WMS outbound creation separate from OMS fulfillment conversion

## Routes
- POST /oms/pdd/fulfillment-order-conversion/convert
- POST /oms/taobao/fulfillment-order-conversion/convert
- POST /oms/jd/fulfillment-order-conversion/convert

## Verification
- python3 -m compileall app/oms/order_facts/contracts/fulfillment_conversion.py app/oms/order_facts/services/fulfillment_conversion_service.py app/oms/order_facts/router_fulfillment_conversion.py app/oms/order_facts/router.py tests/api/test_oms_fulfillment_order_conversion_api.py
- make test TESTS=tests/api/test_oms_fulfillment_order_conversion_api.py
- make test TESTS="tests/api/test_oms_fulfillment_order_conversion_api.py tests/api/test_oms_fsku_mapping_candidates_api.py tests/api/test_oms_platform_order_mirrors_api.py tests/api/test_oms_import_mirrors_from_collector_api.py"
- make alembic-check
