### PR TITLE
fix(oms): return clear test-set guard problems

### DIFF
--- a/app/oms/deps/stores_order_sim_testset_guard.py
+++ b/app/oms/deps/stores_order_sim_testset_guard.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 from fastapi import HTTPException
+from sqlalchemy import text
 
 from app.core.problem import make_problem
-from app.pms.items.services.item_test_set_service import ItemTestSetService
 
 
 def extract_expanded_item_ids(out_dict: dict) -> list[int]:
@@ -31,38 +31,115 @@ def extract_expanded_item_ids(out_dict: dict) -> list[int]:
     return sorted(ids)
 
 
-async def assert_order_sim_all_items_in_test_set(*, session, out_dict: dict, platform: str, store_code: str, store_id: int) -> None:
-    """
-    ✅ 测试域硬隔离护栏：order-sim 必须“全部是测试商品”（DEFAULT 集合）
-    """
-    try:
-        item_ids = extract_expanded_item_ids(out_dict if isinstance(out_dict, dict) else {})
-        ts = ItemTestSetService(session)
-        await ts.assert_items_in_test_set(item_ids=item_ids, set_code="DEFAULT")
-    except ItemTestSetService.NotFound as e:
+async def _load_test_set_id(session, *, set_code: str) -> int:
+    code = (set_code or "").strip()
+    if not code:
         raise HTTPException(
             status_code=500,
             detail=make_problem(
                 status_code=500,
                 error_code="internal_error",
-                message=f"测试集合不可用：{e.message}",
-                context={"platform": platform, "store_code": store_code, "store_id": int(store_id), "set_code": "DEFAULT"},
+                message="测试集合不可用：set_code 不能为空",
+                context={"set_code": set_code},
             ),
         )
-    except ItemTestSetService.Conflict as e:
+
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT id
+                  FROM item_test_sets
+                 WHERE code = :code
+                 LIMIT 1
+                """
+            ),
+            {"code": code},
+        )
+    ).mappings().first()
+
+    if not row or row.get("id") is None:
         raise HTTPException(
-            status_code=409,
+            status_code=500,
             detail=make_problem(
-                status_code=409,
-                error_code="conflict",
-                message=e.message,
-                context={
-                    "platform": platform,
-                    "store_code": store_code,
-                    "store_id": int(store_id),
-                    "set_code": e.set_code,
-                    "out_of_set_item_ids": e.out_of_set_item_ids,
-                    "resolved_item_ids": extract_expanded_item_ids(out_dict if isinstance(out_dict, dict) else {}),
-                },
+                status_code=500,
+                error_code="internal_error",
+                message=f"测试集合不可用：测试集合不存在：{code}",
+                context={"set_code": code},
             ),
         )
+
+    return int(row["id"])
+
+
+async def _load_test_set_member_item_ids(
+    session,
+    *,
+    set_id: int,
+    item_ids: list[int],
+) -> set[int]:
+    ids = sorted({int(x) for x in item_ids if x is not None})
+    if not ids:
+        return set()
+
+    rows = (
+        await session.execute(
+            text(
+                """
+                SELECT item_id
+                  FROM item_test_set_items
+                 WHERE set_id = :set_id
+                   AND item_id = ANY(:item_ids)
+                """
+            ),
+            {"set_id": int(set_id), "item_ids": ids},
+        )
+    ).mappings().all()
+
+    return {int(row["item_id"]) for row in rows if row.get("item_id") is not None}
+
+
+async def assert_order_sim_all_items_in_test_set(
+    *,
+    session,
+    out_dict: dict,
+    platform: str,
+    store_code: str,
+    store_id: int,
+) -> None:
+    """
+    ✅ 测试域硬隔离护栏：order-sim 必须“全部是测试商品”（DEFAULT 集合）
+    """
+
+    resolved_item_ids = extract_expanded_item_ids(out_dict if isinstance(out_dict, dict) else {})
+    if not resolved_item_ids:
+        return
+
+    set_code = "DEFAULT"
+    set_id = await _load_test_set_id(session, set_code=set_code)
+    member_item_ids = await _load_test_set_member_item_ids(
+        session,
+        set_id=set_id,
+        item_ids=resolved_item_ids,
+    )
+
+    out_of_set_item_ids = sorted(set(resolved_item_ids) - member_item_ids)
+    if not out_of_set_item_ids:
+        return
+
+    raise HTTPException(
+        status_code=409,
+        detail=make_problem(
+            status_code=409,
+            error_code="conflict",
+            message=f"order-sim 仅允许测试商品：非测试商品 item_ids={out_of_set_item_ids}",
+            context={
+                "platform": platform,
+                "store_code": store_code,
+                "store_id": int(store_id),
+                "set_code": set_code,
+                "out_of_set_item_ids": out_of_set_item_ids,
+                "resolved_item_ids": resolved_item_ids,
+            },
+        ),
+    )

--- a/app/oms/services/platform_order_ingest_universe_guard.py
+++ b/app/oms/services/platform_order_ingest_universe_guard.py
@@ -68,36 +68,42 @@ async def enforce_no_test_items_in_non_test_store(
     if is_test_store(store_code):
         return
 
-    if not item_ids:
+    normalized_item_ids = sorted({int(x) for x in item_ids if x is not None})
+    if not normalized_item_ids:
         return
 
     ts = ItemTestSetService(session)
     try:
-        await ts.assert_items_not_in_test_set(item_ids=item_ids, set_code="DEFAULT")
+        await ts.assert_items_not_in_test_set(item_ids=normalized_item_ids, set_code="DEFAULT")
     except ItemTestSetService.NotFound as e:
         raise HTTPException(
             status_code=500,
             detail=make_problem(
                 status_code=500,
                 error_code="internal_error",
-                message=f"测试集合不可用：{e.message}",
-                context={"store_code": str(store_code), "test_store_code": str(tid), "set_code": "DEFAULT", "source": source},
+                message=f"测试集合不可用：{str(e)}",
+                context={
+                    "store_code": str(store_code),
+                    "test_store_code": str(tid),
+                    "set_code": "DEFAULT",
+                    "source": source,
+                },
             ),
-        )
-    except ItemTestSetService.Conflict as e:
+        ) from e
+    except ItemTestSetService.InTestSet as e:
         raise HTTPException(
             status_code=409,
             detail=make_problem(
                 status_code=409,
                 error_code="conflict",
-                message=e.message,
+                message=f"测试商品不能进入非测试店铺：{str(e)}",
                 context={
                     "store_code": str(store_code),
                     "test_store_code": str(tid),
                     "store_id": int(store_id) if store_id is not None else None,
-                    "set_code": e.set_code,
-                    "out_of_set_item_ids": e.out_of_set_item_ids,
+                    "set_code": "DEFAULT",
+                    "test_item_ids": normalized_item_ids,
                     "source": source,
                 },
             ),
-        )
+        ) from e

--- a/app/oms/services/test_store_testset_guard_service.py
+++ b/app/oms/services/test_store_testset_guard_service.py
@@ -43,21 +43,28 @@ class TestShopTestSetGuardService:
             # ✅ 兼容合同：允许绑定“无 components”的 published FSKU
             return
 
-        is_test = await self.test_store.is_test_store(platform=str(platform), store_code=str(store_code), code="DEFAULT")
+        is_test = await self.test_store.is_test_store(
+            platform=str(platform),
+            store_code=str(store_code),
+            code="DEFAULT",
+        )
         if is_test:
             # ✅ TEST store 不强制 all-in；order-sim 等调试入口会做更严格兜底
             return
 
         # ✅ 非 TEST store：禁止 Test Set items 进入
         try:
-            await self.ts.assert_items_not_in_test_set(item_ids=comp_item_ids, set_code=set_code)
+            await self.ts.assert_items_not_in_test_set(
+                item_ids=comp_item_ids,
+                set_code=set_code,
+            )
         except ItemTestSetService.NotFound as e:
             raise HTTPException(
                 status_code=500,
                 detail=make_problem(
                     status_code=500,
                     error_code="internal_error",
-                    message=f"测试集合不可用：{e.message}",
+                    message=f"测试集合不可用：{str(e)}",
                     context={
                         "path": path,
                         "method": method,
@@ -68,24 +75,23 @@ class TestShopTestSetGuardService:
                         "fsku_id": int(fsku_id),
                     },
                 ),
-            )
-        except ItemTestSetService.Conflict as e:
-            # e.out_of_set_item_ids 这里代表“命中 Test Set 的 item_ids”（即禁止进入的测试商品）
+            ) from e
+        except ItemTestSetService.InTestSet as e:
             raise HTTPException(
                 status_code=409,
                 detail=make_problem(
                     status_code=409,
                     error_code="conflict",
-                    message=e.message,
+                    message=f"测试商品不能绑定到非测试店铺：{str(e)}",
                     context={
                         "path": path,
                         "method": method,
                         "platform": str(platform),
                         "store_id": int(store_id) if store_id is not None else None,
                         "store_code": str(store_code),
-                        "set_code": e.set_code,
+                        "set_code": str(set_code),
                         "fsku_id": int(fsku_id),
-                        "out_of_set_item_ids": e.out_of_set_item_ids,
+                        "component_item_ids": [int(x) for x in comp_item_ids],
                     },
                 ),
-            )
+            ) from e

--- a/tests/api/test_merchant_code_bindings_contract.py
+++ b/tests/api/test_merchant_code_bindings_contract.py
@@ -136,6 +136,64 @@ async def test_bind_contract_success_or_problem(client):
 
 
 @pytest.mark.anyio
+async def test_bind_returns_conflict_when_test_set_guard_blocks_non_test_store(client, monkeypatch):
+    from app.oms.services import test_store_testset_guard_service as guard_module
+
+    async def fake_load_component_item_ids(_session, *, fsku_id: int) -> list[int]:
+        assert int(fsku_id) == 1
+        return [1]
+
+    class FakePlatformTestStoreService:
+        def __init__(self, _session):
+            pass
+
+        async def is_test_store(self, *, platform: str, store_code: str, code: str = "DEFAULT") -> bool:
+            assert platform == "DEMO"
+            assert store_code == "NON-TEST-STORE"
+            assert code == "DEFAULT"
+            return False
+
+    class FakeItemTestSetService:
+        class NotFound(ValueError):
+            pass
+
+        class InTestSet(ValueError):
+            pass
+
+        def __init__(self, _session):
+            pass
+
+        async def assert_items_not_in_test_set(self, *, item_ids: list[int], set_code: str = "DEFAULT") -> None:
+            assert item_ids == [1]
+            assert set_code == "DEFAULT"
+            raise self.InTestSet("items in test_set[DEFAULT]: [1]")
+
+    monkeypatch.setattr(guard_module, "load_component_item_ids", fake_load_component_item_ids)
+    monkeypatch.setattr(guard_module, "PlatformTestStoreService", FakePlatformTestStoreService)
+    monkeypatch.setattr(guard_module, "ItemTestSetService", FakeItemTestSetService)
+
+    headers = await _auth_headers(client)
+    payload = {
+        "platform": "DEMO",
+        "store_code": "NON-TEST-STORE",
+        "merchant_code": "UT-MC-GUARD-BLOCKED-001",
+        "fsku_id": 1,
+        "reason": "UT: guard should return conflict",
+    }
+
+    resp = await client.post("/oms/merchant-code-bindings/bind", json=payload, headers=headers)
+
+    assert resp.status_code == 409, resp.text
+    problem = resp.json()
+    _assert_problem_shape(problem)
+    assert problem["error_code"] == "conflict"
+    assert "测试商品不能绑定到非测试店铺" in str(problem["message"])
+    assert problem["context"]["platform"] == "DEMO"
+    assert problem["context"]["store_code"] == "NON-TEST-STORE"
+    assert problem["context"]["component_item_ids"] == [1]
+
+
+@pytest.mark.anyio
 async def test_retire_is_blocked_when_fsku_is_referenced_by_merchant_code_binding(client):
     """
     护栏契约：被 merchant_code_fsku_bindings 引用的 published FSKU，不允许 retire。

--- a/tests/unit/test_item_test_set_guard_contract.py
+++ b/tests/unit/test_item_test_set_guard_contract.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from app.oms.deps import stores_order_sim_testset_guard as order_sim_guard
+from app.oms.services import platform_order_ingest_universe_guard as ingest_guard
+
+
+@pytest.mark.asyncio
+async def test_order_sim_guard_returns_conflict_when_item_is_out_of_test_set(monkeypatch):
+    async def fake_load_test_set_id(_session, *, set_code: str) -> int:
+        assert set_code == "DEFAULT"
+        return 1
+
+    async def fake_load_test_set_member_item_ids(_session, *, set_id: int, item_ids: list[int]) -> set[int]:
+        assert set_id == 1
+        assert item_ids == [1, 2]
+        return {1}
+
+    monkeypatch.setattr(order_sim_guard, "_load_test_set_id", fake_load_test_set_id)
+    monkeypatch.setattr(order_sim_guard, "_load_test_set_member_item_ids", fake_load_test_set_member_item_ids)
+
+    out_dict = {
+        "resolved": [
+            {
+                "expanded_items": [
+                    {"item_id": 1},
+                    {"item_id": 2},
+                ]
+            }
+        ]
+    }
+
+    with pytest.raises(HTTPException) as exc:
+        await order_sim_guard.assert_order_sim_all_items_in_test_set(
+            session=object(),
+            out_dict=out_dict,
+            platform="DEMO",
+            store_code="1",
+            store_id=1,
+        )
+
+    assert exc.value.status_code == 409
+    problem = exc.value.detail
+    assert problem["error_code"] == "conflict"
+    assert problem["context"]["out_of_set_item_ids"] == [2]
+    assert problem["context"]["resolved_item_ids"] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_platform_order_ingest_guard_returns_conflict_when_test_item_enters_non_test_store(monkeypatch):
+    monkeypatch.setenv("TEST_STORE_ID", "TEST-STORE")
+
+    class FakeItemTestSetService:
+        class NotFound(ValueError):
+            pass
+
+        class InTestSet(ValueError):
+            pass
+
+        def __init__(self, _session):
+            pass
+
+        async def assert_items_not_in_test_set(self, *, item_ids: list[int], set_code: str = "DEFAULT") -> None:
+            assert item_ids == [1]
+            assert set_code == "DEFAULT"
+            raise self.InTestSet("items in test_set[DEFAULT]: [1]")
+
+    monkeypatch.setattr(ingest_guard, "ItemTestSetService", FakeItemTestSetService)
+
+    with pytest.raises(HTTPException) as exc:
+        await ingest_guard.enforce_no_test_items_in_non_test_store(
+            object(),
+            store_code="PROD-STORE",
+            store_id=100,
+            item_ids=[1],
+            source="unit-test",
+        )
+
+    assert exc.value.status_code == 409
+    problem = exc.value.detail
+    assert problem["error_code"] == "conflict"
+    assert "测试商品不能进入非测试店铺" in problem["message"]
+    assert problem["context"]["store_code"] == "PROD-STORE"
+    assert problem["context"]["test_store_code"] == "TEST-STORE"
+    assert problem["context"]["test_item_ids"] == [1]


### PR DESCRIPTION
## Summary

- Fix OMS test-set guard error handling to return clear Problem responses instead of generic 500.
- Replace legacy ItemTestSetService.Conflict handling with current NotFound / InTestSet semantics.
- Add regression coverage for merchant-code binding guard behavior.
- Keep successful PDD / TAOBAO / JD collector-to-fulfillment chain unchanged.

## Validation

- python3 -m compileall for modified guard/test files
- make test TESTS="tests/api/test_merchant_code_bindings_contract.py tests/unit/test_item_test_set_guard_contract.py"
- precise legacy guard scan
- Local smoke:
  - PDD mirror_id=1 / 4 conversion ok
  - TAOBAO mirror_id=1 / 2 conversion ok
  - JD mirror_id=1 / 2 conversion ok