### PR TITLE
refactor(pms): expand sku length to 128

### DIFF
--- a/alembic/versions/a52459bdb9ed_expand_sku_length_to_128.py
+++ b/alembic/versions/a52459bdb9ed_expand_sku_length_to_128.py
@@ -1,0 +1,112 @@
+"""expand_sku_length_to_128
+
+Revision ID: a52459bdb9ed
+Revises: '0bf1c4ffb51a'
+Create Date: 2026-04-29
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "a52459bdb9ed"
+down_revision: Union[str, Sequence[str], None] = '0bf1c4ffb51a'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Expand SKU-like business code fields to 128."""
+
+    op.alter_column("items", "sku", existing_type=sa.String(length=64), type_=sa.String(length=128), existing_nullable=False)
+    op.alter_column("fskus", "code", existing_type=sa.String(length=64), type_=sa.String(length=128), existing_nullable=False)
+
+    op.alter_column("purchase_order_lines", "item_sku", existing_type=sa.String(length=64), type_=sa.String(length=128), existing_nullable=True)
+    op.alter_column("purchase_order_line_completion", "item_sku", existing_type=sa.String(length=64), type_=sa.String(length=128), existing_nullable=True)
+    op.alter_column("finance_purchase_price_ledger_lines", "item_sku", existing_type=sa.String(length=64), type_=sa.String(length=128), existing_nullable=True)
+
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'outbound_event_lines'
+              AND column_name = 'item_sku_snapshot'
+          ) THEN
+            ALTER TABLE outbound_event_lines
+            ALTER COLUMN item_sku_snapshot TYPE varchar(128);
+          END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    """Shrink SKU-like business code fields back to 64."""
+
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF EXISTS (
+            SELECT 1 FROM items WHERE length(sku) > 64
+          ) THEN
+            RAISE EXCEPTION 'cannot downgrade: items.sku contains values longer than 64';
+          END IF;
+
+          IF EXISTS (
+            SELECT 1 FROM fskus WHERE length(code) > 64
+          ) THEN
+            RAISE EXCEPTION 'cannot downgrade: fskus.code contains values longer than 64';
+          END IF;
+
+          IF EXISTS (
+            SELECT 1 FROM purchase_order_lines WHERE length(item_sku) > 64
+          ) THEN
+            RAISE EXCEPTION 'cannot downgrade: purchase_order_lines.item_sku contains values longer than 64';
+          END IF;
+
+          IF EXISTS (
+            SELECT 1 FROM purchase_order_line_completion WHERE length(item_sku) > 64
+          ) THEN
+            RAISE EXCEPTION 'cannot downgrade: purchase_order_line_completion.item_sku contains values longer than 64';
+          END IF;
+
+          IF EXISTS (
+            SELECT 1 FROM finance_purchase_price_ledger_lines WHERE length(item_sku) > 64
+          ) THEN
+            RAISE EXCEPTION 'cannot downgrade: finance_purchase_price_ledger_lines.item_sku contains values longer than 64';
+          END IF;
+        END $$;
+        """
+    )
+
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'outbound_event_lines'
+              AND column_name = 'item_sku_snapshot'
+          ) THEN
+            ALTER TABLE outbound_event_lines
+            ALTER COLUMN item_sku_snapshot TYPE varchar(64);
+          END IF;
+        END $$;
+        """
+    )
+
+    op.alter_column("finance_purchase_price_ledger_lines", "item_sku", existing_type=sa.String(length=128), type_=sa.String(length=64), existing_nullable=True)
+    op.alter_column("purchase_order_line_completion", "item_sku", existing_type=sa.String(length=128), type_=sa.String(length=64), existing_nullable=True)
+    op.alter_column("purchase_order_lines", "item_sku", existing_type=sa.String(length=128), type_=sa.String(length=64), existing_nullable=True)
+
+    op.alter_column("fskus", "code", existing_type=sa.String(length=128), type_=sa.String(length=64), existing_nullable=False)
+    op.alter_column("items", "sku", existing_type=sa.String(length=128), type_=sa.String(length=64), existing_nullable=False)

--- a/app/finance/models/purchase_price_ledger_line.py
+++ b/app/finance/models/purchase_price_ledger_line.py
@@ -44,7 +44,7 @@ class FinancePurchasePriceLedgerLine(Base):
     line_no: Mapped[int] = mapped_column(sa.Integer, nullable=False)
 
     item_id: Mapped[int] = mapped_column(sa.Integer, nullable=False)
-    item_sku: Mapped[str | None] = mapped_column(sa.String(64), nullable=True)
+    item_sku: Mapped[str | None] = mapped_column(sa.String(128), nullable=True)
     item_name: Mapped[str | None] = mapped_column(sa.String(255), nullable=True)
     spec_text: Mapped[str | None] = mapped_column(sa.String(255), nullable=True)
 

--- a/app/oms/fsku/contracts/merchant_code_bindings.py
+++ b/app/oms/fsku/contracts/merchant_code_bindings.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 
 class MerchantCodeBindingBindIn(BaseModel):
     platform: str = Field(..., min_length=1, max_length=32, description="平台（DEMO/PDD/TB...）")
-    store_code: str = Field(..., min_length=1, max_length=64, description="平台店铺 ID（字符串，与 platform 对齐）")
+    store_code: str = Field(..., min_length=1, max_length=128, description="平台店铺 ID（字符串，与 platform 对齐）")
     merchant_code: str = Field(..., min_length=1, max_length=128, description="商家后端规格编码（merchant_code / filled_code）")
     fsku_id: int = Field(..., ge=1, description="要绑定到的 published FSKU.id")
     reason: Optional[str] = Field(None, max_length=500, description="绑定原因（可选）")
@@ -17,18 +17,18 @@ class MerchantCodeBindingBindIn(BaseModel):
 
 class MerchantCodeBindingCloseIn(BaseModel):
     platform: str = Field(..., min_length=1, max_length=32, description="平台（DEMO/PDD/TB...）")
-    store_code: str = Field(..., min_length=1, max_length=64, description="平台店铺 ID（字符串，与 platform 对齐）")
+    store_code: str = Field(..., min_length=1, max_length=128, description="平台店铺 ID（字符串，与 platform 对齐）")
     merchant_code: str = Field(..., min_length=1, max_length=128, description="商家后端规格编码（merchant_code / filled_code）")
 
 
 class MerchantCodeBindingQueryIn(BaseModel):
     platform: Optional[str] = Field(None, min_length=1, max_length=32, description="平台（精确）")
-    store_code: Optional[str] = Field(None, min_length=1, max_length=64, description="平台店铺 ID（精确，字符串）")
+    store_code: Optional[str] = Field(None, min_length=1, max_length=128, description="平台店铺 ID（精确，字符串）")
     merchant_code: Optional[str] = Field(None, min_length=1, max_length=128, description="商家后端规格编码（模糊 contains）")
     # ✅ current_only 作为兼容字段保留，但简化模型下恒等于 true（无历史、无 effective_to）
     current_only: bool = Field(True, description="兼容字段：简化模型下恒等于 true")
     fsku_id: Optional[int] = Field(None, ge=1, description="按 fsku_id 精确过滤")
-    fsku_code: Optional[str] = Field(None, min_length=1, max_length=64, description="按 fsku.code 过滤（contains）")
+    fsku_code: Optional[str] = Field(None, min_length=1, max_length=128, description="按 fsku.code 过滤（contains）")
     limit: int = Field(50, ge=1, le=200, description="分页大小")
     offset: int = Field(0, ge=0, description="分页偏移")
 

--- a/app/oms/fsku/models/fsku.py
+++ b/app/oms/fsku/models/fsku.py
@@ -19,7 +19,7 @@ class Fsku(Base):
     # ✅ 业务编码（全局唯一）：
     # DB 里是唯一索引（ux_fskus_code），这里用 Index(unique=True) 与之对齐，
     # 避免 alembic-check 误判需要新增 unique constraint。
-    code: Mapped[str] = mapped_column(String(64), nullable=False)
+    code: Mapped[str] = mapped_column(String(128), nullable=False)
 
     name: Mapped[str] = mapped_column(Text, nullable=False)
 

--- a/app/oms/fsku/router_merchant_code_bindings.py
+++ b/app/oms/fsku/router_merchant_code_bindings.py
@@ -49,12 +49,12 @@ def _row_out(*, b: MerchantCodeFskuBinding, f: Fsku, store: Store) -> MerchantCo
 )
 async def list_merchant_code_bindings(
     platform: str | None = Query(None, min_length=1, max_length=32),
-    store_code: str | None = Query(None, min_length=1, max_length=64),
+    store_code: str | None = Query(None, min_length=1, max_length=128),
     merchant_code: str | None = Query(None, min_length=1, max_length=128),
     # ✅ 兼容字段：简化模型下无历史，无 effective_to；该参数忽略
     current_only: bool = Query(True),
     fsku_id: int | None = Query(None, ge=1),
-    fsku_code: str | None = Query(None, min_length=1, max_length=64),
+    fsku_code: str | None = Query(None, min_length=1, max_length=128),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     session: AsyncSession = Depends(get_session),

--- a/app/pms/items/contracts/item.py
+++ b/app/pms/items/contracts/item.py
@@ -29,7 +29,7 @@ def _is_required_expiry_policy(v: object) -> bool:
 
 
 class ItemBase(_Base):
-    sku: Annotated[str, Field(min_length=1, max_length=64)]
+    sku: Annotated[str, Field(min_length=1, max_length=128)]
     name: Annotated[str, Field(min_length=1, max_length=128)]
     spec: Annotated[str | None, Field(default=None, max_length=128)] = None
 
@@ -85,7 +85,7 @@ class ItemCreate(_Base):
         populate_by_name=True,
     )
 
-    sku: Annotated[str, Field(min_length=1, max_length=64)]
+    sku: Annotated[str, Field(min_length=1, max_length=128)]
     name: Annotated[str, Field(min_length=1, max_length=128)]
     spec: Annotated[str | None, Field(default=None, max_length=128)] = None
 

--- a/app/pms/items/models/item.py
+++ b/app/pms/items/models/item.py
@@ -55,7 +55,7 @@ class Item(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
 
-    sku: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    sku: Mapped[str] = mapped_column(String(128), nullable=False, unique=True)
     name: Mapped[str] = mapped_column(String(128), nullable=False)
 
     created_at: Mapped[datetime] = mapped_column(

--- a/app/pms/public/items/contracts/item_basic.py
+++ b/app/pms/public/items/contracts/item_basic.py
@@ -29,7 +29,7 @@ class ItemBasic(_Base):
     """
 
     id: Annotated[int, Field(gt=0)]
-    sku: Annotated[str, Field(min_length=1, max_length=64)]
+    sku: Annotated[str, Field(min_length=1, max_length=128)]
     name: Annotated[str, Field(min_length=1, max_length=128)]
     spec: Annotated[str | None, Field(default=None, max_length=128)] = None
 

--- a/app/procurement/models/purchase_order_line.py
+++ b/app/procurement/models/purchase_order_line.py
@@ -48,7 +48,7 @@ class PurchaseOrderLine(Base):
     )
 
     item_name: Mapped[Optional[str]] = mapped_column(sa.String(255), nullable=True)
-    item_sku: Mapped[Optional[str]] = mapped_column(sa.String(64), nullable=True, index=True)
+    item_sku: Mapped[Optional[str]] = mapped_column(sa.String(128), nullable=True, index=True)
     spec_text: Mapped[Optional[str]] = mapped_column(sa.String(255), nullable=True)
 
     purchase_uom_id_snapshot: Mapped[int] = mapped_column(

--- a/app/procurement/models/purchase_order_line_completion.py
+++ b/app/procurement/models/purchase_order_line_completion.py
@@ -72,7 +72,7 @@ class PurchaseOrderLineCompletion(Base):
 
     item_id: Mapped[int] = mapped_column(Integer, nullable=False)
     item_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    item_sku: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    item_sku: Mapped[str | None] = mapped_column(String(128), nullable=True)
     spec_text: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     purchase_uom_id_snapshot: Mapped[int] = mapped_column(Integer, nullable=False)

--- a/app/wms/inbound/contracts/inbound_event_read.py
+++ b/app/wms/inbound/contracts/inbound_event_read.py
@@ -37,7 +37,7 @@ class InboundEventLineOut(_Base):
 
     item_id: Annotated[int, Field(ge=1, description="商品 ID")]
     item_name: Annotated[str | None, Field(default=None, max_length=255, description="商品名称（展示字段）")]
-    item_sku: Annotated[str | None, Field(default=None, max_length=64, description="商品 SKU（展示字段）")]
+    item_sku: Annotated[str | None, Field(default=None, max_length=128, description="商品 SKU（展示字段）")]
 
     actual_uom_id: Annotated[int, Field(ge=1, description="实际包装单位 ID")]
     actual_uom_name: Annotated[str | None, Field(default=None, max_length=64, description="实际包装单位名称（展示字段）")]

--- a/app/wms/outbound/contracts/manual_doc.py
+++ b/app/wms/outbound/contracts/manual_doc.py
@@ -65,7 +65,7 @@ class ManualOutboundDocCreateLineIn(BaseModel):
     requested_qty: int = Field(..., gt=0)
 
     item_name_snapshot: Optional[str] = Field(default=None, max_length=255)
-    item_sku_snapshot: Optional[str] = Field(default=None, max_length=64)
+    item_sku_snapshot: Optional[str] = Field(default=None, max_length=128)
     item_spec_snapshot: Optional[str] = Field(default=None, max_length=255)
     uom_name_snapshot: Optional[str] = Field(default=None, max_length=64)
 

--- a/app/wms/outbound/models/outbound_event.py
+++ b/app/wms/outbound/models/outbound_event.py
@@ -65,7 +65,7 @@ class OutboundEventLine(Base):
     )
 
     item_name_snapshot: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
-    item_sku_snapshot: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    item_sku_snapshot: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
     item_spec_snapshot: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     remark: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
 


### PR DESCRIPTION
## Summary

- Expand SKU-like fields from 64 to 128:
  - items.sku
  - fskus.code
  - purchase_order_lines.item_sku
  - purchase_order_line_completion.item_sku
  - finance_purchase_price_ledger_lines.item_sku
  - outbound_event_lines.item_sku_snapshot
- Sync ORM models and Pydantic contracts.
- Keep SKU semantics unchanged.

## Validation

- python3 -m compileall selected files
- make upgrade-dev
- make alembic-check
- make test TESTS="tests/api/test_items_main_contract_api.py tests/api/test_pms_sku_coding_api.py tests/ci/test_pms_item_compat_contract.py tests/ci/test_pms_item_openapi_contract.py"

## Notes

- This PR only expands SKU length.
- It does not remove frontend quality hints.
- It does not touch /items/aggregate next_sku behavior.