### PR TITLE
chore(repo): rename backend project to wms-api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,9 +24,9 @@ export WMS_WORKERS=2
 # -------------------------------
 # 运行时路径（systemd / 脚本会使用）
 # -------------------------------
-export WMS_VENV="$HOME/wms-du/.venv"
-export WMS_REPO_DIR="$HOME/wms-du"
-export WMS_VAR_DIR="$HOME/wms-du/var"
+export WMS_VENV="$HOME/wms-api/.venv"
+export WMS_REPO_DIR="$HOME/wms-api"
+export WMS_VAR_DIR="$HOME/wms-api/var"
 # 首次加载时创建对账等目录（安全幂等）
 mkdir -p "$WMS_VAR_DIR/reconcile"
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ WMS-DU backend service for WMS / OMS / TMS / PMS.
 
 ---
 
-## Frontend (wms-fe)
+## Frontend (wms-web)
 
 本仓库包含前端子工程（Vite + React + MSW）：
 - 开发启动：`pnpm dev`

--- a/alembic.ini
+++ b/alembic.ini
@@ -15,7 +15,7 @@ path_separator = os
 sqlalchemy.url = postgresql+psycopg://postgres:wms@127.0.0.1:55432/postgres
 
 # 可选：备用 SQLite 连接（开发环境可用）
-# sqlalchemy.url = sqlite:////home/andy-du/wms-du/dev.db
+# sqlalchemy.url = sqlite:////home/andy-du/wms-api/dev.db
 
 
 # ----------------------------------------------------------------------

--- a/app/db/engine.py
+++ b/app/db/engine.py
@@ -21,7 +21,7 @@ def _connect_args_for(url_str: str) -> dict[str, Any]:
     if backend.startswith("postgresql"):
         return {
             "server_settings": {
-                "application_name": "wms-du-ci",
+                "application_name": "wms-api-ci",
                 # "jit": "off",
             }
         }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 services:
   db:
     image: postgres:14-alpine
-    container_name: wms-du-db
+    container_name: wms-api-db
     restart: unless-stopped
     environment:
       POSTGRES_USER: wms

--- a/ops/compose/docker-compose.dev.yml
+++ b/ops/compose/docker-compose.dev.yml
@@ -1,5 +1,5 @@
 # ops/compose/docker-compose.dev.yml
-# 本地开发栈（复用宿主机 wms-du-db@5433）
+# 本地开发栈（复用宿主机 wms-api-db@5433）
 # 固化端口映射由 ops/compose/.env 管理：
 #   API:     ${API_HOST_PORT:-8001} → 容器 8000
 #   Redis:   ${REDIS_HOST_PORT:-6379}

--- a/ops/env.example
+++ b/ops/env.example
@@ -15,9 +15,9 @@ export WMS_PORT=8000
 export WMS_WORKERS=2
 
 # 可选：虚拟环境位置（systemd 模板会用到）
-export WMS_VENV="$HOME/wms-du/.venv"
-export WMS_REPO_DIR="$HOME/wms-du"
+export WMS_VENV="$HOME/wms-api/.venv"
+export WMS_REPO_DIR="$HOME/wms-api"
 
 # 可选：日志/对账生成目录
-export WMS_VAR_DIR="$HOME/wms-du/var"
+export WMS_VAR_DIR="$HOME/wms-api/var"
 mkdir -p "$WMS_VAR_DIR/reconcile"

--- a/ops/observability/prometheus/prometheus.yml
+++ b/ops/observability/prometheus/prometheus.yml
@@ -6,6 +6,6 @@ rule_files:
   - /etc/prometheus/alerting_rules.yml
 
 scrape_configs:
-  - job_name: "wms-du-api"
+  - job_name: "wms-api"
     static_configs:
       - targets: ["api:8000"]

--- a/ops/systemd/wms-reconcile.service
+++ b/ops/systemd/wms-reconcile.service
@@ -6,9 +6,9 @@ After=network-online.target
 [Service]
 Type=oneshot
 Environment="TZ=Asia/Shanghai"
-Environment="PYTHONPATH=%h/wms-du"
+Environment="PYTHONPATH=%h/wms-api"
 Environment="DATABASE_URL=postgresql+psycopg://wms:wms@127.0.0.1:5433/wms"
-WorkingDirectory=%h/wms-du
-ExecStart=%h/wms-du/.venv/bin/python scripts/reconcile_pdd_daily.py --store-id 1
-StandardOutput=append:%h/wms-du/var/reconcile/run.log
-StandardError=append:%h/wms-du/var/reconcile/run.log
+WorkingDirectory=%h/wms-api
+ExecStart=%h/wms-api/.venv/bin/python scripts/reconcile_pdd_daily.py --store-id 1
+StandardOutput=append:%h/wms-api/var/reconcile/run.log
+StandardError=append:%h/wms-api/var/reconcile/run.log


### PR DESCRIPTION
## Summary
- update backend repository/project references from wms-du to wms-api
- update local path examples and ops/systemd paths
- update compose/prometheus/container naming references
- update application_name from wms-du-ci to wms-api-ci

## Verification
- .venv/bin/python3 -m compileall app/db/engine.py
- make alembic-check
