### PR TITLE
feat(pms): require manual sku on item create

### DIFF
--- a/app/pms/items/contracts/item.py
+++ b/app/pms/items/contracts/item.py
@@ -28,10 +28,6 @@ def _is_required_expiry_policy(v: object) -> bool:
     return str(v or "").upper() == "REQUIRED"
 
 
-class NextSkuOut(_Base):
-    sku: str
-
-
 class ItemBase(_Base):
     sku: Annotated[str, Field(min_length=1, max_length=64)]
     name: Annotated[str, Field(min_length=1, max_length=128)]
@@ -75,8 +71,8 @@ class ItemBase(_Base):
 
 class ItemCreate(_Base):
     """
-    Create Item（统一由后端生成 SKU）：
-    - 不接受 sku 输入
+    Create Item（SKU 由调用方显式输入）：
+    - 必须传 sku；SKU 编码页只负责生成候选 SKU，最终由商品创建合同写入 items.sku
     - 不接受 barcode 输入；主条码请走 /item-barcodes
     - 不接受 weight_kg 输入；基础包装净重请走 item_uoms（base uom）
 
@@ -89,6 +85,7 @@ class ItemCreate(_Base):
         populate_by_name=True,
     )
 
+    sku: Annotated[str, Field(min_length=1, max_length=64)]
     name: Annotated[str, Field(min_length=1, max_length=128)]
     spec: Annotated[str | None, Field(default=None, max_length=128)] = None
 
@@ -107,6 +104,7 @@ class ItemCreate(_Base):
     shelf_life_unit: Annotated[ShelfLifeUnit | None, Field(default=None)] = None
 
     @field_validator(
+        "sku",
         "name",
         "spec",
         "brand",
@@ -189,7 +187,6 @@ class ItemOut(ItemBase):
 
 
 __all__ = [
-    "NextSkuOut",
     "ItemBase",
     "ItemCreate",
     "ItemUpdate",

--- a/app/pms/items/routers/items.py
+++ b/app/pms/items/routers/items.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 from app.db.deps import get_db
-from app.pms.items.contracts.item import ItemCreate, ItemOut, ItemUpdate, NextSkuOut
+from app.pms.items.contracts.item import ItemCreate, ItemOut, ItemUpdate
 from app.pms.items.services.item_service import ItemService
 
 router = APIRouter(prefix="/items", tags=["items"])
@@ -24,11 +24,6 @@ def _normalize_policy(v: Optional[str]) -> Optional[str]:
     return s if s else None
 
 
-@router.post("/sku/next", response_model=NextSkuOut)
-def next_sku(item_service: ItemService = Depends(get_item_service)):
-    return NextSkuOut(sku=item_service.next_sku())
-
-
 @router.post("", response_model=ItemOut, status_code=status.HTTP_201_CREATED)
 def create_item(
     item_in: ItemCreate,
@@ -36,6 +31,7 @@ def create_item(
 ):
     try:
         return item_service.create_item(
+            sku=item_in.sku,
             name=item_in.name,
             spec=item_in.spec,
             brand=item_in.brand,

--- a/app/pms/items/services/item_service.py
+++ b/app/pms/items/services/item_service.py
@@ -29,6 +29,10 @@ class ItemService:
     Phase M-6：
     - items.weight_kg 不再作为写入真相源
     - PMS 主合同的净重读写转移到 base item_uom.net_weight_kg
+
+    SKU coding：
+    - 主合同 POST /items 不再自动生成 SKU
+    - items.sku 必须由调用方显式输入，通常来自 SKU 编码页生成候选后人工确认
     """
 
     def __init__(self, db: Session) -> None:
@@ -37,9 +41,6 @@ class ItemService:
         self._write = ItemWriteService(db)
         self._present = ItemPresenter(db)
         self._test_sets = ItemTestSetService(db)
-
-    def next_sku(self) -> str:
-        return self._write.next_sku()
 
     def enable_item_test_flag(self, *, item_id: int, set_code: str = "DEFAULT") -> Item:
         obj = self.db.get(Item, int(item_id))
@@ -78,6 +79,7 @@ class ItemService:
     def create_item(
         self,
         *,
+        sku: str,
         name: str,
         spec: Optional[str] = None,
         brand: Optional[str] = None,
@@ -92,6 +94,7 @@ class ItemService:
         uom_governance_enabled: Optional[bool] = None,
     ) -> Item:
         obj = self._write.create_item(
+            sku=sku,
             name=name,
             spec=spec,
             brand=brand,

--- a/app/pms/items/services/item_write_service.py
+++ b/app/pms/items/services/item_write_service.py
@@ -1,6 +1,7 @@
 # app/pms/items/services/item_write_service.py
 from __future__ import annotations
 
+import re
 from typing import Optional
 
 from sqlalchemy.exc import IntegrityError
@@ -16,12 +17,12 @@ from app.pms.items.repos.item_write_repo import (
     refresh_item,
     rollback as repo_rollback,
 )
-from app.pms.items.services.item_sku import next_sku
 
 
 _ALLOWED_LOT_SOURCE_POLICIES = {"INTERNAL_ONLY", "SUPPLIER_ONLY"}
 _ALLOWED_EXPIRY_POLICIES = {"NONE", "REQUIRED"}
 _ALLOWED_SHELF_LIFE_UNITS = {"DAY", "WEEK", "MONTH", "YEAR"}
+_SKU_PATTERN = re.compile(r"^[A-Z0-9][A-Z0-9._-]{0,63}$")
 
 
 def _norm_policy_str(v: Optional[str]) -> Optional[str]:
@@ -36,6 +37,17 @@ def _norm_text_or_none(v: Optional[str]) -> Optional[str]:
         return None
     s = str(v).strip()
     return s or None
+
+
+def _validate_sku(v: str) -> str:
+    s = str(v or "").strip().upper()
+    if not s:
+        raise ValueError("sku 不能为空")
+    if len(s) > 64:
+        raise ValueError("sku 长度不能超过 64")
+    if not _SKU_PATTERN.fullmatch(s):
+        raise ValueError("invalid sku")
+    return s
 
 
 def _norm_shelf_life_unit(v: Optional[str]) -> Optional[str]:
@@ -117,20 +129,18 @@ class ItemWriteService:
     - 包装、单位、净重、条码属于商品聚合的其他真相源
     - owner 聚合写接口应在更高一层 orchestrate item + item_uoms + item_barcodes
 
-    兼容保留：
-    - 主合同 `POST /items` 创建 item 时，仍自动补最小 base item_uom
-    - 这是当前 items 主合同与既有测试/调用链约定的一部分
+    主合同语义：
+    - POST /items 必须显式传 sku
+    - 创建 item 时仍自动补最小 base item_uom
     """
 
     def __init__(self, db: Session) -> None:
         self.db = db
 
-    def next_sku(self) -> str:
-        return next_sku(self.db)
-
     def create_item(
         self,
         *,
+        sku: str,
         name: str,
         spec: Optional[str] = None,
         brand: Optional[str] = None,
@@ -144,6 +154,8 @@ class ItemWriteService:
         derivation_allowed: Optional[bool] = None,
         uom_governance_enabled: Optional[bool] = None,
     ) -> Item:
+        sku_val = _validate_sku(sku)
+
         name_val = _norm_text_or_none(name)
         if not name_val:
             raise ValueError("name is required")
@@ -151,8 +163,6 @@ class ItemWriteService:
         spec_val = _norm_text_or_none(spec)
         brand_val = _norm_text_or_none(brand)
         category_val = _norm_text_or_none(category)
-
-        sku_val = self.next_sku()
 
         lot_policy = _norm_policy_str(lot_source_policy) or "SUPPLIER_ONLY"
         if lot_policy not in _ALLOWED_LOT_SOURCE_POLICIES:

--- a/tests/api/test_items_main_contract_api.py
+++ b/tests/api/test_items_main_contract_api.py
@@ -10,6 +10,10 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
+def _sku(prefix: str = "UT-SKU") -> str:
+    return f"{prefix}-{uuid4().hex[:8].upper()}"
+
+
 async def _login_admin_headers(client: httpx.AsyncClient) -> Dict[str, str]:
     r = await client.post("/users/login", json={"username": "admin", "password": "admin123"})
     assert r.status_code == 200, r.text
@@ -23,6 +27,7 @@ async def _create_item(
     **overrides: Any,
 ) -> Dict[str, Any]:
     payload: Dict[str, Any] = {
+        "sku": _sku(),
         "name": f"UT-ITEM-{uuid4().hex[:8]}",
         "spec": "SPEC-A",
         "brand": "BRAND-A",
@@ -45,10 +50,82 @@ async def _create_item(
 
 
 @pytest.mark.asyncio
+async def test_items_create_requires_manual_sku(client: httpx.AsyncClient) -> None:
+    headers = await _login_admin_headers(client)
+
+    payload = {
+        "name": f"UT-ITEM-{uuid4().hex[:8]}",
+        "spec": "SPEC-A",
+        "brand": "BRAND-A",
+        "category": "CATEGORY-A",
+        "enabled": True,
+        "supplier_id": 1,
+        "lot_source_policy": "SUPPLIER_ONLY",
+        "expiry_policy": "NONE",
+        "derivation_allowed": True,
+        "uom_governance_enabled": False,
+    }
+
+    r = await client.post("/items", json=payload, headers=headers)
+    assert r.status_code == 422, r.text
+
+
+@pytest.mark.asyncio
+async def test_items_create_persists_manual_sku_and_normalizes_uppercase(client: httpx.AsyncClient) -> None:
+    headers = await _login_admin_headers(client)
+    sku = _sku("manual-sku")
+
+    data = await _create_item(
+        client,
+        headers,
+        sku=sku.lower(),
+        expiry_policy="NONE",
+        shelf_life_value=None,
+        shelf_life_unit=None,
+    )
+
+    assert data["sku"] == sku.upper()
+
+
+@pytest.mark.asyncio
+async def test_items_create_rejects_duplicate_manual_sku(client: httpx.AsyncClient) -> None:
+    headers = await _login_admin_headers(client)
+    sku = _sku("DUP-SKU")
+
+    first = await _create_item(
+        client,
+        headers,
+        sku=sku,
+        expiry_policy="NONE",
+        shelf_life_value=None,
+        shelf_life_unit=None,
+    )
+    assert first["sku"] == sku
+
+    payload = {
+        "sku": sku,
+        "name": f"UT-ITEM-{uuid4().hex[:8]}",
+        "spec": "SPEC-B",
+        "brand": "BRAND-B",
+        "category": "CATEGORY-B",
+        "enabled": True,
+        "supplier_id": 1,
+        "lot_source_policy": "SUPPLIER_ONLY",
+        "expiry_policy": "NONE",
+        "derivation_allowed": True,
+        "uom_governance_enabled": False,
+    }
+
+    r = await client.post("/items", json=payload, headers=headers)
+    assert r.status_code == 409, r.text
+
+
+@pytest.mark.asyncio
 async def test_items_create_rejects_barcode_field(client: httpx.AsyncClient) -> None:
     headers = await _login_admin_headers(client)
 
     payload = {
+        "sku": _sku(),
         "name": f"UT-ITEM-{uuid4().hex[:8]}",
         "barcode": "6900000000012",
     }
@@ -61,6 +138,7 @@ async def test_items_create_rejects_has_shelf_life_field(client: httpx.AsyncClie
     headers = await _login_admin_headers(client)
 
     payload = {
+        "sku": _sku(),
         "name": f"UT-ITEM-{uuid4().hex[:8]}",
         "has_shelf_life": True,
     }
@@ -73,6 +151,7 @@ async def test_items_create_rejects_weight_kg_field(client: httpx.AsyncClient) -
     headers = await _login_admin_headers(client)
 
     payload = {
+        "sku": _sku(),
         "name": f"UT-ITEM-{uuid4().hex[:8]}",
         "weight_kg": 1.25,
     }
@@ -102,6 +181,7 @@ async def test_items_create_rejects_zero_shelf_life_value(client: httpx.AsyncCli
     headers = await _login_admin_headers(client)
 
     payload = {
+        "sku": _sku(),
         "name": f"UT-ITEM-{uuid4().hex[:8]}",
         "expiry_policy": "REQUIRED",
         "shelf_life_value": 0,

--- a/tests/ci/test_pms_item_openapi_contract.py
+++ b/tests/ci/test_pms_item_openapi_contract.py
@@ -15,7 +15,6 @@ _FORBIDDEN_ITEM_WRITE_FIELDS = {
     "net_weight_kg",
     "uom",
     "unit",
-    "sku",
     "has_shelf_life",
 }
 
@@ -80,3 +79,25 @@ def test_static_openapi_pms_item_write_contract_matches_runtime_boundary() -> No
         assert _OWNER_OUTPUT_COMPAT_FIELDS <= item_out_props, (
             f"{path}:ItemOut must keep owner compat output fields during this governance phase"
         )
+
+
+def test_runtime_openapi_pms_item_create_requires_manual_sku_and_update_keeps_sku_closed() -> None:
+    """
+    SKU 编码终态合同：
+
+    - ItemCreate 必须显式输入 sku；
+    - ItemUpdate 仍然不开放 sku 变更；
+    - sku 的最终真相仍是 items.sku，不再由 POST /items 自动生成。
+    """
+    spec = app.openapi()
+
+    create_schema = spec["components"]["schemas"]["ItemCreate"]
+    update_schema = spec["components"]["schemas"]["ItemUpdate"]
+
+    create_props = create_schema.get("properties") or {}
+    update_props = update_schema.get("properties") or {}
+    create_required = set(create_schema.get("required") or [])
+
+    assert "sku" in create_props
+    assert "sku" in create_required
+    assert "sku" not in update_props


### PR DESCRIPTION
## Summary

- Change POST /items to require explicit sku input.
- Remove /items/sku/next route from the item owner API.
- Stop ItemWriteService from generating sku automatically for POST /items.
- Keep sku immutable on PATCH /items/{id}.
- Update API and OpenAPI contract tests.

## Validation

- python3 -m compileall app/pms/items/contracts/item.py app/pms/items/routers/items.py app/pms/items/services/item_service.py app/pms/items/services/item_write_service.py tests/api/test_items_main_contract_api.py tests/ci/test_pms_item_openapi_contract.py
- make test TESTS="tests/api/test_items_main_contract_api.py tests/ci/test_pms_item_compat_contract.py tests/ci/test_pms_item_openapi_contract.py"

## Notes

- No DB schema change in this PR.
- items.sku was already NOT NULL + UNIQUE.
- /items/aggregate still has next_sku usage and will be handled separately.