### PR TITLE
feat(oms): use client credentials for collector export

### DIFF
--- a/app/oms/order_facts/services/collector_export_client.py
+++ b/app/oms/order_facts/services/collector_export_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import time
 from typing import Any
 
 import httpx
@@ -20,14 +21,27 @@ class CollectorExportUpstreamError(CollectorExportError):
 
 _SUPPORTED_PLATFORMS = {"pdd", "taobao", "jd"}
 
+_SERVICE_ACCESS_TOKEN: str | None = None
+_SERVICE_ACCESS_TOKEN_EXPIRES_AT: float = 0.0
+
 
 def _collector_base_url() -> str:
     return (os.getenv("COLLECTOR_API_BASE_URL") or "http://127.0.0.1:8001").rstrip("/")
 
 
-def _collector_token() -> str | None:
+def _collector_static_token() -> str | None:
     token = (os.getenv("COLLECTOR_API_TOKEN") or "").strip()
     return token or None
+
+
+def _collector_client_id() -> str | None:
+    value = (os.getenv("COLLECTOR_CLIENT_ID") or "").strip()
+    return value or None
+
+
+def _collector_client_secret() -> str | None:
+    value = (os.getenv("COLLECTOR_CLIENT_SECRET") or "").strip()
+    return value or None
 
 
 def _collector_timeout_seconds() -> float:
@@ -39,6 +53,15 @@ def _collector_timeout_seconds() -> float:
     return value if value > 0 else 10.0
 
 
+def _collector_token_refresh_margin_seconds() -> float:
+    raw = (os.getenv("COLLECTOR_TOKEN_REFRESH_MARGIN_SECONDS") or "60").strip()
+    try:
+        value = float(raw)
+    except ValueError:
+        return 60.0
+    return value if value >= 0 else 60.0
+
+
 def _norm_platform(platform: str) -> str:
     plat = (platform or "").strip().lower()
     if plat not in _SUPPORTED_PLATFORMS:
@@ -46,10 +69,90 @@ def _norm_platform(platform: str) -> str:
     return plat
 
 
-def _headers() -> dict[str, str]:
-    token = _collector_token()
+def _client_credentials_configured() -> bool:
+    return bool(_collector_client_id() or _collector_client_secret())
+
+
+def _reset_service_token_cache_for_tests() -> None:
+    global _SERVICE_ACCESS_TOKEN, _SERVICE_ACCESS_TOKEN_EXPIRES_AT
+
+    _SERVICE_ACCESS_TOKEN = None
+    _SERVICE_ACCESS_TOKEN_EXPIRES_AT = 0.0
+
+
+def _cached_service_token_is_valid() -> bool:
+    if not _SERVICE_ACCESS_TOKEN:
+        return False
+
+    return time.time() < (_SERVICE_ACCESS_TOKEN_EXPIRES_AT - _collector_token_refresh_margin_seconds())
+
+
+async def _fetch_service_access_token() -> str:
+    client_id = _collector_client_id()
+    client_secret = _collector_client_secret()
+
+    if not client_id or not client_secret:
+        raise CollectorExportUpstreamError(
+            "collector client credentials are incomplete: "
+            "set COLLECTOR_CLIENT_ID and COLLECTOR_CLIENT_SECRET"
+        )
+
+    url = f"{_collector_base_url()}/oauth/token"
+    payload = {
+        "grant_type": "client_credentials",
+        "client_id": client_id,
+        "client_secret": client_secret,
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=_collector_timeout_seconds()) as client:
+            resp = await client.post(url, json=payload)
+    except httpx.RequestError as exc:
+        raise CollectorExportUpstreamError(f"collector token request failed: {exc}") from exc
+
+    if resp.status_code >= 400:
+        raise CollectorExportUpstreamError(
+            f"collector token request failed: status={resp.status_code} body={resp.text}"
+        )
+
+    body = resp.json()
+    if not isinstance(body, dict):
+        raise CollectorExportUpstreamError("collector token response is not an object")
+
+    access_token = str(body.get("access_token") or "").strip()
+    if not access_token:
+        raise CollectorExportUpstreamError("collector token response missing access_token")
+
+    try:
+        expires_in = int(body.get("expires_in") or 0)
+    except (TypeError, ValueError):
+        expires_in = 0
+
+    if expires_in <= 0:
+        raise CollectorExportUpstreamError("collector token response has invalid expires_in")
+
+    global _SERVICE_ACCESS_TOKEN, _SERVICE_ACCESS_TOKEN_EXPIRES_AT
+    _SERVICE_ACCESS_TOKEN = access_token
+    _SERVICE_ACCESS_TOKEN_EXPIRES_AT = time.time() + expires_in
+
+    return access_token
+
+
+async def _collector_token() -> str | None:
+    if _client_credentials_configured():
+        if _cached_service_token_is_valid():
+            return _SERVICE_ACCESS_TOKEN
+
+        return await _fetch_service_access_token()
+
+    return _collector_static_token()
+
+
+async def _headers() -> dict[str, str]:
+    token = await _collector_token()
     if not token:
         return {}
+
     return {"Authorization": f"Bearer {token}"}
 
 
@@ -62,7 +165,7 @@ async def _collector_get_json(
 
     try:
         async with httpx.AsyncClient(timeout=_collector_timeout_seconds()) as client:
-            resp = await client.get(url, headers=_headers(), params=params)
+            resp = await client.get(url, headers=await _headers(), params=params)
     except httpx.RequestError as exc:
         raise CollectorExportUpstreamError(f"collector request failed: {exc}") from exc
 

--- a/tests/api/test_oms_collector_export_client_credentials.py
+++ b/tests/api/test_oms_collector_export_client_credentials.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.oms.order_facts.services import collector_export_client as subject
+
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        status_code: int,
+        payload: dict[str, Any],
+        *,
+        text: str | None = None,
+    ) -> None:
+        self.status_code = int(status_code)
+        self._payload = payload
+        self.text = text if text is not None else str(payload)
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+def _clear_collector_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    subject._reset_service_token_cache_for_tests()
+    monkeypatch.delenv("COLLECTOR_API_BASE_URL", raising=False)
+    monkeypatch.delenv("COLLECTOR_API_TOKEN", raising=False)
+    monkeypatch.delenv("COLLECTOR_CLIENT_ID", raising=False)
+    monkeypatch.delenv("COLLECTOR_CLIENT_SECRET", raising=False)
+    monkeypatch.delenv("COLLECTOR_TOKEN_REFRESH_MARGIN_SECONDS", raising=False)
+
+
+async def test_fetch_orders_uses_client_credentials_token_and_caches_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_collector_env(monkeypatch)
+    monkeypatch.setenv("COLLECTOR_API_BASE_URL", "http://collector.test")
+    monkeypatch.setenv("COLLECTOR_CLIENT_ID", "wms-api")
+    monkeypatch.setenv("COLLECTOR_CLIENT_SECRET", "client-secret-001")
+
+    calls: list[tuple[str, str, dict[str, Any] | None, dict[str, str] | None]] = []
+
+    class _FakeAsyncClient:
+        def __init__(self, *, timeout: float) -> None:
+            self.timeout = timeout
+
+        async def __aenter__(self) -> "_FakeAsyncClient":
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def post(self, url: str, json: dict[str, Any]) -> _FakeResponse:
+            calls.append(("POST", url, json, None))
+            assert url == "http://collector.test/oauth/token"
+            assert json == {
+                "grant_type": "client_credentials",
+                "client_id": "wms-api",
+                "client_secret": "client-secret-001",
+            }
+            return _FakeResponse(
+                200,
+                {
+                    "access_token": "service-token-001",
+                    "token_type": "bearer",
+                    "expires_in": 1800,
+                    "scope": "collector.export.read",
+                },
+            )
+
+        async def get(
+            self,
+            url: str,
+            *,
+            headers: dict[str, str],
+            params: dict[str, Any] | None = None,
+        ) -> _FakeResponse:
+            calls.append(("GET", url, params, headers))
+            assert headers == {"Authorization": "Bearer service-token-001"}
+
+            if url.endswith("/collector/export/pdd/orders"):
+                assert params == {
+                    "limit": 2,
+                    "offset": 0,
+                    "since": "2026-04-28T00:00:00+08:00",
+                    "until": "2026-04-29T00:00:00+08:00",
+                }
+                return _FakeResponse(
+                    200,
+                    {
+                        "ok": True,
+                        "data": [{"collector_order_id": 1001}],
+                    },
+                )
+
+            if url.endswith("/collector/export/pdd/orders/1001"):
+                return _FakeResponse(
+                    200,
+                    {
+                        "ok": True,
+                        "data": {"collector_order_id": 1001},
+                    },
+                )
+
+            raise AssertionError(f"unexpected GET url: {url}")
+
+    monkeypatch.setattr(subject.httpx, "AsyncClient", _FakeAsyncClient)
+
+    rows = await subject.fetch_collector_export_orders(
+        platform="pdd",
+        limit=2,
+        offset=0,
+        since="2026-04-28T00:00:00+08:00",
+        until="2026-04-29T00:00:00+08:00",
+    )
+    assert rows == [{"collector_order_id": 1001}]
+
+    detail = await subject.fetch_collector_export_order(
+        platform="pdd",
+        collector_order_id=1001,
+    )
+    assert detail == {"collector_order_id": 1001}
+
+    assert [call[0] for call in calls].count("POST") == 1
+    assert [call[0] for call in calls].count("GET") == 2
+
+
+async def test_fetch_orders_falls_back_to_static_collector_api_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_collector_env(monkeypatch)
+    monkeypatch.setenv("COLLECTOR_API_BASE_URL", "http://collector.test")
+    monkeypatch.setenv("COLLECTOR_API_TOKEN", "static-token-001")
+
+    calls: list[tuple[str, str, dict[str, Any] | None, dict[str, str] | None]] = []
+
+    class _FakeAsyncClient:
+        def __init__(self, *, timeout: float) -> None:
+            self.timeout = timeout
+
+        async def __aenter__(self) -> "_FakeAsyncClient":
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def post(self, url: str, json: dict[str, Any]) -> _FakeResponse:
+            raise AssertionError(f"token endpoint must not be called: {url} {json}")
+
+        async def get(
+            self,
+            url: str,
+            *,
+            headers: dict[str, str],
+            params: dict[str, Any] | None = None,
+        ) -> _FakeResponse:
+            calls.append(("GET", url, params, headers))
+            assert url == "http://collector.test/collector/export/pdd/orders"
+            assert headers == {"Authorization": "Bearer static-token-001"}
+            assert params == {"limit": 1, "offset": 0}
+            return _FakeResponse(
+                200,
+                {
+                    "ok": True,
+                    "data": [{"collector_order_id": 2001}],
+                },
+            )
+
+    monkeypatch.setattr(subject.httpx, "AsyncClient", _FakeAsyncClient)
+
+    rows = await subject.fetch_collector_export_orders(
+        platform="pdd",
+        limit=1,
+        offset=0,
+    )
+
+    assert rows == [{"collector_order_id": 2001}]
+    assert len(calls) == 1
+
+
+async def test_incomplete_client_credentials_raise_configuration_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_collector_env(monkeypatch)
+    monkeypatch.setenv("COLLECTOR_CLIENT_ID", "wms-api")
+
+    with pytest.raises(subject.CollectorExportUpstreamError) as exc:
+        await subject.fetch_collector_export_orders(
+            platform="pdd",
+            limit=1,
+            offset=0,
+        )
+
+    assert "COLLECTOR_CLIENT_ID and COLLECTOR_CLIENT_SECRET" in str(exc.value)


### PR DESCRIPTION
## Summary
- add Collector client_credentials token exchange to WMS collector export client
- cache short-lived service tokens in process and refresh before expiry
- prefer COLLECTOR_CLIENT_ID/COLLECTOR_CLIENT_SECRET over static COLLECTOR_API_TOKEN
- keep COLLECTOR_API_TOKEN as local fallback

## Validation
- python3 -m compileall app/oms/order_facts/services/collector_export_client.py tests/api/test_oms_collector_export_client_credentials.py tests/api/test_oms_import_mirrors_from_collector_api.py
- make test TESTS=tests/api/test_oms_collector_export_client_credentials.py
- make test TESTS=tests/api/test_oms_import_mirrors_from_collector_api.py