### PR TITLE
feat(oms): support time window platform mirror sync

### DIFF
--- a/app/oms/order_facts/contracts/collector_import.py
+++ b/app/oms/order_facts/contracts/collector_import.py
@@ -18,6 +18,8 @@ class ImportPlatformOrderMirrorFromCollectorOut(BaseModel):
 class SyncPlatformOrderMirrorsFromCollectorIn(BaseModel):
     limit: int = Field(50, ge=1, le=1000)
     offset: int = Field(0, ge=0)
+    since: str | None = Field(None, description="Inclusive lower bound for Collector Export source update time.")
+    until: str | None = Field(None, description="Exclusive upper bound for Collector Export source update time.")
 
 
 class SyncPlatformOrderMirrorItemOut(BaseModel):
@@ -37,6 +39,8 @@ class SyncPlatformOrderMirrorsFromCollectorOut(BaseModel):
     platform: str
     limit: int
     offset: int
+    since: str | None = None
+    until: str | None = None
     fetched_count: int
     imported_count: int
     failed_count: int

--- a/app/oms/order_facts/router_platform_order_mirrors.py
+++ b/app/oms/order_facts/router_platform_order_mirrors.py
@@ -99,6 +99,8 @@ def _register_platform_routes(platform: str) -> None:
                 platform=platform,
                 limit=payload.limit,
                 offset=payload.offset,
+                since=payload.since,
+                until=payload.until,
             )
         except CollectorExportUpstreamError as exc:
             raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/app/oms/order_facts/services/collector_export_client.py
+++ b/app/oms/order_facts/services/collector_export_client.py
@@ -86,11 +86,22 @@ async def fetch_collector_export_orders(
     platform: str,
     limit: int,
     offset: int,
+    since: str | None = None,
+    until: str | None = None,
 ) -> list[dict[str, Any]]:
     plat = _norm_platform(platform)
+    params: dict[str, Any] = {
+        "limit": int(limit),
+        "offset": int(offset),
+    }
+    if since:
+        params["since"] = since
+    if until:
+        params["until"] = until
+
     body = await _collector_get_json(
         path=f"/collector/export/{plat}/orders",
-        params={"limit": int(limit), "offset": int(offset)},
+        params=params,
     )
 
     data = body.get("data")

--- a/app/oms/order_facts/services/collector_import_service.py
+++ b/app/oms/order_facts/services/collector_import_service.py
@@ -109,12 +109,16 @@ async def sync_platform_order_mirrors_from_collector(
     platform: str,
     limit: int,
     offset: int,
+    since: str | None = None,
+    until: str | None = None,
 ) -> SyncPlatformOrderMirrorsFromCollectorOut:
     plat = _norm_platform(platform)
     fetched_rows = await fetch_collector_export_orders(
         platform=plat,
         limit=int(limit),
         offset=int(offset),
+        since=since,
+        until=until,
     )
 
     items: list[SyncPlatformOrderMirrorItemOut] = []
@@ -160,6 +164,8 @@ async def sync_platform_order_mirrors_from_collector(
         platform=plat,
         limit=int(limit),
         offset=int(offset),
+        since=since,
+        until=until,
         fetched_count=len(fetched_rows),
         imported_count=len(items),
         failed_count=len(errors),

--- a/tests/api/test_oms_import_mirrors_from_collector_api.py
+++ b/tests/api/test_oms_import_mirrors_from_collector_api.py
@@ -241,10 +241,19 @@ async def test_pdd_sync_from_collector_imports_listed_orders(
     store_code = f"PDD-SYNC-{suffix}"
     await _ensure_store(session, platform="pdd", store_code=store_code)
 
-    async def fake_fetch_collector_export_orders(*, platform: str, limit: int, offset: int) -> list[dict[str, Any]]:
+    async def fake_fetch_collector_export_orders(
+        *,
+        platform: str,
+        limit: int,
+        offset: int,
+        since: str | None = None,
+        until: str | None = None,
+    ) -> list[dict[str, Any]]:
         assert platform == "pdd"
         assert limit == 2
         assert offset == 0
+        assert since is None
+        assert until is None
         return [
             {"collector_order_id": 990101},
             {"collector_order_id": 990102},
@@ -303,8 +312,17 @@ async def test_sync_from_collector_keeps_importing_when_one_order_fails(
     store_code = f"PDD-SYNC-PARTIAL-{suffix}"
     await _ensure_store(session, platform="pdd", store_code=store_code)
 
-    async def fake_fetch_collector_export_orders(*, platform: str, limit: int, offset: int) -> list[dict[str, Any]]:
+    async def fake_fetch_collector_export_orders(
+        *,
+        platform: str,
+        limit: int,
+        offset: int,
+        since: str | None = None,
+        until: str | None = None,
+    ) -> list[dict[str, Any]]:
         assert platform == "pdd"
+        assert since is None
+        assert until is None
         return [
             {"collector_order_id": 990201},
             {"collector_order_id": 990202},
@@ -346,3 +364,72 @@ async def test_sync_from_collector_keeps_importing_when_one_order_fails(
     assert body["items"][0]["collector_order_id"] == 990201
     assert body["errors"][0]["collector_order_id"] == 990202
     assert body["errors"][0]["error_code"] == "CollectorExportNotFound"
+
+
+async def test_sync_from_collector_forwards_since_until_to_collector_export(
+    client,
+    session,
+    monkeypatch,
+) -> None:
+    await _clear_mirrors(session)
+
+    suffix = uuid4().hex[:8]
+    store_code = f"PDD-SYNC-WINDOW-{suffix}"
+    await _ensure_store(session, platform="pdd", store_code=store_code)
+
+    async def fake_fetch_collector_export_orders(
+        *,
+        platform: str,
+        limit: int,
+        offset: int,
+        since: str | None = None,
+        until: str | None = None,
+    ) -> list[dict[str, Any]]:
+        assert platform == "pdd"
+        assert limit == 5
+        assert offset == 0
+        assert since == "2026-04-28T00:00:00+08:00"
+        assert until == "2026-04-29T00:00:00+08:00"
+        return [{"collector_order_id": 990301}]
+
+    async def fake_fetch_collector_export_order(*, platform: str, collector_order_id: int) -> dict[str, Any]:
+        assert platform == "pdd"
+        return _collector_payload(
+            platform="pdd",
+            collector_order_id=collector_order_id,
+            collector_store_code=store_code,
+            platform_order_no=f"PDD-SYNC-WINDOW-ORDER-{suffix}-{collector_order_id}",
+            merchant_sku=f"PDD-FSKU-SYNC-WINDOW-{collector_order_id}",
+        )
+
+    monkeypatch.setattr(
+        collector_import_service,
+        "fetch_collector_export_orders",
+        fake_fetch_collector_export_orders,
+    )
+    monkeypatch.setattr(
+        collector_import_service,
+        "fetch_collector_export_order",
+        fake_fetch_collector_export_order,
+    )
+
+    resp = await client.post(
+        "/oms/pdd/platform-order-mirrors/sync-from-collector",
+        json={
+            "limit": 5,
+            "since": "2026-04-28T00:00:00+08:00",
+            "until": "2026-04-29T00:00:00+08:00",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["platform"] == "pdd"
+    assert body["limit"] == 5
+    assert body["offset"] == 0
+    assert body["since"] == "2026-04-28T00:00:00+08:00"
+    assert body["until"] == "2026-04-29T00:00:00+08:00"
+    assert body["fetched_count"] == 1
+    assert body["imported_count"] == 1
+    assert body["failed_count"] == 0


### PR DESCRIPTION
## Summary
- allow OMS platform mirror batch sync to pass since/until to Collector Export
- keep offset as a compatibility/technical paging option
- return since/until in the sync response
- add test coverage for time-window forwarding

## Validation
- python3 -m compileall app/oms/order_facts/contracts/collector_import.py app/oms/order_facts/services/collector_export_client.py app/oms/order_facts/services/collector_import_service.py app/oms/order_facts/router_platform_order_mirrors.py tests/api/test_oms_import_mirrors_from_collector_api.py
- make test TESTS=tests/api/test_oms_import_mirrors_from_collector_api.py
- make test TESTS=tests/api/test_oms_platform_order_mirrors_api.py