### PR TITLE
fix(oms): canonicalize platform code for mirror mapping

### DIFF
--- a/alembic/versions/2d73c129cb75_oms_canonicalize_merchant_binding_.py
+++ b/alembic/versions/2d73c129cb75_oms_canonicalize_merchant_binding_.py
@@ -1,0 +1,52 @@
+"""oms canonicalize merchant binding platform codes
+
+Revision ID: 2d73c129cb75
+Revises: 202604281620
+Create Date: 2026-04-28 18:51:58.243733
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "2d73c129cb75"
+down_revision: Union[str, Sequence[str], None] = "202604281620"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Canonicalize merchant-code binding platform codes."""
+
+    # 先删除小写平台码中已经有大写等价记录的重复行，避免 UPDATE 触发唯一约束冲突。
+    op.execute(
+        """
+        DELETE FROM merchant_code_fsku_bindings lower_b
+        USING merchant_code_fsku_bindings upper_b
+        WHERE lower_b.id <> upper_b.id
+          AND lower_b.platform IN ('pdd', 'taobao', 'jd')
+          AND upper_b.platform = upper(lower_b.platform)
+          AND upper_b.store_code = lower_b.store_code
+          AND upper_b.merchant_code = lower_b.merchant_code
+        """
+    )
+
+    # 再把剩余小写平台码统一为 OMS 业务事实平台码。
+    op.execute(
+        """
+        UPDATE merchant_code_fsku_bindings
+           SET platform = upper(platform),
+               updated_at = now()
+         WHERE platform IN ('pdd', 'taobao', 'jd')
+        """
+    )
+
+
+def downgrade() -> None:
+    """Downgrade is intentionally a no-op for platform-code canonicalization."""
+
+    # 这是业务事实收口迁移：PDD / TAOBAO / JD 是终态平台码。
+    # 不能可靠恢复哪些行历史上是小写，因此不做反向大小写回滚。
+    pass

--- a/app/oms/order_facts/services/fsku_mapping_candidate_service.py
+++ b/app/oms/order_facts/services/fsku_mapping_candidate_service.py
@@ -5,6 +5,7 @@ from typing import Any, Mapping
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.oms.services.platform_order_resolve_utils import norm_platform
 from app.oms.order_facts.contracts.fsku_mapping_candidate import (
     FskuMappingCandidateListDataOut,
     FskuMappingCandidateOut,
@@ -91,12 +92,13 @@ async def list_fsku_mapping_candidates(
     limit: int,
     offset: int,
 ) -> FskuMappingCandidateListDataOut:
-    plat = (platform or "").strip().lower()
-    mirror_table, line_table = _tables(plat)
+    table_platform = (platform or "").strip().lower()
+    binding_platform = norm_platform(platform)
+    mirror_table, line_table = _tables(table_platform)
 
     clauses: list[str] = ["1 = 1"]
     params: dict[str, Any] = {
-        "platform": plat,
+        "platform": binding_platform,
         "limit": int(limit),
         "offset": int(offset),
     }
@@ -180,7 +182,7 @@ async def list_fsku_mapping_candidates(
     ).mappings().all()
 
     return FskuMappingCandidateListDataOut(
-        items=[_candidate_out(plat, row) for row in rows],
+        items=[_candidate_out(binding_platform, row) for row in rows],
         total=int(count_row["total"]),
         limit=int(limit),
         offset=int(offset),

--- a/app/oms/order_facts/services/fulfillment_conversion_service.py
+++ b/app/oms/order_facts/services/fulfillment_conversion_service.py
@@ -11,6 +11,7 @@ from app.oms.order_facts.contracts.fulfillment_conversion import (
     FulfillmentOrderConversionOut,
 )
 from app.oms.services.platform_order_ingest_flow import PlatformOrderIngestFlow
+from app.oms.services.platform_order_resolve_utils import norm_platform
 
 
 _PLATFORM_TABLES = {
@@ -151,6 +152,7 @@ async def _load_line_component_rows(
     mirror_id: int,
 ) -> list[dict[str, Any]]:
     _mirror_table, line_table = _tables(platform)
+    binding_platform = norm_platform(platform)
 
     rows = (
         await session.execute(
@@ -197,7 +199,7 @@ async def _load_line_component_rows(
                 ORDER BY l.id ASC, c.id ASC
                 """
             ),
-            {"platform": platform, "mirror_id": int(mirror_id)},
+            {"platform": binding_platform, "mirror_id": int(mirror_id)},
         )
     ).mappings().all()
 
@@ -289,9 +291,10 @@ async def convert_platform_order_mirror_to_fulfillment_order(
     platform: str,
     mirror_id: int,
 ) -> FulfillmentOrderConversionOut:
-    plat = (platform or "").strip().lower()
-    header = await _load_header(session, platform=plat, mirror_id=int(mirror_id))
-    rows = await _load_line_component_rows(session, platform=plat, mirror_id=int(mirror_id))
+    table_platform = (platform or "").strip().lower()
+    business_platform = norm_platform(platform)
+    header = await _load_header(session, platform=table_platform, mirror_id=int(mirror_id))
+    rows = await _load_line_component_rows(session, platform=table_platform, mirror_id=int(mirror_id))
 
     item_qty_map, resolved, lines_count = _build_item_qty_map(rows)
 
@@ -304,7 +307,7 @@ async def convert_platform_order_mirror_to_fulfillment_order(
     buyer_name = address.get("receiver_name")
     buyer_phone = address.get("receiver_phone")
 
-    trace = new_trace(f"oms:{plat}:fulfillment-order-conversion")
+    trace = new_trace(f"oms:{table_platform}:fulfillment-order-conversion")
 
     items_payload = await PlatformOrderIngestFlow.build_items_payload_from_item_qty_map(
         session,
@@ -321,7 +324,7 @@ async def convert_platform_order_mirror_to_fulfillment_order(
     try:
         out = await PlatformOrderIngestFlow.run_tail_from_items_payload(
             session,
-            platform=plat,
+            platform=business_platform,
             store_code=store_code,
             store_id=store_id,
             ext_order_no=ext_order_no,
@@ -352,10 +355,10 @@ async def convert_platform_order_mirror_to_fulfillment_order(
 
     return FulfillmentOrderConversionOut(
         ok=True,
-        platform=plat,
+        platform=business_platform,
         mirror_id=int(mirror_id),
         order_id=int(out["id"]) if out.get("id") is not None else None,
-        ref=str(out.get("ref") or f"ORD:{plat}:{store_code}:{ext_order_no}"),
+        ref=str(out.get("ref") or f"ORD:{business_platform}:{store_code}:{ext_order_no}"),
         status=str(out.get("status") or "OK"),
         store_id=store_id,
         store_code=store_code,

--- a/tests/api/test_oms_fsku_mapping_candidates_api.py
+++ b/tests/api/test_oms_fsku_mapping_candidates_api.py
@@ -32,7 +32,7 @@ async def _ensure_store(session, *, platform: str, store_code: str) -> int:
                   active
                 )
                 VALUES (
-                  :platform,
+                  upper(:platform),
                   :store_code,
                   :store_name,
                   true
@@ -193,7 +193,7 @@ async def test_pdd_fsku_mapping_candidates_return_binding_status(client, session
               updated_at
             )
             VALUES (
-              'pdd',
+              'PDD',
               :store_code,
               :merchant_code,
               :fsku_id,
@@ -275,7 +275,7 @@ async def test_pdd_fsku_mapping_candidates_can_filter_only_unbound(client, sessi
               updated_at
             )
             VALUES (
-              'pdd',
+              'PDD',
               :store_code,
               :merchant_code,
               :fsku_id,

--- a/tests/api/test_oms_fulfillment_order_conversion_api.py
+++ b/tests/api/test_oms_fulfillment_order_conversion_api.py
@@ -286,7 +286,7 @@ async def test_pdd_fulfillment_order_conversion_creates_oms_order(
               updated_at
             )
             VALUES (
-              'pdd',
+              'PDD',
               :store_code,
               :merchant_code,
               :fsku_id,
@@ -312,7 +312,7 @@ async def test_pdd_fulfillment_order_conversion_creates_oms_order(
 
     data = resp.json()
     assert data["ok"] is True
-    assert data["platform"] == "pdd"
+    assert data["platform"] == "PDD"
     assert data["mirror_id"] == mirror_id
     assert data["store_id"] == store_id
     assert data["store_code"] == store_code


### PR DESCRIPTION
## Summary
- canonicalize OMS mirror mapping and fulfillment conversion binding lookups to business platform codes
- keep URL/table selection using lower-case path platform keys
- add Alembic data migration to collapse lower-case merchant binding platform codes into PDD/TAOBAO/JD
- update mapping/conversion tests to use canonical platform codes

## Validation
- python3 -m compileall app/oms/order_facts/services/fsku_mapping_candidate_service.py app/oms/order_facts/services/fulfillment_conversion_service.py tests/api/test_oms_fsku_mapping_candidates_api.py tests/api/test_oms_fulfillment_order_conversion_api.py alembic/versions/2d73c129cb75_oms_canonicalize_merchant_binding_.py
- make upgrade-dev
- make alembic-check
- make test TESTS=tests/api/test_oms_fsku_mapping_candidates_api.py
- make test TESTS=tests/api/test_oms_fulfillment_order_conversion_api.py