### PR TITLE
feat(oms): add collector batch sync for platform mirrors

### DIFF
--- a/app/oms/order_facts/contracts/collector_import.py
+++ b/app/oms/order_facts/contracts/collector_import.py
@@ -13,3 +13,32 @@ class ImportPlatformOrderMirrorFromCollectorOut(BaseModel):
     platform: str
     collector_order_id: int
     mirror_id: int
+
+
+class SyncPlatformOrderMirrorsFromCollectorIn(BaseModel):
+    limit: int = Field(50, ge=1, le=1000)
+    offset: int = Field(0, ge=0)
+
+
+class SyncPlatformOrderMirrorItemOut(BaseModel):
+    collector_order_id: int
+    mirror_id: int
+    imported: bool = True
+
+
+class SyncPlatformOrderMirrorErrorOut(BaseModel):
+    collector_order_id: int | None = None
+    error_code: str
+    message: str
+
+
+class SyncPlatformOrderMirrorsFromCollectorOut(BaseModel):
+    ok: bool = True
+    platform: str
+    limit: int
+    offset: int
+    fetched_count: int
+    imported_count: int
+    failed_count: int
+    items: list[SyncPlatformOrderMirrorItemOut] = Field(default_factory=list)
+    errors: list[SyncPlatformOrderMirrorErrorOut] = Field(default_factory=list)

--- a/app/oms/order_facts/router_platform_order_mirrors.py
+++ b/app/oms/order_facts/router_platform_order_mirrors.py
@@ -7,6 +7,8 @@ from app.db.deps import get_async_session
 from app.oms.order_facts.contracts.collector_import import (
     ImportPlatformOrderMirrorFromCollectorIn,
     ImportPlatformOrderMirrorFromCollectorOut,
+    SyncPlatformOrderMirrorsFromCollectorIn,
+    SyncPlatformOrderMirrorsFromCollectorOut,
 )
 from app.oms.order_facts.contracts.platform_order_mirror import (
     PlatformOrderMirrorEnvelopeOut,
@@ -20,6 +22,7 @@ from app.oms.order_facts.services.collector_export_client import (
 )
 from app.oms.order_facts.services.collector_import_service import (
     import_platform_order_mirror_from_collector,
+    sync_platform_order_mirrors_from_collector,
 )
 from app.oms.order_facts.services.platform_order_mirror_service import (
     get_platform_order_mirror_detail,
@@ -81,6 +84,28 @@ def _register_platform_routes(platform: str) -> None:
             collector_order_id=int(payload.collector_order_id),
             mirror_id=int(data.id),
         )
+
+    @router.post(
+        f"/{platform}/platform-order-mirrors/sync-from-collector",
+        response_model=SyncPlatformOrderMirrorsFromCollectorOut,
+    )
+    async def sync_platform_order_mirrors_from_collector_route(
+        payload: SyncPlatformOrderMirrorsFromCollectorIn = Body(...),
+        session: AsyncSession = Depends(get_async_session),
+    ) -> SyncPlatformOrderMirrorsFromCollectorOut:
+        try:
+            return await sync_platform_order_mirrors_from_collector(
+                session,
+                platform=platform,
+                limit=payload.limit,
+                offset=payload.offset,
+            )
+        except CollectorExportUpstreamError as exc:
+            raise HTTPException(status_code=502, detail=str(exc)) from exc
+        except CollectorExportError as exc:
+            raise HTTPException(status_code=502, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
 
     @router.get(
         f"/{platform}/platform-order-mirrors",

--- a/app/oms/order_facts/services/collector_export_client.py
+++ b/app/oms/order_facts/services/collector_export_client.py
@@ -18,6 +18,9 @@ class CollectorExportUpstreamError(CollectorExportError):
     pass
 
 
+_SUPPORTED_PLATFORMS = {"pdd", "taobao", "jd"}
+
+
 def _collector_base_url() -> str:
     return (os.getenv("COLLECTOR_API_BASE_URL") or "http://127.0.0.1:8001").rstrip("/")
 
@@ -36,30 +39,35 @@ def _collector_timeout_seconds() -> float:
     return value if value > 0 else 10.0
 
 
-async def fetch_collector_export_order(
-    *,
-    platform: str,
-    collector_order_id: int,
-) -> dict[str, Any]:
+def _norm_platform(platform: str) -> str:
     plat = (platform or "").strip().lower()
-    if plat not in {"pdd", "taobao", "jd"}:
+    if plat not in _SUPPORTED_PLATFORMS:
         raise CollectorExportError(f"unsupported platform: {platform!r}")
+    return plat
 
-    url = f"{_collector_base_url()}/collector/export/{plat}/orders/{int(collector_order_id)}"
 
-    headers: dict[str, str] = {}
+def _headers() -> dict[str, str]:
     token = _collector_token()
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
+    if not token:
+        return {}
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _collector_get_json(
+    *,
+    path: str,
+    params: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    url = f"{_collector_base_url()}{path}"
 
     try:
         async with httpx.AsyncClient(timeout=_collector_timeout_seconds()) as client:
-            resp = await client.get(url, headers=headers)
+            resp = await client.get(url, headers=_headers(), params=params)
     except httpx.RequestError as exc:
         raise CollectorExportUpstreamError(f"collector request failed: {exc}") from exc
 
     if resp.status_code == 404:
-        raise CollectorExportNotFound(f"collector export order not found: platform={plat} id={int(collector_order_id)}")
+        raise CollectorExportNotFound(f"collector export resource not found: path={path}")
 
     if resp.status_code >= 400:
         raise CollectorExportUpstreamError(
@@ -67,7 +75,42 @@ async def fetch_collector_export_order(
         )
 
     body = resp.json()
-    data = body.get("data") if isinstance(body, dict) else None
+    if not isinstance(body, dict):
+        raise CollectorExportUpstreamError("collector export response is not an object")
+
+    return body
+
+
+async def fetch_collector_export_orders(
+    *,
+    platform: str,
+    limit: int,
+    offset: int,
+) -> list[dict[str, Any]]:
+    plat = _norm_platform(platform)
+    body = await _collector_get_json(
+        path=f"/collector/export/{plat}/orders",
+        params={"limit": int(limit), "offset": int(offset)},
+    )
+
+    data = body.get("data")
+    if not isinstance(data, list):
+        raise CollectorExportUpstreamError("collector export list response missing data array")
+
+    return [item for item in data if isinstance(item, dict)]
+
+
+async def fetch_collector_export_order(
+    *,
+    platform: str,
+    collector_order_id: int,
+) -> dict[str, Any]:
+    plat = _norm_platform(platform)
+    body = await _collector_get_json(
+        path=f"/collector/export/{plat}/orders/{int(collector_order_id)}",
+    )
+
+    data = body.get("data")
     if not isinstance(data, dict):
         raise CollectorExportUpstreamError("collector export response missing data object")
 

--- a/app/oms/order_facts/services/collector_import_service.py
+++ b/app/oms/order_facts/services/collector_import_service.py
@@ -4,12 +4,21 @@ from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.oms.order_facts.contracts.collector_import import (
+    SyncPlatformOrderMirrorErrorOut,
+    SyncPlatformOrderMirrorItemOut,
+    SyncPlatformOrderMirrorsFromCollectorOut,
+)
 from app.oms.order_facts.contracts.platform_order_mirror import (
     PlatformOrderMirrorImportIn,
     PlatformOrderMirrorLineImportIn,
     PlatformOrderMirrorOut,
 )
-from app.oms.order_facts.services.collector_export_client import fetch_collector_export_order
+from app.oms.order_facts.services.collector_export_client import (
+    CollectorExportError,
+    fetch_collector_export_order,
+    fetch_collector_export_orders,
+)
 from app.oms.order_facts.services.platform_order_mirror_service import upsert_platform_order_mirror
 
 
@@ -64,13 +73,20 @@ def _payload_from_collector(data: dict[str, Any]) -> PlatformOrderMirrorImportIn
     )
 
 
+def _norm_platform(platform: str) -> str:
+    plat = (platform or "").strip().lower()
+    if plat not in {"pdd", "taobao", "jd"}:
+        raise ValueError(f"unsupported platform: {platform!r}")
+    return plat
+
+
 async def import_platform_order_mirror_from_collector(
     session: AsyncSession,
     *,
     platform: str,
     collector_order_id: int,
 ) -> PlatformOrderMirrorOut:
-    plat = (platform or "").strip().lower()
+    plat = _norm_platform(platform)
     data = await fetch_collector_export_order(
         platform=plat,
         collector_order_id=int(collector_order_id),
@@ -84,4 +100,69 @@ async def import_platform_order_mirror_from_collector(
         session,
         platform=plat,
         payload=payload,
+    )
+
+
+async def sync_platform_order_mirrors_from_collector(
+    session: AsyncSession,
+    *,
+    platform: str,
+    limit: int,
+    offset: int,
+) -> SyncPlatformOrderMirrorsFromCollectorOut:
+    plat = _norm_platform(platform)
+    fetched_rows = await fetch_collector_export_orders(
+        platform=plat,
+        limit=int(limit),
+        offset=int(offset),
+    )
+
+    items: list[SyncPlatformOrderMirrorItemOut] = []
+    errors: list[SyncPlatformOrderMirrorErrorOut] = []
+
+    for row in fetched_rows:
+        raw_order_id = row.get("collector_order_id")
+        try:
+            collector_order_id = int(raw_order_id)
+            mirror = await import_platform_order_mirror_from_collector(
+                session,
+                platform=plat,
+                collector_order_id=collector_order_id,
+            )
+            items.append(
+                SyncPlatformOrderMirrorItemOut(
+                    collector_order_id=collector_order_id,
+                    mirror_id=int(mirror.id),
+                    imported=True,
+                )
+            )
+        except CollectorExportError as exc:
+            await session.rollback()
+            errors.append(
+                SyncPlatformOrderMirrorErrorOut(
+                    collector_order_id=int(raw_order_id) if raw_order_id is not None else None,
+                    error_code=exc.__class__.__name__,
+                    message=str(exc),
+                )
+            )
+        except Exception as exc:
+            await session.rollback()
+            errors.append(
+                SyncPlatformOrderMirrorErrorOut(
+                    collector_order_id=int(raw_order_id) if raw_order_id is not None else None,
+                    error_code=exc.__class__.__name__,
+                    message=str(exc),
+                )
+            )
+
+    return SyncPlatformOrderMirrorsFromCollectorOut(
+        ok=True,
+        platform=plat,
+        limit=int(limit),
+        offset=int(offset),
+        fetched_count=len(fetched_rows),
+        imported_count=len(items),
+        failed_count=len(errors),
+        items=items,
+        errors=errors,
     )

--- a/tests/api/test_oms_import_mirrors_from_collector_api.py
+++ b/tests/api/test_oms_import_mirrors_from_collector_api.py
@@ -228,3 +228,121 @@ async def test_import_from_collector_maps_upstream_error_to_502(
     )
     assert resp.status_code == 502, resp.text
     assert "collector unavailable" in resp.text
+
+
+async def test_pdd_sync_from_collector_imports_listed_orders(
+    client,
+    session,
+    monkeypatch,
+) -> None:
+    await _clear_mirrors(session)
+
+    suffix = uuid4().hex[:8]
+    store_code = f"PDD-SYNC-{suffix}"
+    await _ensure_store(session, platform="pdd", store_code=store_code)
+
+    async def fake_fetch_collector_export_orders(*, platform: str, limit: int, offset: int) -> list[dict[str, Any]]:
+        assert platform == "pdd"
+        assert limit == 2
+        assert offset == 0
+        return [
+            {"collector_order_id": 990101},
+            {"collector_order_id": 990102},
+        ]
+
+    async def fake_fetch_collector_export_order(*, platform: str, collector_order_id: int) -> dict[str, Any]:
+        assert platform == "pdd"
+        return _collector_payload(
+            platform="pdd",
+            collector_order_id=collector_order_id,
+            collector_store_code=store_code,
+            platform_order_no=f"PDD-SYNC-ORDER-{suffix}-{collector_order_id}",
+            merchant_sku=f"PDD-FSKU-SYNC-{collector_order_id}",
+        )
+
+    monkeypatch.setattr(
+        collector_import_service,
+        "fetch_collector_export_orders",
+        fake_fetch_collector_export_orders,
+    )
+    monkeypatch.setattr(
+        collector_import_service,
+        "fetch_collector_export_order",
+        fake_fetch_collector_export_order,
+    )
+
+    resp = await client.post(
+        "/oms/pdd/platform-order-mirrors/sync-from-collector",
+        json={"limit": 2, "offset": 0},
+    )
+    assert resp.status_code == 200, resp.text
+
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["platform"] == "pdd"
+    assert body["fetched_count"] == 2
+    assert body["imported_count"] == 2
+    assert body["failed_count"] == 0
+    assert len(body["items"]) == 2
+    assert body["errors"] == []
+
+    listing = await client.get("/oms/pdd/platform-order-mirrors")
+    assert listing.status_code == 200, listing.text
+    ids = {int(row["collector_order_id"]) for row in listing.json()["data"]}
+    assert {990101, 990102}.issubset(ids)
+
+
+async def test_sync_from_collector_keeps_importing_when_one_order_fails(
+    client,
+    session,
+    monkeypatch,
+) -> None:
+    await _clear_mirrors(session)
+
+    suffix = uuid4().hex[:8]
+    store_code = f"PDD-SYNC-PARTIAL-{suffix}"
+    await _ensure_store(session, platform="pdd", store_code=store_code)
+
+    async def fake_fetch_collector_export_orders(*, platform: str, limit: int, offset: int) -> list[dict[str, Any]]:
+        assert platform == "pdd"
+        return [
+            {"collector_order_id": 990201},
+            {"collector_order_id": 990202},
+        ]
+
+    async def fake_fetch_collector_export_order(*, platform: str, collector_order_id: int) -> dict[str, Any]:
+        if collector_order_id == 990202:
+            raise CollectorExportNotFound("collector export order not found")
+        return _collector_payload(
+            platform="pdd",
+            collector_order_id=collector_order_id,
+            collector_store_code=store_code,
+            platform_order_no=f"PDD-SYNC-PARTIAL-ORDER-{suffix}-{collector_order_id}",
+            merchant_sku=f"PDD-FSKU-SYNC-PARTIAL-{collector_order_id}",
+        )
+
+    monkeypatch.setattr(
+        collector_import_service,
+        "fetch_collector_export_orders",
+        fake_fetch_collector_export_orders,
+    )
+    monkeypatch.setattr(
+        collector_import_service,
+        "fetch_collector_export_order",
+        fake_fetch_collector_export_order,
+    )
+
+    resp = await client.post(
+        "/oms/pdd/platform-order-mirrors/sync-from-collector",
+        json={"limit": 2, "offset": 0},
+    )
+    assert resp.status_code == 200, resp.text
+
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["fetched_count"] == 2
+    assert body["imported_count"] == 1
+    assert body["failed_count"] == 1
+    assert body["items"][0]["collector_order_id"] == 990201
+    assert body["errors"][0]["collector_order_id"] == 990202
+    assert body["errors"][0]["error_code"] == "CollectorExportNotFound"


### PR DESCRIPTION
## Summary
- add POST /oms/{platform}/platform-order-mirrors/sync-from-collector
- fetch Collector Export order list by platform with limit/offset
- import listed orders through the existing single-order collector import flow
- return imported and failed item summaries for batch sync
- keep single-order import-from-collector for operational backfill/debug

## Validation
- python3 -m compileall app/oms/order_facts/contracts/collector_import.py app/oms/order_facts/services/collector_export_client.py app/oms/order_facts/services/collector_import_service.py app/oms/order_facts/router_platform_order_mirrors.py tests/api/test_oms_import_mirrors_from_collector_api.py
- make test TESTS=tests/api/test_oms_import_mirrors_from_collector_api.py
- make test TESTS=tests/api/test_oms_platform_order_mirrors_api.py