### PR TITLE
chore(pms): refresh openapi after sku and test set cleanup

### DIFF
--- a/app/oms/deps/stores_order_sim_testset_guard.py
+++ b/app/oms/deps/stores_order_sim_testset_guard.py
@@ -35,9 +35,9 @@ async def assert_order_sim_all_items_in_test_set(
     store_id: int,
 ) -> None:
     """
-    item_test_sets 已退役。
+    商品集合隔离机制已退役。
 
     该函数保留为兼容入口，避免 order-sim 调用方立即大面积改名；
-    现在不再按商品测试集合做强制校验。
+    现在不再按商品集合做强制校验。
     """
     return None

--- a/app/oms/fsku/services/fsku_service_read.py
+++ b/app/oms/fsku/services/fsku_service_read.py
@@ -28,7 +28,6 @@ def list_fskus(
     limit: int,
     offset: int,
 ) -> FskuListOut:
-    # item_test_sets 已退役：FSKU 列表不再按测试商品集合过滤。
     where_sql = " WHERE 1=1 "
     params: dict[str, Any] = {"limit": int(limit), "offset": int(offset)}
 

--- a/app/oms/routers/stores_crud.py
+++ b/app/oms/routers/stores_crud.py
@@ -203,7 +203,7 @@ def register(router: APIRouter) -> None:
             )
 
         else:
-            # platform_test_stores 仅用于测试店铺识别；商品测试集合已退役
+            # platform_test_stores 仅用于测试店铺识别；商品集合隔离已退役
             await session.execute(
                 text(
                     """

--- a/app/oms/services/platform_order_ingest_flow.py
+++ b/app/oms/services/platform_order_ingest_flow.py
@@ -175,7 +175,7 @@ class PlatformOrderIngestFlow:
 
         item_ids = sorted(item_qty_map.keys())
 
-        # ✅ 宇宙边界兜底：非 TEST 商铺禁止出现测试商品（DEFAULT Test Set）
+        # ✅ 宇宙边界兜底：仅保留测试店铺识别，不再做商品集合隔离
         await enforce_no_test_items_in_non_test_store(
             session,
             store_code=sid,
@@ -273,7 +273,7 @@ class PlatformOrderIngestFlow:
 
         store_id_out = int(store_id) if store_id is not None else None
 
-        # ✅ 宇宙边界兜底：tail/replay/confirm-create 也不能把测试商品写进非 TEST 商铺
+        # ✅ 宇宙边界兜底：仅保留测试店铺识别，不再做商品集合隔离
         item_ids = extract_item_ids_from_items_payload(items_payload)
         await enforce_no_test_items_in_non_test_store(
             session,

--- a/app/oms/services/platform_order_ingest_universe_guard.py
+++ b/app/oms/services/platform_order_ingest_universe_guard.py
@@ -51,9 +51,9 @@ async def enforce_no_test_items_in_non_test_store(
     source: str,
 ) -> None:
     """
-    item_test_sets 已退役。
+    商品集合隔离机制已退役。
 
-    历史上这里用于“测试商品不能进入非测试店铺”的商品级隔离。
+    历史上这里用于商品级隔离。
     现在只保留 platform_test_stores 作为测试店铺识别，不再按商品集合阻断。
     """
     return None

--- a/app/oms/services/test_store_testset_guard_service.py
+++ b/app/oms/services/test_store_testset_guard_service.py
@@ -6,10 +6,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 class TestShopTestSetGuardService:
     """
-    item_test_sets 已退役。
+    商品集合隔离机制已退役。
 
     保留类名和方法签名，兼容现有调用方；
-    不再按 FSKU components 命中测试商品集合做阻断。
+    不再按 FSKU components 做商品集合阻断。
     """
 
     def __init__(self, session: AsyncSession):

--- a/app/pms/items/services/item_presenter.py
+++ b/app/pms/items/services/item_presenter.py
@@ -18,7 +18,6 @@ class ItemPresenter:
       * decorate_rules（requires_batch / requires_dates 等规则投影）
       * primary_barcode（主条码真相）
     - 不负责 CRUD / 事务
-    - item_test_sets / is_test 已退役，不再投影测试集合字段。
     """
 
     def __init__(self, db: Session) -> None:

--- a/app/pms/items/services/item_service.py
+++ b/app/pms/items/services/item_service.py
@@ -33,8 +33,6 @@ class ItemService:
     - 主合同 POST /items 不再自动生成 SKU
     - items.sku 必须由调用方显式输入，通常来自 SKU 编码页生成候选后人工确认
 
-    Test set：
-    - item_test_sets / item_test_set_items / is_test 已退役。
     """
 
     def __init__(self, db: Session) -> None:

--- a/openapi/_current.json
+++ b/openapi/_current.json
@@ -633,14 +633,14 @@
         }
       }
     },
-    "/orders/{platform}/{shop_id}/{ext_order_no}/fulfillment/manual-assign": {
+    "/orders/{platform}/{store_code}/{ext_order_no}/fulfillment/manual-assign": {
       "post": {
         "tags": [
           "orders-fulfillment-v2"
         ],
         "summary": "Fulfillment Manual Assign",
         "description": "Phase 5.1：人工指定执行仓（执行期唯一合法写入路径）\n\n✅ 新世界观（一步到位迁移后）：\n- 实际出库仓写入 order_fulfillment.actual_warehouse_id（执行仓事实）\n- planned/service 归属仓仍由 routing 写入 order_fulfillment.planned_warehouse_id\n- 写 fulfillment_status=MANUALLY_ASSIGNED\n- 写审计事件：MANUAL_WAREHOUSE_ASSIGNED\n\n❌ 禁止回潮：\n- 不允许写 orders.warehouse_id（该列迁移后将被删除/不再承载事实）\n\n注意：\n- manual-assign 是“决策入口”，库存不足应作为 soft-check 记录（审计/提示），不应 409 阻断；\n  真正的库存裁判在 pick/ship 执行点。",
-        "operationId": "fulfillment_manual_assign_orders__platform___shop_id___ext_order_no__fulfillment_manual_assign_post",
+        "operationId": "fulfillment_manual_assign_orders__platform___store_code___ext_order_no__fulfillment_manual_assign_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -657,12 +657,12 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
@@ -709,13 +709,13 @@
         }
       }
     },
-    "/orders/{platform}/{shop_id}/{ext_order_no}/ship-with-waybill": {
+    "/orders/{platform}/{store_code}/{ext_order_no}/ship-with-waybill": {
       "post": {
         "tags": [
           "orders-fulfillment-v2"
         ],
         "summary": "Order Ship With Waybill",
-        "operationId": "order_ship_with_waybill_orders__platform___shop_id___ext_order_no__ship_with_waybill_post",
+        "operationId": "order_ship_with_waybill_orders__platform___store_code___ext_order_no__ship_with_waybill_post",
         "parameters": [
           {
             "name": "platform",
@@ -727,12 +727,12 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
@@ -1565,13 +1565,13 @@
         }
       }
     },
-    "/ship/calc": {
+    "/shipping-assist/shipping/calc": {
       "post": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "Calc Shipping Quotes",
-        "operationId": "calc_shipping_quotes_ship_calc_post",
+        "operationId": "calc_shipping_quotes_shipping_assist_shipping_calc_post",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1611,13 +1611,13 @@
         ]
       }
     },
-    "/ship/prepare/orders": {
+    "/shipping-assist/shipping/prepare/orders": {
       "get": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "List Prepare Orders",
-        "operationId": "list_prepare_orders_ship_prepare_orders_get",
+        "operationId": "list_prepare_orders_shipping_assist_shipping_prepare_orders_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -1661,13 +1661,13 @@
         }
       }
     },
-    "/ship/prepare/orders/{platform}/{shop_id}/{ext_order_no}": {
+    "/shipping-assist/shipping/prepare/orders/{platform}/{store_code}/{ext_order_no}": {
       "get": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "Get Prepare Order Detail",
-        "operationId": "get_prepare_order_detail_ship_prepare_orders__platform___shop_id___ext_order_no__get",
+        "operationId": "get_prepare_order_detail_shipping_assist_shipping_prepare_orders__platform___store_code___ext_order_no__get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -1684,12 +1684,12 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
@@ -1726,13 +1726,13 @@
         }
       }
     },
-    "/ship/prepare/orders/import": {
+    "/shipping-assist/shipping/prepare/orders/import": {
       "post": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "Import Prepare Order",
-        "operationId": "import_prepare_order_ship_prepare_orders_import_post",
+        "operationId": "import_prepare_order_shipping_assist_shipping_prepare_orders_import_post",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1772,13 +1772,13 @@
         ]
       }
     },
-    "/ship/prepare/orders/{platform}/{shop_id}/{ext_order_no}/address-confirm": {
+    "/shipping-assist/shipping/prepare/orders/{platform}/{store_code}/{ext_order_no}/address-confirm": {
       "post": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "Confirm Prepare Order Address",
-        "operationId": "confirm_prepare_order_address_ship_prepare_orders__platform___shop_id___ext_order_no__address_confirm_post",
+        "operationId": "confirm_prepare_order_address_shipping_assist_shipping_prepare_orders__platform___store_code___ext_order_no__address_confirm_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -1795,12 +1795,12 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
@@ -1847,13 +1847,13 @@
         }
       }
     },
-    "/ship/prepare/orders/{platform}/{shop_id}/{ext_order_no}/packages": {
+    "/shipping-assist/shipping/prepare/orders/{platform}/{store_code}/{ext_order_no}/packages": {
       "get": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "List Prepare Packages",
-        "operationId": "list_prepare_packages_ship_prepare_orders__platform___shop_id___ext_order_no__packages_get",
+        "operationId": "list_prepare_packages_shipping_assist_shipping_prepare_orders__platform___store_code___ext_order_no__packages_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -1870,12 +1870,12 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
@@ -1913,10 +1913,10 @@
       },
       "post": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "Create Prepare Package",
-        "operationId": "create_prepare_package_ship_prepare_orders__platform___shop_id___ext_order_no__packages_post",
+        "operationId": "create_prepare_package_shipping_assist_shipping_prepare_orders__platform___store_code___ext_order_no__packages_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -1933,12 +1933,12 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
@@ -1975,13 +1975,13 @@
         }
       }
     },
-    "/ship/prepare/orders/{platform}/{shop_id}/{ext_order_no}/packages/{package_no}": {
+    "/shipping-assist/shipping/prepare/orders/{platform}/{store_code}/{ext_order_no}/packages/{package_no}": {
       "patch": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "Update Prepare Package",
-        "operationId": "update_prepare_package_ship_prepare_orders__platform___shop_id___ext_order_no__packages__package_no__patch",
+        "operationId": "update_prepare_package_shipping_assist_shipping_prepare_orders__platform___store_code___ext_order_no__packages__package_no__patch",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -1998,12 +1998,12 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
@@ -2059,13 +2059,13 @@
         }
       }
     },
-    "/ship/prepare/orders/{platform}/{shop_id}/{ext_order_no}/packages/{package_no}/quote": {
+    "/shipping-assist/shipping/prepare/orders/{platform}/{store_code}/{ext_order_no}/packages/{package_no}/quote": {
       "post": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "Quote Prepare Package",
-        "operationId": "quote_prepare_package_ship_prepare_orders__platform___shop_id___ext_order_no__packages__package_no__quote_post",
+        "operationId": "quote_prepare_package_shipping_assist_shipping_prepare_orders__platform___store_code___ext_order_no__packages__package_no__quote_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -2082,12 +2082,12 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
@@ -2133,13 +2133,13 @@
         }
       }
     },
-    "/ship/prepare/orders/{platform}/{shop_id}/{ext_order_no}/packages/{package_no}/quote/confirm": {
+    "/shipping-assist/shipping/prepare/orders/{platform}/{store_code}/{ext_order_no}/packages/{package_no}/quote/confirm": {
       "post": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "Confirm Prepare Package Quote",
-        "operationId": "confirm_prepare_package_quote_ship_prepare_orders__platform___shop_id___ext_order_no__packages__package_no__quote_confirm_post",
+        "operationId": "confirm_prepare_package_quote_shipping_assist_shipping_prepare_orders__platform___store_code___ext_order_no__packages__package_no__quote_confirm_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -2156,12 +2156,12 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
@@ -2217,13 +2217,13 @@
         }
       }
     },
-    "/ship/waybill-configs": {
+    "/shipping-assist/settings/waybill-configs": {
       "get": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "List Waybill Configs Route",
-        "operationId": "list_waybill_configs_route_ship_waybill_configs_get",
+        "operationId": "list_waybill_configs_route_shipping_assist_settings_waybill_configs_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -2263,7 +2263,7 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -2275,7 +2275,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
@@ -2337,10 +2337,10 @@
       },
       "post": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "Create Waybill Config Route",
-        "operationId": "create_waybill_config_route_ship_waybill_configs_post",
+        "operationId": "create_waybill_config_route_shipping_assist_settings_waybill_configs_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -2380,13 +2380,13 @@
         }
       }
     },
-    "/ship/waybill-configs/{config_id}": {
+    "/shipping-assist/settings/waybill-configs/{config_id}": {
       "get": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "Get Waybill Config Route",
-        "operationId": "get_waybill_config_route_ship_waybill_configs__config_id__get",
+        "operationId": "get_waybill_config_route_shipping_assist_settings_waybill_configs__config_id__get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -2429,10 +2429,10 @@
       },
       "patch": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "Update Waybill Config Route",
-        "operationId": "update_waybill_config_route_ship_waybill_configs__config_id__patch",
+        "operationId": "update_waybill_config_route_shipping_assist_settings_waybill_configs__config_id__patch",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -5276,6 +5276,1122 @@
         ]
       }
     },
+    "/oms/pdd/platform-order-mirrors/import": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "Import Platform Order Mirror",
+        "operationId": "import_platform_order_mirror_oms_pdd_platform_order_mirrors_import_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlatformOrderMirrorImportIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformOrderMirrorEnvelopeOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/pdd/platform-order-mirrors/import-from-collector": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "Import Platform Order Mirror From Collector Route",
+        "operationId": "import_platform_order_mirror_from_collector_route_oms_pdd_platform_order_mirrors_import_from_collector_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportPlatformOrderMirrorFromCollectorIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportPlatformOrderMirrorFromCollectorOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/pdd/platform-order-mirrors/sync-from-collector": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "Sync Platform Order Mirrors From Collector Route",
+        "operationId": "sync_platform_order_mirrors_from_collector_route_oms_pdd_platform_order_mirrors_sync_from_collector_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SyncPlatformOrderMirrorsFromCollectorIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SyncPlatformOrderMirrorsFromCollectorOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/pdd/platform-order-mirrors": {
+      "get": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "List Platform Order Mirror Rows",
+        "operationId": "list_platform_order_mirror_rows_oms_pdd_platform_order_mirrors_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "default": 200,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformOrderMirrorListOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/pdd/platform-order-mirrors/{mirror_id}": {
+      "get": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "Get Platform Order Mirror Row",
+        "operationId": "get_platform_order_mirror_row_oms_pdd_platform_order_mirrors__mirror_id__get",
+        "parameters": [
+          {
+            "name": "mirror_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "title": "Mirror Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformOrderMirrorEnvelopeOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/taobao/platform-order-mirrors/import": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "Import Platform Order Mirror",
+        "operationId": "import_platform_order_mirror_oms_taobao_platform_order_mirrors_import_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlatformOrderMirrorImportIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformOrderMirrorEnvelopeOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/taobao/platform-order-mirrors/import-from-collector": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "Import Platform Order Mirror From Collector Route",
+        "operationId": "import_platform_order_mirror_from_collector_route_oms_taobao_platform_order_mirrors_import_from_collector_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportPlatformOrderMirrorFromCollectorIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportPlatformOrderMirrorFromCollectorOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/taobao/platform-order-mirrors/sync-from-collector": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "Sync Platform Order Mirrors From Collector Route",
+        "operationId": "sync_platform_order_mirrors_from_collector_route_oms_taobao_platform_order_mirrors_sync_from_collector_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SyncPlatformOrderMirrorsFromCollectorIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SyncPlatformOrderMirrorsFromCollectorOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/taobao/platform-order-mirrors": {
+      "get": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "List Platform Order Mirror Rows",
+        "operationId": "list_platform_order_mirror_rows_oms_taobao_platform_order_mirrors_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "default": 200,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformOrderMirrorListOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/taobao/platform-order-mirrors/{mirror_id}": {
+      "get": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "Get Platform Order Mirror Row",
+        "operationId": "get_platform_order_mirror_row_oms_taobao_platform_order_mirrors__mirror_id__get",
+        "parameters": [
+          {
+            "name": "mirror_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "title": "Mirror Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformOrderMirrorEnvelopeOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/jd/platform-order-mirrors/import": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "Import Platform Order Mirror",
+        "operationId": "import_platform_order_mirror_oms_jd_platform_order_mirrors_import_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlatformOrderMirrorImportIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformOrderMirrorEnvelopeOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/jd/platform-order-mirrors/import-from-collector": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "Import Platform Order Mirror From Collector Route",
+        "operationId": "import_platform_order_mirror_from_collector_route_oms_jd_platform_order_mirrors_import_from_collector_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportPlatformOrderMirrorFromCollectorIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportPlatformOrderMirrorFromCollectorOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/jd/platform-order-mirrors/sync-from-collector": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "Sync Platform Order Mirrors From Collector Route",
+        "operationId": "sync_platform_order_mirrors_from_collector_route_oms_jd_platform_order_mirrors_sync_from_collector_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SyncPlatformOrderMirrorsFromCollectorIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SyncPlatformOrderMirrorsFromCollectorOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/jd/platform-order-mirrors": {
+      "get": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "List Platform Order Mirror Rows",
+        "operationId": "list_platform_order_mirror_rows_oms_jd_platform_order_mirrors_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "default": 200,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformOrderMirrorListOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/jd/platform-order-mirrors/{mirror_id}": {
+      "get": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "Get Platform Order Mirror Row",
+        "operationId": "get_platform_order_mirror_row_oms_jd_platform_order_mirrors__mirror_id__get",
+        "parameters": [
+          {
+            "name": "mirror_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "title": "Mirror Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformOrderMirrorEnvelopeOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/pdd/fsku-mapping/candidates": {
+      "get": {
+        "tags": [
+          "OMS",
+          "oms-fsku-mapping-candidates"
+        ],
+        "summary": "List Platform Fsku Mapping Candidates",
+        "operationId": "list_platform_fsku_mapping_candidates_oms_pdd_fsku_mapping_candidates_get",
+        "parameters": [
+          {
+            "name": "store_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 128
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Store Code"
+            }
+          },
+          {
+            "name": "merchant_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 128
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Merchant Code"
+            }
+          },
+          {
+            "name": "only_unbound",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Only Unbound"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "default": 200,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FskuMappingCandidateListOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/taobao/fsku-mapping/candidates": {
+      "get": {
+        "tags": [
+          "OMS",
+          "oms-fsku-mapping-candidates"
+        ],
+        "summary": "List Platform Fsku Mapping Candidates",
+        "operationId": "list_platform_fsku_mapping_candidates_oms_taobao_fsku_mapping_candidates_get",
+        "parameters": [
+          {
+            "name": "store_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 128
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Store Code"
+            }
+          },
+          {
+            "name": "merchant_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 128
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Merchant Code"
+            }
+          },
+          {
+            "name": "only_unbound",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Only Unbound"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "default": 200,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FskuMappingCandidateListOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/jd/fsku-mapping/candidates": {
+      "get": {
+        "tags": [
+          "OMS",
+          "oms-fsku-mapping-candidates"
+        ],
+        "summary": "List Platform Fsku Mapping Candidates",
+        "operationId": "list_platform_fsku_mapping_candidates_oms_jd_fsku_mapping_candidates_get",
+        "parameters": [
+          {
+            "name": "store_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 128
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Store Code"
+            }
+          },
+          {
+            "name": "merchant_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 128
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Merchant Code"
+            }
+          },
+          {
+            "name": "only_unbound",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Only Unbound"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "default": 200,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FskuMappingCandidateListOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/pdd/fulfillment-order-conversion/convert": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-fulfillment-order-conversion"
+        ],
+        "summary": "Convert Platform Fulfillment Order",
+        "operationId": "convert_platform_fulfillment_order_oms_pdd_fulfillment_order_conversion_convert_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FulfillmentOrderConversionIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FulfillmentOrderConversionOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/taobao/fulfillment-order-conversion/convert": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-fulfillment-order-conversion"
+        ],
+        "summary": "Convert Platform Fulfillment Order",
+        "operationId": "convert_platform_fulfillment_order_oms_taobao_fulfillment_order_conversion_convert_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FulfillmentOrderConversionIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FulfillmentOrderConversionOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/jd/fulfillment-order-conversion/convert": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-fulfillment-order-conversion"
+        ],
+        "summary": "Convert Platform Fulfillment Order",
+        "operationId": "convert_platform_fulfillment_order_oms_jd_fulfillment_order_conversion_convert_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FulfillmentOrderConversionIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FulfillmentOrderConversionOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/oms/platform-orders/ingest": {
       "post": {
         "tags": [
@@ -5385,6 +6501,49 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PlatformOrderReplayOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/platform-orders/resolve-preview": {
+      "post": {
+        "tags": [
+          "OMS",
+          "platform-orders"
+        ],
+        "summary": "平台订单事实只读解析预览：读取 platform_order_lines 并展开到 FSKU/SKU，不建单",
+        "description": "只读解析预览。\n\n边界：\n- 读取 platform_order_lines；\n- 复用 resolver 展开 FSKU / item；\n- 返回 resolved / unresolved / item_qty_map；\n- 不写 platform_order_lines；\n- 不建 orders/order_items；\n- 不触碰 finance。",
+        "operationId": "preview_platform_order_resolve_oms_platform_orders_resolve_preview_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlatformOrderResolvePreviewIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformOrderResolvePreviewOut"
                 }
               }
             }
@@ -5572,10 +6731,10 @@
                   "type": "null"
                 }
               ],
-              "description": "模糊搜索：name / shop_id / id",
+              "description": "模糊搜索：store_name / store_code / id",
               "title": "Q"
             },
-            "description": "模糊搜索：name / shop_id / id"
+            "description": "模糊搜索：store_name / store_code / id"
           },
           {
             "name": "limit",
@@ -5630,7 +6789,7 @@
           "stores"
         ],
         "summary": "Create Or Get Store",
-        "description": "店铺建档 / 补录（幂等）。\n\n权限：config.store.write\n\n✅ 合同收敛：\n- shop_type 的唯一真相为 platform_test_shops（code='DEFAULT'）\n- 创建时可选择 TEST/PROD：\n  * TEST：写入/更新 platform_test_shops（绑定 store_id）\n  * PROD：确保该 store_id 不在 platform_test_shops（删除绑定）",
+        "description": "店铺建档 / 补录（幂等）。\n\n权限：config.store.write\n\n✅ 合同收敛：\n- store_type 的唯一真相为 platform_test_stores（code='DEFAULT'）\n- 创建时可选择 TEST/PROD：\n  * TEST：写入/更新 platform_test_stores（绑定 store_id）\n  * PROD：确保该 store_id 不在 platform_test_stores（删除绑定）",
         "operationId": "create_or_get_store_oms_stores_post",
         "security": [
           {
@@ -6682,7 +7841,7 @@
         "tags": [
           "OMS",
           "oms-fsku",
-          "ops - shop-product-bundles"
+          "ops - store-product-bundles"
         ],
         "summary": "Create",
         "operationId": "create_oms_fskus_post",
@@ -6728,7 +7887,7 @@
         "tags": [
           "OMS",
           "oms-fsku",
-          "ops - shop-product-bundles"
+          "ops - store-product-bundles"
         ],
         "summary": "List ",
         "operationId": "list__oms_fskus_get",
@@ -6846,7 +8005,7 @@
         "tags": [
           "OMS",
           "oms-fsku",
-          "ops - shop-product-bundles"
+          "ops - store-product-bundles"
         ],
         "summary": "Detail",
         "operationId": "detail_oms_fskus__fsku_id__get",
@@ -6893,7 +8052,7 @@
         "tags": [
           "OMS",
           "oms-fsku",
-          "ops - shop-product-bundles"
+          "ops - store-product-bundles"
         ],
         "summary": "Patch Fsku",
         "operationId": "patch_fsku_oms_fskus__fsku_id__patch",
@@ -6952,7 +8111,7 @@
         "tags": [
           "OMS",
           "oms-fsku",
-          "ops - shop-product-bundles"
+          "ops - store-product-bundles"
         ],
         "summary": "Components",
         "operationId": "components_oms_fskus__fsku_id__components_get",
@@ -6999,7 +8158,7 @@
         "tags": [
           "OMS",
           "oms-fsku",
-          "ops - shop-product-bundles"
+          "ops - store-product-bundles"
         ],
         "summary": "Replace Components",
         "operationId": "replace_components_oms_fskus__fsku_id__components_post",
@@ -7058,7 +8217,7 @@
         "tags": [
           "OMS",
           "oms-fsku",
-          "ops - shop-product-bundles"
+          "ops - store-product-bundles"
         ],
         "summary": "Publish",
         "operationId": "publish_oms_fskus__fsku_id__publish_post",
@@ -7107,7 +8266,7 @@
         "tags": [
           "OMS",
           "oms-fsku",
-          "ops - shop-product-bundles"
+          "ops - store-product-bundles"
         ],
         "summary": "Retire",
         "operationId": "retire_oms_fskus__fsku_id__retire_post",
@@ -7156,7 +8315,7 @@
         "tags": [
           "OMS",
           "oms-fsku",
-          "ops - shop-product-bundles"
+          "ops - store-product-bundles"
         ],
         "summary": "Unretire",
         "description": "⚠️ 兼容保留：取消归档（不支持）\n- 系统封板：FSKU 生命周期单向（draft → published → retired）\n- 发布事实不可逆，因此该接口将始终返回 409（state_conflict）",
@@ -7338,7 +8497,7 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -7346,13 +8505,13 @@
                 {
                   "type": "string",
                   "minLength": 1,
-                  "maxLength": 64
+                  "maxLength": 128
                 },
                 {
                   "type": "null"
                 }
               ],
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
@@ -7409,7 +8568,7 @@
                 {
                   "type": "string",
                   "minLength": 1,
-                  "maxLength": 64
+                  "maxLength": 128
                 },
                 {
                   "type": "null"
@@ -7473,7 +8632,7 @@
           "oms-fsku",
           "merchant-code-bindings"
         ],
-        "summary": "人工绑定/覆盖：platform+shop_id+merchant_code → published FSKU（一码一对一）",
+        "summary": "人工绑定/覆盖：platform+store_code+merchant_code → published FSKU（一码一对一）",
         "operationId": "bind_merchant_code_oms_merchant_code_bindings_bind_post",
         "requestBody": {
           "content": {
@@ -7594,7 +8753,7 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -7606,7 +8765,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
@@ -7683,1370 +8842,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OrderOutboundViewResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/taobao/app-config/current": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-taobao-app-config"
-        ],
-        "summary": "Get Current Taobao App Config",
-        "description": "读取当前启用中的淘宝系统配置。",
-        "operationId": "get_current_taobao_app_config_oms_taobao_app_config_current_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "type": "object",
-                  "title": "Response Get Current Taobao App Config Oms Taobao App Config Current Get"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      },
-      "put": {
-        "tags": [
-          "OMS",
-          "oms-taobao-app-config"
-        ],
-        "summary": "Put Current Taobao App Config",
-        "description": "保存当前淘宝系统配置。\n\n规则：\n- 若当前没有启用配置，则新建一条 enabled=true 记录\n- 若当前已有启用配置，则原地更新\n- 若 app_secret 为空字符串，则沿用原 secret（已有记录时）",
-        "operationId": "put_current_taobao_app_config_oms_taobao_app_config_current_put",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "additionalProperties": true,
-                "type": "object",
-                "title": "Payload"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "type": "object",
-                  "title": "Response Put Current Taobao App Config Oms Taobao App Config Current Put"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/oms/taobao/oauth/start": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-taobao-auth"
-        ],
-        "summary": "Taobao Oauth Start",
-        "description": "生成淘宝授权链接。",
-        "operationId": "taobao_oauth_start_oms_taobao_oauth_start_get",
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Taobao Oauth Start Oms Taobao Oauth Start Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/taobao/oauth/callback": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-taobao-auth"
-        ],
-        "summary": "Taobao Oauth Callback",
-        "description": "淘宝 OAuth callback。",
-        "operationId": "taobao_oauth_callback_oms_taobao_oauth_callback_get",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "title": "Code"
-            }
-          },
-          {
-            "name": "state",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "title": "State"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Taobao Oauth Callback Oms Taobao Oauth Callback Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/taobao/connection": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-taobao-connection"
-        ],
-        "summary": "Get Store Taobao Connection",
-        "description": "淘宝接入状态读取口（新主线）。\n\n当前返回：\n- store_id / platform\n- credentials 基础存在性与过期信息\n- connection 当前裁决状态\n- 授权返回自带的基础身份线索\n\n说明：\n- 第一版先直接读新两张表",
-        "operationId": "get_store_taobao_connection_oms_stores__store_id__taobao_connection_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Get Store Taobao Connection Oms Stores  Store Id  Taobao Connection Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/taobao/test-pull": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-taobao-pull"
-        ],
-        "summary": "Test Store Taobao Pull",
-        "description": "淘宝 test-pull（第一版）。",
-        "operationId": "test_store_taobao_pull_oms_stores__store_id__taobao_test_pull_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          },
-          {
-            "name": "allow_real_request",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Allow Real Request"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Test Store Taobao Pull Oms Stores  Store Id  Taobao Test Pull Post"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/taobao/orders": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-taobao-orders"
-        ],
-        "summary": "List Taobao Orders Ledger",
-        "operationId": "list_taobao_orders_ledger_oms_taobao_orders_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 1000,
-              "minimum": 1,
-              "default": 200,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TaobaoOrderLedgerListOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/taobao/orders/{taobao_order_id}": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-taobao-orders"
-        ],
-        "summary": "Get Taobao Order Ledger",
-        "operationId": "get_taobao_order_ledger_oms_taobao_orders__taobao_order_id__get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "taobao_order_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Taobao Order Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TaobaoOrderLedgerDetailEnvelopeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/pdd/app-config/current": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-pdd-app-config"
-        ],
-        "summary": "Get Current Pdd App Config",
-        "description": "读取当前启用中的拼多多系统配置。",
-        "operationId": "get_current_pdd_app_config_oms_pdd_app_config_current_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "type": "object",
-                  "title": "Response Get Current Pdd App Config Oms Pdd App Config Current Get"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      },
-      "put": {
-        "tags": [
-          "OMS",
-          "oms-pdd-app-config"
-        ],
-        "summary": "Put Current Pdd App Config",
-        "description": "保存当前拼多多系统配置。\n\n规则：\n- 若当前没有启用配置，则新建一条 enabled=true 记录\n- 若当前已有启用配置，则原地更新\n- 若 client_secret 为空字符串，则沿用原 secret（已有记录时）",
-        "operationId": "put_current_pdd_app_config_oms_pdd_app_config_current_put",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "additionalProperties": true,
-                "type": "object",
-                "title": "Payload"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "type": "object",
-                  "title": "Response Put Current Pdd App Config Oms Pdd App Config Current Put"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/oms/pdd/oauth/start": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-pdd-auth"
-        ],
-        "summary": "Pdd Oauth Start",
-        "operationId": "pdd_oauth_start_oms_pdd_oauth_start_get",
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Pdd Oauth Start Oms Pdd Oauth Start Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/pdd/oauth/callback": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-pdd-auth"
-        ],
-        "summary": "Oms Pdd Oauth Callback",
-        "operationId": "oms_pdd_oauth_callback_oms_pdd_oauth_callback_get",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          },
-          {
-            "name": "state",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "State"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Oms Pdd Oauth Callback Oms Pdd Oauth Callback Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/pdd/connection": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-pdd-connection"
-        ],
-        "summary": "Get Store Pdd Connection",
-        "description": "读取店铺 × 拼多多当前 connection 视图。\n\n说明：\n- credential 是授权材料当前态\n- connection 是 OMS 当前裁决状态",
-        "operationId": "get_store_pdd_connection_oms_stores__store_id__pdd_connection_get",
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Store Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Get Store Pdd Connection Oms Stores  Store Id  Pdd Connection Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/pdd/test-pull": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-pdd-pull"
-        ],
-        "summary": "Test Store Pdd Pull",
-        "description": "拼多多 test-pull（第二版）。\n\n当前阶段：\n- 先做前置校验与 connection 状态推进\n- 前置校验通过后，真实拉取一页订单摘要\n- 不执行 OMS ingest",
-        "operationId": "test_store_pdd_pull_oms_stores__store_id__pdd_test_pull_post",
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Store Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "anyOf": [
-                  {
-                    "type": "object",
-                    "additionalProperties": true
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "title": "Payload"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Test Store Pdd Pull Oms Stores  Store Id  Pdd Test Pull Post"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/pdd/orders": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-pdd-orders"
-        ],
-        "summary": "List Pdd Orders Ledger",
-        "operationId": "list_pdd_orders_ledger_oms_pdd_orders_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 1000,
-              "minimum": 1,
-              "default": 200,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PddOrderLedgerListOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/pdd/orders/{pdd_order_id}": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-pdd-orders"
-        ],
-        "summary": "Get Pdd Order Ledger",
-        "operationId": "get_pdd_order_ledger_oms_pdd_orders__pdd_order_id__get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "pdd_order_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Pdd Order Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PddOrderLedgerDetailEnvelopeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/pdd/mock/stores/{store_id}/authorize": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-pdd-mock"
-        ],
-        "summary": "Authorize Pdd Store Mock",
-        "operationId": "authorize_pdd_store_mock_oms_pdd_mock_stores__store_id__authorize_post",
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Store Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PddMockAuthorizeRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Authorize Pdd Store Mock Oms Pdd Mock Stores  Store Id  Authorize Post"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/pdd/mock/stores/{store_id}/orders/ingest": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-pdd-mock"
-        ],
-        "summary": "Ingest Pdd Orders Mock",
-        "operationId": "ingest_pdd_orders_mock_oms_pdd_mock_stores__store_id__orders_ingest_post",
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Store Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PddMockIngestOrdersRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Ingest Pdd Orders Mock Oms Pdd Mock Stores  Store Id  Orders Ingest Post"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/pdd/mock/stores/{store_id}/orders": {
-      "delete": {
-        "tags": [
-          "OMS",
-          "oms-pdd-mock"
-        ],
-        "summary": "Clear Pdd Orders Mock",
-        "operationId": "clear_pdd_orders_mock_oms_pdd_mock_stores__store_id__orders_delete",
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Store Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PddMockClearOrdersRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Clear Pdd Orders Mock Oms Pdd Mock Stores  Store Id  Orders Delete"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/jd/app-config/current": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-jd-app-config"
-        ],
-        "summary": "Get Jd App Config Current",
-        "operationId": "get_jd_app_config_current_oms_jd_app_config_current_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "type": "object",
-                  "title": "Response Get Jd App Config Current Oms Jd App Config Current Get"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "OMS",
-          "oms-jd-app-config"
-        ],
-        "summary": "Put Jd App Config Current",
-        "description": "约定：\n- 若 client_secret 为空字符串，则沿用原 secret（已有记录时）\n- 若当前无记录，则创建时 client_secret 必填",
-        "operationId": "put_jd_app_config_current_oms_jd_app_config_current_put",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "additionalProperties": true,
-                "type": "object",
-                "title": "Payload"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "type": "object",
-                  "title": "Response Put Jd App Config Current Oms Jd App Config Current Put"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/jd/oauth/start": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-jd-auth"
-        ],
-        "summary": "Jd Oauth Start",
-        "operationId": "jd_oauth_start_oms_jd_oauth_start_get",
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Jd Oauth Start Oms Jd Oauth Start Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/jd/oauth/callback": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-jd-auth"
-        ],
-        "summary": "Jd Oauth Callback",
-        "operationId": "jd_oauth_callback_oms_jd_oauth_callback_get",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "title": "Code"
-            }
-          },
-          {
-            "name": "state",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "title": "State"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Jd Oauth Callback Oms Jd Oauth Callback Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/jd/connection": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-jd-connection"
-        ],
-        "summary": "Get Store Jd Connection",
-        "operationId": "get_store_jd_connection_oms_stores__store_id__jd_connection_get",
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Get Store Jd Connection Oms Stores  Store Id  Jd Connection Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/jd/test-pull": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-jd-pull"
-        ],
-        "summary": "Test Store Jd Pull",
-        "description": "京东 test-pull（第一版）。\n\n当前阶段：\n- 先做前置校验与 connection 状态推进\n- 前置校验通过后，真实拉取一页订单摘要\n- 逐单补详情\n- 不执行 OMS ingest\n- 不落事实表",
-        "operationId": "test_store_jd_pull_oms_stores__store_id__jd_test_pull_post",
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Store Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "anyOf": [
-                  {
-                    "type": "object",
-                    "additionalProperties": true
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "title": "Payload"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Test Store Jd Pull Oms Stores  Store Id  Jd Test Pull Post"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/jd/orders": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-jd-orders"
-        ],
-        "summary": "List Jd Orders Ledger",
-        "operationId": "list_jd_orders_ledger_oms_jd_orders_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 1000,
-              "minimum": 1,
-              "default": 200,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JdOrderLedgerListOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/jd/orders/{jd_order_id}": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-jd-orders"
-        ],
-        "summary": "Get Jd Order Ledger",
-        "operationId": "get_jd_order_ledger_oms_jd_orders__jd_order_id__get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "jd_order_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Jd Order Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JdOrderLedgerDetailEnvelopeOut"
                 }
               }
             }
@@ -9998,27 +9793,6 @@
         }
       }
     },
-    "/items/sku/next": {
-      "post": {
-        "tags": [
-          "items"
-        ],
-        "summary": "Next Sku",
-        "operationId": "next_sku_items_sku_next_post",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NextSkuOut"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/items": {
       "post": {
         "tags": [
@@ -10304,21 +10078,22 @@
         }
       }
     },
-    "/items/{id}/test:enable": {
-      "post": {
+    "/pms/sku-coding/brands": {
+      "get": {
         "tags": [
-          "items"
+          "pms-sku-coding"
         ],
-        "summary": "Enable Test Item",
-        "operationId": "enable_test_item_items__id__test_enable_post",
+        "summary": "List Brands",
+        "operationId": "list_brands_pms_sku_coding_brands_get",
         "parameters": [
           {
-            "name": "id",
-            "in": "path",
-            "required": true,
+            "name": "active_only",
+            "in": "query",
+            "required": false,
             "schema": {
-              "type": "integer",
-              "title": "Id"
+              "type": "boolean",
+              "default": false,
+              "title": "Active Only"
             }
           }
         ],
@@ -10328,7 +10103,46 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ItemOut"
+                  "$ref": "#/components/schemas/ListOut_SkuCodeBrandOut_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "Create Brand",
+        "operationId": "create_brand_pms_sku_coding_brands_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SkuCodeBrandCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuCodeBrandOut"
                 }
               }
             }
@@ -10346,21 +10160,73 @@
         }
       }
     },
-    "/items/{id}/test:disable": {
-      "post": {
+    "/pms/sku-coding/brands/{brand_id}": {
+      "patch": {
         "tags": [
-          "items"
+          "pms-sku-coding"
         ],
-        "summary": "Disable Test Item",
-        "operationId": "disable_test_item_items__id__test_disable_post",
+        "summary": "Update Brand",
+        "operationId": "update_brand_pms_sku_coding_brands__brand_id__patch",
         "parameters": [
           {
-            "name": "id",
+            "name": "brand_id",
             "in": "path",
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Id"
+              "title": "Brand Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SkuCodeBrandUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuCodeBrandOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/sku-coding/brands/{brand_id}/enable": {
+      "post": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "Enable Brand",
+        "operationId": "enable_brand_pms_sku_coding_brands__brand_id__enable_post",
+        "parameters": [
+          {
+            "name": "brand_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Brand Id"
             }
           }
         ],
@@ -10370,7 +10236,618 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ItemOut"
+                  "$ref": "#/components/schemas/SkuCodeBrandOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/sku-coding/brands/{brand_id}/disable": {
+      "post": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "Disable Brand",
+        "operationId": "disable_brand_pms_sku_coding_brands__brand_id__disable_post",
+        "parameters": [
+          {
+            "name": "brand_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Brand Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuCodeBrandOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/sku-coding/business-categories": {
+      "get": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "List Business Categories",
+        "operationId": "list_business_categories_pms_sku_coding_business_categories_get",
+        "parameters": [
+          {
+            "name": "product_kind",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Product Kind"
+            }
+          },
+          {
+            "name": "active_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Active Only"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListOut_SkuBusinessCategoryOut_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "Create Business Category",
+        "operationId": "create_business_category_pms_sku_coding_business_categories_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SkuBusinessCategoryCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuBusinessCategoryOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/sku-coding/business-categories/{category_id}": {
+      "patch": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "Update Business Category",
+        "operationId": "update_business_category_pms_sku_coding_business_categories__category_id__patch",
+        "parameters": [
+          {
+            "name": "category_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Category Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SkuBusinessCategoryUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuBusinessCategoryOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/sku-coding/business-categories/{category_id}/enable": {
+      "post": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "Enable Business Category",
+        "operationId": "enable_business_category_pms_sku_coding_business_categories__category_id__enable_post",
+        "parameters": [
+          {
+            "name": "category_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Category Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuBusinessCategoryOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/sku-coding/business-categories/{category_id}/disable": {
+      "post": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "Disable Business Category",
+        "operationId": "disable_business_category_pms_sku_coding_business_categories__category_id__disable_post",
+        "parameters": [
+          {
+            "name": "category_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Category Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuBusinessCategoryOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/sku-coding/term-groups": {
+      "get": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "List Term Groups",
+        "operationId": "list_term_groups_pms_sku_coding_term_groups_get",
+        "parameters": [
+          {
+            "name": "product_kind",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Product Kind"
+            }
+          },
+          {
+            "name": "active_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Active Only"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListOut_SkuCodeTermGroupOut_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/sku-coding/terms": {
+      "get": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "List Terms",
+        "operationId": "list_terms_pms_sku_coding_terms_get",
+        "parameters": [
+          {
+            "name": "group_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Group Id"
+            }
+          },
+          {
+            "name": "active_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Active Only"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListOut_SkuCodeTermOut_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "Create Term",
+        "operationId": "create_term_pms_sku_coding_terms_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SkuCodeTermCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuCodeTermOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/sku-coding/terms/{term_id}": {
+      "patch": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "Update Term",
+        "operationId": "update_term_pms_sku_coding_terms__term_id__patch",
+        "parameters": [
+          {
+            "name": "term_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Term Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SkuCodeTermUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuCodeTermOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/sku-coding/terms/{term_id}/enable": {
+      "post": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "Enable Term",
+        "operationId": "enable_term_pms_sku_coding_terms__term_id__enable_post",
+        "parameters": [
+          {
+            "name": "term_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Term Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuCodeTermOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/sku-coding/terms/{term_id}/disable": {
+      "post": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "Disable Term",
+        "operationId": "disable_term_pms_sku_coding_terms__term_id__disable_post",
+        "parameters": [
+          {
+            "name": "term_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Term Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuCodeTermOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/sku-coding/generate": {
+      "post": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "Generate Sku",
+        "operationId": "generate_sku_pms_sku_coding_generate_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SkuGenerateIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuGenerateOut"
                 }
               }
             }
@@ -11411,14 +11888,14 @@
         }
       }
     },
-    "/shipping-providers": {
+    "/shipping-assist/pricing/providers": {
       "get": {
         "tags": [
-          "shipping-providers"
+          "shipping-assist-providers"
         ],
         "summary": "List Shipping Providers",
         "description": "物流/快递网点列表（读聚合 contacts）。\n\n权限：config.store.read",
-        "operationId": "list_shipping_providers_shipping_providers_get",
+        "operationId": "list_shipping_providers_shipping_assist_pricing_providers_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -11487,10 +11964,10 @@
       },
       "post": {
         "tags": [
-          "shipping-providers"
+          "shipping-assist-providers"
         ],
         "summary": "Create Shipping Provider",
-        "operationId": "create_shipping_provider_shipping_providers_post",
+        "operationId": "create_shipping_provider_shipping_assist_pricing_providers_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -11530,14 +12007,14 @@
         }
       }
     },
-    "/shipping-providers/{provider_id}": {
+    "/shipping-assist/pricing/providers/{provider_id}": {
       "get": {
         "tags": [
-          "shipping-providers"
+          "shipping-assist-providers"
         ],
         "summary": "Get Shipping Provider",
         "description": "物流/快递网点详情（读聚合 contacts）。\n\n权限：config.store.read",
-        "operationId": "get_shipping_provider_shipping_providers__provider_id__get",
+        "operationId": "get_shipping_provider_shipping_assist_pricing_providers__provider_id__get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -11580,10 +12057,10 @@
       },
       "patch": {
         "tags": [
-          "shipping-providers"
+          "shipping-assist-providers"
         ],
         "summary": "Update Shipping Provider",
-        "operationId": "update_shipping_provider_shipping_providers__provider_id__patch",
+        "operationId": "update_shipping_provider_shipping_assist_pricing_providers__provider_id__patch",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -11635,13 +12112,13 @@
         }
       }
     },
-    "/shipping-providers/{provider_id}/contacts": {
+    "/shipping-assist/pricing/providers/{provider_id}/contacts": {
       "post": {
         "tags": [
-          "shipping-providers"
+          "shipping-assist-providers"
         ],
         "summary": "Shipping Provider Create Contact",
-        "operationId": "shipping_provider_create_contact_shipping_providers__provider_id__contacts_post",
+        "operationId": "shipping_provider_create_contact_shipping_assist_pricing_providers__provider_id__contacts_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -11693,13 +12170,13 @@
         }
       }
     },
-    "/shipping-provider-contacts/{contact_id}": {
+    "/shipping-assist/pricing/provider-contacts/{contact_id}": {
       "patch": {
         "tags": [
-          "shipping-providers"
+          "shipping-assist-providers"
         ],
         "summary": "Shipping Provider Update Contact",
-        "operationId": "shipping_provider_update_contact_shipping_provider_contacts__contact_id__patch",
+        "operationId": "shipping_provider_update_contact_shipping_assist_pricing_provider_contacts__contact_id__patch",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -11752,10 +12229,10 @@
       },
       "delete": {
         "tags": [
-          "shipping-providers"
+          "shipping-assist-providers"
         ],
         "summary": "Shipping Provider Delete Contact",
-        "operationId": "shipping_provider_delete_contact_shipping_provider_contacts__contact_id__delete",
+        "operationId": "shipping_provider_delete_contact_shipping_assist_pricing_provider_contacts__contact_id__delete",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -11920,13 +12397,13 @@
         }
       }
     },
-    "/shipping-quote/calc": {
+    "/shipping-assist/shipping/quote/calc": {
       "post": {
         "tags": [
-          "tms-quote"
+          "shipping-assist-quote"
         ],
         "summary": "Calc Shipping Quote",
-        "operationId": "calc_shipping_quote_shipping_quote_calc_post",
+        "operationId": "calc_shipping_quote_shipping_assist_shipping_quote_calc_post",
         "requestBody": {
           "content": {
             "application/json": {
@@ -11966,13 +12443,13 @@
         ]
       }
     },
-    "/shipping-quote/recommend": {
+    "/shipping-assist/shipping/quote/recommend": {
       "post": {
         "tags": [
-          "tms-quote"
+          "shipping-assist-quote"
         ],
         "summary": "Recommend Shipping Quote",
-        "operationId": "recommend_shipping_quote_shipping_quote_recommend_post",
+        "operationId": "recommend_shipping_quote_shipping_assist_shipping_quote_recommend_post",
         "requestBody": {
           "content": {
             "application/json": {
@@ -12012,13 +12489,86 @@
         ]
       }
     },
-    "/tms/pricing/list": {
+    "/metrics/shipping-assist/shipping/quote/failures": {
       "get": {
         "tags": [
-          "tms-pricing"
+          "shipping-assist-quote"
+        ],
+        "summary": "Get Shipping Quote Failures",
+        "operationId": "get_shipping_quote_failures_metrics_shipping_assist_shipping_quote_failures_get",
+        "parameters": [
+          {
+            "name": "day",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "description": "UTC date, format YYYY-MM-DD",
+              "title": "Day"
+            },
+            "description": "UTC date, format YYYY-MM-DD"
+          },
+          {
+            "name": "platform",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Platform"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "default": 200,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShippingQuoteFailuresMetricsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/shipping-assist/pricing/list": {
+      "get": {
+        "tags": [
+          "shipping-assist-pricing"
         ],
         "summary": "Pricing List View",
-        "operationId": "pricing_list_view_tms_pricing_list_get",
+        "operationId": "pricing_list_view_shipping_assist_pricing_list_get",
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -12033,13 +12583,13 @@
         }
       }
     },
-    "/tms/pricing/warehouses/{warehouse_id}/bindings": {
+    "/shipping-assist/pricing/warehouses/{warehouse_id}/bindings": {
       "get": {
         "tags": [
-          "tms-pricing"
+          "shipping-assist-pricing"
         ],
         "summary": "Pricing List Warehouse Bindings",
-        "operationId": "pricing_list_warehouse_bindings_tms_pricing_warehouses__warehouse_id__bindings_get",
+        "operationId": "pricing_list_warehouse_bindings_shipping_assist_pricing_warehouses__warehouse_id__bindings_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12082,10 +12632,10 @@
       },
       "post": {
         "tags": [
-          "tms-pricing"
+          "shipping-assist-pricing"
         ],
         "summary": "Pricing Bind Provider To Warehouse",
-        "operationId": "pricing_bind_provider_to_warehouse_tms_pricing_warehouses__warehouse_id__bindings_post",
+        "operationId": "pricing_bind_provider_to_warehouse_shipping_assist_pricing_warehouses__warehouse_id__bindings_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12138,10 +12688,10 @@
       },
       "put": {
         "tags": [
-          "tms-pricing"
+          "shipping-assist-pricing"
         ],
         "summary": "Pricing Bulk Upsert Warehouse Bindings",
-        "operationId": "pricing_bulk_upsert_warehouse_bindings_tms_pricing_warehouses__warehouse_id__bindings_put",
+        "operationId": "pricing_bulk_upsert_warehouse_bindings_shipping_assist_pricing_warehouses__warehouse_id__bindings_put",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12193,13 +12743,13 @@
         }
       }
     },
-    "/tms/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/template-candidates": {
+    "/shipping-assist/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/template-candidates": {
       "get": {
         "tags": [
-          "tms-pricing"
+          "shipping-assist-pricing"
         ],
         "summary": "Pricing Binding Template Candidates",
-        "operationId": "pricing_binding_template_candidates_tms_pricing_warehouses__warehouse_id__bindings__shipping_provider_id__template_candidates_get",
+        "operationId": "pricing_binding_template_candidates_shipping_assist_pricing_warehouses__warehouse_id__bindings__shipping_provider_id__template_candidates_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12251,13 +12801,13 @@
         }
       }
     },
-    "/tms/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}": {
+    "/shipping-assist/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}": {
       "patch": {
         "tags": [
-          "tms-pricing"
+          "shipping-assist-pricing"
         ],
         "summary": "Pricing Update Warehouse Binding",
-        "operationId": "pricing_update_warehouse_binding_tms_pricing_warehouses__warehouse_id__bindings__shipping_provider_id__patch",
+        "operationId": "pricing_update_warehouse_binding_shipping_assist_pricing_warehouses__warehouse_id__bindings__shipping_provider_id__patch",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12320,10 +12870,10 @@
       },
       "delete": {
         "tags": [
-          "tms-pricing"
+          "shipping-assist-pricing"
         ],
         "summary": "Pricing Unbind Provider From Warehouse",
-        "operationId": "pricing_unbind_provider_from_warehouse_tms_pricing_warehouses__warehouse_id__bindings__shipping_provider_id__delete",
+        "operationId": "pricing_unbind_provider_from_warehouse_shipping_assist_pricing_warehouses__warehouse_id__bindings__shipping_provider_id__delete",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12375,13 +12925,13 @@
         }
       }
     },
-    "/tms/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/activate": {
+    "/shipping-assist/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/activate": {
       "post": {
         "tags": [
-          "tms-pricing"
+          "shipping-assist-pricing"
         ],
         "summary": "Pricing Activate Warehouse Binding",
-        "operationId": "pricing_activate_warehouse_binding_tms_pricing_warehouses__warehouse_id__bindings__shipping_provider_id__activate_post",
+        "operationId": "pricing_activate_warehouse_binding_shipping_assist_pricing_warehouses__warehouse_id__bindings__shipping_provider_id__activate_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12443,13 +12993,13 @@
         }
       }
     },
-    "/tms/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/deactivate": {
+    "/shipping-assist/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/deactivate": {
       "post": {
         "tags": [
-          "tms-pricing"
+          "shipping-assist-pricing"
         ],
         "summary": "Pricing Deactivate Warehouse Binding",
-        "operationId": "pricing_deactivate_warehouse_binding_tms_pricing_warehouses__warehouse_id__bindings__shipping_provider_id__deactivate_post",
+        "operationId": "pricing_deactivate_warehouse_binding_shipping_assist_pricing_warehouses__warehouse_id__bindings__shipping_provider_id__deactivate_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12501,14 +13051,14 @@
         }
       }
     },
-    "/tms/pricing/warehouses/active-carriers/summary": {
+    "/shipping-assist/pricing/warehouses/active-carriers/summary": {
       "get": {
         "tags": [
-          "tms-pricing"
+          "shipping-assist-pricing"
         ],
         "summary": "Pricing List Warehouses Active Carriers Summary",
         "description": "bindings 辅助汇总接口（消除 N+1）\n\n刚性契约口径：\n- 只返回当前真正正在服务的快递公司：\n  1) wsp.active = true\n  2) sp.active = true\n  3) wsp.active_template_id IS NOT NULL\n  4) effective_from 为空或已到生效时间\n- 不做推荐策略，不做 fallback\n- 排序仅用于展示稳定：\n  warehouse_id ASC, wsp.priority ASC, sp.priority ASC, sp.id ASC",
-        "operationId": "pricing_list_warehouses_active_carriers_summary_tms_pricing_warehouses_active_carriers_summary_get",
+        "operationId": "pricing_list_warehouses_active_carriers_summary_shipping_assist_pricing_warehouses_active_carriers_summary_get",
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -12528,14 +13078,14 @@
         ]
       }
     },
-    "/tms/pricing/templates": {
+    "/shipping-assist/pricing/templates": {
       "get": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Templates List",
-        "operationId": "pricing_templates_list_tms_pricing_templates_get",
+        "operationId": "pricing_templates_list_shipping_assist_pricing_templates_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12611,11 +13161,11 @@
       },
       "post": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Create",
-        "operationId": "pricing_template_create_tms_pricing_templates_post",
+        "operationId": "pricing_template_create_shipping_assist_pricing_templates_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12655,14 +13205,14 @@
         }
       }
     },
-    "/tms/pricing/shipping-providers/{provider_id}/templates": {
+    "/shipping-assist/pricing/providers/{provider_id}/templates": {
       "get": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Templates Provider List",
-        "operationId": "pricing_templates_provider_list_tms_pricing_shipping_providers__provider_id__templates_get",
+        "operationId": "pricing_templates_provider_list_shipping_assist_pricing_providers__provider_id__templates_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12730,14 +13280,14 @@
         }
       }
     },
-    "/tms/pricing/templates/{template_id}": {
+    "/shipping-assist/pricing/templates/{template_id}": {
       "get": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Detail",
-        "operationId": "pricing_template_detail_tms_pricing_templates__template_id__get",
+        "operationId": "pricing_template_detail_shipping_assist_pricing_templates__template_id__get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12780,11 +13330,11 @@
       },
       "patch": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Update",
-        "operationId": "pricing_template_update_tms_pricing_templates__template_id__patch",
+        "operationId": "pricing_template_update_shipping_assist_pricing_templates__template_id__patch",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12836,14 +13386,14 @@
         }
       }
     },
-    "/tms/pricing/templates/{template_id}/clone": {
+    "/shipping-assist/pricing/templates/{template_id}/clone": {
       "post": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Clone",
-        "operationId": "pricing_template_clone_tms_pricing_templates__template_id__clone_post",
+        "operationId": "pricing_template_clone_shipping_assist_pricing_templates__template_id__clone_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12895,14 +13445,14 @@
         }
       }
     },
-    "/tms/pricing/templates/{template_id}/submit-validation": {
+    "/shipping-assist/pricing/templates/{template_id}/submit-validation": {
       "post": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Submit Validation",
-        "operationId": "pricing_template_submit_validation_tms_pricing_templates__template_id__submit_validation_post",
+        "operationId": "pricing_template_submit_validation_shipping_assist_pricing_templates__template_id__submit_validation_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12954,14 +13504,14 @@
         }
       }
     },
-    "/tms/pricing/templates/{template_id}/ranges": {
+    "/shipping-assist/pricing/templates/{template_id}/ranges": {
       "get": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Ranges Get",
-        "operationId": "pricing_template_ranges_get_tms_pricing_templates__template_id__ranges_get",
+        "operationId": "pricing_template_ranges_get_shipping_assist_pricing_templates__template_id__ranges_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13004,11 +13554,11 @@
       },
       "put": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Ranges Put",
-        "operationId": "pricing_template_ranges_put_tms_pricing_templates__template_id__ranges_put",
+        "operationId": "pricing_template_ranges_put_shipping_assist_pricing_templates__template_id__ranges_put",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13060,14 +13610,14 @@
         }
       }
     },
-    "/tms/pricing/templates/{template_id}/groups": {
+    "/shipping-assist/pricing/templates/{template_id}/groups": {
       "get": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Groups Get",
-        "operationId": "pricing_template_groups_get_tms_pricing_templates__template_id__groups_get",
+        "operationId": "pricing_template_groups_get_shipping_assist_pricing_templates__template_id__groups_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13110,11 +13660,11 @@
       },
       "post": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Groups Create",
-        "operationId": "pricing_template_groups_create_tms_pricing_templates__template_id__groups_post",
+        "operationId": "pricing_template_groups_create_shipping_assist_pricing_templates__template_id__groups_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13166,14 +13716,14 @@
         }
       }
     },
-    "/tms/pricing/templates/{template_id}/groups/{group_id}": {
+    "/shipping-assist/pricing/templates/{template_id}/groups/{group_id}": {
       "put": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Groups Update",
-        "operationId": "pricing_template_groups_update_tms_pricing_templates__template_id__groups__group_id__put",
+        "operationId": "pricing_template_groups_update_shipping_assist_pricing_templates__template_id__groups__group_id__put",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13236,11 +13786,11 @@
       },
       "delete": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Groups Delete",
-        "operationId": "pricing_template_groups_delete_tms_pricing_templates__template_id__groups__group_id__delete",
+        "operationId": "pricing_template_groups_delete_shipping_assist_pricing_templates__template_id__groups__group_id__delete",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13292,14 +13842,14 @@
         }
       }
     },
-    "/tms/pricing/templates/{template_id}/matrix-cells": {
+    "/shipping-assist/pricing/templates/{template_id}/matrix-cells": {
       "get": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Matrix Get",
-        "operationId": "pricing_template_matrix_get_tms_pricing_templates__template_id__matrix_cells_get",
+        "operationId": "pricing_template_matrix_get_shipping_assist_pricing_templates__template_id__matrix_cells_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13342,11 +13892,11 @@
       },
       "put": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Matrix Put",
-        "operationId": "pricing_template_matrix_put_tms_pricing_templates__template_id__matrix_cells_put",
+        "operationId": "pricing_template_matrix_put_shipping_assist_pricing_templates__template_id__matrix_cells_put",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13398,14 +13948,14 @@
         }
       }
     },
-    "/tms/pricing/templates/{template_id}/surcharge-configs/batch-province": {
+    "/shipping-assist/pricing/templates/{template_id}/surcharge-configs/batch-province": {
       "post": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Surcharge Batch Province",
-        "operationId": "pricing_template_surcharge_batch_province_tms_pricing_templates__template_id__surcharge_configs_batch_province_post",
+        "operationId": "pricing_template_surcharge_batch_province_shipping_assist_pricing_templates__template_id__surcharge_configs_batch_province_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13457,14 +14007,14 @@
         }
       }
     },
-    "/tms/pricing/templates/{template_id}/surcharge-configs/city-container": {
+    "/shipping-assist/pricing/templates/{template_id}/surcharge-configs/city-container": {
       "post": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Surcharge City Container Create",
-        "operationId": "pricing_template_surcharge_city_container_create_tms_pricing_templates__template_id__surcharge_configs_city_container_post",
+        "operationId": "pricing_template_surcharge_city_container_create_shipping_assist_pricing_templates__template_id__surcharge_configs_city_container_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13516,14 +14066,14 @@
         }
       }
     },
-    "/tms/pricing/templates/{template_id}/surcharge-configs": {
+    "/shipping-assist/pricing/templates/{template_id}/surcharge-configs": {
       "post": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Surcharge Create",
-        "operationId": "pricing_template_surcharge_create_tms_pricing_templates__template_id__surcharge_configs_post",
+        "operationId": "pricing_template_surcharge_create_shipping_assist_pricing_templates__template_id__surcharge_configs_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13575,14 +14125,14 @@
         }
       }
     },
-    "/tms/pricing/surcharge-configs/{config_id}": {
+    "/shipping-assist/pricing/surcharge-configs/{config_id}": {
       "patch": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Surcharge Update",
-        "operationId": "pricing_template_surcharge_update_tms_pricing_surcharge_configs__config_id__patch",
+        "operationId": "pricing_template_surcharge_update_shipping_assist_pricing_surcharge_configs__config_id__patch",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13635,11 +14185,11 @@
       },
       "delete": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Surcharge Delete",
-        "operationId": "pricing_template_surcharge_delete_tms_pricing_surcharge_configs__config_id__delete",
+        "operationId": "pricing_template_surcharge_delete_shipping_assist_pricing_surcharge_configs__config_id__delete",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13679,13 +14229,13 @@
         }
       }
     },
-    "/shipping-reports/by-carrier": {
+    "/shipping-assist/reports/by-carrier": {
       "get": {
         "tags": [
-          "shipping-reports"
+          "shipping-assist-reports"
         ],
         "summary": "Shipping Reports By Carrier",
-        "operationId": "shipping_reports_by_carrier_shipping_reports_by_carrier_get",
+        "operationId": "shipping_reports_by_carrier_shipping_assist_reports_by_carrier_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13741,7 +14291,7 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -13753,11 +14303,11 @@
                   "type": "null"
                 }
               ],
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
-            "name": "carrier_code",
+            "name": "shipping_provider_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -13769,7 +14319,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Carrier Code"
+              "title": "Shipping Provider Code"
             }
           },
           {
@@ -13845,13 +14395,13 @@
         }
       }
     },
-    "/shipping-reports/by-province": {
+    "/shipping-assist/reports/by-province": {
       "get": {
         "tags": [
-          "shipping-reports"
+          "shipping-assist-reports"
         ],
         "summary": "Shipping Reports By Province",
-        "operationId": "shipping_reports_by_province_shipping_reports_by_province_get",
+        "operationId": "shipping_reports_by_province_shipping_assist_reports_by_province_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13907,7 +14457,7 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -13919,11 +14469,11 @@
                   "type": "null"
                 }
               ],
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
-            "name": "carrier_code",
+            "name": "shipping_provider_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -13935,7 +14485,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Carrier Code"
+              "title": "Shipping Provider Code"
             }
           },
           {
@@ -14011,13 +14561,13 @@
         }
       }
     },
-    "/shipping-reports/by-shop": {
+    "/shipping-assist/reports/by-store": {
       "get": {
         "tags": [
-          "shipping-reports"
+          "shipping-assist-reports"
         ],
-        "summary": "Shipping Reports By Shop",
-        "operationId": "shipping_reports_by_shop_shipping_reports_by_shop_get",
+        "summary": "Shipping Reports By Store",
+        "operationId": "shipping_reports_by_store_shipping_assist_reports_by_store_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -14073,7 +14623,7 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -14085,11 +14635,11 @@
                   "type": "null"
                 }
               ],
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
-            "name": "carrier_code",
+            "name": "shipping_provider_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -14101,7 +14651,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Carrier Code"
+              "title": "Shipping Provider Code"
             }
           },
           {
@@ -14159,7 +14709,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ShippingByShopResponse"
+                  "$ref": "#/components/schemas/ShippingByStoreResponse"
                 }
               }
             }
@@ -14177,13 +14727,13 @@
         }
       }
     },
-    "/shipping-reports/by-warehouse": {
+    "/shipping-assist/reports/by-warehouse": {
       "get": {
         "tags": [
-          "shipping-reports"
+          "shipping-assist-reports"
         ],
         "summary": "Shipping Reports By Warehouse",
-        "operationId": "shipping_reports_by_warehouse_shipping_reports_by_warehouse_get",
+        "operationId": "shipping_reports_by_warehouse_shipping_assist_reports_by_warehouse_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -14239,7 +14789,7 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -14251,11 +14801,11 @@
                   "type": "null"
                 }
               ],
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
-            "name": "carrier_code",
+            "name": "shipping_provider_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -14267,7 +14817,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Carrier Code"
+              "title": "Shipping Provider Code"
             }
           },
           {
@@ -14343,13 +14893,13 @@
         }
       }
     },
-    "/shipping-reports/daily": {
+    "/shipping-assist/reports/daily": {
       "get": {
         "tags": [
-          "shipping-reports"
+          "shipping-assist-reports"
         ],
         "summary": "Shipping Reports Daily",
-        "operationId": "shipping_reports_daily_shipping_reports_daily_get",
+        "operationId": "shipping_reports_daily_shipping_assist_reports_daily_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -14405,7 +14955,7 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -14417,11 +14967,11 @@
                   "type": "null"
                 }
               ],
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
-            "name": "carrier_code",
+            "name": "shipping_provider_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -14433,7 +14983,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Carrier Code"
+              "title": "Shipping Provider Code"
             }
           },
           {
@@ -14509,13 +15059,13 @@
         }
       }
     },
-    "/shipping-reports/options": {
+    "/shipping-assist/reports/options": {
       "get": {
         "tags": [
-          "shipping-reports"
+          "shipping-assist-reports"
         ],
         "summary": "Shipping Reports Options",
-        "operationId": "shipping_reports_options_shipping_reports_options_get",
+        "operationId": "shipping_reports_options_shipping_assist_reports_options_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -14595,13 +15145,13 @@
         }
       }
     },
-    "/tms/records": {
+    "/shipping-assist/shipping/records": {
       "get": {
         "tags": [
-          "tms-records"
+          "shipping-assist-records"
         ],
         "summary": "物流台帐列表",
-        "operationId": "get_shipping_ledger_tms_records_get",
+        "operationId": "get_shipping_ledger_shipping_assist_shipping_records_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -14673,7 +15223,7 @@
             }
           },
           {
-            "name": "carrier_code",
+            "name": "shipping_provider_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -14685,7 +15235,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Carrier Code"
+              "title": "Shipping Provider Code"
             }
           },
           {
@@ -14802,13 +15352,13 @@
         }
       }
     },
-    "/tms/records/export": {
+    "/shipping-assist/shipping/records/export": {
       "get": {
         "tags": [
-          "tms-records"
+          "shipping-assist-records"
         ],
         "summary": "导出物流台帐",
-        "operationId": "export_shipping_ledger_tms_records_export_get",
+        "operationId": "export_shipping_ledger_shipping_assist_shipping_records_export_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -14880,7 +15430,7 @@
             }
           },
           {
-            "name": "carrier_code",
+            "name": "shipping_provider_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -14892,7 +15442,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Carrier Code"
+              "title": "Shipping Provider Code"
             }
           },
           {
@@ -14984,13 +15534,13 @@
         }
       }
     },
-    "/tms/records/cost-analysis": {
+    "/shipping-assist/shipping/records/cost-analysis": {
       "get": {
         "tags": [
-          "tms-records"
+          "shipping-assist-records"
         ],
         "summary": "物流台帐预估成本分析",
-        "operationId": "get_records_cost_analysis_route_tms_records_cost_analysis_get",
+        "operationId": "get_records_cost_analysis_route_shipping_assist_shipping_records_cost_analysis_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -14998,7 +15548,7 @@
         ],
         "parameters": [
           {
-            "name": "carrier_code",
+            "name": "shipping_provider_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -15010,7 +15560,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Carrier Code"
+              "title": "Shipping Provider Code"
             }
           },
           {
@@ -15070,18 +15620,18 @@
         }
       }
     },
-    "/tms/billing/import": {
+    "/shipping-assist/billing/import": {
       "post": {
         "tags": [
-          "tms-billing"
+          "shipping-assist-billing"
         ],
         "summary": "Import Shipping Bill",
-        "operationId": "import_shipping_bill_tms_billing_import_post",
+        "operationId": "import_shipping_bill_shipping_assist_billing_import_post",
         "requestBody": {
           "content": {
             "multipart/form-data": {
               "schema": {
-                "$ref": "#/components/schemas/Body_import_shipping_bill_tms_billing_import_post"
+                "$ref": "#/components/schemas/Body_import_shipping_bill_shipping_assist_billing_import_post"
               }
             }
           },
@@ -15093,7 +15643,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CarrierBillImportResult"
+                  "$ref": "#/components/schemas/ShippingProviderBillImportResult"
                 }
               }
             }
@@ -15116,13 +15666,13 @@
         ]
       }
     },
-    "/tms/billing/items": {
+    "/shipping-assist/billing/items": {
       "get": {
         "tags": [
-          "tms-billing"
+          "shipping-assist-billing"
         ],
         "summary": "Get Shipping Bill Items",
-        "operationId": "get_shipping_bill_items_tms_billing_items_get",
+        "operationId": "get_shipping_bill_items_shipping_assist_billing_items_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -15130,7 +15680,7 @@
         ],
         "parameters": [
           {
-            "name": "carrier_code",
+            "name": "shipping_provider_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -15142,7 +15692,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Carrier Code"
+              "title": "Shipping Provider Code"
             }
           },
           {
@@ -15191,7 +15741,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CarrierBillItemsResponse"
+                  "$ref": "#/components/schemas/ShippingProviderBillItemsResponse"
                 }
               }
             }
@@ -15209,18 +15759,18 @@
         }
       }
     },
-    "/tms/billing/reconcile": {
+    "/shipping-assist/billing/reconcile": {
       "post": {
         "tags": [
-          "tms-billing"
+          "shipping-assist-billing"
         ],
         "summary": "Reconcile Shipping Bill",
-        "operationId": "reconcile_shipping_bill_tms_billing_reconcile_post",
+        "operationId": "reconcile_shipping_bill_shipping_assist_billing_reconcile_post",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ReconcileCarrierBillIn"
+                "$ref": "#/components/schemas/ReconcileShippingProviderBillIn"
               }
             }
           },
@@ -15232,7 +15782,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ReconcileCarrierBillResult"
+                  "$ref": "#/components/schemas/ReconcileShippingProviderBillResult"
                 }
               }
             }
@@ -15255,13 +15805,13 @@
         ]
       }
     },
-    "/tms/billing/reconciliations": {
+    "/shipping-assist/billing/reconciliations": {
       "get": {
         "tags": [
-          "tms-billing"
+          "shipping-assist-billing"
         ],
         "summary": "Get Shipping Bill Reconciliations",
-        "operationId": "get_shipping_bill_reconciliations_tms_billing_reconciliations_get",
+        "operationId": "get_shipping_bill_reconciliations_shipping_assist_billing_reconciliations_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -15269,7 +15819,7 @@
         ],
         "parameters": [
           {
-            "name": "carrier_code",
+            "name": "shipping_provider_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -15281,7 +15831,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Carrier Code"
+              "title": "Shipping Provider Code"
             }
           },
           {
@@ -15364,13 +15914,13 @@
         }
       }
     },
-    "/tms/billing/reconciliation-histories": {
+    "/shipping-assist/billing/reconciliation-histories": {
       "get": {
         "tags": [
-          "tms-billing"
+          "shipping-assist-billing"
         ],
         "summary": "Get Shipping Bill Reconciliation Histories",
-        "operationId": "get_shipping_bill_reconciliation_histories_tms_billing_reconciliation_histories_get",
+        "operationId": "get_shipping_bill_reconciliation_histories_shipping_assist_billing_reconciliation_histories_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -15378,7 +15928,7 @@
         ],
         "parameters": [
           {
-            "name": "carrier_code",
+            "name": "shipping_provider_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -15390,7 +15940,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Carrier Code"
+              "title": "Shipping Provider Code"
             }
           },
           {
@@ -15473,13 +16023,13 @@
         }
       }
     },
-    "/tms/billing/reconciliations/{reconciliation_id}/approve": {
+    "/shipping-assist/billing/reconciliations/{reconciliation_id}/approve": {
       "post": {
         "tags": [
-          "tms-billing"
+          "shipping-assist-billing"
         ],
         "summary": "Approve Reconciliation",
-        "operationId": "approve_reconciliation_tms_billing_reconciliations__reconciliation_id__approve_post",
+        "operationId": "approve_reconciliation_shipping_assist_billing_reconciliations__reconciliation_id__approve_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -15530,13 +16080,13 @@
         }
       }
     },
-    "/tms/billing/cost-analysis": {
+    "/shipping-assist/billing/cost-analysis": {
       "get": {
         "tags": [
-          "tms-billing"
+          "shipping-assist-billing"
         ],
         "summary": "快递账单成本分析",
-        "operationId": "get_billing_cost_analysis_route_tms_billing_cost_analysis_get",
+        "operationId": "get_billing_cost_analysis_route_shipping_assist_billing_cost_analysis_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -15544,7 +16094,7 @@
         ],
         "parameters": [
           {
-            "name": "carrier_code",
+            "name": "shipping_provider_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -15556,7 +16106,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Carrier Code"
+              "title": "Shipping Provider Code"
             }
           },
           {
@@ -16357,7 +16907,7 @@
             "description": "可选平台过滤（如 PDD）"
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -16369,10 +16919,10 @@
                   "type": "null"
                 }
               ],
-              "description": "可选店铺过滤（字符串，与 orders.shop_id 一致）",
-              "title": "Shop Id"
+              "description": "可选店铺过滤（字符串，与 orders.store_code 一致）",
+              "title": "Store Code"
             },
-            "description": "可选店铺过滤（字符串，与 orders.shop_id 一致）"
+            "description": "可选店铺过滤（字符串，与 orders.store_code 一致）"
           }
         ],
         "responses": {
@@ -16427,7 +16977,7 @@
             "description": "可选平台过滤（如 PDD）"
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -16440,7 +16990,7 @@
                 }
               ],
               "description": "可选店铺过滤",
-              "title": "Shop Id"
+              "title": "Store Code"
             },
             "description": "可选店铺过滤"
           }
@@ -16475,7 +17025,7 @@
           "orders-sla"
         ],
         "summary": "Get Orders Sla Stats",
-        "description": "订单发货 SLA 统计：\n\n- 以 orders.created_at 为下单时间；\n- 以 order_fulfillment.shipped_at 为发货完成时间；\n- 通过 order_fulfillment.order_id 关联 orders.id。\n\n只统计在给定时间窗口内发货的订单（按 order_fulfillment.shipped_at 过滤）。\n\n✅ PROD-only（简化口径）：\n- 排除测试店铺（platform_test_shops.code='DEFAULT'，以 store_id 为事实锚点）",
+        "description": "订单发货 SLA 统计：\n\n- 以 orders.created_at 为下单时间；\n- 以 order_fulfillment.shipped_at 为发货完成时间；\n- 通过 order_fulfillment.order_id 关联 orders.id。\n\n只统计在给定时间窗口内发货的订单（按 order_fulfillment.shipped_at 过滤）。\n\n✅ PROD-only（简化口径）：\n- 排除测试店铺（platform_test_stores.code='DEFAULT'，以 store_id 为事实锚点）",
         "operationId": "get_orders_sla_stats_orders_stats_sla_get",
         "parameters": [
           {
@@ -16535,7 +17085,7 @@
             "description": "可选平台过滤（如 PDD），大写/小写均可"
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -16547,10 +17097,10 @@
                   "type": "null"
                 }
               ],
-              "description": "可选店铺过滤（字符串，与 orders.shop_id 一致）",
-              "title": "Shop Id"
+              "description": "可选店铺过滤（字符串，与 orders.store_code 一致）",
+              "title": "Store Code"
             },
-            "description": "可选店铺过滤（字符串，与 orders.shop_id 一致）"
+            "description": "可选店铺过滤（字符串，与 orders.store_code 一致）"
           },
           {
             "name": "sla_hours",
@@ -17249,14 +17799,13 @@
         }
       }
     },
-    "/finance/overview/daily": {
+    "/finance/overview": {
       "get": {
         "tags": [
           "finance"
         ],
-        "summary": "按日汇总的收入 / 成本 / 毛利趋势（运营视角粗粒度）",
-        "description": "财务总览（按日）——运营视角粗估版本（PROD-only）：\n\n✅ 统计口径（封板）：\n- 收入：orders.pay_amount（缺失则退回 order_amount），按 orders.created_at::date 汇总\n- 商品成本：以 purchase_order_lines 的平均单价（总金额 / 总最小单位数）粗算\n         行金额口径：qty_ordered_base * supply_price - discount_amount（line_amount 不落库）\n- 发货成本：shipping_records.cost_estimated，按 shipping_records.created_at::date 汇总",
-        "operationId": "finance_overview_daily_finance_overview_daily_get",
+        "summary": "财务分析综合分析",
+        "operationId": "get_overview_finance_overview_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -17276,10 +17825,10 @@
                   "type": "null"
                 }
               ],
-              "description": "起始日期（YYYY-MM-DD，含）。默认=今天往前 6 天。",
+              "description": "起始日期 YYYY-MM-DD，默认最近 30 天",
               "title": "From Date"
             },
-            "description": "起始日期（YYYY-MM-DD，含）。默认=今天往前 6 天。"
+            "description": "起始日期 YYYY-MM-DD，默认最近 30 天"
           },
           {
             "name": "to_date",
@@ -17294,10 +17843,46 @@
                   "type": "null"
                 }
               ],
-              "description": "结束日期（YYYY-MM-DD，含）。默认=今天。",
+              "description": "结束日期 YYYY-MM-DD，默认今天",
               "title": "To Date"
             },
-            "description": "结束日期（YYYY-MM-DD，含）。默认=今天。"
+            "description": "结束日期 YYYY-MM-DD，默认今天"
+          },
+          {
+            "name": "platform",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "平台过滤，可选",
+              "title": "Platform"
+            },
+            "description": "平台过滤，可选"
+          },
+          {
+            "name": "store_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "店铺过滤，可选",
+              "title": "Store Code"
+            },
+            "description": "店铺过滤，可选"
           }
         ],
         "responses": {
@@ -17306,11 +17891,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/FinanceDailyRow"
-                  },
-                  "title": "Response Finance Overview Daily Finance Overview Daily Get"
+                  "$ref": "#/components/schemas/FinanceOverviewResponse"
                 }
               }
             }
@@ -17328,14 +17909,13 @@
         }
       }
     },
-    "/finance/shop": {
+    "/finance/order-sales": {
       "get": {
         "tags": [
           "finance"
         ],
-        "summary": "按店铺聚合的收入 / 成本 / 毛利（运营视角粗粒度）",
-        "description": "店铺盈利能力（粗粒度）（PROD-only）：\n\n- 商品成本：基于 purchase_order_lines 推导的 avg_unit_cost × order_items.qty\n  行金额口径：qty_ordered_base*supply_price - discount_amount（line_amount 不落库）",
-        "operationId": "finance_by_shop_finance_shop_get",
+        "summary": "财务分析订单销售",
+        "operationId": "get_finance_order_sales_finance_order_sales_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -17355,10 +17935,10 @@
                   "type": "null"
                 }
               ],
-              "description": "起始日期（YYYY-MM-DD，含）。默认=今天往前 6 天。",
+              "description": "起始日期 YYYY-MM-DD，默认最近 30 天",
               "title": "From Date"
             },
-            "description": "起始日期（YYYY-MM-DD，含）。默认=今天往前 6 天。"
+            "description": "起始日期 YYYY-MM-DD，默认最近 30 天"
           },
           {
             "name": "to_date",
@@ -17373,10 +17953,10 @@
                   "type": "null"
                 }
               ],
-              "description": "结束日期（YYYY-MM-DD，含）。默认=今天。",
+              "description": "结束日期 YYYY-MM-DD，默认今天",
               "title": "To Date"
             },
-            "description": "结束日期（YYYY-MM-DD，含）。默认=今天。"
+            "description": "结束日期 YYYY-MM-DD，默认今天"
           },
           {
             "name": "platform",
@@ -17391,13 +17971,13 @@
                   "type": "null"
                 }
               ],
-              "description": "按平台过滤，例如 PDD / JD（可选）",
+              "description": "平台过滤，可选",
               "title": "Platform"
             },
-            "description": "按平台过滤，例如 PDD / JD（可选）"
+            "description": "平台过滤，可选"
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -17409,10 +17989,55 @@
                   "type": "null"
                 }
               ],
-              "description": "按店铺 ID 过滤（可选）",
-              "title": "Shop Id"
+              "description": "店铺过滤，可选",
+              "title": "Store Code"
             },
-            "description": "按店铺 ID 过滤（可选）"
+            "description": "店铺过滤，可选"
+          },
+          {
+            "name": "order_no",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "订单号 / 订单引用模糊搜索，可选",
+              "title": "Order No"
+            },
+            "description": "订单号 / 订单引用模糊搜索，可选"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "description": "分页大小",
+              "default": 100,
+              "title": "Limit"
+            },
+            "description": "分页大小"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "分页偏移量",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "分页偏移量"
           }
         ],
         "responses": {
@@ -17421,11 +18046,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/FinanceShopRow"
-                  },
-                  "title": "Response Finance By Shop Finance Shop Get"
+                  "$ref": "#/components/schemas/OrderSalesResponse"
                 }
               }
             }
@@ -17443,14 +18064,13 @@
         }
       }
     },
-    "/finance/sku": {
+    "/finance/purchase-costs": {
       "get": {
         "tags": [
           "finance"
         ],
-        "summary": "SKU 毛利榜（不含运费，基于平均进货价）",
-        "description": "SKU 毛利榜（粗粒度版本）：\n\n- 商品成本：avg_unit_cost(item_id) × SUM(order_items.qty)\n  avg_unit_cost = total_amount / total_units\n  total_amount = SUM(qty_ordered_base*supply_price - discount_amount)\n  total_units  = SUM(qty_ordered_base)",
-        "operationId": "finance_by_sku_finance_sku_get",
+        "summary": "财务分析采购成本",
+        "operationId": "get_finance_purchase_costs_finance_purchase_costs_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -17470,10 +18090,10 @@
                   "type": "null"
                 }
               ],
-              "description": "起始日期（YYYY-MM-DD，含）。默认=今天往前 6 天。",
+              "description": "起始日期 YYYY-MM-DD，默认最近 30 天",
               "title": "From Date"
             },
-            "description": "起始日期（YYYY-MM-DD，含）。默认=今天往前 6 天。"
+            "description": "起始日期 YYYY-MM-DD，默认最近 30 天"
           },
           {
             "name": "to_date",
@@ -17488,28 +18108,10 @@
                   "type": "null"
                 }
               ],
-              "description": "结束日期（YYYY-MM-DD，含）。默认=今天。",
+              "description": "结束日期 YYYY-MM-DD，默认今天",
               "title": "To Date"
             },
-            "description": "结束日期（YYYY-MM-DD，含）。默认=今天。"
-          },
-          {
-            "name": "platform",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "按平台过滤，例如 PDD / JD（可选）",
-              "title": "Platform"
-            },
-            "description": "按平台过滤，例如 PDD / JD（可选）"
+            "description": "结束日期 YYYY-MM-DD，默认今天"
           }
         ],
         "responses": {
@@ -17518,11 +18120,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/FinanceSkuRow"
-                  },
-                  "title": "Response Finance By Sku Finance Sku Get"
+                  "$ref": "#/components/schemas/PurchaseCostResponse"
                 }
               }
             }
@@ -17540,14 +18138,105 @@
         }
       }
     },
-    "/finance/order-unit": {
+    "/finance/purchase-costs/sku-purchase-ledger/options": {
       "get": {
         "tags": [
           "finance"
         ],
-        "summary": "客单价 & 贡献度分析（按订单维度）",
-        "description": "客单价 & 贡献度分析：\n\n- 每一条记录 = 一笔订单（order_value = pay_amount 或 order_amount）\n- summary：订单数 / 总收入 / 平均客单价 / 中位客单价\n- contribution_curve：前 20%/40%/60%/80%/100% 订单贡献的收入占比\n- top_orders：按金额从大到小列出前 N 笔订单",
-        "operationId": "finance_order_unit_finance_order_unit_get",
+        "summary": "财务分析 SKU 采购价格核算表筛选选项",
+        "operationId": "get_finance_sku_purchase_ledger_options_finance_purchase_costs_sku_purchase_ledger_options_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "supplier_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "供应商过滤，可选",
+              "title": "Supplier Id"
+            },
+            "description": "供应商过滤，可选"
+          },
+          {
+            "name": "warehouse_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "仓库过滤，可选",
+              "title": "Warehouse Id"
+            },
+            "description": "仓库过滤，可选"
+          },
+          {
+            "name": "item_keyword",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "商品名 / SKU / item_id 过滤，可选",
+              "title": "Item Keyword"
+            },
+            "description": "商品名 / SKU / item_id 过滤，可选"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuPurchaseLedgerOptionsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/finance/purchase-costs/sku-purchase-ledger": {
+      "get": {
+        "tags": [
+          "finance"
+        ],
+        "summary": "财务分析 SKU 采购价格核算表",
+        "operationId": "get_finance_sku_purchase_ledger_finance_purchase_costs_sku_purchase_ledger_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -17567,10 +18256,10 @@
                   "type": "null"
                 }
               ],
-              "description": "起始日期（YYYY-MM-DD，含）。默认=今天往前 6 天。",
+              "description": "起始日期 YYYY-MM-DD，可选",
               "title": "From Date"
             },
-            "description": "起始日期（YYYY-MM-DD，含）。默认=今天往前 6 天。"
+            "description": "起始日期 YYYY-MM-DD，可选"
           },
           {
             "name": "to_date",
@@ -17585,10 +18274,138 @@
                   "type": "null"
                 }
               ],
-              "description": "结束日期（YYYY-MM-DD，含）。默认=今天。",
+              "description": "结束日期 YYYY-MM-DD，可选",
               "title": "To Date"
             },
-            "description": "结束日期（YYYY-MM-DD，含）。默认=今天。"
+            "description": "结束日期 YYYY-MM-DD，可选"
+          },
+          {
+            "name": "supplier_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "供应商过滤，可选",
+              "title": "Supplier Id"
+            },
+            "description": "供应商过滤，可选"
+          },
+          {
+            "name": "warehouse_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "仓库过滤，可选",
+              "title": "Warehouse Id"
+            },
+            "description": "仓库过滤，可选"
+          },
+          {
+            "name": "item_keyword",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "商品名 / SKU / item_id 过滤，可选",
+              "title": "Item Keyword"
+            },
+            "description": "商品名 / SKU / item_id 过滤，可选"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuPurchaseLedgerResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/finance/shipping-costs": {
+      "get": {
+        "tags": [
+          "finance"
+        ],
+        "summary": "财务分析物流成本",
+        "operationId": "get_finance_shipping_costs_finance_shipping_costs_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "from_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "起始日期 YYYY-MM-DD，默认最近 30 天",
+              "title": "From Date"
+            },
+            "description": "起始日期 YYYY-MM-DD，默认最近 30 天"
+          },
+          {
+            "name": "to_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "结束日期 YYYY-MM-DD，默认今天",
+              "title": "To Date"
+            },
+            "description": "结束日期 YYYY-MM-DD，默认今天"
           },
           {
             "name": "platform",
@@ -17603,13 +18420,13 @@
                   "type": "null"
                 }
               ],
-              "description": "按平台过滤，例如 PDD / JD（可选）",
+              "description": "平台过滤，可选",
               "title": "Platform"
             },
-            "description": "按平台过滤，例如 PDD / JD（可选）"
+            "description": "平台过滤，可选"
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -17621,10 +18438,10 @@
                   "type": "null"
                 }
               ],
-              "description": "按店铺 ID 过滤（可选）",
-              "title": "Shop Id"
+              "description": "店铺过滤，可选",
+              "title": "Store Code"
             },
-            "description": "按店铺 ID 过滤（可选）"
+            "description": "店铺过滤，可选"
           }
         ],
         "responses": {
@@ -17633,9 +18450,335 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Finance Order Unit Finance Order Unit Get"
+                  "$ref": "#/components/schemas/ShippingCostResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/finance/shipping-costs/shipping-ledger/options": {
+      "get": {
+        "tags": [
+          "finance"
+        ],
+        "summary": "财务分析物流成本明细筛选选项",
+        "operationId": "get_finance_shipping_ledger_options_finance_shipping_costs_shipping_ledger_options_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "from_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "起始日期 YYYY-MM-DD，可选",
+              "title": "From Date"
+            },
+            "description": "起始日期 YYYY-MM-DD，可选"
+          },
+          {
+            "name": "to_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "结束日期 YYYY-MM-DD，可选",
+              "title": "To Date"
+            },
+            "description": "结束日期 YYYY-MM-DD，可选"
+          },
+          {
+            "name": "platform",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "平台过滤，可选",
+              "title": "Platform"
+            },
+            "description": "平台过滤，可选"
+          },
+          {
+            "name": "store_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "店铺过滤，可选",
+              "title": "Store Code"
+            },
+            "description": "店铺过滤，可选"
+          },
+          {
+            "name": "warehouse_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "仓库过滤，可选",
+              "title": "Warehouse Id"
+            },
+            "description": "仓库过滤，可选"
+          },
+          {
+            "name": "shipping_provider_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "物流网点过滤，可选",
+              "title": "Shipping Provider Id"
+            },
+            "description": "物流网点过滤，可选"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShippingCostLedgerOptionsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/finance/shipping-costs/shipping-ledger": {
+      "get": {
+        "tags": [
+          "finance"
+        ],
+        "summary": "财务分析物流成本核算明细表",
+        "operationId": "get_finance_shipping_ledger_finance_shipping_costs_shipping_ledger_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "from_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "起始日期 YYYY-MM-DD，可选",
+              "title": "From Date"
+            },
+            "description": "起始日期 YYYY-MM-DD，可选"
+          },
+          {
+            "name": "to_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "结束日期 YYYY-MM-DD，可选",
+              "title": "To Date"
+            },
+            "description": "结束日期 YYYY-MM-DD，可选"
+          },
+          {
+            "name": "platform",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "平台过滤，可选",
+              "title": "Platform"
+            },
+            "description": "平台过滤，可选"
+          },
+          {
+            "name": "store_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "店铺过滤，可选",
+              "title": "Store Code"
+            },
+            "description": "店铺过滤，可选"
+          },
+          {
+            "name": "warehouse_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "仓库过滤，可选",
+              "title": "Warehouse Id"
+            },
+            "description": "仓库过滤，可选"
+          },
+          {
+            "name": "shipping_provider_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "物流网点过滤，可选",
+              "title": "Shipping Provider Id"
+            },
+            "description": "物流网点过滤，可选"
+          },
+          {
+            "name": "order_keyword",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "订单号 / 运单号模糊过滤，可选",
+              "title": "Order Keyword"
+            },
+            "description": "订单号 / 运单号模糊过滤，可选"
+          },
+          {
+            "name": "tracking_no",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "运单号精确过滤，可选",
+              "title": "Tracking No"
+            },
+            "description": "运单号精确过滤，可选"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShippingCostLedgerResponse"
                 }
               }
             }
@@ -17722,7 +18865,7 @@
             "type": "integer",
             "title": "Provider Id"
           },
-          "code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -17731,7 +18874,7 @@
                 "type": "null"
               }
             ],
-            "title": "Code"
+            "title": "Shipping Provider Code"
           },
           "name": {
             "type": "string",
@@ -17852,6 +18995,12 @@
       },
       "AggregateItemInput": {
         "properties": {
+          "sku": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Sku"
+          },
           "name": {
             "type": "string",
             "maxLength": 128,
@@ -17995,6 +19144,7 @@
         "additionalProperties": false,
         "type": "object",
         "required": [
+          "sku",
           "name"
         ],
         "title": "AggregateItemInput"
@@ -18291,7 +19441,7 @@
       },
       "BillingCostAnalysisByCarrierRowOut": {
         "properties": {
-          "carrier_code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -18300,7 +19450,7 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
           "ticket_count": {
             "type": "integer",
@@ -18528,11 +19678,11 @@
         ],
         "title": "BindingUpdateOut"
       },
-      "Body_import_shipping_bill_tms_billing_import_post": {
+      "Body_import_shipping_bill_shipping_assist_billing_import_post": {
         "properties": {
-          "carrier_code": {
+          "shipping_provider_code": {
             "type": "string",
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
           "bill_month": {
             "anyOf": [
@@ -18547,292 +19697,16 @@
           },
           "file": {
             "type": "string",
-            "format": "binary",
+            "contentMediaType": "application/octet-stream",
             "title": "File"
           }
         },
         "type": "object",
         "required": [
-          "carrier_code",
+          "shipping_provider_code",
           "file"
         ],
-        "title": "Body_import_shipping_bill_tms_billing_import_post"
-      },
-      "CarrierBillImportResult": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "carrier_code": {
-            "type": "string",
-            "title": "Carrier Code"
-          },
-          "imported_count": {
-            "type": "integer",
-            "title": "Imported Count"
-          },
-          "skipped_count": {
-            "type": "integer",
-            "title": "Skipped Count"
-          },
-          "error_count": {
-            "type": "integer",
-            "title": "Error Count"
-          },
-          "errors": {
-            "items": {
-              "$ref": "#/components/schemas/CarrierBillImportRowError"
-            },
-            "type": "array",
-            "title": "Errors"
-          }
-        },
-        "type": "object",
-        "required": [
-          "carrier_code",
-          "imported_count",
-          "skipped_count",
-          "error_count"
-        ],
-        "title": "CarrierBillImportResult"
-      },
-      "CarrierBillImportRowError": {
-        "properties": {
-          "row_no": {
-            "type": "integer",
-            "title": "Row No",
-            "description": "Excel 行号（从 1 开始）"
-          },
-          "message": {
-            "type": "string",
-            "title": "Message",
-            "description": "错误原因"
-          }
-        },
-        "type": "object",
-        "required": [
-          "row_no",
-          "message"
-        ],
-        "title": "CarrierBillImportRowError"
-      },
-      "CarrierBillItemOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "carrier_code": {
-            "type": "string",
-            "title": "Carrier Code"
-          },
-          "bill_month": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Bill Month"
-          },
-          "tracking_no": {
-            "type": "string",
-            "title": "Tracking No"
-          },
-          "business_time": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Business Time"
-          },
-          "destination_province": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Destination Province"
-          },
-          "destination_city": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Destination City"
-          },
-          "billing_weight_kg": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Billing Weight Kg"
-          },
-          "freight_amount": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Freight Amount"
-          },
-          "surcharge_amount": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Surcharge Amount"
-          },
-          "total_amount": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Total Amount"
-          },
-          "settlement_object": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Settlement Object"
-          },
-          "order_customer": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order Customer"
-          },
-          "sender_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sender Name"
-          },
-          "network_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Network Name"
-          },
-          "size_text": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Size Text"
-          },
-          "parent_customer": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Parent Customer"
-          },
-          "raw_payload": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Raw Payload"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "carrier_code",
-          "tracking_no",
-          "raw_payload",
-          "created_at"
-        ],
-        "title": "CarrierBillItemOut"
-      },
-      "CarrierBillItemsResponse": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "rows": {
-            "items": {
-              "$ref": "#/components/schemas/CarrierBillItemOut"
-            },
-            "type": "array",
-            "title": "Rows"
-          },
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          }
-        },
-        "type": "object",
-        "required": [
-          "rows",
-          "total"
-        ],
-        "title": "CarrierBillItemsResponse"
+        "title": "Body_import_shipping_bill_shipping_assist_billing_import_post"
       },
       "CartLineItemIn": {
         "properties": {
@@ -20450,7 +21324,7 @@
         ],
         "title": "ExplainReceiptLine"
       },
-      "FinanceDailyRow": {
+      "FinanceOverviewDailyRow": {
         "properties": {
           "day": {
             "type": "string",
@@ -20510,18 +21384,30 @@
           "shipping_cost",
           "gross_profit"
         ],
-        "title": "FinanceDailyRow"
+        "title": "FinanceOverviewDailyRow"
       },
-      "FinanceShopRow": {
+      "FinanceOverviewResponse": {
         "properties": {
-          "platform": {
-            "type": "string",
-            "title": "Platform"
+          "summary": {
+            "$ref": "#/components/schemas/FinanceOverviewSummary"
           },
-          "shop_id": {
-            "type": "string",
-            "title": "Shop Id"
-          },
+          "daily": {
+            "items": {
+              "$ref": "#/components/schemas/FinanceOverviewDailyRow"
+            },
+            "type": "array",
+            "title": "Daily"
+          }
+        },
+        "type": "object",
+        "required": [
+          "summary",
+          "daily"
+        ],
+        "title": "FinanceOverviewResponse"
+      },
+      "FinanceOverviewSummary": {
+        "properties": {
           "revenue": {
             "type": "string",
             "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
@@ -20569,84 +21455,12 @@
         },
         "type": "object",
         "required": [
-          "platform",
-          "shop_id",
           "revenue",
           "purchase_cost",
           "shipping_cost",
           "gross_profit"
         ],
-        "title": "FinanceShopRow"
-      },
-      "FinanceSkuRow": {
-        "properties": {
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "sku_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sku Id"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title"
-          },
-          "qty_sold": {
-            "type": "integer",
-            "title": "Qty Sold"
-          },
-          "revenue": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Revenue"
-          },
-          "purchase_cost": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Purchase Cost"
-          },
-          "gross_profit": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Gross Profit"
-          },
-          "gross_margin": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Gross Margin"
-          }
-        },
-        "type": "object",
-        "required": [
-          "item_id",
-          "qty_sold",
-          "revenue",
-          "purchase_cost",
-          "gross_profit"
-        ],
-        "title": "FinanceSkuRow"
+        "title": "FinanceOverviewSummary"
       },
       "FskuComponentIn": {
         "properties": {
@@ -20978,6 +21792,258 @@
         ],
         "title": "FskuLiteOut"
       },
+      "FskuMappingCandidateListDataOut": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/FskuMappingCandidateOut"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          }
+        },
+        "type": "object",
+        "required": [
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "FskuMappingCandidateListDataOut"
+      },
+      "FskuMappingCandidateListOut": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok",
+            "default": true
+          },
+          "data": {
+            "$ref": "#/components/schemas/FskuMappingCandidateListDataOut"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "FskuMappingCandidateListOut"
+      },
+      "FskuMappingCandidateOut": {
+        "properties": {
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "mirror_id": {
+            "type": "integer",
+            "title": "Mirror Id"
+          },
+          "line_id": {
+            "type": "integer",
+            "title": "Line Id"
+          },
+          "collector_order_id": {
+            "type": "integer",
+            "title": "Collector Order Id"
+          },
+          "collector_line_id": {
+            "type": "integer",
+            "title": "Collector Line Id"
+          },
+          "store_code": {
+            "type": "string",
+            "title": "Store Code"
+          },
+          "collector_store_id": {
+            "type": "integer",
+            "title": "Collector Store Id"
+          },
+          "collector_store_name": {
+            "type": "string",
+            "title": "Collector Store Name"
+          },
+          "platform_order_no": {
+            "type": "string",
+            "title": "Platform Order No"
+          },
+          "merchant_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Merchant Code"
+          },
+          "platform_item_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform Item Id"
+          },
+          "platform_sku_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform Sku Id"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "quantity": {
+            "type": "string",
+            "title": "Quantity"
+          },
+          "line_amount": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Line Amount"
+          },
+          "is_bound": {
+            "type": "boolean",
+            "title": "Is Bound"
+          },
+          "mapping_status": {
+            "type": "string",
+            "enum": [
+              "bound",
+              "unbound",
+              "missing_merchant_code"
+            ],
+            "title": "Mapping Status"
+          },
+          "binding_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Binding Id"
+          },
+          "fsku_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fsku Id"
+          },
+          "fsku_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fsku Code"
+          },
+          "fsku_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fsku Name"
+          },
+          "fsku_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fsku Status"
+          },
+          "binding_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Binding Reason"
+          },
+          "binding_updated_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Binding Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "platform",
+          "mirror_id",
+          "line_id",
+          "collector_order_id",
+          "collector_line_id",
+          "store_code",
+          "collector_store_id",
+          "collector_store_name",
+          "platform_order_no",
+          "quantity",
+          "is_bound",
+          "mapping_status"
+        ],
+        "title": "FskuMappingCandidateOut"
+      },
       "FskuNameUpdateIn": {
         "properties": {
           "name": {
@@ -21058,9 +22124,9 @@
             "type": "string",
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "ext_order_no": {
             "anyOf": [
@@ -21089,10 +22155,115 @@
         "required": [
           "order_id",
           "platform",
-          "shop_id"
+          "store_code"
         ],
         "title": "FulfillmentDebugOut",
         "description": "v4-min：只回答“归属仓是谁”\n- 不返回 fulfillment_status / blocked_reasons（blocked 事实由订单履约快照表承载）\n- 不返回 candidates / scan / check（全部砍掉）"
+      },
+      "FulfillmentOrderConversionIn": {
+        "properties": {
+          "mirror_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Mirror Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "mirror_id"
+        ],
+        "title": "FulfillmentOrderConversionIn"
+      },
+      "FulfillmentOrderConversionOut": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok",
+            "default": true
+          },
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "mirror_id": {
+            "type": "integer",
+            "title": "Mirror Id"
+          },
+          "order_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Order Id"
+          },
+          "ref": {
+            "type": "string",
+            "title": "Ref"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "store_id": {
+            "type": "integer",
+            "title": "Store Id"
+          },
+          "store_code": {
+            "type": "string",
+            "title": "Store Code"
+          },
+          "ext_order_no": {
+            "type": "string",
+            "title": "Ext Order No"
+          },
+          "lines_count": {
+            "type": "integer",
+            "title": "Lines Count"
+          },
+          "item_lines_count": {
+            "type": "integer",
+            "title": "Item Lines Count"
+          },
+          "fulfillment_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fulfillment Status"
+          },
+          "blocked_reasons": {
+            "title": "Blocked Reasons"
+          },
+          "risk_flags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Risk Flags"
+          }
+        },
+        "type": "object",
+        "required": [
+          "platform",
+          "mirror_id",
+          "order_id",
+          "ref",
+          "status",
+          "store_id",
+          "store_code",
+          "ext_order_no",
+          "lines_count",
+          "item_lines_count"
+        ],
+        "title": "FulfillmentOrderConversionOut"
       },
       "FulfillmentServiceDebug": {
         "properties": {
@@ -21180,6 +22351,53 @@
         },
         "type": "object",
         "title": "HTTPValidationError"
+      },
+      "ImportPlatformOrderMirrorFromCollectorIn": {
+        "properties": {
+          "collector_order_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Collector Order Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "collector_order_id"
+        ],
+        "title": "ImportPlatformOrderMirrorFromCollectorIn"
+      },
+      "ImportPlatformOrderMirrorFromCollectorOut": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok",
+            "default": true
+          },
+          "imported": {
+            "type": "boolean",
+            "title": "Imported",
+            "default": true
+          },
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "collector_order_id": {
+            "type": "integer",
+            "title": "Collector Order Id"
+          },
+          "mirror_id": {
+            "type": "integer",
+            "title": "Mirror Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "platform",
+          "collector_order_id",
+          "mirror_id"
+        ],
+        "title": "ImportPlatformOrderMirrorFromCollectorOut"
       },
       "InboundCommitIn": {
         "properties": {
@@ -21633,7 +22851,7 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 64
+                "maxLength": 128
               },
               {
                 "type": "null"
@@ -22425,7 +23643,7 @@
             "maxLength": 128,
             "minLength": 1,
             "title": "Order Key",
-            "description": "订单键：支持 ORD:PLAT:SHOP:EXT / PLAT:SHOP:EXT / 唯一 ext_order_no"
+            "description": "订单键：支持 ORD:PLAT:STORE:EXT / PLAT:STORE:EXT / 唯一 ext_order_no"
           },
           "remark": {
             "anyOf": [
@@ -23356,7 +24574,7 @@
             "title": "Platform",
             "description": "平台"
           },
-          "shop_id": {
+          "store_code": {
             "anyOf": [
               {
                 "type": "string",
@@ -23366,7 +24584,7 @@
                 "type": "null"
               }
             ],
-            "title": "Shop Id",
+            "title": "Store Code",
             "description": "店铺 ID"
           },
           "ext_order_no": {
@@ -26298,7 +27516,7 @@
           },
           "sku": {
             "type": "string",
-            "maxLength": 64,
+            "maxLength": 128,
             "minLength": 1,
             "title": "Sku"
           },
@@ -26372,6 +27590,12 @@
       },
       "ItemCreate": {
         "properties": {
+          "sku": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Sku"
+          },
           "name": {
             "type": "string",
             "maxLength": 128,
@@ -26515,16 +27739,17 @@
         "additionalProperties": false,
         "type": "object",
         "required": [
+          "sku",
           "name"
         ],
         "title": "ItemCreate",
-        "description": "Create Item（统一由后端生成 SKU）：\n- 不接受 sku 输入\n- 不接受 barcode 输入；主条码请走 /item-barcodes\n- 不接受 weight_kg 输入；基础包装净重请走 item_uoms（base uom）\n\nPhase M-3：\n- items.case_ratio/case_uom 已删除；包装单位请走 item_uoms"
+        "description": "Create Item（SKU 由调用方显式输入）：\n- 必须传 sku；SKU 编码页只负责生成候选 SKU，最终由商品创建合同写入 items.sku\n- 不接受 barcode 输入；主条码请走 /item-barcodes\n- 不接受 weight_kg 输入；基础包装净重请走 item_uoms（base uom）\n\nPhase M-3：\n- items.case_ratio/case_uom 已删除；包装单位请走 item_uoms"
       },
       "ItemOut": {
         "properties": {
           "sku": {
             "type": "string",
-            "maxLength": 64,
+            "maxLength": 128,
             "minLength": 1,
             "title": "Sku"
           },
@@ -26751,11 +27976,6 @@
             "type": "boolean",
             "title": "Requires Dates",
             "default": true
-          },
-          "is_test": {
-            "type": "boolean",
-            "title": "Is Test",
-            "default": false
           }
         },
         "type": "object",
@@ -26968,11 +28188,6 @@
             ],
             "title": "Supply Price Snapshot"
           },
-          "discount_amount_snapshot": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Discount Amount Snapshot"
-          },
           "planned_line_amount": {
             "type": "string",
             "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
@@ -26992,7 +28207,6 @@
           "purchase_uom_name_snapshot",
           "qty_ordered_input",
           "qty_ordered_base",
-          "discount_amount_snapshot",
           "planned_line_amount"
         ],
         "title": "ItemPurchaseReportLineItem"
@@ -27528,575 +28742,6 @@
         "type": "object",
         "title": "ItemUpdate",
         "description": "Patch Item：\n\n- 不开放 sku 变更\n- 不接受 barcode / has_shelf_life\n- 不接受 weight_kg；基础包装净重请改 item_uoms\n- nullable 字段支持显式传 null 清空"
-      },
-      "JdOrderLedgerDetailEnvelopeOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "$ref": "#/components/schemas/JdOrderLedgerDetailOut"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "JdOrderLedgerDetailEnvelopeOut"
-      },
-      "JdOrderLedgerDetailOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "store_id": {
-            "type": "integer",
-            "title": "Store Id"
-          },
-          "order_id": {
-            "type": "string",
-            "title": "Order Id"
-          },
-          "vender_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vender Id"
-          },
-          "order_type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order Type"
-          },
-          "order_state": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order State"
-          },
-          "buyer_pin": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Buyer Pin"
-          },
-          "consignee_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Consignee Name"
-          },
-          "consignee_mobile": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Consignee Mobile"
-          },
-          "consignee_phone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Consignee Phone"
-          },
-          "consignee_province": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Consignee Province"
-          },
-          "consignee_city": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Consignee City"
-          },
-          "consignee_county": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Consignee County"
-          },
-          "consignee_town": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Consignee Town"
-          },
-          "consignee_address": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Consignee Address"
-          },
-          "order_remark": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order Remark"
-          },
-          "seller_remark": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Seller Remark"
-          },
-          "order_total_price": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order Total Price"
-          },
-          "order_seller_price": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order Seller Price"
-          },
-          "freight_price": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Freight Price"
-          },
-          "payment_confirm": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Payment Confirm"
-          },
-          "order_start_time": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order Start Time"
-          },
-          "order_end_time": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order End Time"
-          },
-          "modified": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Modified"
-          },
-          "raw_summary_payload": {
-            "title": "Raw Summary Payload"
-          },
-          "raw_detail_payload": {
-            "title": "Raw Detail Payload"
-          },
-          "pulled_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pulled At"
-          },
-          "last_synced_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Synced At"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          },
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/JdOrderLedgerItemOut"
-            },
-            "type": "array",
-            "title": "Items"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "store_id",
-          "order_id",
-          "items"
-        ],
-        "title": "JdOrderLedgerDetailOut"
-      },
-      "JdOrderLedgerItemOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "jd_order_id": {
-            "type": "integer",
-            "title": "Jd Order Id"
-          },
-          "order_id": {
-            "type": "string",
-            "title": "Order Id"
-          },
-          "sku_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sku Id"
-          },
-          "outer_sku_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Outer Sku Id"
-          },
-          "ware_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Ware Id"
-          },
-          "item_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Item Name"
-          },
-          "item_total": {
-            "type": "integer",
-            "title": "Item Total"
-          },
-          "item_price": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Item Price"
-          },
-          "sku_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sku Name"
-          },
-          "gift_point": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Gift Point"
-          },
-          "raw_item_payload": {
-            "title": "Raw Item Payload"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "jd_order_id",
-          "order_id",
-          "item_total"
-        ],
-        "title": "JdOrderLedgerItemOut"
-      },
-      "JdOrderLedgerListOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/JdOrderLedgerRowOut"
-            },
-            "type": "array",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "JdOrderLedgerListOut"
-      },
-      "JdOrderLedgerRowOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "store_id": {
-            "type": "integer",
-            "title": "Store Id"
-          },
-          "order_id": {
-            "type": "string",
-            "title": "Order Id"
-          },
-          "order_state": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order State"
-          },
-          "order_type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order Type"
-          },
-          "order_start_time": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order Start Time"
-          },
-          "modified": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Modified"
-          },
-          "order_total_price": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order Total Price"
-          },
-          "order_seller_price": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order Seller Price"
-          },
-          "pulled_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pulled At"
-          },
-          "last_synced_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Synced At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "store_id",
-          "order_id"
-        ],
-        "title": "JdOrderLedgerRowOut"
       },
       "LedgerDateViolationRow": {
         "properties": {
@@ -28687,6 +29332,90 @@
         ],
         "title": "LedgerSummary"
       },
+      "ListOut_SkuBusinessCategoryOut_": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok",
+            "default": true
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/SkuBusinessCategoryOut"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ListOut[SkuBusinessCategoryOut]"
+      },
+      "ListOut_SkuCodeBrandOut_": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok",
+            "default": true
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/SkuCodeBrandOut"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ListOut[SkuCodeBrandOut]"
+      },
+      "ListOut_SkuCodeTermGroupOut_": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok",
+            "default": true
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/SkuCodeTermGroupOut"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ListOut[SkuCodeTermGroupOut]"
+      },
+      "ListOut_SkuCodeTermOut_": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok",
+            "default": true
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/SkuCodeTermOut"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ListOut[SkuCodeTermOut]"
+      },
       "LotShadowAggRow": {
         "properties": {
           "lot_id": {
@@ -29072,9 +29801,9 @@
             "type": "string",
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "ext_order_no": {
             "type": "string",
@@ -29120,7 +29849,7 @@
           "created_at",
           "order_id",
           "platform",
-          "shop_id",
+          "store_code",
           "ext_order_no",
           "ref",
           "store_id"
@@ -29237,7 +29966,7 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 64
+                "maxLength": 128
               },
               {
                 "type": "null"
@@ -29665,11 +30394,11 @@
             "title": "Platform",
             "description": "平台（DEMO/PDD/TB...）"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "maxLength": 64,
+            "maxLength": 128,
             "minLength": 1,
-            "title": "Shop Id",
+            "title": "Store Code",
             "description": "平台店铺 ID（字符串，与 platform 对齐）"
           },
           "merchant_code": {
@@ -29702,7 +30431,7 @@
         "type": "object",
         "required": [
           "platform",
-          "shop_id",
+          "store_code",
           "merchant_code",
           "fsku_id"
         ],
@@ -29717,11 +30446,11 @@
             "title": "Platform",
             "description": "平台（DEMO/PDD/TB...）"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "maxLength": 64,
+            "maxLength": 128,
             "minLength": 1,
-            "title": "Shop Id",
+            "title": "Store Code",
             "description": "平台店铺 ID（字符串，与 platform 对齐）"
           },
           "merchant_code": {
@@ -29735,7 +30464,7 @@
         "type": "object",
         "required": [
           "platform",
-          "shop_id",
+          "store_code",
           "merchant_code"
         ],
         "title": "MerchantCodeBindingCloseIn"
@@ -29815,9 +30544,9 @@
             "type": "string",
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "store": {
             "$ref": "#/components/schemas/StoreLiteOut"
@@ -29859,7 +30588,7 @@
         "required": [
           "id",
           "platform",
-          "shop_id",
+          "store_code",
           "store",
           "merchant_code",
           "fsku_id",
@@ -30702,19 +31431,6 @@
         ],
         "title": "NavigationRoutePrefixOut"
       },
-      "NextSkuOut": {
-        "properties": {
-          "sku": {
-            "type": "string",
-            "title": "Sku"
-          }
-        },
-        "type": "object",
-        "required": [
-          "sku"
-        ],
-        "title": "NextSkuOut"
-      },
       "OrderOutboundOptionOut": {
         "properties": {
           "id": {
@@ -30725,9 +31441,9 @@
             "type": "string",
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "ext_order_no": {
             "type": "string",
@@ -30765,7 +31481,7 @@
         "required": [
           "id",
           "platform",
-          "shop_id",
+          "store_code",
           "ext_order_no",
           "created_at"
         ],
@@ -31033,9 +31749,9 @@
             "type": "string",
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "ext_order_no": {
             "type": "string",
@@ -31120,7 +31836,7 @@
         "required": [
           "id",
           "platform",
-          "shop_id",
+          "store_code",
           "ext_order_no",
           "created_at"
         ],
@@ -31151,6 +31867,521 @@
         ],
         "title": "OrderOutboundViewResponse",
         "description": "订单出库页专用：只读聚合响应\n\n结构：\n- order: 订单头（orders）\n- lines: 订单行（order_lines + display）"
+      },
+      "OrderSalesDailyRow": {
+        "properties": {
+          "day": {
+            "type": "string",
+            "format": "date",
+            "title": "Day"
+          },
+          "order_count": {
+            "type": "integer",
+            "title": "Order Count"
+          },
+          "line_count": {
+            "type": "integer",
+            "title": "Line Count"
+          },
+          "qty_sold": {
+            "type": "integer",
+            "title": "Qty Sold"
+          },
+          "revenue": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Revenue"
+          }
+        },
+        "type": "object",
+        "required": [
+          "day",
+          "order_count",
+          "line_count",
+          "qty_sold",
+          "revenue"
+        ],
+        "title": "OrderSalesDailyRow"
+      },
+      "OrderSalesItemRow": {
+        "properties": {
+          "item_id": {
+            "type": "integer",
+            "title": "Item Id"
+          },
+          "item_sku": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Item Sku"
+          },
+          "item_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Item Name"
+          },
+          "sku_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sku Id"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "qty_sold": {
+            "type": "integer",
+            "title": "Qty Sold"
+          },
+          "revenue": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Revenue"
+          }
+        },
+        "type": "object",
+        "required": [
+          "item_id",
+          "qty_sold",
+          "revenue"
+        ],
+        "title": "OrderSalesItemRow"
+      },
+      "OrderSalesLineRow": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "order_id": {
+            "type": "integer",
+            "title": "Order Id"
+          },
+          "order_item_id": {
+            "type": "integer",
+            "title": "Order Item Id"
+          },
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "store_id": {
+            "type": "integer",
+            "title": "Store Id"
+          },
+          "store_code": {
+            "type": "string",
+            "title": "Store Code"
+          },
+          "store_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Store Name"
+          },
+          "ext_order_no": {
+            "type": "string",
+            "title": "Ext Order No"
+          },
+          "order_ref": {
+            "type": "string",
+            "title": "Order Ref"
+          },
+          "order_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Order Status"
+          },
+          "order_created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Order Created At"
+          },
+          "order_date": {
+            "type": "string",
+            "format": "date",
+            "title": "Order Date"
+          },
+          "receiver_province": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Receiver Province"
+          },
+          "receiver_city": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Receiver City"
+          },
+          "receiver_district": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Receiver District"
+          },
+          "warehouse_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Warehouse Id"
+          },
+          "warehouse_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Warehouse Name"
+          },
+          "warehouse_source": {
+            "type": "string",
+            "title": "Warehouse Source"
+          },
+          "item_id": {
+            "type": "integer",
+            "title": "Item Id"
+          },
+          "item_sku": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Item Sku"
+          },
+          "item_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Item Name"
+          },
+          "sku_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sku Id"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "qty_sold": {
+            "type": "integer",
+            "title": "Qty Sold"
+          },
+          "unit_price": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit Price"
+          },
+          "discount_amount": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Discount Amount"
+          },
+          "line_amount": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Line Amount"
+          },
+          "order_amount": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Order Amount"
+          },
+          "pay_amount": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pay Amount"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "order_id",
+          "order_item_id",
+          "platform",
+          "store_id",
+          "store_code",
+          "ext_order_no",
+          "order_ref",
+          "order_created_at",
+          "order_date",
+          "warehouse_source",
+          "item_id",
+          "qty_sold",
+          "line_amount"
+        ],
+        "title": "OrderSalesLineRow"
+      },
+      "OrderSalesResponse": {
+        "properties": {
+          "summary": {
+            "$ref": "#/components/schemas/OrderSalesSummary"
+          },
+          "daily": {
+            "items": {
+              "$ref": "#/components/schemas/OrderSalesDailyRow"
+            },
+            "type": "array",
+            "title": "Daily"
+          },
+          "by_store": {
+            "items": {
+              "$ref": "#/components/schemas/OrderSalesStoreRow"
+            },
+            "type": "array",
+            "title": "By Store"
+          },
+          "by_item": {
+            "items": {
+              "$ref": "#/components/schemas/OrderSalesItemRow"
+            },
+            "type": "array",
+            "title": "By Item"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/OrderSalesLineRow"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          }
+        },
+        "type": "object",
+        "required": [
+          "summary",
+          "daily",
+          "by_store",
+          "by_item",
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "OrderSalesResponse"
+      },
+      "OrderSalesStoreRow": {
+        "properties": {
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "store_code": {
+            "type": "string",
+            "title": "Store Code"
+          },
+          "store_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Store Name"
+          },
+          "order_count": {
+            "type": "integer",
+            "title": "Order Count"
+          },
+          "line_count": {
+            "type": "integer",
+            "title": "Line Count"
+          },
+          "qty_sold": {
+            "type": "integer",
+            "title": "Qty Sold"
+          },
+          "revenue": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Revenue"
+          }
+        },
+        "type": "object",
+        "required": [
+          "platform",
+          "store_code",
+          "order_count",
+          "line_count",
+          "qty_sold",
+          "revenue"
+        ],
+        "title": "OrderSalesStoreRow"
+      },
+      "OrderSalesSummary": {
+        "properties": {
+          "order_count": {
+            "type": "integer",
+            "title": "Order Count"
+          },
+          "line_count": {
+            "type": "integer",
+            "title": "Line Count"
+          },
+          "qty_sold": {
+            "type": "integer",
+            "title": "Qty Sold"
+          },
+          "revenue": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Revenue"
+          },
+          "avg_order_value": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avg Order Value"
+          },
+          "median_order_value": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Median Order Value"
+          }
+        },
+        "type": "object",
+        "required": [
+          "order_count",
+          "line_count",
+          "qty_sold",
+          "revenue"
+        ],
+        "title": "OrderSalesSummary"
       },
       "OrderSimCartGetOut": {
         "properties": {
@@ -31406,7 +32637,7 @@
             "title": "Platform",
             "description": "可选平台过滤（如 PDD），大写"
           },
-          "shop_id": {
+          "store_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -31415,8 +32646,8 @@
                 "type": "null"
               }
             ],
-            "title": "Shop Id",
-            "description": "可选店铺过滤（字符串，与 orders.shop_id 一致）"
+            "title": "Store Code",
+            "description": "可选店铺过滤（字符串，与 orders.store_code 一致）"
           },
           "orders_created": {
             "type": "integer",
@@ -32516,514 +33747,6 @@
         "type": "object",
         "title": "PasswordResetIn"
       },
-      "PddMockAuthorizeRequest": {
-        "properties": {
-          "granted_identity_display": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Granted Identity Display",
-            "description": "授权展示名；为空时默认使用 shop_id"
-          },
-          "access_token": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Access Token",
-            "description": "可选，默认自动生成 mock token"
-          },
-          "expires_in_days": {
-            "type": "integer",
-            "maximum": 3650.0,
-            "minimum": 1.0,
-            "title": "Expires In Days",
-            "description": "mock token 过期天数",
-            "default": 365
-          }
-        },
-        "type": "object",
-        "title": "PddMockAuthorizeRequest"
-      },
-      "PddMockClearOrdersRequest": {
-        "properties": {
-          "clear_connection": {
-            "type": "boolean",
-            "title": "Clear Connection",
-            "description": "是否同时清理连接状态",
-            "default": false
-          },
-          "clear_credential": {
-            "type": "boolean",
-            "title": "Clear Credential",
-            "description": "是否同时清理凭据",
-            "default": false
-          }
-        },
-        "type": "object",
-        "title": "PddMockClearOrdersRequest"
-      },
-      "PddMockIngestOrdersRequest": {
-        "properties": {
-          "scenario": {
-            "type": "string",
-            "enum": [
-              "normal",
-              "address_missing",
-              "item_abnormal",
-              "mixed"
-            ],
-            "title": "Scenario",
-            "description": "生成场景：normal / address_missing / item_abnormal / mixed",
-            "default": "mixed"
-          },
-          "count": {
-            "type": "integer",
-            "maximum": 100.0,
-            "minimum": 1.0,
-            "title": "Count",
-            "description": "生成订单数量",
-            "default": 6
-          }
-        },
-        "type": "object",
-        "title": "PddMockIngestOrdersRequest"
-      },
-      "PddOrderLedgerDetailEnvelopeOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "$ref": "#/components/schemas/PddOrderLedgerDetailOut"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "PddOrderLedgerDetailEnvelopeOut"
-      },
-      "PddOrderLedgerDetailOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "store_id": {
-            "type": "integer",
-            "title": "Store Id"
-          },
-          "order_sn": {
-            "type": "string",
-            "title": "Order Sn"
-          },
-          "order_status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order Status"
-          },
-          "receiver_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Name"
-          },
-          "receiver_phone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Phone"
-          },
-          "receiver_province": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Province"
-          },
-          "receiver_city": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver City"
-          },
-          "receiver_district": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver District"
-          },
-          "receiver_address": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Address"
-          },
-          "buyer_memo": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Buyer Memo"
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          },
-          "confirm_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Confirm At"
-          },
-          "goods_amount": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Goods Amount"
-          },
-          "pay_amount": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pay Amount"
-          },
-          "raw_summary_payload": {
-            "title": "Raw Summary Payload"
-          },
-          "raw_detail_payload": {
-            "title": "Raw Detail Payload"
-          },
-          "pulled_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pulled At"
-          },
-          "last_synced_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Synced At"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          },
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/PddOrderLedgerItemOut"
-            },
-            "type": "array",
-            "title": "Items"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "store_id",
-          "order_sn",
-          "items"
-        ],
-        "title": "PddOrderLedgerDetailOut"
-      },
-      "PddOrderLedgerItemOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "pdd_order_id": {
-            "type": "integer",
-            "title": "Pdd Order Id"
-          },
-          "order_sn": {
-            "type": "string",
-            "title": "Order Sn"
-          },
-          "platform_goods_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Goods Id"
-          },
-          "platform_sku_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Sku Id"
-          },
-          "outer_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Outer Id"
-          },
-          "goods_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Goods Name"
-          },
-          "goods_count": {
-            "type": "integer",
-            "title": "Goods Count"
-          },
-          "goods_price": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Goods Price"
-          },
-          "raw_item_payload": {
-            "title": "Raw Item Payload"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "pdd_order_id",
-          "order_sn",
-          "goods_count"
-        ],
-        "title": "PddOrderLedgerItemOut"
-      },
-      "PddOrderLedgerListOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/PddOrderLedgerRowOut"
-            },
-            "type": "array",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "PddOrderLedgerListOut"
-      },
-      "PddOrderLedgerRowOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "store_id": {
-            "type": "integer",
-            "title": "Store Id"
-          },
-          "order_sn": {
-            "type": "string",
-            "title": "Order Sn"
-          },
-          "order_status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order Status"
-          },
-          "confirm_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Confirm At"
-          },
-          "goods_amount": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Goods Amount"
-          },
-          "pay_amount": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pay Amount"
-          },
-          "pulled_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pulled At"
-          },
-          "last_synced_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Synced At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "store_id",
-          "order_sn"
-        ],
-        "title": "PddOrderLedgerRowOut"
-      },
       "PermissionMatrixPageOut": {
         "properties": {
           "page_code": {
@@ -33475,7 +34198,7 @@
             ],
             "title": "Store Id"
           },
-          "shop_id": {
+          "store_code": {
             "anyOf": [
               {
                 "type": "string",
@@ -33485,7 +34208,7 @@
                 "type": "null"
               }
             ],
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "ext_order_no": {
             "type": "string",
@@ -33972,6 +34695,562 @@
         "title": "PlatformOrderLineResult",
         "description": "行级解析结果（Phase N+2 输出）"
       },
+      "PlatformOrderMirrorEnvelopeOut": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok",
+            "default": true
+          },
+          "data": {
+            "$ref": "#/components/schemas/PlatformOrderMirrorOut"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "PlatformOrderMirrorEnvelopeOut"
+      },
+      "PlatformOrderMirrorImportIn": {
+        "properties": {
+          "collector_order_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Collector Order Id"
+          },
+          "collector_store_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Collector Store Id"
+          },
+          "collector_store_code": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Collector Store Code"
+          },
+          "collector_store_name": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Collector Store Name"
+          },
+          "platform": {
+            "type": "string",
+            "enum": [
+              "pdd",
+              "taobao",
+              "jd"
+            ],
+            "title": "Platform"
+          },
+          "platform_order_no": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Platform Order No"
+          },
+          "platform_status": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 64
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform Status"
+          },
+          "source_updated_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Updated At"
+          },
+          "pulled_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pulled At"
+          },
+          "last_synced_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Synced At"
+          },
+          "receiver": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Receiver"
+          },
+          "amounts": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Amounts"
+          },
+          "platform_fields": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Platform Fields"
+          },
+          "raw_refs": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Raw Refs"
+          },
+          "lines": {
+            "items": {
+              "$ref": "#/components/schemas/PlatformOrderMirrorLineImportIn"
+            },
+            "type": "array",
+            "title": "Lines"
+          }
+        },
+        "type": "object",
+        "required": [
+          "collector_order_id",
+          "collector_store_id",
+          "collector_store_code",
+          "collector_store_name",
+          "platform",
+          "platform_order_no"
+        ],
+        "title": "PlatformOrderMirrorImportIn"
+      },
+      "PlatformOrderMirrorLineImportIn": {
+        "properties": {
+          "collector_line_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Collector Line Id"
+          },
+          "collector_order_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Collector Order Id"
+          },
+          "platform_order_no": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Platform Order No"
+          },
+          "merchant_sku": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Merchant Sku"
+          },
+          "platform_item_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform Item Id"
+          },
+          "platform_sku_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform Sku Id"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "quantity": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              }
+            ],
+            "title": "Quantity",
+            "default": "0"
+          },
+          "unit_price": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit Price"
+          },
+          "line_amount": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Line Amount"
+          },
+          "platform_fields": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Platform Fields"
+          },
+          "raw_item_payload": {
+            "title": "Raw Item Payload"
+          }
+        },
+        "type": "object",
+        "required": [
+          "collector_line_id",
+          "collector_order_id",
+          "platform_order_no"
+        ],
+        "title": "PlatformOrderMirrorLineImportIn"
+      },
+      "PlatformOrderMirrorLineOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "collector_line_id": {
+            "type": "integer",
+            "title": "Collector Line Id"
+          },
+          "collector_order_id": {
+            "type": "integer",
+            "title": "Collector Order Id"
+          },
+          "platform_order_no": {
+            "type": "string",
+            "title": "Platform Order No"
+          },
+          "merchant_sku": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Merchant Sku"
+          },
+          "platform_item_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform Item Id"
+          },
+          "platform_sku_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform Sku Id"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "quantity": {
+            "type": "string",
+            "title": "Quantity"
+          },
+          "unit_price": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit Price"
+          },
+          "line_amount": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Line Amount"
+          },
+          "platform_fields": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Platform Fields"
+          },
+          "raw_item_payload": {
+            "title": "Raw Item Payload"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "collector_line_id",
+          "collector_order_id",
+          "platform_order_no",
+          "quantity"
+        ],
+        "title": "PlatformOrderMirrorLineOut"
+      },
+      "PlatformOrderMirrorListOut": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok",
+            "default": true
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/PlatformOrderMirrorOut"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "PlatformOrderMirrorListOut"
+      },
+      "PlatformOrderMirrorOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "collector_order_id": {
+            "type": "integer",
+            "title": "Collector Order Id"
+          },
+          "collector_store_id": {
+            "type": "integer",
+            "title": "Collector Store Id"
+          },
+          "collector_store_code": {
+            "type": "string",
+            "title": "Collector Store Code"
+          },
+          "collector_store_name": {
+            "type": "string",
+            "title": "Collector Store Name"
+          },
+          "wms_store_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wms Store Id"
+          },
+          "platform": {
+            "type": "string",
+            "enum": [
+              "pdd",
+              "taobao",
+              "jd"
+            ],
+            "title": "Platform"
+          },
+          "platform_order_no": {
+            "type": "string",
+            "title": "Platform Order No"
+          },
+          "platform_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform Status"
+          },
+          "import_status": {
+            "type": "string",
+            "title": "Import Status"
+          },
+          "mirror_status": {
+            "type": "string",
+            "title": "Mirror Status"
+          },
+          "source_updated_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Updated At"
+          },
+          "pulled_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pulled At"
+          },
+          "collector_last_synced_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Collector Last Synced At"
+          },
+          "imported_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Imported At"
+          },
+          "last_synced_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Synced At"
+          },
+          "receiver": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Receiver"
+          },
+          "amounts": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Amounts"
+          },
+          "platform_fields": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Platform Fields"
+          },
+          "raw_refs": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Raw Refs"
+          },
+          "lines": {
+            "items": {
+              "$ref": "#/components/schemas/PlatformOrderMirrorLineOut"
+            },
+            "type": "array",
+            "title": "Lines"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "collector_order_id",
+          "collector_store_id",
+          "collector_store_code",
+          "collector_store_name",
+          "platform",
+          "platform_order_no",
+          "import_status",
+          "mirror_status"
+        ],
+        "title": "PlatformOrderMirrorOut"
+      },
       "PlatformOrderReplayIn": {
         "properties": {
           "platform": {
@@ -34090,6 +35369,275 @@
         ],
         "title": "PlatformOrderReplayOut"
       },
+      "PlatformOrderResolvePreviewFactLineOut": {
+        "properties": {
+          "line_no": {
+            "type": "integer",
+            "title": "Line No"
+          },
+          "line_key": {
+            "type": "string",
+            "title": "Line Key"
+          },
+          "locator_kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Locator Kind"
+          },
+          "locator_value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Locator Value"
+          },
+          "filled_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Filled Code"
+          },
+          "qty": {
+            "type": "integer",
+            "title": "Qty"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "spec": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spec"
+          },
+          "extras": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Extras"
+          }
+        },
+        "type": "object",
+        "required": [
+          "line_no",
+          "line_key",
+          "qty"
+        ],
+        "title": "PlatformOrderResolvePreviewFactLineOut"
+      },
+      "PlatformOrderResolvePreviewIn": {
+        "properties": {
+          "platform": {
+            "type": "string",
+            "maxLength": 50,
+            "minLength": 1,
+            "title": "Platform"
+          },
+          "store_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Store Id"
+          },
+          "ext_order_no": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Ext Order No"
+          }
+        },
+        "type": "object",
+        "required": [
+          "platform",
+          "store_id",
+          "ext_order_no"
+        ],
+        "title": "PlatformOrderResolvePreviewIn"
+      },
+      "PlatformOrderResolvePreviewItemQtyOut": {
+        "properties": {
+          "item_id": {
+            "type": "integer",
+            "title": "Item Id"
+          },
+          "qty": {
+            "type": "integer",
+            "title": "Qty"
+          },
+          "sku": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sku"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "item_id",
+          "qty"
+        ],
+        "title": "PlatformOrderResolvePreviewItemQtyOut"
+      },
+      "PlatformOrderResolvePreviewOut": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "ref": {
+            "type": "string",
+            "title": "Ref"
+          },
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "store_id": {
+            "type": "integer",
+            "title": "Store Id"
+          },
+          "ext_order_no": {
+            "type": "string",
+            "title": "Ext Order No"
+          },
+          "facts_n": {
+            "type": "integer",
+            "title": "Facts N"
+          },
+          "fact_lines": {
+            "items": {
+              "$ref": "#/components/schemas/PlatformOrderResolvePreviewFactLineOut"
+            },
+            "type": "array",
+            "title": "Fact Lines"
+          },
+          "resolved": {
+            "items": {
+              "$ref": "#/components/schemas/PlatformOrderResolvePreviewResolvedLineOut"
+            },
+            "type": "array",
+            "title": "Resolved"
+          },
+          "unresolved": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Unresolved"
+          },
+          "item_qty_map": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "type": "object",
+            "title": "Item Qty Map"
+          },
+          "item_qty_items": {
+            "items": {
+              "$ref": "#/components/schemas/PlatformOrderResolvePreviewItemQtyOut"
+            },
+            "type": "array",
+            "title": "Item Qty Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "ref",
+          "platform",
+          "store_id",
+          "ext_order_no",
+          "facts_n",
+          "fact_lines",
+          "resolved",
+          "unresolved",
+          "item_qty_map",
+          "item_qty_items"
+        ],
+        "title": "PlatformOrderResolvePreviewOut"
+      },
+      "PlatformOrderResolvePreviewResolvedLineOut": {
+        "properties": {
+          "filled_code": {
+            "type": "string",
+            "title": "Filled Code"
+          },
+          "qty": {
+            "type": "integer",
+            "title": "Qty"
+          },
+          "fsku_id": {
+            "type": "integer",
+            "title": "Fsku Id"
+          },
+          "expanded_items": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Expanded Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "filled_code",
+          "qty",
+          "fsku_id",
+          "expanded_items"
+        ],
+        "title": "PlatformOrderResolvePreviewResolvedLineOut"
+      },
       "PricingListResponse": {
         "properties": {
           "ok": {
@@ -34117,13 +35665,13 @@
             "type": "integer",
             "title": "Provider Id"
           },
-          "provider_code": {
+          "shipping_provider_code": {
             "type": "string",
-            "title": "Provider Code"
+            "title": "Shipping Provider Code"
           },
-          "provider_name": {
+          "shipping_provider_name": {
             "type": "string",
-            "title": "Provider Name"
+            "title": "Shipping Provider Name"
           },
           "provider_active": {
             "type": "boolean",
@@ -34202,8 +35750,8 @@
         "type": "object",
         "required": [
           "provider_id",
-          "provider_code",
-          "provider_name",
+          "shipping_provider_code",
+          "shipping_provider_name",
           "provider_active",
           "warehouse_id",
           "warehouse_name",
@@ -34675,6 +36223,213 @@
           "barcodes"
         ],
         "title": "PublicItemAggregateOut"
+      },
+      "PurchaseCostDailyRow": {
+        "properties": {
+          "day": {
+            "type": "string",
+            "format": "date",
+            "title": "Day"
+          },
+          "purchase_order_count": {
+            "type": "integer",
+            "title": "Purchase Order Count"
+          },
+          "purchase_amount": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Purchase Amount"
+          }
+        },
+        "type": "object",
+        "required": [
+          "day",
+          "purchase_order_count",
+          "purchase_amount"
+        ],
+        "title": "PurchaseCostDailyRow"
+      },
+      "PurchaseCostItemRow": {
+        "properties": {
+          "item_id": {
+            "type": "integer",
+            "title": "Item Id"
+          },
+          "item_sku": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Item Sku"
+          },
+          "item_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Item Name"
+          },
+          "total_units": {
+            "type": "integer",
+            "title": "Total Units"
+          },
+          "purchase_amount": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Purchase Amount"
+          },
+          "avg_unit_cost": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avg Unit Cost"
+          }
+        },
+        "type": "object",
+        "required": [
+          "item_id",
+          "total_units",
+          "purchase_amount"
+        ],
+        "title": "PurchaseCostItemRow"
+      },
+      "PurchaseCostResponse": {
+        "properties": {
+          "summary": {
+            "$ref": "#/components/schemas/PurchaseCostSummary"
+          },
+          "daily": {
+            "items": {
+              "$ref": "#/components/schemas/PurchaseCostDailyRow"
+            },
+            "type": "array",
+            "title": "Daily"
+          },
+          "by_supplier": {
+            "items": {
+              "$ref": "#/components/schemas/PurchaseCostSupplierRow"
+            },
+            "type": "array",
+            "title": "By Supplier"
+          },
+          "by_item": {
+            "items": {
+              "$ref": "#/components/schemas/PurchaseCostItemRow"
+            },
+            "type": "array",
+            "title": "By Item"
+          }
+        },
+        "type": "object",
+        "required": [
+          "summary",
+          "daily",
+          "by_supplier",
+          "by_item"
+        ],
+        "title": "PurchaseCostResponse"
+      },
+      "PurchaseCostSummary": {
+        "properties": {
+          "purchase_order_count": {
+            "type": "integer",
+            "title": "Purchase Order Count"
+          },
+          "supplier_count": {
+            "type": "integer",
+            "title": "Supplier Count"
+          },
+          "item_count": {
+            "type": "integer",
+            "title": "Item Count"
+          },
+          "purchase_amount": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Purchase Amount"
+          },
+          "avg_unit_cost": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avg Unit Cost"
+          }
+        },
+        "type": "object",
+        "required": [
+          "purchase_order_count",
+          "supplier_count",
+          "item_count",
+          "purchase_amount"
+        ],
+        "title": "PurchaseCostSummary"
+      },
+      "PurchaseCostSupplierRow": {
+        "properties": {
+          "supplier_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Supplier Id"
+          },
+          "supplier_name": {
+            "type": "string",
+            "title": "Supplier Name"
+          },
+          "purchase_order_count": {
+            "type": "integer",
+            "title": "Purchase Order Count"
+          },
+          "purchase_amount": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Purchase Amount"
+          },
+          "avg_unit_cost": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avg Unit Cost"
+          }
+        },
+        "type": "object",
+        "required": [
+          "supplier_name",
+          "purchase_order_count",
+          "purchase_amount"
+        ],
+        "title": "PurchaseCostSupplierRow"
       },
       "PurchaseOrderCloseIn": {
         "properties": {
@@ -35216,31 +36971,6 @@
             ],
             "title": "Supply Price"
           },
-          "discount_amount": {
-            "anyOf": [
-              {
-                "type": "number",
-                "minimum": 0.0
-              },
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              }
-            ],
-            "title": "Discount Amount",
-            "default": "0"
-          },
-          "discount_note": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Discount Note"
-          },
           "remark": {
             "anyOf": [
               {
@@ -35262,7 +36992,7 @@
           "qty_input"
         ],
         "title": "PurchaseOrderCreateLineV2",
-        "description": "PO 创建行输入（V2）——终态合同\n\n严格合同：\n- 必填：line_no / item_id / uom_id / qty_input\n- 可选商业字段：supply_price / discount_amount / discount_note / remark\n- 快照与派生字段（item_name / ratio_to_base / qty_ordered_base）不允许前端直传"
+        "description": "PO 创建行输入（V2）——终态合同\n\n严格合同：\n- 必填：line_no / item_id / uom_id / qty_input\n- 可选商业字段：supply_price / remark\n- 快照与派生字段（item_name / ratio_to_base / qty_ordered_base）不允许前端直传"
       },
       "PurchaseOrderCreateV2": {
         "properties": {
@@ -35395,23 +37125,6 @@
               }
             ],
             "title": "Supply Price"
-          },
-          "discount_amount": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Discount Amount",
-            "default": "0"
-          },
-          "discount_note": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Discount Note"
           },
           "remark": {
             "anyOf": [
@@ -36314,7 +38027,7 @@
             "type": "integer",
             "title": "Provider Id"
           },
-          "carrier_code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -36323,11 +38036,11 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
-          "carrier_name": {
+          "shipping_provider_name": {
             "type": "string",
-            "title": "Carrier Name"
+            "title": "Shipping Provider Name"
           },
           "template_id": {
             "type": "integer",
@@ -36418,7 +38131,7 @@
         "type": "object",
         "required": [
           "provider_id",
-          "carrier_name",
+          "shipping_provider_name",
           "template_id",
           "total_amount",
           "quote_status",
@@ -36528,7 +38241,7 @@
             ],
             "title": "Provider Id"
           },
-          "carrier_code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -36537,9 +38250,9 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
-          "carrier_name": {
+          "shipping_provider_name": {
             "anyOf": [
               {
                 "type": "string"
@@ -36548,7 +38261,7 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Name"
+            "title": "Shipping Provider Name"
           },
           "currency": {
             "anyOf": [
@@ -36623,30 +38336,30 @@
         ],
         "title": "ReasonCanon"
       },
-      "ReconcileCarrierBillIn": {
+      "ReconcileShippingProviderBillIn": {
         "properties": {
-          "carrier_code": {
+          "shipping_provider_code": {
             "type": "string",
-            "title": "Carrier Code",
-            "description": "承运商代码"
+            "title": "Shipping Provider Code",
+            "description": "物流网点编码"
           }
         },
         "type": "object",
         "required": [
-          "carrier_code"
+          "shipping_provider_code"
         ],
-        "title": "ReconcileCarrierBillIn"
+        "title": "ReconcileShippingProviderBillIn"
       },
-      "ReconcileCarrierBillResult": {
+      "ReconcileShippingProviderBillResult": {
         "properties": {
           "ok": {
             "type": "boolean",
             "title": "Ok",
             "default": true
           },
-          "carrier_code": {
+          "shipping_provider_code": {
             "type": "string",
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
           "bill_item_count": {
             "type": "integer",
@@ -36676,14 +38389,14 @@
         },
         "type": "object",
         "required": [
-          "carrier_code",
+          "shipping_provider_code",
           "bill_item_count",
           "matched_count",
           "bill_only_count",
           "diff_count",
           "updated_count"
         ],
-        "title": "ReconcileCarrierBillResult"
+        "title": "ReconcileShippingProviderBillResult"
       },
       "ReconcileSummaryPayload": {
         "properties": {
@@ -36717,7 +38430,7 @@
       },
       "RecordsCostAnalysisByCarrierRowOut": {
         "properties": {
-          "carrier_code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -36726,7 +38439,7 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
           "ticket_count": {
             "type": "integer",
@@ -36835,7 +38548,7 @@
             ],
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -36844,7 +38557,7 @@
                 "type": "null"
               }
             ],
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "ext_order_no": {
             "anyOf": [
@@ -37845,9 +39558,9 @@
             "title": "Platform",
             "description": "平台，例如 PDD"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "title": "Shop Id",
+            "title": "Store Code",
             "description": "店铺 ID，例如 '1'"
           },
           "ext_order_no": {
@@ -37864,7 +39577,7 @@
         "type": "object",
         "required": [
           "platform",
-          "shop_id",
+          "store_code",
           "ext_order_no",
           "address_ready_status"
         ],
@@ -37885,9 +39598,9 @@
             "type": "string",
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "ext_order_no": {
             "type": "string",
@@ -37902,7 +39615,7 @@
         "required": [
           "order_id",
           "platform",
-          "shop_id",
+          "store_code",
           "ext_order_no",
           "address_ready_status"
         ],
@@ -37918,9 +39631,9 @@
             "type": "string",
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "ext_order_no": {
             "type": "string",
@@ -38005,7 +39718,7 @@
         "required": [
           "order_id",
           "platform",
-          "shop_id",
+          "store_code",
           "ext_order_no",
           "address_summary",
           "address_ready_status"
@@ -38039,9 +39752,9 @@
             "type": "string",
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "ext_order_no": {
             "type": "string",
@@ -38122,7 +39835,7 @@
         "required": [
           "order_id",
           "platform",
-          "shop_id",
+          "store_code",
           "ext_order_no",
           "address_summary"
         ],
@@ -38425,7 +40138,7 @@
             "type": "integer",
             "title": "Provider Id"
           },
-          "carrier_code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -38434,11 +40147,11 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
-          "carrier_name": {
+          "shipping_provider_name": {
             "type": "string",
-            "title": "Carrier Name"
+            "title": "Shipping Provider Name"
           },
           "template_id": {
             "type": "integer",
@@ -38515,7 +40228,7 @@
         "type": "object",
         "required": [
           "provider_id",
-          "carrier_name",
+          "shipping_provider_name",
           "template_id",
           "quote_status"
         ],
@@ -38527,7 +40240,7 @@
             "type": "integer",
             "title": "Provider Id"
           },
-          "carrier_code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -38536,11 +40249,11 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
-          "carrier_name": {
+          "shipping_provider_name": {
             "type": "string",
-            "title": "Carrier Name"
+            "title": "Shipping Provider Name"
           },
           "template_id": {
             "type": "integer",
@@ -38617,7 +40330,7 @@
         "type": "object",
         "required": [
           "provider_id",
-          "carrier_name",
+          "shipping_provider_name",
           "template_id",
           "quote_status"
         ],
@@ -38629,7 +40342,7 @@
             "type": "integer",
             "title": "Provider Id"
           },
-          "carrier_code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -38638,7 +40351,7 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
           "template_id": {
             "type": "integer",
@@ -38798,7 +40511,7 @@
             "type": "integer",
             "title": "Shipping Provider Id"
           },
-          "carrier_code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -38807,9 +40520,9 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
-          "carrier_name": {
+          "shipping_provider_name": {
             "anyOf": [
               {
                 "type": "string"
@@ -38818,7 +40531,7 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Name"
+            "title": "Shipping Provider Name"
           },
           "status": {
             "type": "string",
@@ -38906,9 +40619,9 @@
             ],
             "title": "Shipping Record Id"
           },
-          "carrier_code": {
+          "shipping_provider_code": {
             "type": "string",
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
           "tracking_no": {
             "type": "string",
@@ -38986,7 +40699,7 @@
         "required": [
           "id",
           "carrier_bill_item_id",
-          "carrier_code",
+          "shipping_provider_code",
           "tracking_no",
           "result_status",
           "approved_reason_code",
@@ -39008,9 +40721,9 @@
             ],
             "title": "Status"
           },
-          "carrier_code": {
+          "shipping_provider_code": {
             "type": "string",
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
           "tracking_no": {
             "type": "string",
@@ -39113,7 +40826,7 @@
         "required": [
           "reconciliation_id",
           "status",
-          "carrier_code",
+          "shipping_provider_code",
           "tracking_no",
           "carrier_bill_item_id",
           "created_at"
@@ -39169,7 +40882,7 @@
       },
       "ShippingByCarrierRow": {
         "properties": {
-          "carrier_code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -39178,9 +40891,9 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
-          "carrier_name": {
+          "shipping_provider_name": {
             "anyOf": [
               {
                 "type": "string"
@@ -39189,7 +40902,7 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Name"
+            "title": "Shipping Provider Name"
           },
           "ship_cnt": {
             "type": "integer",
@@ -39267,7 +40980,7 @@
         ],
         "title": "ShippingByProvinceRow"
       },
-      "ShippingByShopResponse": {
+      "ShippingByStoreResponse": {
         "properties": {
           "ok": {
             "type": "boolean",
@@ -39276,7 +40989,7 @@
           },
           "rows": {
             "items": {
-              "$ref": "#/components/schemas/ShippingByShopRow"
+              "$ref": "#/components/schemas/ShippingByStoreRow"
             },
             "type": "array",
             "title": "Rows"
@@ -39286,17 +40999,17 @@
         "required": [
           "rows"
         ],
-        "title": "ShippingByShopResponse"
+        "title": "ShippingByStoreResponse"
       },
-      "ShippingByShopRow": {
+      "ShippingByStoreRow": {
         "properties": {
           "platform": {
             "type": "string",
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "ship_cnt": {
             "type": "integer",
@@ -39314,12 +41027,12 @@
         "type": "object",
         "required": [
           "platform",
-          "shop_id",
+          "store_code",
           "ship_cnt",
           "total_cost",
           "avg_cost"
         ],
-        "title": "ShippingByShopRow"
+        "title": "ShippingByStoreRow"
       },
       "ShippingByWarehouseResponse": {
         "properties": {
@@ -39375,6 +41088,530 @@
           "avg_cost"
         ],
         "title": "ShippingByWarehouseRow"
+      },
+      "ShippingCostDailyRow": {
+        "properties": {
+          "day": {
+            "type": "string",
+            "format": "date",
+            "title": "Day"
+          },
+          "shipment_count": {
+            "type": "integer",
+            "title": "Shipment Count"
+          },
+          "estimated_shipping_cost": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Estimated Shipping Cost"
+          },
+          "billed_shipping_cost": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Billed Shipping Cost"
+          },
+          "cost_diff": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Cost Diff"
+          },
+          "adjusted_cost": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Adjusted Cost"
+          }
+        },
+        "type": "object",
+        "required": [
+          "day",
+          "shipment_count",
+          "estimated_shipping_cost",
+          "billed_shipping_cost",
+          "cost_diff",
+          "adjusted_cost"
+        ],
+        "title": "ShippingCostDailyRow"
+      },
+      "ShippingCostLedgerOptionsResponse": {
+        "properties": {
+          "stores": {
+            "items": {
+              "$ref": "#/components/schemas/ShippingCostLedgerShopOption"
+            },
+            "type": "array",
+            "title": "Stores"
+          },
+          "warehouses": {
+            "items": {
+              "$ref": "#/components/schemas/ShippingCostLedgerWarehouseOption"
+            },
+            "type": "array",
+            "title": "Warehouses"
+          },
+          "providers": {
+            "items": {
+              "$ref": "#/components/schemas/ShippingCostLedgerProviderOption"
+            },
+            "type": "array",
+            "title": "Providers"
+          }
+        },
+        "type": "object",
+        "required": [
+          "stores",
+          "warehouses",
+          "providers"
+        ],
+        "title": "ShippingCostLedgerOptionsResponse"
+      },
+      "ShippingCostLedgerProviderOption": {
+        "properties": {
+          "shipping_provider_id": {
+            "type": "integer",
+            "title": "Shipping Provider Id"
+          },
+          "shipping_provider_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shipping Provider Code"
+          },
+          "shipping_provider_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shipping Provider Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "shipping_provider_id"
+        ],
+        "title": "ShippingCostLedgerProviderOption"
+      },
+      "ShippingCostLedgerResponse": {
+        "properties": {
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/ShippingCostLedgerRow"
+            },
+            "type": "array",
+            "title": "Rows"
+          }
+        },
+        "type": "object",
+        "required": [
+          "rows"
+        ],
+        "title": "ShippingCostLedgerResponse"
+      },
+      "ShippingCostLedgerRow": {
+        "properties": {
+          "shipping_record_id": {
+            "type": "integer",
+            "title": "Shipping Record Id"
+          },
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "store_code": {
+            "type": "string",
+            "title": "Store Code"
+          },
+          "store_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Store Name"
+          },
+          "order_ref": {
+            "type": "string",
+            "title": "Order Ref"
+          },
+          "package_no": {
+            "type": "integer",
+            "title": "Package No"
+          },
+          "tracking_no": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tracking No"
+          },
+          "warehouse_id": {
+            "type": "integer",
+            "title": "Warehouse Id"
+          },
+          "warehouse_name": {
+            "type": "string",
+            "title": "Warehouse Name"
+          },
+          "shipping_provider_id": {
+            "type": "integer",
+            "title": "Shipping Provider Id"
+          },
+          "shipping_provider_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shipping Provider Code"
+          },
+          "shipping_provider_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shipping Provider Name"
+          },
+          "shipped_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Shipped Time"
+          },
+          "shipped_date": {
+            "type": "string",
+            "format": "date",
+            "title": "Shipped Date"
+          },
+          "dest_province": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dest Province"
+          },
+          "dest_city": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dest City"
+          },
+          "gross_weight_kg": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gross Weight Kg"
+          },
+          "freight_estimated": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Freight Estimated"
+          },
+          "surcharge_estimated": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Surcharge Estimated"
+          },
+          "cost_estimated": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cost Estimated"
+          }
+        },
+        "type": "object",
+        "required": [
+          "shipping_record_id",
+          "platform",
+          "store_code",
+          "order_ref",
+          "package_no",
+          "warehouse_id",
+          "warehouse_name",
+          "shipping_provider_id",
+          "shipped_time",
+          "shipped_date"
+        ],
+        "title": "ShippingCostLedgerRow"
+      },
+      "ShippingCostLedgerShopOption": {
+        "properties": {
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "store_code": {
+            "type": "string",
+            "title": "Store Code"
+          },
+          "store_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Store Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "platform",
+          "store_code"
+        ],
+        "title": "ShippingCostLedgerShopOption"
+      },
+      "ShippingCostLedgerWarehouseOption": {
+        "properties": {
+          "warehouse_id": {
+            "type": "integer",
+            "title": "Warehouse Id"
+          },
+          "warehouse_name": {
+            "type": "string",
+            "title": "Warehouse Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "warehouse_id",
+          "warehouse_name"
+        ],
+        "title": "ShippingCostLedgerWarehouseOption"
+      },
+      "ShippingCostProviderRow": {
+        "properties": {
+          "shipping_provider_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shipping Provider Id"
+          },
+          "shipping_provider_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shipping Provider Code"
+          },
+          "shipping_provider_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shipping Provider Name"
+          },
+          "shipment_count": {
+            "type": "integer",
+            "title": "Shipment Count"
+          },
+          "estimated_shipping_cost": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Estimated Shipping Cost"
+          },
+          "billed_shipping_cost": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Billed Shipping Cost"
+          }
+        },
+        "type": "object",
+        "required": [
+          "shipment_count",
+          "estimated_shipping_cost",
+          "billed_shipping_cost"
+        ],
+        "title": "ShippingCostProviderRow"
+      },
+      "ShippingCostResponse": {
+        "properties": {
+          "summary": {
+            "$ref": "#/components/schemas/ShippingCostSummary"
+          },
+          "daily": {
+            "items": {
+              "$ref": "#/components/schemas/ShippingCostDailyRow"
+            },
+            "type": "array",
+            "title": "Daily"
+          },
+          "by_carrier": {
+            "items": {
+              "$ref": "#/components/schemas/ShippingCostProviderRow"
+            },
+            "type": "array",
+            "title": "By Carrier"
+          },
+          "by_store": {
+            "items": {
+              "$ref": "#/components/schemas/ShippingCostShopRow"
+            },
+            "type": "array",
+            "title": "By Store"
+          }
+        },
+        "type": "object",
+        "required": [
+          "summary",
+          "daily",
+          "by_carrier",
+          "by_store"
+        ],
+        "title": "ShippingCostResponse"
+      },
+      "ShippingCostShopRow": {
+        "properties": {
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "store_code": {
+            "type": "string",
+            "title": "Store Code"
+          },
+          "store_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Store Name"
+          },
+          "shipment_count": {
+            "type": "integer",
+            "title": "Shipment Count"
+          },
+          "estimated_shipping_cost": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Estimated Shipping Cost"
+          },
+          "billed_shipping_cost": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Billed Shipping Cost"
+          }
+        },
+        "type": "object",
+        "required": [
+          "platform",
+          "store_code",
+          "shipment_count",
+          "estimated_shipping_cost",
+          "billed_shipping_cost"
+        ],
+        "title": "ShippingCostShopRow"
+      },
+      "ShippingCostSummary": {
+        "properties": {
+          "shipment_count": {
+            "type": "integer",
+            "title": "Shipment Count"
+          },
+          "estimated_shipping_cost": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Estimated Shipping Cost"
+          },
+          "billed_shipping_cost": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Billed Shipping Cost"
+          },
+          "cost_diff": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Cost Diff"
+          },
+          "adjusted_cost": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Adjusted Cost"
+          }
+        },
+        "type": "object",
+        "required": [
+          "shipment_count",
+          "estimated_shipping_cost",
+          "billed_shipping_cost",
+          "cost_diff",
+          "adjusted_cost"
+        ],
+        "title": "ShippingCostSummary"
       },
       "ShippingDailyResponse": {
         "properties": {
@@ -39483,7 +41720,7 @@
             ],
             "title": "Shipping Provider Id"
           },
-          "carrier_code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -39492,9 +41729,9 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
-          "carrier_name": {
+          "shipping_provider_name": {
             "anyOf": [
               {
                 "type": "string"
@@ -39503,7 +41740,7 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Name"
+            "title": "Shipping Provider Name"
           },
           "tracking_no": {
             "anyOf": [
@@ -39639,6 +41876,282 @@
           "created_at"
         ],
         "title": "ShippingLedgerRow"
+      },
+      "ShippingProviderBillImportResult": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok",
+            "default": true
+          },
+          "shipping_provider_code": {
+            "type": "string",
+            "title": "Shipping Provider Code"
+          },
+          "imported_count": {
+            "type": "integer",
+            "title": "Imported Count"
+          },
+          "skipped_count": {
+            "type": "integer",
+            "title": "Skipped Count"
+          },
+          "error_count": {
+            "type": "integer",
+            "title": "Error Count"
+          },
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/ShippingProviderBillImportRowError"
+            },
+            "type": "array",
+            "title": "Errors"
+          }
+        },
+        "type": "object",
+        "required": [
+          "shipping_provider_code",
+          "imported_count",
+          "skipped_count",
+          "error_count"
+        ],
+        "title": "ShippingProviderBillImportResult"
+      },
+      "ShippingProviderBillImportRowError": {
+        "properties": {
+          "row_no": {
+            "type": "integer",
+            "title": "Row No",
+            "description": "Excel 行号（从 1 开始）"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message",
+            "description": "错误原因"
+          }
+        },
+        "type": "object",
+        "required": [
+          "row_no",
+          "message"
+        ],
+        "title": "ShippingProviderBillImportRowError"
+      },
+      "ShippingProviderBillItemOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "shipping_provider_code": {
+            "type": "string",
+            "title": "Shipping Provider Code"
+          },
+          "bill_month": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bill Month"
+          },
+          "tracking_no": {
+            "type": "string",
+            "title": "Tracking No"
+          },
+          "business_time": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Business Time"
+          },
+          "destination_province": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destination Province"
+          },
+          "destination_city": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destination City"
+          },
+          "billing_weight_kg": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Billing Weight Kg"
+          },
+          "freight_amount": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Freight Amount"
+          },
+          "surcharge_amount": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Surcharge Amount"
+          },
+          "total_amount": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Amount"
+          },
+          "settlement_object": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Settlement Object"
+          },
+          "order_customer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Order Customer"
+          },
+          "sender_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sender Name"
+          },
+          "network_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Network Name"
+          },
+          "size_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Text"
+          },
+          "parent_customer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Customer"
+          },
+          "raw_payload": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Raw Payload"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "shipping_provider_code",
+          "tracking_no",
+          "raw_payload",
+          "created_at"
+        ],
+        "title": "ShippingProviderBillItemOut"
+      },
+      "ShippingProviderBillItemsResponse": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok",
+            "default": true
+          },
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/ShippingProviderBillItemOut"
+            },
+            "type": "array",
+            "title": "Rows"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
+        },
+        "type": "object",
+        "required": [
+          "rows",
+          "total"
+        ],
+        "title": "ShippingProviderBillItemsResponse"
       },
       "ShippingProviderContactCreateIn": {
         "properties": {
@@ -39886,11 +42399,11 @@
             "minLength": 1,
             "title": "Name"
           },
-          "code": {
+          "shipping_provider_code": {
             "type": "string",
             "maxLength": 64,
             "minLength": 1,
-            "title": "Code"
+            "title": "Shipping Provider Code"
           },
           "company_code": {
             "anyOf": [
@@ -39951,7 +42464,7 @@
         "type": "object",
         "required": [
           "name",
-          "code"
+          "shipping_provider_code"
         ],
         "title": "ShippingProviderCreateIn"
       },
@@ -40020,7 +42533,7 @@
             "type": "string",
             "title": "Name"
           },
-          "code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -40029,7 +42542,7 @@
                 "type": "null"
               }
             ],
-            "title": "Code"
+            "title": "Shipping Provider Code"
           },
           "active": {
             "type": "boolean",
@@ -40054,9 +42567,9 @@
             "type": "string",
             "title": "Name"
           },
-          "code": {
+          "shipping_provider_code": {
             "type": "string",
-            "title": "Code"
+            "title": "Shipping Provider Code"
           },
           "display_label": {
             "type": "string",
@@ -40120,11 +42633,11 @@
         "required": [
           "id",
           "name",
-          "code",
+          "shipping_provider_code",
           "display_label"
         ],
         "title": "ShippingProviderOut",
-        "description": "刚性契约（最新）：\n- 本对象语义为「运输网点实体」（保留表名 shipping_providers）\n- 与仓库为 M:N 关系，通过 warehouse_shipping_providers 表表达\n- code 为内部业务键（允许修改，但保持唯一与规范化）\n- company_code / resource_code 为电子面单固定接入参数"
+        "description": "刚性契约（最新）：\n- 本对象语义为「运输网点实体」（保留表名 shipping_providers）\n- 与仓库为 M:N 关系，通过 warehouse_shipping_providers 表表达\n- shipping_provider_code 为物流网点号码 / 网点编码（由网点提供，保持唯一与规范化）\n- company_code / resource_code 为电子面单固定接入参数"
       },
       "ShippingProviderUpdateIn": {
         "properties": {
@@ -40141,7 +42654,7 @@
             ],
             "title": "Name"
           },
-          "code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string",
@@ -40152,7 +42665,7 @@
                 "type": "null"
               }
             ],
-            "title": "Code"
+            "title": "Shipping Provider Code"
           },
           "company_code": {
             "anyOf": [
@@ -40234,6 +42747,104 @@
         ],
         "title": "ShippingProviderUpdateOut"
       },
+      "ShippingQuoteFailureDetail": {
+        "properties": {
+          "ref": {
+            "type": "string",
+            "title": "Ref"
+          },
+          "event": {
+            "type": "string",
+            "title": "Event"
+          },
+          "error_code": {
+            "type": "string",
+            "title": "Error Code"
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Message"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ref",
+          "event",
+          "error_code",
+          "created_at"
+        ],
+        "title": "ShippingQuoteFailureDetail"
+      },
+      "ShippingQuoteFailuresMetricsResponse": {
+        "properties": {
+          "day": {
+            "type": "string",
+            "format": "date",
+            "title": "Day"
+          },
+          "platform": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform"
+          },
+          "calc_failed_total": {
+            "type": "integer",
+            "title": "Calc Failed Total"
+          },
+          "recommend_failed_total": {
+            "type": "integer",
+            "title": "Recommend Failed Total"
+          },
+          "calc_failures_by_code": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "type": "object",
+            "title": "Calc Failures By Code",
+            "default": {}
+          },
+          "recommend_failures_by_code": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "type": "object",
+            "title": "Recommend Failures By Code",
+            "default": {}
+          },
+          "details": {
+            "items": {
+              "$ref": "#/components/schemas/ShippingQuoteFailureDetail"
+            },
+            "type": "array",
+            "title": "Details",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "day",
+          "calc_failed_total",
+          "recommend_failed_total"
+        ],
+        "title": "ShippingQuoteFailuresMetricsResponse"
+      },
       "ShippingReportFilterOptions": {
         "properties": {
           "platforms": {
@@ -40243,12 +42854,12 @@
             "type": "array",
             "title": "Platforms"
           },
-          "shop_ids": {
+          "store_codes": {
             "items": {
               "type": "string"
             },
             "type": "array",
-            "title": "Shop Ids"
+            "title": "Store Codes"
           },
           "provinces": {
             "items": {
@@ -40268,11 +42879,1125 @@
         "type": "object",
         "required": [
           "platforms",
-          "shop_ids",
+          "store_codes",
           "provinces",
           "cities"
         ],
         "title": "ShippingReportFilterOptions"
+      },
+      "SimilarItemOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "sku": {
+            "type": "string",
+            "title": "Sku"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "spec": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spec"
+          },
+          "brand": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Brand"
+          },
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "sku",
+          "name",
+          "spec",
+          "brand",
+          "category"
+        ],
+        "title": "SimilarItemOut"
+      },
+      "SkuBusinessCategoryCreate": {
+        "properties": {
+          "parent_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Id"
+          },
+          "level": {
+            "type": "integer",
+            "maximum": 3.0,
+            "minimum": 1.0,
+            "title": "Level"
+          },
+          "product_kind": {
+            "type": "string",
+            "enum": [
+              "FOOD",
+              "SUPPLY"
+            ],
+            "title": "Product Kind"
+          },
+          "category_name": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Category Name"
+          },
+          "category_code": {
+            "type": "string",
+            "maxLength": 32,
+            "minLength": 1,
+            "title": "Category Code"
+          },
+          "is_leaf": {
+            "type": "boolean",
+            "title": "Is Leaf",
+            "default": false
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order",
+            "default": 0
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 500
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          }
+        },
+        "type": "object",
+        "required": [
+          "level",
+          "product_kind",
+          "category_name",
+          "category_code"
+        ],
+        "title": "SkuBusinessCategoryCreate"
+      },
+      "SkuBusinessCategoryOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "parent_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Id"
+          },
+          "level": {
+            "type": "integer",
+            "title": "Level"
+          },
+          "product_kind": {
+            "type": "string",
+            "title": "Product Kind"
+          },
+          "category_name": {
+            "type": "string",
+            "title": "Category Name"
+          },
+          "category_code": {
+            "type": "string",
+            "title": "Category Code"
+          },
+          "path_code": {
+            "type": "string",
+            "title": "Path Code"
+          },
+          "is_leaf": {
+            "type": "boolean",
+            "title": "Is Leaf"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "is_locked": {
+            "type": "boolean",
+            "title": "Is Locked"
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order"
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "parent_id",
+          "level",
+          "product_kind",
+          "category_name",
+          "category_code",
+          "path_code",
+          "is_leaf",
+          "is_active",
+          "is_locked",
+          "sort_order",
+          "remark"
+        ],
+        "title": "SkuBusinessCategoryOut"
+      },
+      "SkuBusinessCategoryUpdate": {
+        "properties": {
+          "category_name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category Name"
+          },
+          "category_code": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 32
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category Code"
+          },
+          "is_leaf": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Leaf"
+          },
+          "sort_order": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sort Order"
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 500
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          }
+        },
+        "type": "object",
+        "title": "SkuBusinessCategoryUpdate"
+      },
+      "SkuCodeBrandCreate": {
+        "properties": {
+          "name_cn": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Name Cn"
+          },
+          "code": {
+            "type": "string",
+            "maxLength": 32,
+            "minLength": 1,
+            "title": "Code"
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order",
+            "default": 0
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 500
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name_cn",
+          "code"
+        ],
+        "title": "SkuCodeBrandCreate"
+      },
+      "SkuCodeBrandOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "name_cn": {
+            "type": "string",
+            "title": "Name Cn"
+          },
+          "code": {
+            "type": "string",
+            "title": "Code"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "is_locked": {
+            "type": "boolean",
+            "title": "Is Locked"
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order"
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name_cn",
+          "code",
+          "is_active",
+          "is_locked",
+          "sort_order",
+          "remark"
+        ],
+        "title": "SkuCodeBrandOut"
+      },
+      "SkuCodeBrandUpdate": {
+        "properties": {
+          "name_cn": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name Cn"
+          },
+          "code": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 32
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Code"
+          },
+          "sort_order": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sort Order"
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 500
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          }
+        },
+        "type": "object",
+        "title": "SkuCodeBrandUpdate"
+      },
+      "SkuCodeTermCreate": {
+        "properties": {
+          "group_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Group Id"
+          },
+          "name_cn": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Name Cn"
+          },
+          "code": {
+            "type": "string",
+            "maxLength": 32,
+            "minLength": 1,
+            "title": "Code"
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order",
+            "default": 0
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 500
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          }
+        },
+        "type": "object",
+        "required": [
+          "group_id",
+          "name_cn",
+          "code"
+        ],
+        "title": "SkuCodeTermCreate"
+      },
+      "SkuCodeTermGroupOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "product_kind": {
+            "type": "string",
+            "title": "Product Kind"
+          },
+          "group_code": {
+            "type": "string",
+            "title": "Group Code"
+          },
+          "group_name": {
+            "type": "string",
+            "title": "Group Name"
+          },
+          "is_multi_select": {
+            "type": "boolean",
+            "title": "Is Multi Select"
+          },
+          "is_required": {
+            "type": "boolean",
+            "title": "Is Required"
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "product_kind",
+          "group_code",
+          "group_name",
+          "is_multi_select",
+          "is_required",
+          "sort_order",
+          "is_active",
+          "remark"
+        ],
+        "title": "SkuCodeTermGroupOut"
+      },
+      "SkuCodeTermOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "group_id": {
+            "type": "integer",
+            "title": "Group Id"
+          },
+          "name_cn": {
+            "type": "string",
+            "title": "Name Cn"
+          },
+          "code": {
+            "type": "string",
+            "title": "Code"
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "is_locked": {
+            "type": "boolean",
+            "title": "Is Locked"
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "group_id",
+          "name_cn",
+          "code",
+          "sort_order",
+          "is_active",
+          "is_locked",
+          "remark"
+        ],
+        "title": "SkuCodeTermOut"
+      },
+      "SkuCodeTermUpdate": {
+        "properties": {
+          "name_cn": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name Cn"
+          },
+          "code": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 32
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Code"
+          },
+          "sort_order": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sort Order"
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 500
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          }
+        },
+        "type": "object",
+        "title": "SkuCodeTermUpdate"
+      },
+      "SkuGenerateDataOut": {
+        "properties": {
+          "sku": {
+            "type": "string",
+            "title": "Sku"
+          },
+          "segments": {
+            "items": {
+              "$ref": "#/components/schemas/SkuGeneratedSegmentOut"
+            },
+            "type": "array",
+            "title": "Segments"
+          },
+          "exists": {
+            "type": "boolean",
+            "title": "Exists"
+          },
+          "similar_items": {
+            "items": {
+              "$ref": "#/components/schemas/SimilarItemOut"
+            },
+            "type": "array",
+            "title": "Similar Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "sku",
+          "segments",
+          "exists",
+          "similar_items"
+        ],
+        "title": "SkuGenerateDataOut"
+      },
+      "SkuGenerateIn": {
+        "properties": {
+          "product_kind": {
+            "type": "string",
+            "enum": [
+              "FOOD",
+              "SUPPLY"
+            ],
+            "title": "Product Kind"
+          },
+          "brand_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Brand Id"
+          },
+          "category_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Category Id"
+          },
+          "term_ids": {
+            "additionalProperties": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "type": "object",
+            "title": "Term Ids"
+          },
+          "text_segments": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Text Segments"
+          },
+          "spec_text": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Spec Text"
+          }
+        },
+        "type": "object",
+        "required": [
+          "product_kind",
+          "brand_id",
+          "category_id",
+          "spec_text"
+        ],
+        "title": "SkuGenerateIn"
+      },
+      "SkuGenerateOut": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok",
+            "default": true
+          },
+          "data": {
+            "$ref": "#/components/schemas/SkuGenerateDataOut"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "SkuGenerateOut"
+      },
+      "SkuGeneratedSegmentOut": {
+        "properties": {
+          "segment_key": {
+            "type": "string",
+            "title": "Segment Key"
+          },
+          "name_cn": {
+            "type": "string",
+            "title": "Name Cn"
+          },
+          "code": {
+            "type": "string",
+            "title": "Code"
+          }
+        },
+        "type": "object",
+        "required": [
+          "segment_key",
+          "name_cn",
+          "code"
+        ],
+        "title": "SkuGeneratedSegmentOut"
+      },
+      "SkuPurchaseLedgerItemOption": {
+        "properties": {
+          "item_id": {
+            "type": "integer",
+            "title": "Item Id"
+          },
+          "item_sku": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Item Sku"
+          },
+          "item_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Item Name"
+          },
+          "spec_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spec Text"
+          }
+        },
+        "type": "object",
+        "required": [
+          "item_id"
+        ],
+        "title": "SkuPurchaseLedgerItemOption"
+      },
+      "SkuPurchaseLedgerOptionsResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/SkuPurchaseLedgerItemOption"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "suppliers": {
+            "items": {
+              "$ref": "#/components/schemas/SkuPurchaseLedgerSupplierOption"
+            },
+            "type": "array",
+            "title": "Suppliers"
+          },
+          "warehouses": {
+            "items": {
+              "$ref": "#/components/schemas/SkuPurchaseLedgerWarehouseOption"
+            },
+            "type": "array",
+            "title": "Warehouses"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "suppliers",
+          "warehouses"
+        ],
+        "title": "SkuPurchaseLedgerOptionsResponse"
+      },
+      "SkuPurchaseLedgerResponse": {
+        "properties": {
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/SkuPurchaseLedgerRow"
+            },
+            "type": "array",
+            "title": "Rows"
+          }
+        },
+        "type": "object",
+        "required": [
+          "rows"
+        ],
+        "title": "SkuPurchaseLedgerResponse"
+      },
+      "SkuPurchaseLedgerRow": {
+        "properties": {
+          "po_line_id": {
+            "type": "integer",
+            "title": "Po Line Id"
+          },
+          "po_id": {
+            "type": "integer",
+            "title": "Po Id"
+          },
+          "po_no": {
+            "type": "string",
+            "title": "Po No"
+          },
+          "line_no": {
+            "type": "integer",
+            "title": "Line No"
+          },
+          "item_id": {
+            "type": "integer",
+            "title": "Item Id"
+          },
+          "item_sku": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Item Sku"
+          },
+          "item_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Item Name"
+          },
+          "spec_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spec Text"
+          },
+          "supplier_id": {
+            "type": "integer",
+            "title": "Supplier Id"
+          },
+          "supplier_name": {
+            "type": "string",
+            "title": "Supplier Name"
+          },
+          "warehouse_id": {
+            "type": "integer",
+            "title": "Warehouse Id"
+          },
+          "warehouse_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Warehouse Name"
+          },
+          "purchase_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Purchase Time"
+          },
+          "purchase_date": {
+            "type": "string",
+            "format": "date",
+            "title": "Purchase Date"
+          },
+          "qty_ordered_input": {
+            "type": "integer",
+            "title": "Qty Ordered Input"
+          },
+          "purchase_uom_name_snapshot": {
+            "type": "string",
+            "title": "Purchase Uom Name Snapshot"
+          },
+          "purchase_ratio_to_base_snapshot": {
+            "type": "integer",
+            "title": "Purchase Ratio To Base Snapshot"
+          },
+          "qty_ordered_base": {
+            "type": "integer",
+            "title": "Qty Ordered Base"
+          },
+          "purchase_unit_price": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Purchase Unit Price"
+          },
+          "planned_line_amount": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Planned Line Amount"
+          },
+          "accounting_unit_price": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Accounting Unit Price"
+          }
+        },
+        "type": "object",
+        "required": [
+          "po_line_id",
+          "po_id",
+          "po_no",
+          "line_no",
+          "item_id",
+          "supplier_id",
+          "supplier_name",
+          "warehouse_id",
+          "purchase_time",
+          "purchase_date",
+          "qty_ordered_input",
+          "purchase_uom_name_snapshot",
+          "purchase_ratio_to_base_snapshot",
+          "qty_ordered_base",
+          "planned_line_amount"
+        ],
+        "title": "SkuPurchaseLedgerRow"
+      },
+      "SkuPurchaseLedgerSupplierOption": {
+        "properties": {
+          "supplier_id": {
+            "type": "integer",
+            "title": "Supplier Id"
+          },
+          "supplier_name": {
+            "type": "string",
+            "title": "Supplier Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "supplier_id",
+          "supplier_name"
+        ],
+        "title": "SkuPurchaseLedgerSupplierOption"
+      },
+      "SkuPurchaseLedgerWarehouseOption": {
+        "properties": {
+          "warehouse_id": {
+            "type": "integer",
+            "title": "Warehouse Id"
+          },
+          "warehouse_name": {
+            "type": "string",
+            "title": "Warehouse Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "warehouse_id",
+          "warehouse_name"
+        ],
+        "title": "SkuPurchaseLedgerWarehouseOption"
       },
       "StockRecountRequest": {
         "properties": {
@@ -40335,13 +44060,13 @@
             "minLength": 2,
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
             "maxLength": 128,
             "minLength": 1,
-            "title": "Shop Id"
+            "title": "Store Code"
           },
-          "name": {
+          "store_name": {
             "anyOf": [
               {
                 "type": "string",
@@ -40352,22 +44077,22 @@
                 "type": "null"
               }
             ],
-            "title": "Name"
+            "title": "Store Name"
           },
-          "shop_type": {
+          "store_type": {
             "type": "string",
             "enum": [
               "TEST",
               "PROD"
             ],
-            "title": "Shop Type",
+            "title": "Store Type",
             "default": "PROD"
           }
         },
         "type": "object",
         "required": [
           "platform",
-          "shop_id"
+          "store_code"
         ],
         "title": "StoreCreateIn"
       },
@@ -40419,13 +44144,13 @@
             "type": "string",
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "title": "Shop Id"
+            "title": "Store Code"
           },
-          "name": {
+          "store_name": {
             "type": "string",
-            "title": "Name"
+            "title": "Store Name"
           },
           "active": {
             "type": "boolean",
@@ -40435,9 +44160,9 @@
             "type": "string",
             "title": "Route Mode"
           },
-          "shop_type": {
+          "store_type": {
             "type": "string",
-            "title": "Shop Type",
+            "title": "Store Type",
             "default": "PROD"
           },
           "email": {
@@ -40478,8 +44203,8 @@
         "required": [
           "id",
           "platform",
-          "shop_id",
-          "name",
+          "store_code",
+          "store_name",
           "active",
           "route_mode"
         ],
@@ -40512,21 +44237,21 @@
             "type": "integer",
             "title": "Id"
           },
-          "name": {
+          "store_name": {
             "type": "string",
-            "title": "Name"
+            "title": "Store Name"
           }
         },
         "type": "object",
         "required": [
           "id",
-          "name"
+          "store_name"
         ],
         "title": "StoreLiteOut"
       },
       "StoreUpdateIn": {
         "properties": {
-          "name": {
+          "store_name": {
             "anyOf": [
               {
                 "type": "string",
@@ -40537,7 +44262,7 @@
                 "type": "null"
               }
             ],
-            "title": "Name"
+            "title": "Store Name"
           },
           "active": {
             "anyOf": [
@@ -41570,214 +45295,9 @@
         "type": "object",
         "title": "SurchargeConfigUpdateIn"
       },
-      "TaobaoOrderLedgerDetailEnvelopeOut": {
+      "SyncPlatformOrderMirrorErrorOut": {
         "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "$ref": "#/components/schemas/TaobaoOrderLedgerDetailOut"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "TaobaoOrderLedgerDetailEnvelopeOut"
-      },
-      "TaobaoOrderLedgerDetailOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "store_id": {
-            "type": "integer",
-            "title": "Store Id"
-          },
-          "tid": {
-            "type": "string",
-            "title": "Tid"
-          },
-          "status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Status"
-          },
-          "type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Type"
-          },
-          "buyer_nick": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Buyer Nick"
-          },
-          "buyer_open_uid": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Buyer Open Uid"
-          },
-          "receiver_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Name"
-          },
-          "receiver_mobile": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Mobile"
-          },
-          "receiver_phone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Phone"
-          },
-          "receiver_state": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver State"
-          },
-          "receiver_city": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver City"
-          },
-          "receiver_district": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver District"
-          },
-          "receiver_town": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Town"
-          },
-          "receiver_address": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Address"
-          },
-          "receiver_zip": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Zip"
-          },
-          "buyer_memo": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Buyer Memo"
-          },
-          "buyer_message": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Buyer Message"
-          },
-          "seller_memo": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Seller Memo"
-          },
-          "seller_flag": {
+          "collector_order_id": {
             "anyOf": [
               {
                 "type": "integer"
@@ -41786,418 +45306,168 @@
                 "type": "null"
               }
             ],
-            "title": "Seller Flag"
+            "title": "Collector Order Id"
           },
-          "payment": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Payment"
+          "error_code": {
+            "type": "string",
+            "title": "Error Code"
           },
-          "total_fee": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Total Fee"
-          },
-          "post_fee": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Post Fee"
-          },
-          "coupon_fee": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Coupon Fee"
-          },
-          "created": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created"
-          },
-          "pay_time": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pay Time"
-          },
-          "modified": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Modified"
-          },
-          "raw_summary_payload": {
-            "title": "Raw Summary Payload"
-          },
-          "raw_detail_payload": {
-            "title": "Raw Detail Payload"
-          },
-          "pulled_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pulled At"
-          },
-          "last_synced_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Synced At"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          },
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/TaobaoOrderLedgerItemOut"
-            },
-            "type": "array",
-            "title": "Items"
+          "message": {
+            "type": "string",
+            "title": "Message"
           }
         },
         "type": "object",
         "required": [
-          "id",
-          "store_id",
-          "tid",
-          "items"
+          "error_code",
+          "message"
         ],
-        "title": "TaobaoOrderLedgerDetailOut"
+        "title": "SyncPlatformOrderMirrorErrorOut"
       },
-      "TaobaoOrderLedgerItemOut": {
+      "SyncPlatformOrderMirrorItemOut": {
         "properties": {
-          "id": {
+          "collector_order_id": {
             "type": "integer",
-            "title": "Id"
+            "title": "Collector Order Id"
           },
-          "taobao_order_id": {
+          "mirror_id": {
             "type": "integer",
-            "title": "Taobao Order Id"
+            "title": "Mirror Id"
           },
-          "tid": {
-            "type": "string",
-            "title": "Tid"
-          },
-          "oid": {
-            "type": "string",
-            "title": "Oid"
-          },
-          "num_iid": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Num Iid"
-          },
-          "sku_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sku Id"
-          },
-          "outer_iid": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Outer Iid"
-          },
-          "outer_sku_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Outer Sku Id"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title"
-          },
-          "price": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Price"
-          },
-          "num": {
-            "type": "integer",
-            "title": "Num"
-          },
-          "payment": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Payment"
-          },
-          "total_fee": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Total Fee"
-          },
-          "sku_properties_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sku Properties Name"
-          },
-          "raw_item_payload": {
-            "title": "Raw Item Payload"
+          "imported": {
+            "type": "boolean",
+            "title": "Imported",
+            "default": true
           }
         },
         "type": "object",
         "required": [
-          "id",
-          "taobao_order_id",
-          "tid",
-          "oid",
-          "num"
+          "collector_order_id",
+          "mirror_id"
         ],
-        "title": "TaobaoOrderLedgerItemOut"
+        "title": "SyncPlatformOrderMirrorItemOut"
       },
-      "TaobaoOrderLedgerListOut": {
+      "SyncPlatformOrderMirrorsFromCollectorIn": {
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "maximum": 1000.0,
+            "minimum": 1.0,
+            "title": "Limit",
+            "default": 50
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Offset",
+            "default": 0
+          },
+          "since": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Since",
+            "description": "Inclusive lower bound for Collector Export source update time."
+          },
+          "until": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Until",
+            "description": "Exclusive upper bound for Collector Export source update time."
+          }
+        },
+        "type": "object",
+        "title": "SyncPlatformOrderMirrorsFromCollectorIn"
+      },
+      "SyncPlatformOrderMirrorsFromCollectorOut": {
         "properties": {
           "ok": {
             "type": "boolean",
             "title": "Ok",
             "default": true
           },
-          "data": {
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          },
+          "since": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Since"
+          },
+          "until": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Until"
+          },
+          "fetched_count": {
+            "type": "integer",
+            "title": "Fetched Count"
+          },
+          "imported_count": {
+            "type": "integer",
+            "title": "Imported Count"
+          },
+          "failed_count": {
+            "type": "integer",
+            "title": "Failed Count"
+          },
+          "items": {
             "items": {
-              "$ref": "#/components/schemas/TaobaoOrderLedgerRowOut"
+              "$ref": "#/components/schemas/SyncPlatformOrderMirrorItemOut"
             },
             "type": "array",
-            "title": "Data"
+            "title": "Items"
+          },
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/SyncPlatformOrderMirrorErrorOut"
+            },
+            "type": "array",
+            "title": "Errors"
           }
         },
         "type": "object",
         "required": [
-          "data"
+          "platform",
+          "limit",
+          "offset",
+          "fetched_count",
+          "imported_count",
+          "failed_count"
         ],
-        "title": "TaobaoOrderLedgerListOut"
-      },
-      "TaobaoOrderLedgerRowOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "store_id": {
-            "type": "integer",
-            "title": "Store Id"
-          },
-          "tid": {
-            "type": "string",
-            "title": "Tid"
-          },
-          "status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Status"
-          },
-          "type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Type"
-          },
-          "created": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created"
-          },
-          "pay_time": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pay Time"
-          },
-          "payment": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Payment"
-          },
-          "total_fee": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Total Fee"
-          },
-          "pulled_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pulled At"
-          },
-          "last_synced_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Synced At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "store_id",
-          "tid"
-        ],
-        "title": "TaobaoOrderLedgerRowOut"
+        "title": "SyncPlatformOrderMirrorsFromCollectorOut"
       },
       "TemplateCapabilitiesOut": {
         "properties": {
@@ -42833,6 +46103,13 @@
           "type": {
             "type": "string",
             "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
           }
         },
         "type": "object",
@@ -43842,11 +47119,11 @@
             "minLength": 1,
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
             "maxLength": 64,
             "minLength": 1,
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "shipping_provider_id": {
             "type": "integer",
@@ -43952,7 +47229,7 @@
         "type": "object",
         "required": [
           "platform",
-          "shop_id",
+          "store_code",
           "shipping_provider_id",
           "customer_code"
         ],
@@ -44023,9 +47300,9 @@
             "type": "string",
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "shipping_provider_id": {
             "type": "integer",
@@ -44140,7 +47417,7 @@
         "required": [
           "id",
           "platform",
-          "shop_id",
+          "store_code",
           "shipping_provider_id",
           "customer_code"
         ],
@@ -44161,7 +47438,7 @@
             ],
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "anyOf": [
               {
                 "type": "string",
@@ -44172,7 +47449,7 @@
                 "type": "null"
               }
             ],
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "shipping_provider_id": {
             "anyOf": [

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -633,14 +633,14 @@
         }
       }
     },
-    "/orders/{platform}/{shop_id}/{ext_order_no}/fulfillment/manual-assign": {
+    "/orders/{platform}/{store_code}/{ext_order_no}/fulfillment/manual-assign": {
       "post": {
         "tags": [
           "orders-fulfillment-v2"
         ],
         "summary": "Fulfillment Manual Assign",
         "description": "Phase 5.1：人工指定执行仓（执行期唯一合法写入路径）\n\n✅ 新世界观（一步到位迁移后）：\n- 实际出库仓写入 order_fulfillment.actual_warehouse_id（执行仓事实）\n- planned/service 归属仓仍由 routing 写入 order_fulfillment.planned_warehouse_id\n- 写 fulfillment_status=MANUALLY_ASSIGNED\n- 写审计事件：MANUAL_WAREHOUSE_ASSIGNED\n\n❌ 禁止回潮：\n- 不允许写 orders.warehouse_id（该列迁移后将被删除/不再承载事实）\n\n注意：\n- manual-assign 是“决策入口”，库存不足应作为 soft-check 记录（审计/提示），不应 409 阻断；\n  真正的库存裁判在 pick/ship 执行点。",
-        "operationId": "fulfillment_manual_assign_orders__platform___shop_id___ext_order_no__fulfillment_manual_assign_post",
+        "operationId": "fulfillment_manual_assign_orders__platform___store_code___ext_order_no__fulfillment_manual_assign_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -657,12 +657,12 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
@@ -709,13 +709,13 @@
         }
       }
     },
-    "/orders/{platform}/{shop_id}/{ext_order_no}/ship-with-waybill": {
+    "/orders/{platform}/{store_code}/{ext_order_no}/ship-with-waybill": {
       "post": {
         "tags": [
           "orders-fulfillment-v2"
         ],
         "summary": "Order Ship With Waybill",
-        "operationId": "order_ship_with_waybill_orders__platform___shop_id___ext_order_no__ship_with_waybill_post",
+        "operationId": "order_ship_with_waybill_orders__platform___store_code___ext_order_no__ship_with_waybill_post",
         "parameters": [
           {
             "name": "platform",
@@ -727,12 +727,12 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
@@ -1565,13 +1565,13 @@
         }
       }
     },
-    "/ship/calc": {
+    "/shipping-assist/shipping/calc": {
       "post": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "Calc Shipping Quotes",
-        "operationId": "calc_shipping_quotes_ship_calc_post",
+        "operationId": "calc_shipping_quotes_shipping_assist_shipping_calc_post",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1611,13 +1611,13 @@
         ]
       }
     },
-    "/ship/prepare/orders": {
+    "/shipping-assist/shipping/prepare/orders": {
       "get": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "List Prepare Orders",
-        "operationId": "list_prepare_orders_ship_prepare_orders_get",
+        "operationId": "list_prepare_orders_shipping_assist_shipping_prepare_orders_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -1661,13 +1661,13 @@
         }
       }
     },
-    "/ship/prepare/orders/{platform}/{shop_id}/{ext_order_no}": {
+    "/shipping-assist/shipping/prepare/orders/{platform}/{store_code}/{ext_order_no}": {
       "get": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "Get Prepare Order Detail",
-        "operationId": "get_prepare_order_detail_ship_prepare_orders__platform___shop_id___ext_order_no__get",
+        "operationId": "get_prepare_order_detail_shipping_assist_shipping_prepare_orders__platform___store_code___ext_order_no__get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -1684,12 +1684,12 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
@@ -1726,13 +1726,13 @@
         }
       }
     },
-    "/ship/prepare/orders/import": {
+    "/shipping-assist/shipping/prepare/orders/import": {
       "post": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "Import Prepare Order",
-        "operationId": "import_prepare_order_ship_prepare_orders_import_post",
+        "operationId": "import_prepare_order_shipping_assist_shipping_prepare_orders_import_post",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1772,13 +1772,13 @@
         ]
       }
     },
-    "/ship/prepare/orders/{platform}/{shop_id}/{ext_order_no}/address-confirm": {
+    "/shipping-assist/shipping/prepare/orders/{platform}/{store_code}/{ext_order_no}/address-confirm": {
       "post": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "Confirm Prepare Order Address",
-        "operationId": "confirm_prepare_order_address_ship_prepare_orders__platform___shop_id___ext_order_no__address_confirm_post",
+        "operationId": "confirm_prepare_order_address_shipping_assist_shipping_prepare_orders__platform___store_code___ext_order_no__address_confirm_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -1795,12 +1795,12 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
@@ -1847,13 +1847,13 @@
         }
       }
     },
-    "/ship/prepare/orders/{platform}/{shop_id}/{ext_order_no}/packages": {
+    "/shipping-assist/shipping/prepare/orders/{platform}/{store_code}/{ext_order_no}/packages": {
       "get": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "List Prepare Packages",
-        "operationId": "list_prepare_packages_ship_prepare_orders__platform___shop_id___ext_order_no__packages_get",
+        "operationId": "list_prepare_packages_shipping_assist_shipping_prepare_orders__platform___store_code___ext_order_no__packages_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -1870,12 +1870,12 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
@@ -1913,10 +1913,10 @@
       },
       "post": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "Create Prepare Package",
-        "operationId": "create_prepare_package_ship_prepare_orders__platform___shop_id___ext_order_no__packages_post",
+        "operationId": "create_prepare_package_shipping_assist_shipping_prepare_orders__platform___store_code___ext_order_no__packages_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -1933,12 +1933,12 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
@@ -1975,13 +1975,13 @@
         }
       }
     },
-    "/ship/prepare/orders/{platform}/{shop_id}/{ext_order_no}/packages/{package_no}": {
+    "/shipping-assist/shipping/prepare/orders/{platform}/{store_code}/{ext_order_no}/packages/{package_no}": {
       "patch": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "Update Prepare Package",
-        "operationId": "update_prepare_package_ship_prepare_orders__platform___shop_id___ext_order_no__packages__package_no__patch",
+        "operationId": "update_prepare_package_shipping_assist_shipping_prepare_orders__platform___store_code___ext_order_no__packages__package_no__patch",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -1998,12 +1998,12 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
@@ -2059,13 +2059,13 @@
         }
       }
     },
-    "/ship/prepare/orders/{platform}/{shop_id}/{ext_order_no}/packages/{package_no}/quote": {
+    "/shipping-assist/shipping/prepare/orders/{platform}/{store_code}/{ext_order_no}/packages/{package_no}/quote": {
       "post": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "Quote Prepare Package",
-        "operationId": "quote_prepare_package_ship_prepare_orders__platform___shop_id___ext_order_no__packages__package_no__quote_post",
+        "operationId": "quote_prepare_package_shipping_assist_shipping_prepare_orders__platform___store_code___ext_order_no__packages__package_no__quote_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -2082,12 +2082,12 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
@@ -2133,13 +2133,13 @@
         }
       }
     },
-    "/ship/prepare/orders/{platform}/{shop_id}/{ext_order_no}/packages/{package_no}/quote/confirm": {
+    "/shipping-assist/shipping/prepare/orders/{platform}/{store_code}/{ext_order_no}/packages/{package_no}/quote/confirm": {
       "post": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "Confirm Prepare Package Quote",
-        "operationId": "confirm_prepare_package_quote_ship_prepare_orders__platform___shop_id___ext_order_no__packages__package_no__quote_confirm_post",
+        "operationId": "confirm_prepare_package_quote_shipping_assist_shipping_prepare_orders__platform___store_code___ext_order_no__packages__package_no__quote_confirm_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -2156,12 +2156,12 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
@@ -2217,13 +2217,13 @@
         }
       }
     },
-    "/ship/waybill-configs": {
+    "/shipping-assist/settings/waybill-configs": {
       "get": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "List Waybill Configs Route",
-        "operationId": "list_waybill_configs_route_ship_waybill_configs_get",
+        "operationId": "list_waybill_configs_route_shipping_assist_settings_waybill_configs_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -2263,7 +2263,7 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -2275,7 +2275,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
@@ -2337,10 +2337,10 @@
       },
       "post": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "Create Waybill Config Route",
-        "operationId": "create_waybill_config_route_ship_waybill_configs_post",
+        "operationId": "create_waybill_config_route_shipping_assist_settings_waybill_configs_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -2380,13 +2380,13 @@
         }
       }
     },
-    "/ship/waybill-configs/{config_id}": {
+    "/shipping-assist/settings/waybill-configs/{config_id}": {
       "get": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "Get Waybill Config Route",
-        "operationId": "get_waybill_config_route_ship_waybill_configs__config_id__get",
+        "operationId": "get_waybill_config_route_shipping_assist_settings_waybill_configs__config_id__get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -2429,10 +2429,10 @@
       },
       "patch": {
         "tags": [
-          "ship"
+          "shipping-assist-shipping"
         ],
         "summary": "Update Waybill Config Route",
-        "operationId": "update_waybill_config_route_ship_waybill_configs__config_id__patch",
+        "operationId": "update_waybill_config_route_shipping_assist_settings_waybill_configs__config_id__patch",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -5276,6 +5276,1122 @@
         ]
       }
     },
+    "/oms/pdd/platform-order-mirrors/import": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "Import Platform Order Mirror",
+        "operationId": "import_platform_order_mirror_oms_pdd_platform_order_mirrors_import_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlatformOrderMirrorImportIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformOrderMirrorEnvelopeOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/pdd/platform-order-mirrors/import-from-collector": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "Import Platform Order Mirror From Collector Route",
+        "operationId": "import_platform_order_mirror_from_collector_route_oms_pdd_platform_order_mirrors_import_from_collector_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportPlatformOrderMirrorFromCollectorIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportPlatformOrderMirrorFromCollectorOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/pdd/platform-order-mirrors/sync-from-collector": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "Sync Platform Order Mirrors From Collector Route",
+        "operationId": "sync_platform_order_mirrors_from_collector_route_oms_pdd_platform_order_mirrors_sync_from_collector_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SyncPlatformOrderMirrorsFromCollectorIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SyncPlatformOrderMirrorsFromCollectorOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/pdd/platform-order-mirrors": {
+      "get": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "List Platform Order Mirror Rows",
+        "operationId": "list_platform_order_mirror_rows_oms_pdd_platform_order_mirrors_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "default": 200,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformOrderMirrorListOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/pdd/platform-order-mirrors/{mirror_id}": {
+      "get": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "Get Platform Order Mirror Row",
+        "operationId": "get_platform_order_mirror_row_oms_pdd_platform_order_mirrors__mirror_id__get",
+        "parameters": [
+          {
+            "name": "mirror_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "title": "Mirror Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformOrderMirrorEnvelopeOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/taobao/platform-order-mirrors/import": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "Import Platform Order Mirror",
+        "operationId": "import_platform_order_mirror_oms_taobao_platform_order_mirrors_import_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlatformOrderMirrorImportIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformOrderMirrorEnvelopeOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/taobao/platform-order-mirrors/import-from-collector": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "Import Platform Order Mirror From Collector Route",
+        "operationId": "import_platform_order_mirror_from_collector_route_oms_taobao_platform_order_mirrors_import_from_collector_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportPlatformOrderMirrorFromCollectorIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportPlatformOrderMirrorFromCollectorOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/taobao/platform-order-mirrors/sync-from-collector": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "Sync Platform Order Mirrors From Collector Route",
+        "operationId": "sync_platform_order_mirrors_from_collector_route_oms_taobao_platform_order_mirrors_sync_from_collector_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SyncPlatformOrderMirrorsFromCollectorIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SyncPlatformOrderMirrorsFromCollectorOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/taobao/platform-order-mirrors": {
+      "get": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "List Platform Order Mirror Rows",
+        "operationId": "list_platform_order_mirror_rows_oms_taobao_platform_order_mirrors_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "default": 200,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformOrderMirrorListOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/taobao/platform-order-mirrors/{mirror_id}": {
+      "get": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "Get Platform Order Mirror Row",
+        "operationId": "get_platform_order_mirror_row_oms_taobao_platform_order_mirrors__mirror_id__get",
+        "parameters": [
+          {
+            "name": "mirror_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "title": "Mirror Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformOrderMirrorEnvelopeOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/jd/platform-order-mirrors/import": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "Import Platform Order Mirror",
+        "operationId": "import_platform_order_mirror_oms_jd_platform_order_mirrors_import_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlatformOrderMirrorImportIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformOrderMirrorEnvelopeOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/jd/platform-order-mirrors/import-from-collector": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "Import Platform Order Mirror From Collector Route",
+        "operationId": "import_platform_order_mirror_from_collector_route_oms_jd_platform_order_mirrors_import_from_collector_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportPlatformOrderMirrorFromCollectorIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportPlatformOrderMirrorFromCollectorOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/jd/platform-order-mirrors/sync-from-collector": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "Sync Platform Order Mirrors From Collector Route",
+        "operationId": "sync_platform_order_mirrors_from_collector_route_oms_jd_platform_order_mirrors_sync_from_collector_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SyncPlatformOrderMirrorsFromCollectorIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SyncPlatformOrderMirrorsFromCollectorOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/jd/platform-order-mirrors": {
+      "get": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "List Platform Order Mirror Rows",
+        "operationId": "list_platform_order_mirror_rows_oms_jd_platform_order_mirrors_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "default": 200,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformOrderMirrorListOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/jd/platform-order-mirrors/{mirror_id}": {
+      "get": {
+        "tags": [
+          "OMS",
+          "oms-platform-order-mirrors"
+        ],
+        "summary": "Get Platform Order Mirror Row",
+        "operationId": "get_platform_order_mirror_row_oms_jd_platform_order_mirrors__mirror_id__get",
+        "parameters": [
+          {
+            "name": "mirror_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "title": "Mirror Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformOrderMirrorEnvelopeOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/pdd/fsku-mapping/candidates": {
+      "get": {
+        "tags": [
+          "OMS",
+          "oms-fsku-mapping-candidates"
+        ],
+        "summary": "List Platform Fsku Mapping Candidates",
+        "operationId": "list_platform_fsku_mapping_candidates_oms_pdd_fsku_mapping_candidates_get",
+        "parameters": [
+          {
+            "name": "store_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 128
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Store Code"
+            }
+          },
+          {
+            "name": "merchant_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 128
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Merchant Code"
+            }
+          },
+          {
+            "name": "only_unbound",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Only Unbound"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "default": 200,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FskuMappingCandidateListOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/taobao/fsku-mapping/candidates": {
+      "get": {
+        "tags": [
+          "OMS",
+          "oms-fsku-mapping-candidates"
+        ],
+        "summary": "List Platform Fsku Mapping Candidates",
+        "operationId": "list_platform_fsku_mapping_candidates_oms_taobao_fsku_mapping_candidates_get",
+        "parameters": [
+          {
+            "name": "store_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 128
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Store Code"
+            }
+          },
+          {
+            "name": "merchant_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 128
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Merchant Code"
+            }
+          },
+          {
+            "name": "only_unbound",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Only Unbound"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "default": 200,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FskuMappingCandidateListOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/jd/fsku-mapping/candidates": {
+      "get": {
+        "tags": [
+          "OMS",
+          "oms-fsku-mapping-candidates"
+        ],
+        "summary": "List Platform Fsku Mapping Candidates",
+        "operationId": "list_platform_fsku_mapping_candidates_oms_jd_fsku_mapping_candidates_get",
+        "parameters": [
+          {
+            "name": "store_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 128
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Store Code"
+            }
+          },
+          {
+            "name": "merchant_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 128
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Merchant Code"
+            }
+          },
+          {
+            "name": "only_unbound",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Only Unbound"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "default": 200,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FskuMappingCandidateListOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/pdd/fulfillment-order-conversion/convert": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-fulfillment-order-conversion"
+        ],
+        "summary": "Convert Platform Fulfillment Order",
+        "operationId": "convert_platform_fulfillment_order_oms_pdd_fulfillment_order_conversion_convert_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FulfillmentOrderConversionIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FulfillmentOrderConversionOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/taobao/fulfillment-order-conversion/convert": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-fulfillment-order-conversion"
+        ],
+        "summary": "Convert Platform Fulfillment Order",
+        "operationId": "convert_platform_fulfillment_order_oms_taobao_fulfillment_order_conversion_convert_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FulfillmentOrderConversionIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FulfillmentOrderConversionOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/jd/fulfillment-order-conversion/convert": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-fulfillment-order-conversion"
+        ],
+        "summary": "Convert Platform Fulfillment Order",
+        "operationId": "convert_platform_fulfillment_order_oms_jd_fulfillment_order_conversion_convert_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FulfillmentOrderConversionIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FulfillmentOrderConversionOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/oms/platform-orders/ingest": {
       "post": {
         "tags": [
@@ -5385,6 +6501,49 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PlatformOrderReplayOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/platform-orders/resolve-preview": {
+      "post": {
+        "tags": [
+          "OMS",
+          "platform-orders"
+        ],
+        "summary": "平台订单事实只读解析预览：读取 platform_order_lines 并展开到 FSKU/SKU，不建单",
+        "description": "只读解析预览。\n\n边界：\n- 读取 platform_order_lines；\n- 复用 resolver 展开 FSKU / item；\n- 返回 resolved / unresolved / item_qty_map；\n- 不写 platform_order_lines；\n- 不建 orders/order_items；\n- 不触碰 finance。",
+        "operationId": "preview_platform_order_resolve_oms_platform_orders_resolve_preview_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlatformOrderResolvePreviewIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformOrderResolvePreviewOut"
                 }
               }
             }
@@ -5572,10 +6731,10 @@
                   "type": "null"
                 }
               ],
-              "description": "模糊搜索：name / shop_id / id",
+              "description": "模糊搜索：store_name / store_code / id",
               "title": "Q"
             },
-            "description": "模糊搜索：name / shop_id / id"
+            "description": "模糊搜索：store_name / store_code / id"
           },
           {
             "name": "limit",
@@ -5630,7 +6789,7 @@
           "stores"
         ],
         "summary": "Create Or Get Store",
-        "description": "店铺建档 / 补录（幂等）。\n\n权限：config.store.write\n\n✅ 合同收敛：\n- shop_type 的唯一真相为 platform_test_shops（code='DEFAULT'）\n- 创建时可选择 TEST/PROD：\n  * TEST：写入/更新 platform_test_shops（绑定 store_id）\n  * PROD：确保该 store_id 不在 platform_test_shops（删除绑定）",
+        "description": "店铺建档 / 补录（幂等）。\n\n权限：config.store.write\n\n✅ 合同收敛：\n- store_type 的唯一真相为 platform_test_stores（code='DEFAULT'）\n- 创建时可选择 TEST/PROD：\n  * TEST：写入/更新 platform_test_stores（绑定 store_id）\n  * PROD：确保该 store_id 不在 platform_test_stores（删除绑定）",
         "operationId": "create_or_get_store_oms_stores_post",
         "security": [
           {
@@ -6682,7 +7841,7 @@
         "tags": [
           "OMS",
           "oms-fsku",
-          "ops - shop-product-bundles"
+          "ops - store-product-bundles"
         ],
         "summary": "Create",
         "operationId": "create_oms_fskus_post",
@@ -6728,7 +7887,7 @@
         "tags": [
           "OMS",
           "oms-fsku",
-          "ops - shop-product-bundles"
+          "ops - store-product-bundles"
         ],
         "summary": "List ",
         "operationId": "list__oms_fskus_get",
@@ -6846,7 +8005,7 @@
         "tags": [
           "OMS",
           "oms-fsku",
-          "ops - shop-product-bundles"
+          "ops - store-product-bundles"
         ],
         "summary": "Detail",
         "operationId": "detail_oms_fskus__fsku_id__get",
@@ -6893,7 +8052,7 @@
         "tags": [
           "OMS",
           "oms-fsku",
-          "ops - shop-product-bundles"
+          "ops - store-product-bundles"
         ],
         "summary": "Patch Fsku",
         "operationId": "patch_fsku_oms_fskus__fsku_id__patch",
@@ -6952,7 +8111,7 @@
         "tags": [
           "OMS",
           "oms-fsku",
-          "ops - shop-product-bundles"
+          "ops - store-product-bundles"
         ],
         "summary": "Components",
         "operationId": "components_oms_fskus__fsku_id__components_get",
@@ -6999,7 +8158,7 @@
         "tags": [
           "OMS",
           "oms-fsku",
-          "ops - shop-product-bundles"
+          "ops - store-product-bundles"
         ],
         "summary": "Replace Components",
         "operationId": "replace_components_oms_fskus__fsku_id__components_post",
@@ -7058,7 +8217,7 @@
         "tags": [
           "OMS",
           "oms-fsku",
-          "ops - shop-product-bundles"
+          "ops - store-product-bundles"
         ],
         "summary": "Publish",
         "operationId": "publish_oms_fskus__fsku_id__publish_post",
@@ -7107,7 +8266,7 @@
         "tags": [
           "OMS",
           "oms-fsku",
-          "ops - shop-product-bundles"
+          "ops - store-product-bundles"
         ],
         "summary": "Retire",
         "operationId": "retire_oms_fskus__fsku_id__retire_post",
@@ -7156,7 +8315,7 @@
         "tags": [
           "OMS",
           "oms-fsku",
-          "ops - shop-product-bundles"
+          "ops - store-product-bundles"
         ],
         "summary": "Unretire",
         "description": "⚠️ 兼容保留：取消归档（不支持）\n- 系统封板：FSKU 生命周期单向（draft → published → retired）\n- 发布事实不可逆，因此该接口将始终返回 409（state_conflict）",
@@ -7338,7 +8497,7 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -7346,13 +8505,13 @@
                 {
                   "type": "string",
                   "minLength": 1,
-                  "maxLength": 64
+                  "maxLength": 128
                 },
                 {
                   "type": "null"
                 }
               ],
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
@@ -7409,7 +8568,7 @@
                 {
                   "type": "string",
                   "minLength": 1,
-                  "maxLength": 64
+                  "maxLength": 128
                 },
                 {
                   "type": "null"
@@ -7473,7 +8632,7 @@
           "oms-fsku",
           "merchant-code-bindings"
         ],
-        "summary": "人工绑定/覆盖：platform+shop_id+merchant_code → published FSKU（一码一对一）",
+        "summary": "人工绑定/覆盖：platform+store_code+merchant_code → published FSKU（一码一对一）",
         "operationId": "bind_merchant_code_oms_merchant_code_bindings_bind_post",
         "requestBody": {
           "content": {
@@ -7594,7 +8753,7 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -7606,7 +8765,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
@@ -7683,1370 +8842,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OrderOutboundViewResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/taobao/app-config/current": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-taobao-app-config"
-        ],
-        "summary": "Get Current Taobao App Config",
-        "description": "读取当前启用中的淘宝系统配置。",
-        "operationId": "get_current_taobao_app_config_oms_taobao_app_config_current_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "type": "object",
-                  "title": "Response Get Current Taobao App Config Oms Taobao App Config Current Get"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      },
-      "put": {
-        "tags": [
-          "OMS",
-          "oms-taobao-app-config"
-        ],
-        "summary": "Put Current Taobao App Config",
-        "description": "保存当前淘宝系统配置。\n\n规则：\n- 若当前没有启用配置，则新建一条 enabled=true 记录\n- 若当前已有启用配置，则原地更新\n- 若 app_secret 为空字符串，则沿用原 secret（已有记录时）",
-        "operationId": "put_current_taobao_app_config_oms_taobao_app_config_current_put",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "additionalProperties": true,
-                "type": "object",
-                "title": "Payload"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "type": "object",
-                  "title": "Response Put Current Taobao App Config Oms Taobao App Config Current Put"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/oms/taobao/oauth/start": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-taobao-auth"
-        ],
-        "summary": "Taobao Oauth Start",
-        "description": "生成淘宝授权链接。",
-        "operationId": "taobao_oauth_start_oms_taobao_oauth_start_get",
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Taobao Oauth Start Oms Taobao Oauth Start Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/taobao/oauth/callback": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-taobao-auth"
-        ],
-        "summary": "Taobao Oauth Callback",
-        "description": "淘宝 OAuth callback。",
-        "operationId": "taobao_oauth_callback_oms_taobao_oauth_callback_get",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "title": "Code"
-            }
-          },
-          {
-            "name": "state",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "title": "State"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Taobao Oauth Callback Oms Taobao Oauth Callback Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/taobao/connection": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-taobao-connection"
-        ],
-        "summary": "Get Store Taobao Connection",
-        "description": "淘宝接入状态读取口（新主线）。\n\n当前返回：\n- store_id / platform\n- credentials 基础存在性与过期信息\n- connection 当前裁决状态\n- 授权返回自带的基础身份线索\n\n说明：\n- 第一版先直接读新两张表",
-        "operationId": "get_store_taobao_connection_oms_stores__store_id__taobao_connection_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Get Store Taobao Connection Oms Stores  Store Id  Taobao Connection Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/taobao/test-pull": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-taobao-pull"
-        ],
-        "summary": "Test Store Taobao Pull",
-        "description": "淘宝 test-pull（第一版）。",
-        "operationId": "test_store_taobao_pull_oms_stores__store_id__taobao_test_pull_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          },
-          {
-            "name": "allow_real_request",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Allow Real Request"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Test Store Taobao Pull Oms Stores  Store Id  Taobao Test Pull Post"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/taobao/orders": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-taobao-orders"
-        ],
-        "summary": "List Taobao Orders Ledger",
-        "operationId": "list_taobao_orders_ledger_oms_taobao_orders_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 1000,
-              "minimum": 1,
-              "default": 200,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TaobaoOrderLedgerListOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/taobao/orders/{taobao_order_id}": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-taobao-orders"
-        ],
-        "summary": "Get Taobao Order Ledger",
-        "operationId": "get_taobao_order_ledger_oms_taobao_orders__taobao_order_id__get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "taobao_order_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Taobao Order Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TaobaoOrderLedgerDetailEnvelopeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/pdd/app-config/current": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-pdd-app-config"
-        ],
-        "summary": "Get Current Pdd App Config",
-        "description": "读取当前启用中的拼多多系统配置。",
-        "operationId": "get_current_pdd_app_config_oms_pdd_app_config_current_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "type": "object",
-                  "title": "Response Get Current Pdd App Config Oms Pdd App Config Current Get"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      },
-      "put": {
-        "tags": [
-          "OMS",
-          "oms-pdd-app-config"
-        ],
-        "summary": "Put Current Pdd App Config",
-        "description": "保存当前拼多多系统配置。\n\n规则：\n- 若当前没有启用配置，则新建一条 enabled=true 记录\n- 若当前已有启用配置，则原地更新\n- 若 client_secret 为空字符串，则沿用原 secret（已有记录时）",
-        "operationId": "put_current_pdd_app_config_oms_pdd_app_config_current_put",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "additionalProperties": true,
-                "type": "object",
-                "title": "Payload"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "type": "object",
-                  "title": "Response Put Current Pdd App Config Oms Pdd App Config Current Put"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/oms/pdd/oauth/start": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-pdd-auth"
-        ],
-        "summary": "Pdd Oauth Start",
-        "operationId": "pdd_oauth_start_oms_pdd_oauth_start_get",
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Pdd Oauth Start Oms Pdd Oauth Start Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/pdd/oauth/callback": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-pdd-auth"
-        ],
-        "summary": "Oms Pdd Oauth Callback",
-        "operationId": "oms_pdd_oauth_callback_oms_pdd_oauth_callback_get",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          },
-          {
-            "name": "state",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "State"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Oms Pdd Oauth Callback Oms Pdd Oauth Callback Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/pdd/connection": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-pdd-connection"
-        ],
-        "summary": "Get Store Pdd Connection",
-        "description": "读取店铺 × 拼多多当前 connection 视图。\n\n说明：\n- credential 是授权材料当前态\n- connection 是 OMS 当前裁决状态",
-        "operationId": "get_store_pdd_connection_oms_stores__store_id__pdd_connection_get",
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Store Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Get Store Pdd Connection Oms Stores  Store Id  Pdd Connection Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/pdd/test-pull": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-pdd-pull"
-        ],
-        "summary": "Test Store Pdd Pull",
-        "description": "拼多多 test-pull（第二版）。\n\n当前阶段：\n- 先做前置校验与 connection 状态推进\n- 前置校验通过后，真实拉取一页订单摘要\n- 不执行 OMS ingest",
-        "operationId": "test_store_pdd_pull_oms_stores__store_id__pdd_test_pull_post",
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Store Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "anyOf": [
-                  {
-                    "type": "object",
-                    "additionalProperties": true
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "title": "Payload"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Test Store Pdd Pull Oms Stores  Store Id  Pdd Test Pull Post"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/pdd/orders": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-pdd-orders"
-        ],
-        "summary": "List Pdd Orders Ledger",
-        "operationId": "list_pdd_orders_ledger_oms_pdd_orders_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 1000,
-              "minimum": 1,
-              "default": 200,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PddOrderLedgerListOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/pdd/orders/{pdd_order_id}": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-pdd-orders"
-        ],
-        "summary": "Get Pdd Order Ledger",
-        "operationId": "get_pdd_order_ledger_oms_pdd_orders__pdd_order_id__get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "pdd_order_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Pdd Order Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PddOrderLedgerDetailEnvelopeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/pdd/mock/stores/{store_id}/authorize": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-pdd-mock"
-        ],
-        "summary": "Authorize Pdd Store Mock",
-        "operationId": "authorize_pdd_store_mock_oms_pdd_mock_stores__store_id__authorize_post",
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Store Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PddMockAuthorizeRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Authorize Pdd Store Mock Oms Pdd Mock Stores  Store Id  Authorize Post"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/pdd/mock/stores/{store_id}/orders/ingest": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-pdd-mock"
-        ],
-        "summary": "Ingest Pdd Orders Mock",
-        "operationId": "ingest_pdd_orders_mock_oms_pdd_mock_stores__store_id__orders_ingest_post",
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Store Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PddMockIngestOrdersRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Ingest Pdd Orders Mock Oms Pdd Mock Stores  Store Id  Orders Ingest Post"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/pdd/mock/stores/{store_id}/orders": {
-      "delete": {
-        "tags": [
-          "OMS",
-          "oms-pdd-mock"
-        ],
-        "summary": "Clear Pdd Orders Mock",
-        "operationId": "clear_pdd_orders_mock_oms_pdd_mock_stores__store_id__orders_delete",
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Store Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PddMockClearOrdersRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Clear Pdd Orders Mock Oms Pdd Mock Stores  Store Id  Orders Delete"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/jd/app-config/current": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-jd-app-config"
-        ],
-        "summary": "Get Jd App Config Current",
-        "operationId": "get_jd_app_config_current_oms_jd_app_config_current_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "type": "object",
-                  "title": "Response Get Jd App Config Current Oms Jd App Config Current Get"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "OMS",
-          "oms-jd-app-config"
-        ],
-        "summary": "Put Jd App Config Current",
-        "description": "约定：\n- 若 client_secret 为空字符串，则沿用原 secret（已有记录时）\n- 若当前无记录，则创建时 client_secret 必填",
-        "operationId": "put_jd_app_config_current_oms_jd_app_config_current_put",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "additionalProperties": true,
-                "type": "object",
-                "title": "Payload"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "type": "object",
-                  "title": "Response Put Jd App Config Current Oms Jd App Config Current Put"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/jd/oauth/start": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-jd-auth"
-        ],
-        "summary": "Jd Oauth Start",
-        "operationId": "jd_oauth_start_oms_jd_oauth_start_get",
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Jd Oauth Start Oms Jd Oauth Start Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/jd/oauth/callback": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-jd-auth"
-        ],
-        "summary": "Jd Oauth Callback",
-        "operationId": "jd_oauth_callback_oms_jd_oauth_callback_get",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "title": "Code"
-            }
-          },
-          {
-            "name": "state",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "title": "State"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Jd Oauth Callback Oms Jd Oauth Callback Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/jd/connection": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-jd-connection"
-        ],
-        "summary": "Get Store Jd Connection",
-        "operationId": "get_store_jd_connection_oms_stores__store_id__jd_connection_get",
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Get Store Jd Connection Oms Stores  Store Id  Jd Connection Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/jd/test-pull": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-jd-pull"
-        ],
-        "summary": "Test Store Jd Pull",
-        "description": "京东 test-pull（第一版）。\n\n当前阶段：\n- 先做前置校验与 connection 状态推进\n- 前置校验通过后，真实拉取一页订单摘要\n- 逐单补详情\n- 不执行 OMS ingest\n- 不落事实表",
-        "operationId": "test_store_jd_pull_oms_stores__store_id__jd_test_pull_post",
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Store Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "anyOf": [
-                  {
-                    "type": "object",
-                    "additionalProperties": true
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "title": "Payload"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Test Store Jd Pull Oms Stores  Store Id  Jd Test Pull Post"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/jd/orders": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-jd-orders"
-        ],
-        "summary": "List Jd Orders Ledger",
-        "operationId": "list_jd_orders_ledger_oms_jd_orders_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 1000,
-              "minimum": 1,
-              "default": 200,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JdOrderLedgerListOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/jd/orders/{jd_order_id}": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-jd-orders"
-        ],
-        "summary": "Get Jd Order Ledger",
-        "operationId": "get_jd_order_ledger_oms_jd_orders__jd_order_id__get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "jd_order_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Jd Order Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JdOrderLedgerDetailEnvelopeOut"
                 }
               }
             }
@@ -9998,27 +9793,6 @@
         }
       }
     },
-    "/items/sku/next": {
-      "post": {
-        "tags": [
-          "items"
-        ],
-        "summary": "Next Sku",
-        "operationId": "next_sku_items_sku_next_post",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NextSkuOut"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/items": {
       "post": {
         "tags": [
@@ -10304,21 +10078,22 @@
         }
       }
     },
-    "/items/{id}/test:enable": {
-      "post": {
+    "/pms/sku-coding/brands": {
+      "get": {
         "tags": [
-          "items"
+          "pms-sku-coding"
         ],
-        "summary": "Enable Test Item",
-        "operationId": "enable_test_item_items__id__test_enable_post",
+        "summary": "List Brands",
+        "operationId": "list_brands_pms_sku_coding_brands_get",
         "parameters": [
           {
-            "name": "id",
-            "in": "path",
-            "required": true,
+            "name": "active_only",
+            "in": "query",
+            "required": false,
             "schema": {
-              "type": "integer",
-              "title": "Id"
+              "type": "boolean",
+              "default": false,
+              "title": "Active Only"
             }
           }
         ],
@@ -10328,7 +10103,46 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ItemOut"
+                  "$ref": "#/components/schemas/ListOut_SkuCodeBrandOut_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "Create Brand",
+        "operationId": "create_brand_pms_sku_coding_brands_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SkuCodeBrandCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuCodeBrandOut"
                 }
               }
             }
@@ -10346,21 +10160,73 @@
         }
       }
     },
-    "/items/{id}/test:disable": {
-      "post": {
+    "/pms/sku-coding/brands/{brand_id}": {
+      "patch": {
         "tags": [
-          "items"
+          "pms-sku-coding"
         ],
-        "summary": "Disable Test Item",
-        "operationId": "disable_test_item_items__id__test_disable_post",
+        "summary": "Update Brand",
+        "operationId": "update_brand_pms_sku_coding_brands__brand_id__patch",
         "parameters": [
           {
-            "name": "id",
+            "name": "brand_id",
             "in": "path",
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Id"
+              "title": "Brand Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SkuCodeBrandUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuCodeBrandOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/sku-coding/brands/{brand_id}/enable": {
+      "post": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "Enable Brand",
+        "operationId": "enable_brand_pms_sku_coding_brands__brand_id__enable_post",
+        "parameters": [
+          {
+            "name": "brand_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Brand Id"
             }
           }
         ],
@@ -10370,7 +10236,618 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ItemOut"
+                  "$ref": "#/components/schemas/SkuCodeBrandOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/sku-coding/brands/{brand_id}/disable": {
+      "post": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "Disable Brand",
+        "operationId": "disable_brand_pms_sku_coding_brands__brand_id__disable_post",
+        "parameters": [
+          {
+            "name": "brand_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Brand Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuCodeBrandOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/sku-coding/business-categories": {
+      "get": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "List Business Categories",
+        "operationId": "list_business_categories_pms_sku_coding_business_categories_get",
+        "parameters": [
+          {
+            "name": "product_kind",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Product Kind"
+            }
+          },
+          {
+            "name": "active_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Active Only"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListOut_SkuBusinessCategoryOut_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "Create Business Category",
+        "operationId": "create_business_category_pms_sku_coding_business_categories_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SkuBusinessCategoryCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuBusinessCategoryOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/sku-coding/business-categories/{category_id}": {
+      "patch": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "Update Business Category",
+        "operationId": "update_business_category_pms_sku_coding_business_categories__category_id__patch",
+        "parameters": [
+          {
+            "name": "category_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Category Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SkuBusinessCategoryUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuBusinessCategoryOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/sku-coding/business-categories/{category_id}/enable": {
+      "post": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "Enable Business Category",
+        "operationId": "enable_business_category_pms_sku_coding_business_categories__category_id__enable_post",
+        "parameters": [
+          {
+            "name": "category_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Category Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuBusinessCategoryOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/sku-coding/business-categories/{category_id}/disable": {
+      "post": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "Disable Business Category",
+        "operationId": "disable_business_category_pms_sku_coding_business_categories__category_id__disable_post",
+        "parameters": [
+          {
+            "name": "category_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Category Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuBusinessCategoryOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/sku-coding/term-groups": {
+      "get": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "List Term Groups",
+        "operationId": "list_term_groups_pms_sku_coding_term_groups_get",
+        "parameters": [
+          {
+            "name": "product_kind",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Product Kind"
+            }
+          },
+          {
+            "name": "active_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Active Only"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListOut_SkuCodeTermGroupOut_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/sku-coding/terms": {
+      "get": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "List Terms",
+        "operationId": "list_terms_pms_sku_coding_terms_get",
+        "parameters": [
+          {
+            "name": "group_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Group Id"
+            }
+          },
+          {
+            "name": "active_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Active Only"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListOut_SkuCodeTermOut_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "Create Term",
+        "operationId": "create_term_pms_sku_coding_terms_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SkuCodeTermCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuCodeTermOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/sku-coding/terms/{term_id}": {
+      "patch": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "Update Term",
+        "operationId": "update_term_pms_sku_coding_terms__term_id__patch",
+        "parameters": [
+          {
+            "name": "term_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Term Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SkuCodeTermUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuCodeTermOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/sku-coding/terms/{term_id}/enable": {
+      "post": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "Enable Term",
+        "operationId": "enable_term_pms_sku_coding_terms__term_id__enable_post",
+        "parameters": [
+          {
+            "name": "term_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Term Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuCodeTermOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/sku-coding/terms/{term_id}/disable": {
+      "post": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "Disable Term",
+        "operationId": "disable_term_pms_sku_coding_terms__term_id__disable_post",
+        "parameters": [
+          {
+            "name": "term_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Term Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuCodeTermOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/sku-coding/generate": {
+      "post": {
+        "tags": [
+          "pms-sku-coding"
+        ],
+        "summary": "Generate Sku",
+        "operationId": "generate_sku_pms_sku_coding_generate_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SkuGenerateIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuGenerateOut"
                 }
               }
             }
@@ -11411,14 +11888,14 @@
         }
       }
     },
-    "/shipping-providers": {
+    "/shipping-assist/pricing/providers": {
       "get": {
         "tags": [
-          "shipping-providers"
+          "shipping-assist-providers"
         ],
         "summary": "List Shipping Providers",
         "description": "物流/快递网点列表（读聚合 contacts）。\n\n权限：config.store.read",
-        "operationId": "list_shipping_providers_shipping_providers_get",
+        "operationId": "list_shipping_providers_shipping_assist_pricing_providers_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -11487,10 +11964,10 @@
       },
       "post": {
         "tags": [
-          "shipping-providers"
+          "shipping-assist-providers"
         ],
         "summary": "Create Shipping Provider",
-        "operationId": "create_shipping_provider_shipping_providers_post",
+        "operationId": "create_shipping_provider_shipping_assist_pricing_providers_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -11530,14 +12007,14 @@
         }
       }
     },
-    "/shipping-providers/{provider_id}": {
+    "/shipping-assist/pricing/providers/{provider_id}": {
       "get": {
         "tags": [
-          "shipping-providers"
+          "shipping-assist-providers"
         ],
         "summary": "Get Shipping Provider",
         "description": "物流/快递网点详情（读聚合 contacts）。\n\n权限：config.store.read",
-        "operationId": "get_shipping_provider_shipping_providers__provider_id__get",
+        "operationId": "get_shipping_provider_shipping_assist_pricing_providers__provider_id__get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -11580,10 +12057,10 @@
       },
       "patch": {
         "tags": [
-          "shipping-providers"
+          "shipping-assist-providers"
         ],
         "summary": "Update Shipping Provider",
-        "operationId": "update_shipping_provider_shipping_providers__provider_id__patch",
+        "operationId": "update_shipping_provider_shipping_assist_pricing_providers__provider_id__patch",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -11635,13 +12112,13 @@
         }
       }
     },
-    "/shipping-providers/{provider_id}/contacts": {
+    "/shipping-assist/pricing/providers/{provider_id}/contacts": {
       "post": {
         "tags": [
-          "shipping-providers"
+          "shipping-assist-providers"
         ],
         "summary": "Shipping Provider Create Contact",
-        "operationId": "shipping_provider_create_contact_shipping_providers__provider_id__contacts_post",
+        "operationId": "shipping_provider_create_contact_shipping_assist_pricing_providers__provider_id__contacts_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -11693,13 +12170,13 @@
         }
       }
     },
-    "/shipping-provider-contacts/{contact_id}": {
+    "/shipping-assist/pricing/provider-contacts/{contact_id}": {
       "patch": {
         "tags": [
-          "shipping-providers"
+          "shipping-assist-providers"
         ],
         "summary": "Shipping Provider Update Contact",
-        "operationId": "shipping_provider_update_contact_shipping_provider_contacts__contact_id__patch",
+        "operationId": "shipping_provider_update_contact_shipping_assist_pricing_provider_contacts__contact_id__patch",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -11752,10 +12229,10 @@
       },
       "delete": {
         "tags": [
-          "shipping-providers"
+          "shipping-assist-providers"
         ],
         "summary": "Shipping Provider Delete Contact",
-        "operationId": "shipping_provider_delete_contact_shipping_provider_contacts__contact_id__delete",
+        "operationId": "shipping_provider_delete_contact_shipping_assist_pricing_provider_contacts__contact_id__delete",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -11920,13 +12397,13 @@
         }
       }
     },
-    "/shipping-quote/calc": {
+    "/shipping-assist/shipping/quote/calc": {
       "post": {
         "tags": [
-          "tms-quote"
+          "shipping-assist-quote"
         ],
         "summary": "Calc Shipping Quote",
-        "operationId": "calc_shipping_quote_shipping_quote_calc_post",
+        "operationId": "calc_shipping_quote_shipping_assist_shipping_quote_calc_post",
         "requestBody": {
           "content": {
             "application/json": {
@@ -11966,13 +12443,13 @@
         ]
       }
     },
-    "/shipping-quote/recommend": {
+    "/shipping-assist/shipping/quote/recommend": {
       "post": {
         "tags": [
-          "tms-quote"
+          "shipping-assist-quote"
         ],
         "summary": "Recommend Shipping Quote",
-        "operationId": "recommend_shipping_quote_shipping_quote_recommend_post",
+        "operationId": "recommend_shipping_quote_shipping_assist_shipping_quote_recommend_post",
         "requestBody": {
           "content": {
             "application/json": {
@@ -12012,13 +12489,86 @@
         ]
       }
     },
-    "/tms/pricing/list": {
+    "/metrics/shipping-assist/shipping/quote/failures": {
       "get": {
         "tags": [
-          "tms-pricing"
+          "shipping-assist-quote"
+        ],
+        "summary": "Get Shipping Quote Failures",
+        "operationId": "get_shipping_quote_failures_metrics_shipping_assist_shipping_quote_failures_get",
+        "parameters": [
+          {
+            "name": "day",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "description": "UTC date, format YYYY-MM-DD",
+              "title": "Day"
+            },
+            "description": "UTC date, format YYYY-MM-DD"
+          },
+          {
+            "name": "platform",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Platform"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "default": 200,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShippingQuoteFailuresMetricsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/shipping-assist/pricing/list": {
+      "get": {
+        "tags": [
+          "shipping-assist-pricing"
         ],
         "summary": "Pricing List View",
-        "operationId": "pricing_list_view_tms_pricing_list_get",
+        "operationId": "pricing_list_view_shipping_assist_pricing_list_get",
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -12033,13 +12583,13 @@
         }
       }
     },
-    "/tms/pricing/warehouses/{warehouse_id}/bindings": {
+    "/shipping-assist/pricing/warehouses/{warehouse_id}/bindings": {
       "get": {
         "tags": [
-          "tms-pricing"
+          "shipping-assist-pricing"
         ],
         "summary": "Pricing List Warehouse Bindings",
-        "operationId": "pricing_list_warehouse_bindings_tms_pricing_warehouses__warehouse_id__bindings_get",
+        "operationId": "pricing_list_warehouse_bindings_shipping_assist_pricing_warehouses__warehouse_id__bindings_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12082,10 +12632,10 @@
       },
       "post": {
         "tags": [
-          "tms-pricing"
+          "shipping-assist-pricing"
         ],
         "summary": "Pricing Bind Provider To Warehouse",
-        "operationId": "pricing_bind_provider_to_warehouse_tms_pricing_warehouses__warehouse_id__bindings_post",
+        "operationId": "pricing_bind_provider_to_warehouse_shipping_assist_pricing_warehouses__warehouse_id__bindings_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12138,10 +12688,10 @@
       },
       "put": {
         "tags": [
-          "tms-pricing"
+          "shipping-assist-pricing"
         ],
         "summary": "Pricing Bulk Upsert Warehouse Bindings",
-        "operationId": "pricing_bulk_upsert_warehouse_bindings_tms_pricing_warehouses__warehouse_id__bindings_put",
+        "operationId": "pricing_bulk_upsert_warehouse_bindings_shipping_assist_pricing_warehouses__warehouse_id__bindings_put",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12193,13 +12743,13 @@
         }
       }
     },
-    "/tms/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/template-candidates": {
+    "/shipping-assist/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/template-candidates": {
       "get": {
         "tags": [
-          "tms-pricing"
+          "shipping-assist-pricing"
         ],
         "summary": "Pricing Binding Template Candidates",
-        "operationId": "pricing_binding_template_candidates_tms_pricing_warehouses__warehouse_id__bindings__shipping_provider_id__template_candidates_get",
+        "operationId": "pricing_binding_template_candidates_shipping_assist_pricing_warehouses__warehouse_id__bindings__shipping_provider_id__template_candidates_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12251,13 +12801,13 @@
         }
       }
     },
-    "/tms/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}": {
+    "/shipping-assist/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}": {
       "patch": {
         "tags": [
-          "tms-pricing"
+          "shipping-assist-pricing"
         ],
         "summary": "Pricing Update Warehouse Binding",
-        "operationId": "pricing_update_warehouse_binding_tms_pricing_warehouses__warehouse_id__bindings__shipping_provider_id__patch",
+        "operationId": "pricing_update_warehouse_binding_shipping_assist_pricing_warehouses__warehouse_id__bindings__shipping_provider_id__patch",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12320,10 +12870,10 @@
       },
       "delete": {
         "tags": [
-          "tms-pricing"
+          "shipping-assist-pricing"
         ],
         "summary": "Pricing Unbind Provider From Warehouse",
-        "operationId": "pricing_unbind_provider_from_warehouse_tms_pricing_warehouses__warehouse_id__bindings__shipping_provider_id__delete",
+        "operationId": "pricing_unbind_provider_from_warehouse_shipping_assist_pricing_warehouses__warehouse_id__bindings__shipping_provider_id__delete",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12375,13 +12925,13 @@
         }
       }
     },
-    "/tms/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/activate": {
+    "/shipping-assist/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/activate": {
       "post": {
         "tags": [
-          "tms-pricing"
+          "shipping-assist-pricing"
         ],
         "summary": "Pricing Activate Warehouse Binding",
-        "operationId": "pricing_activate_warehouse_binding_tms_pricing_warehouses__warehouse_id__bindings__shipping_provider_id__activate_post",
+        "operationId": "pricing_activate_warehouse_binding_shipping_assist_pricing_warehouses__warehouse_id__bindings__shipping_provider_id__activate_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12443,13 +12993,13 @@
         }
       }
     },
-    "/tms/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/deactivate": {
+    "/shipping-assist/pricing/warehouses/{warehouse_id}/bindings/{shipping_provider_id}/deactivate": {
       "post": {
         "tags": [
-          "tms-pricing"
+          "shipping-assist-pricing"
         ],
         "summary": "Pricing Deactivate Warehouse Binding",
-        "operationId": "pricing_deactivate_warehouse_binding_tms_pricing_warehouses__warehouse_id__bindings__shipping_provider_id__deactivate_post",
+        "operationId": "pricing_deactivate_warehouse_binding_shipping_assist_pricing_warehouses__warehouse_id__bindings__shipping_provider_id__deactivate_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12501,14 +13051,14 @@
         }
       }
     },
-    "/tms/pricing/warehouses/active-carriers/summary": {
+    "/shipping-assist/pricing/warehouses/active-carriers/summary": {
       "get": {
         "tags": [
-          "tms-pricing"
+          "shipping-assist-pricing"
         ],
         "summary": "Pricing List Warehouses Active Carriers Summary",
         "description": "bindings 辅助汇总接口（消除 N+1）\n\n刚性契约口径：\n- 只返回当前真正正在服务的快递公司：\n  1) wsp.active = true\n  2) sp.active = true\n  3) wsp.active_template_id IS NOT NULL\n  4) effective_from 为空或已到生效时间\n- 不做推荐策略，不做 fallback\n- 排序仅用于展示稳定：\n  warehouse_id ASC, wsp.priority ASC, sp.priority ASC, sp.id ASC",
-        "operationId": "pricing_list_warehouses_active_carriers_summary_tms_pricing_warehouses_active_carriers_summary_get",
+        "operationId": "pricing_list_warehouses_active_carriers_summary_shipping_assist_pricing_warehouses_active_carriers_summary_get",
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -12528,14 +13078,14 @@
         ]
       }
     },
-    "/tms/pricing/templates": {
+    "/shipping-assist/pricing/templates": {
       "get": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Templates List",
-        "operationId": "pricing_templates_list_tms_pricing_templates_get",
+        "operationId": "pricing_templates_list_shipping_assist_pricing_templates_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12611,11 +13161,11 @@
       },
       "post": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Create",
-        "operationId": "pricing_template_create_tms_pricing_templates_post",
+        "operationId": "pricing_template_create_shipping_assist_pricing_templates_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12655,14 +13205,14 @@
         }
       }
     },
-    "/tms/pricing/shipping-providers/{provider_id}/templates": {
+    "/shipping-assist/pricing/providers/{provider_id}/templates": {
       "get": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Templates Provider List",
-        "operationId": "pricing_templates_provider_list_tms_pricing_shipping_providers__provider_id__templates_get",
+        "operationId": "pricing_templates_provider_list_shipping_assist_pricing_providers__provider_id__templates_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12730,14 +13280,14 @@
         }
       }
     },
-    "/tms/pricing/templates/{template_id}": {
+    "/shipping-assist/pricing/templates/{template_id}": {
       "get": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Detail",
-        "operationId": "pricing_template_detail_tms_pricing_templates__template_id__get",
+        "operationId": "pricing_template_detail_shipping_assist_pricing_templates__template_id__get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12780,11 +13330,11 @@
       },
       "patch": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Update",
-        "operationId": "pricing_template_update_tms_pricing_templates__template_id__patch",
+        "operationId": "pricing_template_update_shipping_assist_pricing_templates__template_id__patch",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12836,14 +13386,14 @@
         }
       }
     },
-    "/tms/pricing/templates/{template_id}/clone": {
+    "/shipping-assist/pricing/templates/{template_id}/clone": {
       "post": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Clone",
-        "operationId": "pricing_template_clone_tms_pricing_templates__template_id__clone_post",
+        "operationId": "pricing_template_clone_shipping_assist_pricing_templates__template_id__clone_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12895,14 +13445,14 @@
         }
       }
     },
-    "/tms/pricing/templates/{template_id}/submit-validation": {
+    "/shipping-assist/pricing/templates/{template_id}/submit-validation": {
       "post": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Submit Validation",
-        "operationId": "pricing_template_submit_validation_tms_pricing_templates__template_id__submit_validation_post",
+        "operationId": "pricing_template_submit_validation_shipping_assist_pricing_templates__template_id__submit_validation_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -12954,14 +13504,14 @@
         }
       }
     },
-    "/tms/pricing/templates/{template_id}/ranges": {
+    "/shipping-assist/pricing/templates/{template_id}/ranges": {
       "get": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Ranges Get",
-        "operationId": "pricing_template_ranges_get_tms_pricing_templates__template_id__ranges_get",
+        "operationId": "pricing_template_ranges_get_shipping_assist_pricing_templates__template_id__ranges_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13004,11 +13554,11 @@
       },
       "put": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Ranges Put",
-        "operationId": "pricing_template_ranges_put_tms_pricing_templates__template_id__ranges_put",
+        "operationId": "pricing_template_ranges_put_shipping_assist_pricing_templates__template_id__ranges_put",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13060,14 +13610,14 @@
         }
       }
     },
-    "/tms/pricing/templates/{template_id}/groups": {
+    "/shipping-assist/pricing/templates/{template_id}/groups": {
       "get": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Groups Get",
-        "operationId": "pricing_template_groups_get_tms_pricing_templates__template_id__groups_get",
+        "operationId": "pricing_template_groups_get_shipping_assist_pricing_templates__template_id__groups_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13110,11 +13660,11 @@
       },
       "post": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Groups Create",
-        "operationId": "pricing_template_groups_create_tms_pricing_templates__template_id__groups_post",
+        "operationId": "pricing_template_groups_create_shipping_assist_pricing_templates__template_id__groups_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13166,14 +13716,14 @@
         }
       }
     },
-    "/tms/pricing/templates/{template_id}/groups/{group_id}": {
+    "/shipping-assist/pricing/templates/{template_id}/groups/{group_id}": {
       "put": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Groups Update",
-        "operationId": "pricing_template_groups_update_tms_pricing_templates__template_id__groups__group_id__put",
+        "operationId": "pricing_template_groups_update_shipping_assist_pricing_templates__template_id__groups__group_id__put",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13236,11 +13786,11 @@
       },
       "delete": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Groups Delete",
-        "operationId": "pricing_template_groups_delete_tms_pricing_templates__template_id__groups__group_id__delete",
+        "operationId": "pricing_template_groups_delete_shipping_assist_pricing_templates__template_id__groups__group_id__delete",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13292,14 +13842,14 @@
         }
       }
     },
-    "/tms/pricing/templates/{template_id}/matrix-cells": {
+    "/shipping-assist/pricing/templates/{template_id}/matrix-cells": {
       "get": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Matrix Get",
-        "operationId": "pricing_template_matrix_get_tms_pricing_templates__template_id__matrix_cells_get",
+        "operationId": "pricing_template_matrix_get_shipping_assist_pricing_templates__template_id__matrix_cells_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13342,11 +13892,11 @@
       },
       "put": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Matrix Put",
-        "operationId": "pricing_template_matrix_put_tms_pricing_templates__template_id__matrix_cells_put",
+        "operationId": "pricing_template_matrix_put_shipping_assist_pricing_templates__template_id__matrix_cells_put",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13398,14 +13948,14 @@
         }
       }
     },
-    "/tms/pricing/templates/{template_id}/surcharge-configs/batch-province": {
+    "/shipping-assist/pricing/templates/{template_id}/surcharge-configs/batch-province": {
       "post": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Surcharge Batch Province",
-        "operationId": "pricing_template_surcharge_batch_province_tms_pricing_templates__template_id__surcharge_configs_batch_province_post",
+        "operationId": "pricing_template_surcharge_batch_province_shipping_assist_pricing_templates__template_id__surcharge_configs_batch_province_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13457,14 +14007,14 @@
         }
       }
     },
-    "/tms/pricing/templates/{template_id}/surcharge-configs/city-container": {
+    "/shipping-assist/pricing/templates/{template_id}/surcharge-configs/city-container": {
       "post": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Surcharge City Container Create",
-        "operationId": "pricing_template_surcharge_city_container_create_tms_pricing_templates__template_id__surcharge_configs_city_container_post",
+        "operationId": "pricing_template_surcharge_city_container_create_shipping_assist_pricing_templates__template_id__surcharge_configs_city_container_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13516,14 +14066,14 @@
         }
       }
     },
-    "/tms/pricing/templates/{template_id}/surcharge-configs": {
+    "/shipping-assist/pricing/templates/{template_id}/surcharge-configs": {
       "post": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Surcharge Create",
-        "operationId": "pricing_template_surcharge_create_tms_pricing_templates__template_id__surcharge_configs_post",
+        "operationId": "pricing_template_surcharge_create_shipping_assist_pricing_templates__template_id__surcharge_configs_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13575,14 +14125,14 @@
         }
       }
     },
-    "/tms/pricing/surcharge-configs/{config_id}": {
+    "/shipping-assist/pricing/surcharge-configs/{config_id}": {
       "patch": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Surcharge Update",
-        "operationId": "pricing_template_surcharge_update_tms_pricing_surcharge_configs__config_id__patch",
+        "operationId": "pricing_template_surcharge_update_shipping_assist_pricing_surcharge_configs__config_id__patch",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13635,11 +14185,11 @@
       },
       "delete": {
         "tags": [
-          "tms-pricing",
-          "tms-pricing-templates"
+          "shipping-assist-pricing",
+          "shipping-assist-pricing-templates"
         ],
         "summary": "Pricing Template Surcharge Delete",
-        "operationId": "pricing_template_surcharge_delete_tms_pricing_surcharge_configs__config_id__delete",
+        "operationId": "pricing_template_surcharge_delete_shipping_assist_pricing_surcharge_configs__config_id__delete",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13679,13 +14229,13 @@
         }
       }
     },
-    "/shipping-reports/by-carrier": {
+    "/shipping-assist/reports/by-carrier": {
       "get": {
         "tags": [
-          "shipping-reports"
+          "shipping-assist-reports"
         ],
         "summary": "Shipping Reports By Carrier",
-        "operationId": "shipping_reports_by_carrier_shipping_reports_by_carrier_get",
+        "operationId": "shipping_reports_by_carrier_shipping_assist_reports_by_carrier_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13741,7 +14291,7 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -13753,11 +14303,11 @@
                   "type": "null"
                 }
               ],
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
-            "name": "carrier_code",
+            "name": "shipping_provider_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -13769,7 +14319,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Carrier Code"
+              "title": "Shipping Provider Code"
             }
           },
           {
@@ -13845,13 +14395,13 @@
         }
       }
     },
-    "/shipping-reports/by-province": {
+    "/shipping-assist/reports/by-province": {
       "get": {
         "tags": [
-          "shipping-reports"
+          "shipping-assist-reports"
         ],
         "summary": "Shipping Reports By Province",
-        "operationId": "shipping_reports_by_province_shipping_reports_by_province_get",
+        "operationId": "shipping_reports_by_province_shipping_assist_reports_by_province_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -13907,7 +14457,7 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -13919,11 +14469,11 @@
                   "type": "null"
                 }
               ],
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
-            "name": "carrier_code",
+            "name": "shipping_provider_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -13935,7 +14485,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Carrier Code"
+              "title": "Shipping Provider Code"
             }
           },
           {
@@ -14011,13 +14561,13 @@
         }
       }
     },
-    "/shipping-reports/by-shop": {
+    "/shipping-assist/reports/by-store": {
       "get": {
         "tags": [
-          "shipping-reports"
+          "shipping-assist-reports"
         ],
-        "summary": "Shipping Reports By Shop",
-        "operationId": "shipping_reports_by_shop_shipping_reports_by_shop_get",
+        "summary": "Shipping Reports By Store",
+        "operationId": "shipping_reports_by_store_shipping_assist_reports_by_store_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -14073,7 +14623,7 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -14085,11 +14635,11 @@
                   "type": "null"
                 }
               ],
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
-            "name": "carrier_code",
+            "name": "shipping_provider_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -14101,7 +14651,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Carrier Code"
+              "title": "Shipping Provider Code"
             }
           },
           {
@@ -14159,7 +14709,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ShippingByShopResponse"
+                  "$ref": "#/components/schemas/ShippingByStoreResponse"
                 }
               }
             }
@@ -14177,13 +14727,13 @@
         }
       }
     },
-    "/shipping-reports/by-warehouse": {
+    "/shipping-assist/reports/by-warehouse": {
       "get": {
         "tags": [
-          "shipping-reports"
+          "shipping-assist-reports"
         ],
         "summary": "Shipping Reports By Warehouse",
-        "operationId": "shipping_reports_by_warehouse_shipping_reports_by_warehouse_get",
+        "operationId": "shipping_reports_by_warehouse_shipping_assist_reports_by_warehouse_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -14239,7 +14789,7 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -14251,11 +14801,11 @@
                   "type": "null"
                 }
               ],
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
-            "name": "carrier_code",
+            "name": "shipping_provider_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -14267,7 +14817,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Carrier Code"
+              "title": "Shipping Provider Code"
             }
           },
           {
@@ -14343,13 +14893,13 @@
         }
       }
     },
-    "/shipping-reports/daily": {
+    "/shipping-assist/reports/daily": {
       "get": {
         "tags": [
-          "shipping-reports"
+          "shipping-assist-reports"
         ],
         "summary": "Shipping Reports Daily",
-        "operationId": "shipping_reports_daily_shipping_reports_daily_get",
+        "operationId": "shipping_reports_daily_shipping_assist_reports_daily_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -14405,7 +14955,7 @@
             }
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -14417,11 +14967,11 @@
                   "type": "null"
                 }
               ],
-              "title": "Shop Id"
+              "title": "Store Code"
             }
           },
           {
-            "name": "carrier_code",
+            "name": "shipping_provider_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -14433,7 +14983,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Carrier Code"
+              "title": "Shipping Provider Code"
             }
           },
           {
@@ -14509,13 +15059,13 @@
         }
       }
     },
-    "/shipping-reports/options": {
+    "/shipping-assist/reports/options": {
       "get": {
         "tags": [
-          "shipping-reports"
+          "shipping-assist-reports"
         ],
         "summary": "Shipping Reports Options",
-        "operationId": "shipping_reports_options_shipping_reports_options_get",
+        "operationId": "shipping_reports_options_shipping_assist_reports_options_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -14595,13 +15145,13 @@
         }
       }
     },
-    "/tms/records": {
+    "/shipping-assist/shipping/records": {
       "get": {
         "tags": [
-          "tms-records"
+          "shipping-assist-records"
         ],
         "summary": "物流台帐列表",
-        "operationId": "get_shipping_ledger_tms_records_get",
+        "operationId": "get_shipping_ledger_shipping_assist_shipping_records_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -14673,7 +15223,7 @@
             }
           },
           {
-            "name": "carrier_code",
+            "name": "shipping_provider_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -14685,7 +15235,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Carrier Code"
+              "title": "Shipping Provider Code"
             }
           },
           {
@@ -14802,13 +15352,13 @@
         }
       }
     },
-    "/tms/records/export": {
+    "/shipping-assist/shipping/records/export": {
       "get": {
         "tags": [
-          "tms-records"
+          "shipping-assist-records"
         ],
         "summary": "导出物流台帐",
-        "operationId": "export_shipping_ledger_tms_records_export_get",
+        "operationId": "export_shipping_ledger_shipping_assist_shipping_records_export_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -14880,7 +15430,7 @@
             }
           },
           {
-            "name": "carrier_code",
+            "name": "shipping_provider_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -14892,7 +15442,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Carrier Code"
+              "title": "Shipping Provider Code"
             }
           },
           {
@@ -14984,13 +15534,13 @@
         }
       }
     },
-    "/tms/records/cost-analysis": {
+    "/shipping-assist/shipping/records/cost-analysis": {
       "get": {
         "tags": [
-          "tms-records"
+          "shipping-assist-records"
         ],
         "summary": "物流台帐预估成本分析",
-        "operationId": "get_records_cost_analysis_route_tms_records_cost_analysis_get",
+        "operationId": "get_records_cost_analysis_route_shipping_assist_shipping_records_cost_analysis_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -14998,7 +15548,7 @@
         ],
         "parameters": [
           {
-            "name": "carrier_code",
+            "name": "shipping_provider_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -15010,7 +15560,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Carrier Code"
+              "title": "Shipping Provider Code"
             }
           },
           {
@@ -15070,18 +15620,18 @@
         }
       }
     },
-    "/tms/billing/import": {
+    "/shipping-assist/billing/import": {
       "post": {
         "tags": [
-          "tms-billing"
+          "shipping-assist-billing"
         ],
         "summary": "Import Shipping Bill",
-        "operationId": "import_shipping_bill_tms_billing_import_post",
+        "operationId": "import_shipping_bill_shipping_assist_billing_import_post",
         "requestBody": {
           "content": {
             "multipart/form-data": {
               "schema": {
-                "$ref": "#/components/schemas/Body_import_shipping_bill_tms_billing_import_post"
+                "$ref": "#/components/schemas/Body_import_shipping_bill_shipping_assist_billing_import_post"
               }
             }
           },
@@ -15093,7 +15643,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CarrierBillImportResult"
+                  "$ref": "#/components/schemas/ShippingProviderBillImportResult"
                 }
               }
             }
@@ -15116,13 +15666,13 @@
         ]
       }
     },
-    "/tms/billing/items": {
+    "/shipping-assist/billing/items": {
       "get": {
         "tags": [
-          "tms-billing"
+          "shipping-assist-billing"
         ],
         "summary": "Get Shipping Bill Items",
-        "operationId": "get_shipping_bill_items_tms_billing_items_get",
+        "operationId": "get_shipping_bill_items_shipping_assist_billing_items_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -15130,7 +15680,7 @@
         ],
         "parameters": [
           {
-            "name": "carrier_code",
+            "name": "shipping_provider_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -15142,7 +15692,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Carrier Code"
+              "title": "Shipping Provider Code"
             }
           },
           {
@@ -15191,7 +15741,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CarrierBillItemsResponse"
+                  "$ref": "#/components/schemas/ShippingProviderBillItemsResponse"
                 }
               }
             }
@@ -15209,18 +15759,18 @@
         }
       }
     },
-    "/tms/billing/reconcile": {
+    "/shipping-assist/billing/reconcile": {
       "post": {
         "tags": [
-          "tms-billing"
+          "shipping-assist-billing"
         ],
         "summary": "Reconcile Shipping Bill",
-        "operationId": "reconcile_shipping_bill_tms_billing_reconcile_post",
+        "operationId": "reconcile_shipping_bill_shipping_assist_billing_reconcile_post",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ReconcileCarrierBillIn"
+                "$ref": "#/components/schemas/ReconcileShippingProviderBillIn"
               }
             }
           },
@@ -15232,7 +15782,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ReconcileCarrierBillResult"
+                  "$ref": "#/components/schemas/ReconcileShippingProviderBillResult"
                 }
               }
             }
@@ -15255,13 +15805,13 @@
         ]
       }
     },
-    "/tms/billing/reconciliations": {
+    "/shipping-assist/billing/reconciliations": {
       "get": {
         "tags": [
-          "tms-billing"
+          "shipping-assist-billing"
         ],
         "summary": "Get Shipping Bill Reconciliations",
-        "operationId": "get_shipping_bill_reconciliations_tms_billing_reconciliations_get",
+        "operationId": "get_shipping_bill_reconciliations_shipping_assist_billing_reconciliations_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -15269,7 +15819,7 @@
         ],
         "parameters": [
           {
-            "name": "carrier_code",
+            "name": "shipping_provider_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -15281,7 +15831,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Carrier Code"
+              "title": "Shipping Provider Code"
             }
           },
           {
@@ -15364,13 +15914,13 @@
         }
       }
     },
-    "/tms/billing/reconciliation-histories": {
+    "/shipping-assist/billing/reconciliation-histories": {
       "get": {
         "tags": [
-          "tms-billing"
+          "shipping-assist-billing"
         ],
         "summary": "Get Shipping Bill Reconciliation Histories",
-        "operationId": "get_shipping_bill_reconciliation_histories_tms_billing_reconciliation_histories_get",
+        "operationId": "get_shipping_bill_reconciliation_histories_shipping_assist_billing_reconciliation_histories_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -15378,7 +15928,7 @@
         ],
         "parameters": [
           {
-            "name": "carrier_code",
+            "name": "shipping_provider_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -15390,7 +15940,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Carrier Code"
+              "title": "Shipping Provider Code"
             }
           },
           {
@@ -15473,13 +16023,13 @@
         }
       }
     },
-    "/tms/billing/reconciliations/{reconciliation_id}/approve": {
+    "/shipping-assist/billing/reconciliations/{reconciliation_id}/approve": {
       "post": {
         "tags": [
-          "tms-billing"
+          "shipping-assist-billing"
         ],
         "summary": "Approve Reconciliation",
-        "operationId": "approve_reconciliation_tms_billing_reconciliations__reconciliation_id__approve_post",
+        "operationId": "approve_reconciliation_shipping_assist_billing_reconciliations__reconciliation_id__approve_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -15530,13 +16080,13 @@
         }
       }
     },
-    "/tms/billing/cost-analysis": {
+    "/shipping-assist/billing/cost-analysis": {
       "get": {
         "tags": [
-          "tms-billing"
+          "shipping-assist-billing"
         ],
         "summary": "快递账单成本分析",
-        "operationId": "get_billing_cost_analysis_route_tms_billing_cost_analysis_get",
+        "operationId": "get_billing_cost_analysis_route_shipping_assist_billing_cost_analysis_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -15544,7 +16094,7 @@
         ],
         "parameters": [
           {
-            "name": "carrier_code",
+            "name": "shipping_provider_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -15556,7 +16106,7 @@
                   "type": "null"
                 }
               ],
-              "title": "Carrier Code"
+              "title": "Shipping Provider Code"
             }
           },
           {
@@ -16357,7 +16907,7 @@
             "description": "可选平台过滤（如 PDD）"
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -16369,10 +16919,10 @@
                   "type": "null"
                 }
               ],
-              "description": "可选店铺过滤（字符串，与 orders.shop_id 一致）",
-              "title": "Shop Id"
+              "description": "可选店铺过滤（字符串，与 orders.store_code 一致）",
+              "title": "Store Code"
             },
-            "description": "可选店铺过滤（字符串，与 orders.shop_id 一致）"
+            "description": "可选店铺过滤（字符串，与 orders.store_code 一致）"
           }
         ],
         "responses": {
@@ -16427,7 +16977,7 @@
             "description": "可选平台过滤（如 PDD）"
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -16440,7 +16990,7 @@
                 }
               ],
               "description": "可选店铺过滤",
-              "title": "Shop Id"
+              "title": "Store Code"
             },
             "description": "可选店铺过滤"
           }
@@ -16475,7 +17025,7 @@
           "orders-sla"
         ],
         "summary": "Get Orders Sla Stats",
-        "description": "订单发货 SLA 统计：\n\n- 以 orders.created_at 为下单时间；\n- 以 order_fulfillment.shipped_at 为发货完成时间；\n- 通过 order_fulfillment.order_id 关联 orders.id。\n\n只统计在给定时间窗口内发货的订单（按 order_fulfillment.shipped_at 过滤）。\n\n✅ PROD-only（简化口径）：\n- 排除测试店铺（platform_test_shops.code='DEFAULT'，以 store_id 为事实锚点）",
+        "description": "订单发货 SLA 统计：\n\n- 以 orders.created_at 为下单时间；\n- 以 order_fulfillment.shipped_at 为发货完成时间；\n- 通过 order_fulfillment.order_id 关联 orders.id。\n\n只统计在给定时间窗口内发货的订单（按 order_fulfillment.shipped_at 过滤）。\n\n✅ PROD-only（简化口径）：\n- 排除测试店铺（platform_test_stores.code='DEFAULT'，以 store_id 为事实锚点）",
         "operationId": "get_orders_sla_stats_orders_stats_sla_get",
         "parameters": [
           {
@@ -16535,7 +17085,7 @@
             "description": "可选平台过滤（如 PDD），大写/小写均可"
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -16547,10 +17097,10 @@
                   "type": "null"
                 }
               ],
-              "description": "可选店铺过滤（字符串，与 orders.shop_id 一致）",
-              "title": "Shop Id"
+              "description": "可选店铺过滤（字符串，与 orders.store_code 一致）",
+              "title": "Store Code"
             },
-            "description": "可选店铺过滤（字符串，与 orders.shop_id 一致）"
+            "description": "可选店铺过滤（字符串，与 orders.store_code 一致）"
           },
           {
             "name": "sla_hours",
@@ -17249,14 +17799,13 @@
         }
       }
     },
-    "/finance/overview/daily": {
+    "/finance/overview": {
       "get": {
         "tags": [
           "finance"
         ],
-        "summary": "按日汇总的收入 / 成本 / 毛利趋势（运营视角粗粒度）",
-        "description": "财务总览（按日）——运营视角粗估版本（PROD-only）：\n\n✅ 统计口径（封板）：\n- 收入：orders.pay_amount（缺失则退回 order_amount），按 orders.created_at::date 汇总\n- 商品成本：以 purchase_order_lines 的平均单价（总金额 / 总最小单位数）粗算\n         行金额口径：qty_ordered_base * supply_price - discount_amount（line_amount 不落库）\n- 发货成本：shipping_records.cost_estimated，按 shipping_records.created_at::date 汇总",
-        "operationId": "finance_overview_daily_finance_overview_daily_get",
+        "summary": "财务分析综合分析",
+        "operationId": "get_overview_finance_overview_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -17276,10 +17825,10 @@
                   "type": "null"
                 }
               ],
-              "description": "起始日期（YYYY-MM-DD，含）。默认=今天往前 6 天。",
+              "description": "起始日期 YYYY-MM-DD，默认最近 30 天",
               "title": "From Date"
             },
-            "description": "起始日期（YYYY-MM-DD，含）。默认=今天往前 6 天。"
+            "description": "起始日期 YYYY-MM-DD，默认最近 30 天"
           },
           {
             "name": "to_date",
@@ -17294,10 +17843,46 @@
                   "type": "null"
                 }
               ],
-              "description": "结束日期（YYYY-MM-DD，含）。默认=今天。",
+              "description": "结束日期 YYYY-MM-DD，默认今天",
               "title": "To Date"
             },
-            "description": "结束日期（YYYY-MM-DD，含）。默认=今天。"
+            "description": "结束日期 YYYY-MM-DD，默认今天"
+          },
+          {
+            "name": "platform",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "平台过滤，可选",
+              "title": "Platform"
+            },
+            "description": "平台过滤，可选"
+          },
+          {
+            "name": "store_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "店铺过滤，可选",
+              "title": "Store Code"
+            },
+            "description": "店铺过滤，可选"
           }
         ],
         "responses": {
@@ -17306,11 +17891,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/FinanceDailyRow"
-                  },
-                  "title": "Response Finance Overview Daily Finance Overview Daily Get"
+                  "$ref": "#/components/schemas/FinanceOverviewResponse"
                 }
               }
             }
@@ -17328,14 +17909,13 @@
         }
       }
     },
-    "/finance/shop": {
+    "/finance/order-sales": {
       "get": {
         "tags": [
           "finance"
         ],
-        "summary": "按店铺聚合的收入 / 成本 / 毛利（运营视角粗粒度）",
-        "description": "店铺盈利能力（粗粒度）（PROD-only）：\n\n- 商品成本：基于 purchase_order_lines 推导的 avg_unit_cost × order_items.qty\n  行金额口径：qty_ordered_base*supply_price - discount_amount（line_amount 不落库）",
-        "operationId": "finance_by_shop_finance_shop_get",
+        "summary": "财务分析订单销售",
+        "operationId": "get_finance_order_sales_finance_order_sales_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -17355,10 +17935,10 @@
                   "type": "null"
                 }
               ],
-              "description": "起始日期（YYYY-MM-DD，含）。默认=今天往前 6 天。",
+              "description": "起始日期 YYYY-MM-DD，默认最近 30 天",
               "title": "From Date"
             },
-            "description": "起始日期（YYYY-MM-DD，含）。默认=今天往前 6 天。"
+            "description": "起始日期 YYYY-MM-DD，默认最近 30 天"
           },
           {
             "name": "to_date",
@@ -17373,10 +17953,10 @@
                   "type": "null"
                 }
               ],
-              "description": "结束日期（YYYY-MM-DD，含）。默认=今天。",
+              "description": "结束日期 YYYY-MM-DD，默认今天",
               "title": "To Date"
             },
-            "description": "结束日期（YYYY-MM-DD，含）。默认=今天。"
+            "description": "结束日期 YYYY-MM-DD，默认今天"
           },
           {
             "name": "platform",
@@ -17391,13 +17971,13 @@
                   "type": "null"
                 }
               ],
-              "description": "按平台过滤，例如 PDD / JD（可选）",
+              "description": "平台过滤，可选",
               "title": "Platform"
             },
-            "description": "按平台过滤，例如 PDD / JD（可选）"
+            "description": "平台过滤，可选"
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -17409,10 +17989,55 @@
                   "type": "null"
                 }
               ],
-              "description": "按店铺 ID 过滤（可选）",
-              "title": "Shop Id"
+              "description": "店铺过滤，可选",
+              "title": "Store Code"
             },
-            "description": "按店铺 ID 过滤（可选）"
+            "description": "店铺过滤，可选"
+          },
+          {
+            "name": "order_no",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "订单号 / 订单引用模糊搜索，可选",
+              "title": "Order No"
+            },
+            "description": "订单号 / 订单引用模糊搜索，可选"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "description": "分页大小",
+              "default": 100,
+              "title": "Limit"
+            },
+            "description": "分页大小"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "分页偏移量",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "分页偏移量"
           }
         ],
         "responses": {
@@ -17421,11 +18046,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/FinanceShopRow"
-                  },
-                  "title": "Response Finance By Shop Finance Shop Get"
+                  "$ref": "#/components/schemas/OrderSalesResponse"
                 }
               }
             }
@@ -17443,14 +18064,13 @@
         }
       }
     },
-    "/finance/sku": {
+    "/finance/purchase-costs": {
       "get": {
         "tags": [
           "finance"
         ],
-        "summary": "SKU 毛利榜（不含运费，基于平均进货价）",
-        "description": "SKU 毛利榜（粗粒度版本）：\n\n- 商品成本：avg_unit_cost(item_id) × SUM(order_items.qty)\n  avg_unit_cost = total_amount / total_units\n  total_amount = SUM(qty_ordered_base*supply_price - discount_amount)\n  total_units  = SUM(qty_ordered_base)",
-        "operationId": "finance_by_sku_finance_sku_get",
+        "summary": "财务分析采购成本",
+        "operationId": "get_finance_purchase_costs_finance_purchase_costs_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -17470,10 +18090,10 @@
                   "type": "null"
                 }
               ],
-              "description": "起始日期（YYYY-MM-DD，含）。默认=今天往前 6 天。",
+              "description": "起始日期 YYYY-MM-DD，默认最近 30 天",
               "title": "From Date"
             },
-            "description": "起始日期（YYYY-MM-DD，含）。默认=今天往前 6 天。"
+            "description": "起始日期 YYYY-MM-DD，默认最近 30 天"
           },
           {
             "name": "to_date",
@@ -17488,28 +18108,10 @@
                   "type": "null"
                 }
               ],
-              "description": "结束日期（YYYY-MM-DD，含）。默认=今天。",
+              "description": "结束日期 YYYY-MM-DD，默认今天",
               "title": "To Date"
             },
-            "description": "结束日期（YYYY-MM-DD，含）。默认=今天。"
-          },
-          {
-            "name": "platform",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "按平台过滤，例如 PDD / JD（可选）",
-              "title": "Platform"
-            },
-            "description": "按平台过滤，例如 PDD / JD（可选）"
+            "description": "结束日期 YYYY-MM-DD，默认今天"
           }
         ],
         "responses": {
@@ -17518,11 +18120,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/FinanceSkuRow"
-                  },
-                  "title": "Response Finance By Sku Finance Sku Get"
+                  "$ref": "#/components/schemas/PurchaseCostResponse"
                 }
               }
             }
@@ -17540,14 +18138,105 @@
         }
       }
     },
-    "/finance/order-unit": {
+    "/finance/purchase-costs/sku-purchase-ledger/options": {
       "get": {
         "tags": [
           "finance"
         ],
-        "summary": "客单价 & 贡献度分析（按订单维度）",
-        "description": "客单价 & 贡献度分析：\n\n- 每一条记录 = 一笔订单（order_value = pay_amount 或 order_amount）\n- summary：订单数 / 总收入 / 平均客单价 / 中位客单价\n- contribution_curve：前 20%/40%/60%/80%/100% 订单贡献的收入占比\n- top_orders：按金额从大到小列出前 N 笔订单",
-        "operationId": "finance_order_unit_finance_order_unit_get",
+        "summary": "财务分析 SKU 采购价格核算表筛选选项",
+        "operationId": "get_finance_sku_purchase_ledger_options_finance_purchase_costs_sku_purchase_ledger_options_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "supplier_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "供应商过滤，可选",
+              "title": "Supplier Id"
+            },
+            "description": "供应商过滤，可选"
+          },
+          {
+            "name": "warehouse_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "仓库过滤，可选",
+              "title": "Warehouse Id"
+            },
+            "description": "仓库过滤，可选"
+          },
+          {
+            "name": "item_keyword",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "商品名 / SKU / item_id 过滤，可选",
+              "title": "Item Keyword"
+            },
+            "description": "商品名 / SKU / item_id 过滤，可选"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuPurchaseLedgerOptionsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/finance/purchase-costs/sku-purchase-ledger": {
+      "get": {
+        "tags": [
+          "finance"
+        ],
+        "summary": "财务分析 SKU 采购价格核算表",
+        "operationId": "get_finance_sku_purchase_ledger_finance_purchase_costs_sku_purchase_ledger_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -17567,10 +18256,10 @@
                   "type": "null"
                 }
               ],
-              "description": "起始日期（YYYY-MM-DD，含）。默认=今天往前 6 天。",
+              "description": "起始日期 YYYY-MM-DD，可选",
               "title": "From Date"
             },
-            "description": "起始日期（YYYY-MM-DD，含）。默认=今天往前 6 天。"
+            "description": "起始日期 YYYY-MM-DD，可选"
           },
           {
             "name": "to_date",
@@ -17585,10 +18274,138 @@
                   "type": "null"
                 }
               ],
-              "description": "结束日期（YYYY-MM-DD，含）。默认=今天。",
+              "description": "结束日期 YYYY-MM-DD，可选",
               "title": "To Date"
             },
-            "description": "结束日期（YYYY-MM-DD，含）。默认=今天。"
+            "description": "结束日期 YYYY-MM-DD，可选"
+          },
+          {
+            "name": "supplier_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "供应商过滤，可选",
+              "title": "Supplier Id"
+            },
+            "description": "供应商过滤，可选"
+          },
+          {
+            "name": "warehouse_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "仓库过滤，可选",
+              "title": "Warehouse Id"
+            },
+            "description": "仓库过滤，可选"
+          },
+          {
+            "name": "item_keyword",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "商品名 / SKU / item_id 过滤，可选",
+              "title": "Item Keyword"
+            },
+            "description": "商品名 / SKU / item_id 过滤，可选"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkuPurchaseLedgerResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/finance/shipping-costs": {
+      "get": {
+        "tags": [
+          "finance"
+        ],
+        "summary": "财务分析物流成本",
+        "operationId": "get_finance_shipping_costs_finance_shipping_costs_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "from_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "起始日期 YYYY-MM-DD，默认最近 30 天",
+              "title": "From Date"
+            },
+            "description": "起始日期 YYYY-MM-DD，默认最近 30 天"
+          },
+          {
+            "name": "to_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "结束日期 YYYY-MM-DD，默认今天",
+              "title": "To Date"
+            },
+            "description": "结束日期 YYYY-MM-DD，默认今天"
           },
           {
             "name": "platform",
@@ -17603,13 +18420,13 @@
                   "type": "null"
                 }
               ],
-              "description": "按平台过滤，例如 PDD / JD（可选）",
+              "description": "平台过滤，可选",
               "title": "Platform"
             },
-            "description": "按平台过滤，例如 PDD / JD（可选）"
+            "description": "平台过滤，可选"
           },
           {
-            "name": "shop_id",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
@@ -17621,10 +18438,10 @@
                   "type": "null"
                 }
               ],
-              "description": "按店铺 ID 过滤（可选）",
-              "title": "Shop Id"
+              "description": "店铺过滤，可选",
+              "title": "Store Code"
             },
-            "description": "按店铺 ID 过滤（可选）"
+            "description": "店铺过滤，可选"
           }
         ],
         "responses": {
@@ -17633,9 +18450,335 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Finance Order Unit Finance Order Unit Get"
+                  "$ref": "#/components/schemas/ShippingCostResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/finance/shipping-costs/shipping-ledger/options": {
+      "get": {
+        "tags": [
+          "finance"
+        ],
+        "summary": "财务分析物流成本明细筛选选项",
+        "operationId": "get_finance_shipping_ledger_options_finance_shipping_costs_shipping_ledger_options_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "from_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "起始日期 YYYY-MM-DD，可选",
+              "title": "From Date"
+            },
+            "description": "起始日期 YYYY-MM-DD，可选"
+          },
+          {
+            "name": "to_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "结束日期 YYYY-MM-DD，可选",
+              "title": "To Date"
+            },
+            "description": "结束日期 YYYY-MM-DD，可选"
+          },
+          {
+            "name": "platform",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "平台过滤，可选",
+              "title": "Platform"
+            },
+            "description": "平台过滤，可选"
+          },
+          {
+            "name": "store_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "店铺过滤，可选",
+              "title": "Store Code"
+            },
+            "description": "店铺过滤，可选"
+          },
+          {
+            "name": "warehouse_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "仓库过滤，可选",
+              "title": "Warehouse Id"
+            },
+            "description": "仓库过滤，可选"
+          },
+          {
+            "name": "shipping_provider_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "物流网点过滤，可选",
+              "title": "Shipping Provider Id"
+            },
+            "description": "物流网点过滤，可选"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShippingCostLedgerOptionsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/finance/shipping-costs/shipping-ledger": {
+      "get": {
+        "tags": [
+          "finance"
+        ],
+        "summary": "财务分析物流成本核算明细表",
+        "operationId": "get_finance_shipping_ledger_finance_shipping_costs_shipping_ledger_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "from_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "起始日期 YYYY-MM-DD，可选",
+              "title": "From Date"
+            },
+            "description": "起始日期 YYYY-MM-DD，可选"
+          },
+          {
+            "name": "to_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "结束日期 YYYY-MM-DD，可选",
+              "title": "To Date"
+            },
+            "description": "结束日期 YYYY-MM-DD，可选"
+          },
+          {
+            "name": "platform",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "平台过滤，可选",
+              "title": "Platform"
+            },
+            "description": "平台过滤，可选"
+          },
+          {
+            "name": "store_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "店铺过滤，可选",
+              "title": "Store Code"
+            },
+            "description": "店铺过滤，可选"
+          },
+          {
+            "name": "warehouse_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "仓库过滤，可选",
+              "title": "Warehouse Id"
+            },
+            "description": "仓库过滤，可选"
+          },
+          {
+            "name": "shipping_provider_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "物流网点过滤，可选",
+              "title": "Shipping Provider Id"
+            },
+            "description": "物流网点过滤，可选"
+          },
+          {
+            "name": "order_keyword",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "订单号 / 运单号模糊过滤，可选",
+              "title": "Order Keyword"
+            },
+            "description": "订单号 / 运单号模糊过滤，可选"
+          },
+          {
+            "name": "tracking_no",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "运单号精确过滤，可选",
+              "title": "Tracking No"
+            },
+            "description": "运单号精确过滤，可选"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShippingCostLedgerResponse"
                 }
               }
             }
@@ -17722,7 +18865,7 @@
             "type": "integer",
             "title": "Provider Id"
           },
-          "code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -17731,7 +18874,7 @@
                 "type": "null"
               }
             ],
-            "title": "Code"
+            "title": "Shipping Provider Code"
           },
           "name": {
             "type": "string",
@@ -17852,6 +18995,12 @@
       },
       "AggregateItemInput": {
         "properties": {
+          "sku": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Sku"
+          },
           "name": {
             "type": "string",
             "maxLength": 128,
@@ -17995,6 +19144,7 @@
         "additionalProperties": false,
         "type": "object",
         "required": [
+          "sku",
           "name"
         ],
         "title": "AggregateItemInput"
@@ -18291,7 +19441,7 @@
       },
       "BillingCostAnalysisByCarrierRowOut": {
         "properties": {
-          "carrier_code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -18300,7 +19450,7 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
           "ticket_count": {
             "type": "integer",
@@ -18528,11 +19678,11 @@
         ],
         "title": "BindingUpdateOut"
       },
-      "Body_import_shipping_bill_tms_billing_import_post": {
+      "Body_import_shipping_bill_shipping_assist_billing_import_post": {
         "properties": {
-          "carrier_code": {
+          "shipping_provider_code": {
             "type": "string",
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
           "bill_month": {
             "anyOf": [
@@ -18547,292 +19697,16 @@
           },
           "file": {
             "type": "string",
-            "format": "binary",
+            "contentMediaType": "application/octet-stream",
             "title": "File"
           }
         },
         "type": "object",
         "required": [
-          "carrier_code",
+          "shipping_provider_code",
           "file"
         ],
-        "title": "Body_import_shipping_bill_tms_billing_import_post"
-      },
-      "CarrierBillImportResult": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "carrier_code": {
-            "type": "string",
-            "title": "Carrier Code"
-          },
-          "imported_count": {
-            "type": "integer",
-            "title": "Imported Count"
-          },
-          "skipped_count": {
-            "type": "integer",
-            "title": "Skipped Count"
-          },
-          "error_count": {
-            "type": "integer",
-            "title": "Error Count"
-          },
-          "errors": {
-            "items": {
-              "$ref": "#/components/schemas/CarrierBillImportRowError"
-            },
-            "type": "array",
-            "title": "Errors"
-          }
-        },
-        "type": "object",
-        "required": [
-          "carrier_code",
-          "imported_count",
-          "skipped_count",
-          "error_count"
-        ],
-        "title": "CarrierBillImportResult"
-      },
-      "CarrierBillImportRowError": {
-        "properties": {
-          "row_no": {
-            "type": "integer",
-            "title": "Row No",
-            "description": "Excel 行号（从 1 开始）"
-          },
-          "message": {
-            "type": "string",
-            "title": "Message",
-            "description": "错误原因"
-          }
-        },
-        "type": "object",
-        "required": [
-          "row_no",
-          "message"
-        ],
-        "title": "CarrierBillImportRowError"
-      },
-      "CarrierBillItemOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "carrier_code": {
-            "type": "string",
-            "title": "Carrier Code"
-          },
-          "bill_month": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Bill Month"
-          },
-          "tracking_no": {
-            "type": "string",
-            "title": "Tracking No"
-          },
-          "business_time": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Business Time"
-          },
-          "destination_province": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Destination Province"
-          },
-          "destination_city": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Destination City"
-          },
-          "billing_weight_kg": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Billing Weight Kg"
-          },
-          "freight_amount": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Freight Amount"
-          },
-          "surcharge_amount": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Surcharge Amount"
-          },
-          "total_amount": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Total Amount"
-          },
-          "settlement_object": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Settlement Object"
-          },
-          "order_customer": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order Customer"
-          },
-          "sender_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sender Name"
-          },
-          "network_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Network Name"
-          },
-          "size_text": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Size Text"
-          },
-          "parent_customer": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Parent Customer"
-          },
-          "raw_payload": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Raw Payload"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "carrier_code",
-          "tracking_no",
-          "raw_payload",
-          "created_at"
-        ],
-        "title": "CarrierBillItemOut"
-      },
-      "CarrierBillItemsResponse": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "rows": {
-            "items": {
-              "$ref": "#/components/schemas/CarrierBillItemOut"
-            },
-            "type": "array",
-            "title": "Rows"
-          },
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          }
-        },
-        "type": "object",
-        "required": [
-          "rows",
-          "total"
-        ],
-        "title": "CarrierBillItemsResponse"
+        "title": "Body_import_shipping_bill_shipping_assist_billing_import_post"
       },
       "CartLineItemIn": {
         "properties": {
@@ -20450,7 +21324,7 @@
         ],
         "title": "ExplainReceiptLine"
       },
-      "FinanceDailyRow": {
+      "FinanceOverviewDailyRow": {
         "properties": {
           "day": {
             "type": "string",
@@ -20510,18 +21384,30 @@
           "shipping_cost",
           "gross_profit"
         ],
-        "title": "FinanceDailyRow"
+        "title": "FinanceOverviewDailyRow"
       },
-      "FinanceShopRow": {
+      "FinanceOverviewResponse": {
         "properties": {
-          "platform": {
-            "type": "string",
-            "title": "Platform"
+          "summary": {
+            "$ref": "#/components/schemas/FinanceOverviewSummary"
           },
-          "shop_id": {
-            "type": "string",
-            "title": "Shop Id"
-          },
+          "daily": {
+            "items": {
+              "$ref": "#/components/schemas/FinanceOverviewDailyRow"
+            },
+            "type": "array",
+            "title": "Daily"
+          }
+        },
+        "type": "object",
+        "required": [
+          "summary",
+          "daily"
+        ],
+        "title": "FinanceOverviewResponse"
+      },
+      "FinanceOverviewSummary": {
+        "properties": {
           "revenue": {
             "type": "string",
             "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
@@ -20569,84 +21455,12 @@
         },
         "type": "object",
         "required": [
-          "platform",
-          "shop_id",
           "revenue",
           "purchase_cost",
           "shipping_cost",
           "gross_profit"
         ],
-        "title": "FinanceShopRow"
-      },
-      "FinanceSkuRow": {
-        "properties": {
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "sku_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sku Id"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title"
-          },
-          "qty_sold": {
-            "type": "integer",
-            "title": "Qty Sold"
-          },
-          "revenue": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Revenue"
-          },
-          "purchase_cost": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Purchase Cost"
-          },
-          "gross_profit": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Gross Profit"
-          },
-          "gross_margin": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Gross Margin"
-          }
-        },
-        "type": "object",
-        "required": [
-          "item_id",
-          "qty_sold",
-          "revenue",
-          "purchase_cost",
-          "gross_profit"
-        ],
-        "title": "FinanceSkuRow"
+        "title": "FinanceOverviewSummary"
       },
       "FskuComponentIn": {
         "properties": {
@@ -20978,6 +21792,258 @@
         ],
         "title": "FskuLiteOut"
       },
+      "FskuMappingCandidateListDataOut": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/FskuMappingCandidateOut"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          }
+        },
+        "type": "object",
+        "required": [
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "FskuMappingCandidateListDataOut"
+      },
+      "FskuMappingCandidateListOut": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok",
+            "default": true
+          },
+          "data": {
+            "$ref": "#/components/schemas/FskuMappingCandidateListDataOut"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "FskuMappingCandidateListOut"
+      },
+      "FskuMappingCandidateOut": {
+        "properties": {
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "mirror_id": {
+            "type": "integer",
+            "title": "Mirror Id"
+          },
+          "line_id": {
+            "type": "integer",
+            "title": "Line Id"
+          },
+          "collector_order_id": {
+            "type": "integer",
+            "title": "Collector Order Id"
+          },
+          "collector_line_id": {
+            "type": "integer",
+            "title": "Collector Line Id"
+          },
+          "store_code": {
+            "type": "string",
+            "title": "Store Code"
+          },
+          "collector_store_id": {
+            "type": "integer",
+            "title": "Collector Store Id"
+          },
+          "collector_store_name": {
+            "type": "string",
+            "title": "Collector Store Name"
+          },
+          "platform_order_no": {
+            "type": "string",
+            "title": "Platform Order No"
+          },
+          "merchant_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Merchant Code"
+          },
+          "platform_item_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform Item Id"
+          },
+          "platform_sku_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform Sku Id"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "quantity": {
+            "type": "string",
+            "title": "Quantity"
+          },
+          "line_amount": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Line Amount"
+          },
+          "is_bound": {
+            "type": "boolean",
+            "title": "Is Bound"
+          },
+          "mapping_status": {
+            "type": "string",
+            "enum": [
+              "bound",
+              "unbound",
+              "missing_merchant_code"
+            ],
+            "title": "Mapping Status"
+          },
+          "binding_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Binding Id"
+          },
+          "fsku_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fsku Id"
+          },
+          "fsku_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fsku Code"
+          },
+          "fsku_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fsku Name"
+          },
+          "fsku_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fsku Status"
+          },
+          "binding_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Binding Reason"
+          },
+          "binding_updated_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Binding Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "platform",
+          "mirror_id",
+          "line_id",
+          "collector_order_id",
+          "collector_line_id",
+          "store_code",
+          "collector_store_id",
+          "collector_store_name",
+          "platform_order_no",
+          "quantity",
+          "is_bound",
+          "mapping_status"
+        ],
+        "title": "FskuMappingCandidateOut"
+      },
       "FskuNameUpdateIn": {
         "properties": {
           "name": {
@@ -21058,9 +22124,9 @@
             "type": "string",
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "ext_order_no": {
             "anyOf": [
@@ -21089,10 +22155,115 @@
         "required": [
           "order_id",
           "platform",
-          "shop_id"
+          "store_code"
         ],
         "title": "FulfillmentDebugOut",
         "description": "v4-min：只回答“归属仓是谁”\n- 不返回 fulfillment_status / blocked_reasons（blocked 事实由订单履约快照表承载）\n- 不返回 candidates / scan / check（全部砍掉）"
+      },
+      "FulfillmentOrderConversionIn": {
+        "properties": {
+          "mirror_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Mirror Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "mirror_id"
+        ],
+        "title": "FulfillmentOrderConversionIn"
+      },
+      "FulfillmentOrderConversionOut": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok",
+            "default": true
+          },
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "mirror_id": {
+            "type": "integer",
+            "title": "Mirror Id"
+          },
+          "order_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Order Id"
+          },
+          "ref": {
+            "type": "string",
+            "title": "Ref"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "store_id": {
+            "type": "integer",
+            "title": "Store Id"
+          },
+          "store_code": {
+            "type": "string",
+            "title": "Store Code"
+          },
+          "ext_order_no": {
+            "type": "string",
+            "title": "Ext Order No"
+          },
+          "lines_count": {
+            "type": "integer",
+            "title": "Lines Count"
+          },
+          "item_lines_count": {
+            "type": "integer",
+            "title": "Item Lines Count"
+          },
+          "fulfillment_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fulfillment Status"
+          },
+          "blocked_reasons": {
+            "title": "Blocked Reasons"
+          },
+          "risk_flags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Risk Flags"
+          }
+        },
+        "type": "object",
+        "required": [
+          "platform",
+          "mirror_id",
+          "order_id",
+          "ref",
+          "status",
+          "store_id",
+          "store_code",
+          "ext_order_no",
+          "lines_count",
+          "item_lines_count"
+        ],
+        "title": "FulfillmentOrderConversionOut"
       },
       "FulfillmentServiceDebug": {
         "properties": {
@@ -21180,6 +22351,53 @@
         },
         "type": "object",
         "title": "HTTPValidationError"
+      },
+      "ImportPlatformOrderMirrorFromCollectorIn": {
+        "properties": {
+          "collector_order_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Collector Order Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "collector_order_id"
+        ],
+        "title": "ImportPlatformOrderMirrorFromCollectorIn"
+      },
+      "ImportPlatformOrderMirrorFromCollectorOut": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok",
+            "default": true
+          },
+          "imported": {
+            "type": "boolean",
+            "title": "Imported",
+            "default": true
+          },
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "collector_order_id": {
+            "type": "integer",
+            "title": "Collector Order Id"
+          },
+          "mirror_id": {
+            "type": "integer",
+            "title": "Mirror Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "platform",
+          "collector_order_id",
+          "mirror_id"
+        ],
+        "title": "ImportPlatformOrderMirrorFromCollectorOut"
       },
       "InboundCommitIn": {
         "properties": {
@@ -21633,7 +22851,7 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 64
+                "maxLength": 128
               },
               {
                 "type": "null"
@@ -22425,7 +23643,7 @@
             "maxLength": 128,
             "minLength": 1,
             "title": "Order Key",
-            "description": "订单键：支持 ORD:PLAT:SHOP:EXT / PLAT:SHOP:EXT / 唯一 ext_order_no"
+            "description": "订单键：支持 ORD:PLAT:STORE:EXT / PLAT:STORE:EXT / 唯一 ext_order_no"
           },
           "remark": {
             "anyOf": [
@@ -23356,7 +24574,7 @@
             "title": "Platform",
             "description": "平台"
           },
-          "shop_id": {
+          "store_code": {
             "anyOf": [
               {
                 "type": "string",
@@ -23366,7 +24584,7 @@
                 "type": "null"
               }
             ],
-            "title": "Shop Id",
+            "title": "Store Code",
             "description": "店铺 ID"
           },
           "ext_order_no": {
@@ -26298,7 +27516,7 @@
           },
           "sku": {
             "type": "string",
-            "maxLength": 64,
+            "maxLength": 128,
             "minLength": 1,
             "title": "Sku"
           },
@@ -26372,6 +27590,12 @@
       },
       "ItemCreate": {
         "properties": {
+          "sku": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Sku"
+          },
           "name": {
             "type": "string",
             "maxLength": 128,
@@ -26515,16 +27739,17 @@
         "additionalProperties": false,
         "type": "object",
         "required": [
+          "sku",
           "name"
         ],
         "title": "ItemCreate",
-        "description": "Create Item（统一由后端生成 SKU）：\n- 不接受 sku 输入\n- 不接受 barcode 输入；主条码请走 /item-barcodes\n- 不接受 weight_kg 输入；基础包装净重请走 item_uoms（base uom）\n\nPhase M-3：\n- items.case_ratio/case_uom 已删除；包装单位请走 item_uoms"
+        "description": "Create Item（SKU 由调用方显式输入）：\n- 必须传 sku；SKU 编码页只负责生成候选 SKU，最终由商品创建合同写入 items.sku\n- 不接受 barcode 输入；主条码请走 /item-barcodes\n- 不接受 weight_kg 输入；基础包装净重请走 item_uoms（base uom）\n\nPhase M-3：\n- items.case_ratio/case_uom 已删除；包装单位请走 item_uoms"
       },
       "ItemOut": {
         "properties": {
           "sku": {
             "type": "string",
-            "maxLength": 64,
+            "maxLength": 128,
             "minLength": 1,
             "title": "Sku"
           },
@@ -26751,11 +27976,6 @@
             "type": "boolean",
             "title": "Requires Dates",
             "default": true
-          },
-          "is_test": {
-            "type": "boolean",
-            "title": "Is Test",
-            "default": false
           }
         },
         "type": "object",
@@ -26968,11 +28188,6 @@
             ],
             "title": "Supply Price Snapshot"
           },
-          "discount_amount_snapshot": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Discount Amount Snapshot"
-          },
           "planned_line_amount": {
             "type": "string",
             "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
@@ -26992,7 +28207,6 @@
           "purchase_uom_name_snapshot",
           "qty_ordered_input",
           "qty_ordered_base",
-          "discount_amount_snapshot",
           "planned_line_amount"
         ],
         "title": "ItemPurchaseReportLineItem"
@@ -27528,575 +28742,6 @@
         "type": "object",
         "title": "ItemUpdate",
         "description": "Patch Item：\n\n- 不开放 sku 变更\n- 不接受 barcode / has_shelf_life\n- 不接受 weight_kg；基础包装净重请改 item_uoms\n- nullable 字段支持显式传 null 清空"
-      },
-      "JdOrderLedgerDetailEnvelopeOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "$ref": "#/components/schemas/JdOrderLedgerDetailOut"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "JdOrderLedgerDetailEnvelopeOut"
-      },
-      "JdOrderLedgerDetailOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "store_id": {
-            "type": "integer",
-            "title": "Store Id"
-          },
-          "order_id": {
-            "type": "string",
-            "title": "Order Id"
-          },
-          "vender_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vender Id"
-          },
-          "order_type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order Type"
-          },
-          "order_state": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order State"
-          },
-          "buyer_pin": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Buyer Pin"
-          },
-          "consignee_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Consignee Name"
-          },
-          "consignee_mobile": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Consignee Mobile"
-          },
-          "consignee_phone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Consignee Phone"
-          },
-          "consignee_province": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Consignee Province"
-          },
-          "consignee_city": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Consignee City"
-          },
-          "consignee_county": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Consignee County"
-          },
-          "consignee_town": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Consignee Town"
-          },
-          "consignee_address": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Consignee Address"
-          },
-          "order_remark": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order Remark"
-          },
-          "seller_remark": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Seller Remark"
-          },
-          "order_total_price": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order Total Price"
-          },
-          "order_seller_price": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order Seller Price"
-          },
-          "freight_price": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Freight Price"
-          },
-          "payment_confirm": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Payment Confirm"
-          },
-          "order_start_time": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order Start Time"
-          },
-          "order_end_time": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order End Time"
-          },
-          "modified": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Modified"
-          },
-          "raw_summary_payload": {
-            "title": "Raw Summary Payload"
-          },
-          "raw_detail_payload": {
-            "title": "Raw Detail Payload"
-          },
-          "pulled_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pulled At"
-          },
-          "last_synced_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Synced At"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          },
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/JdOrderLedgerItemOut"
-            },
-            "type": "array",
-            "title": "Items"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "store_id",
-          "order_id",
-          "items"
-        ],
-        "title": "JdOrderLedgerDetailOut"
-      },
-      "JdOrderLedgerItemOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "jd_order_id": {
-            "type": "integer",
-            "title": "Jd Order Id"
-          },
-          "order_id": {
-            "type": "string",
-            "title": "Order Id"
-          },
-          "sku_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sku Id"
-          },
-          "outer_sku_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Outer Sku Id"
-          },
-          "ware_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Ware Id"
-          },
-          "item_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Item Name"
-          },
-          "item_total": {
-            "type": "integer",
-            "title": "Item Total"
-          },
-          "item_price": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Item Price"
-          },
-          "sku_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sku Name"
-          },
-          "gift_point": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Gift Point"
-          },
-          "raw_item_payload": {
-            "title": "Raw Item Payload"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "jd_order_id",
-          "order_id",
-          "item_total"
-        ],
-        "title": "JdOrderLedgerItemOut"
-      },
-      "JdOrderLedgerListOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/JdOrderLedgerRowOut"
-            },
-            "type": "array",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "JdOrderLedgerListOut"
-      },
-      "JdOrderLedgerRowOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "store_id": {
-            "type": "integer",
-            "title": "Store Id"
-          },
-          "order_id": {
-            "type": "string",
-            "title": "Order Id"
-          },
-          "order_state": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order State"
-          },
-          "order_type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order Type"
-          },
-          "order_start_time": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order Start Time"
-          },
-          "modified": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Modified"
-          },
-          "order_total_price": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order Total Price"
-          },
-          "order_seller_price": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order Seller Price"
-          },
-          "pulled_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pulled At"
-          },
-          "last_synced_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Synced At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "store_id",
-          "order_id"
-        ],
-        "title": "JdOrderLedgerRowOut"
       },
       "LedgerDateViolationRow": {
         "properties": {
@@ -28687,6 +29332,90 @@
         ],
         "title": "LedgerSummary"
       },
+      "ListOut_SkuBusinessCategoryOut_": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok",
+            "default": true
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/SkuBusinessCategoryOut"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ListOut[SkuBusinessCategoryOut]"
+      },
+      "ListOut_SkuCodeBrandOut_": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok",
+            "default": true
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/SkuCodeBrandOut"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ListOut[SkuCodeBrandOut]"
+      },
+      "ListOut_SkuCodeTermGroupOut_": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok",
+            "default": true
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/SkuCodeTermGroupOut"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ListOut[SkuCodeTermGroupOut]"
+      },
+      "ListOut_SkuCodeTermOut_": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok",
+            "default": true
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/SkuCodeTermOut"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ListOut[SkuCodeTermOut]"
+      },
       "LotShadowAggRow": {
         "properties": {
           "lot_id": {
@@ -29072,9 +29801,9 @@
             "type": "string",
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "ext_order_no": {
             "type": "string",
@@ -29120,7 +29849,7 @@
           "created_at",
           "order_id",
           "platform",
-          "shop_id",
+          "store_code",
           "ext_order_no",
           "ref",
           "store_id"
@@ -29237,7 +29966,7 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 64
+                "maxLength": 128
               },
               {
                 "type": "null"
@@ -29665,11 +30394,11 @@
             "title": "Platform",
             "description": "平台（DEMO/PDD/TB...）"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "maxLength": 64,
+            "maxLength": 128,
             "minLength": 1,
-            "title": "Shop Id",
+            "title": "Store Code",
             "description": "平台店铺 ID（字符串，与 platform 对齐）"
           },
           "merchant_code": {
@@ -29702,7 +30431,7 @@
         "type": "object",
         "required": [
           "platform",
-          "shop_id",
+          "store_code",
           "merchant_code",
           "fsku_id"
         ],
@@ -29717,11 +30446,11 @@
             "title": "Platform",
             "description": "平台（DEMO/PDD/TB...）"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "maxLength": 64,
+            "maxLength": 128,
             "minLength": 1,
-            "title": "Shop Id",
+            "title": "Store Code",
             "description": "平台店铺 ID（字符串，与 platform 对齐）"
           },
           "merchant_code": {
@@ -29735,7 +30464,7 @@
         "type": "object",
         "required": [
           "platform",
-          "shop_id",
+          "store_code",
           "merchant_code"
         ],
         "title": "MerchantCodeBindingCloseIn"
@@ -29815,9 +30544,9 @@
             "type": "string",
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "store": {
             "$ref": "#/components/schemas/StoreLiteOut"
@@ -29859,7 +30588,7 @@
         "required": [
           "id",
           "platform",
-          "shop_id",
+          "store_code",
           "store",
           "merchant_code",
           "fsku_id",
@@ -30702,19 +31431,6 @@
         ],
         "title": "NavigationRoutePrefixOut"
       },
-      "NextSkuOut": {
-        "properties": {
-          "sku": {
-            "type": "string",
-            "title": "Sku"
-          }
-        },
-        "type": "object",
-        "required": [
-          "sku"
-        ],
-        "title": "NextSkuOut"
-      },
       "OrderOutboundOptionOut": {
         "properties": {
           "id": {
@@ -30725,9 +31441,9 @@
             "type": "string",
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "ext_order_no": {
             "type": "string",
@@ -30765,7 +31481,7 @@
         "required": [
           "id",
           "platform",
-          "shop_id",
+          "store_code",
           "ext_order_no",
           "created_at"
         ],
@@ -31033,9 +31749,9 @@
             "type": "string",
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "ext_order_no": {
             "type": "string",
@@ -31120,7 +31836,7 @@
         "required": [
           "id",
           "platform",
-          "shop_id",
+          "store_code",
           "ext_order_no",
           "created_at"
         ],
@@ -31151,6 +31867,521 @@
         ],
         "title": "OrderOutboundViewResponse",
         "description": "订单出库页专用：只读聚合响应\n\n结构：\n- order: 订单头（orders）\n- lines: 订单行（order_lines + display）"
+      },
+      "OrderSalesDailyRow": {
+        "properties": {
+          "day": {
+            "type": "string",
+            "format": "date",
+            "title": "Day"
+          },
+          "order_count": {
+            "type": "integer",
+            "title": "Order Count"
+          },
+          "line_count": {
+            "type": "integer",
+            "title": "Line Count"
+          },
+          "qty_sold": {
+            "type": "integer",
+            "title": "Qty Sold"
+          },
+          "revenue": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Revenue"
+          }
+        },
+        "type": "object",
+        "required": [
+          "day",
+          "order_count",
+          "line_count",
+          "qty_sold",
+          "revenue"
+        ],
+        "title": "OrderSalesDailyRow"
+      },
+      "OrderSalesItemRow": {
+        "properties": {
+          "item_id": {
+            "type": "integer",
+            "title": "Item Id"
+          },
+          "item_sku": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Item Sku"
+          },
+          "item_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Item Name"
+          },
+          "sku_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sku Id"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "qty_sold": {
+            "type": "integer",
+            "title": "Qty Sold"
+          },
+          "revenue": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Revenue"
+          }
+        },
+        "type": "object",
+        "required": [
+          "item_id",
+          "qty_sold",
+          "revenue"
+        ],
+        "title": "OrderSalesItemRow"
+      },
+      "OrderSalesLineRow": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "order_id": {
+            "type": "integer",
+            "title": "Order Id"
+          },
+          "order_item_id": {
+            "type": "integer",
+            "title": "Order Item Id"
+          },
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "store_id": {
+            "type": "integer",
+            "title": "Store Id"
+          },
+          "store_code": {
+            "type": "string",
+            "title": "Store Code"
+          },
+          "store_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Store Name"
+          },
+          "ext_order_no": {
+            "type": "string",
+            "title": "Ext Order No"
+          },
+          "order_ref": {
+            "type": "string",
+            "title": "Order Ref"
+          },
+          "order_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Order Status"
+          },
+          "order_created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Order Created At"
+          },
+          "order_date": {
+            "type": "string",
+            "format": "date",
+            "title": "Order Date"
+          },
+          "receiver_province": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Receiver Province"
+          },
+          "receiver_city": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Receiver City"
+          },
+          "receiver_district": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Receiver District"
+          },
+          "warehouse_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Warehouse Id"
+          },
+          "warehouse_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Warehouse Name"
+          },
+          "warehouse_source": {
+            "type": "string",
+            "title": "Warehouse Source"
+          },
+          "item_id": {
+            "type": "integer",
+            "title": "Item Id"
+          },
+          "item_sku": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Item Sku"
+          },
+          "item_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Item Name"
+          },
+          "sku_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sku Id"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "qty_sold": {
+            "type": "integer",
+            "title": "Qty Sold"
+          },
+          "unit_price": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit Price"
+          },
+          "discount_amount": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Discount Amount"
+          },
+          "line_amount": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Line Amount"
+          },
+          "order_amount": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Order Amount"
+          },
+          "pay_amount": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pay Amount"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "order_id",
+          "order_item_id",
+          "platform",
+          "store_id",
+          "store_code",
+          "ext_order_no",
+          "order_ref",
+          "order_created_at",
+          "order_date",
+          "warehouse_source",
+          "item_id",
+          "qty_sold",
+          "line_amount"
+        ],
+        "title": "OrderSalesLineRow"
+      },
+      "OrderSalesResponse": {
+        "properties": {
+          "summary": {
+            "$ref": "#/components/schemas/OrderSalesSummary"
+          },
+          "daily": {
+            "items": {
+              "$ref": "#/components/schemas/OrderSalesDailyRow"
+            },
+            "type": "array",
+            "title": "Daily"
+          },
+          "by_store": {
+            "items": {
+              "$ref": "#/components/schemas/OrderSalesStoreRow"
+            },
+            "type": "array",
+            "title": "By Store"
+          },
+          "by_item": {
+            "items": {
+              "$ref": "#/components/schemas/OrderSalesItemRow"
+            },
+            "type": "array",
+            "title": "By Item"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/OrderSalesLineRow"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          }
+        },
+        "type": "object",
+        "required": [
+          "summary",
+          "daily",
+          "by_store",
+          "by_item",
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "OrderSalesResponse"
+      },
+      "OrderSalesStoreRow": {
+        "properties": {
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "store_code": {
+            "type": "string",
+            "title": "Store Code"
+          },
+          "store_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Store Name"
+          },
+          "order_count": {
+            "type": "integer",
+            "title": "Order Count"
+          },
+          "line_count": {
+            "type": "integer",
+            "title": "Line Count"
+          },
+          "qty_sold": {
+            "type": "integer",
+            "title": "Qty Sold"
+          },
+          "revenue": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Revenue"
+          }
+        },
+        "type": "object",
+        "required": [
+          "platform",
+          "store_code",
+          "order_count",
+          "line_count",
+          "qty_sold",
+          "revenue"
+        ],
+        "title": "OrderSalesStoreRow"
+      },
+      "OrderSalesSummary": {
+        "properties": {
+          "order_count": {
+            "type": "integer",
+            "title": "Order Count"
+          },
+          "line_count": {
+            "type": "integer",
+            "title": "Line Count"
+          },
+          "qty_sold": {
+            "type": "integer",
+            "title": "Qty Sold"
+          },
+          "revenue": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Revenue"
+          },
+          "avg_order_value": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avg Order Value"
+          },
+          "median_order_value": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Median Order Value"
+          }
+        },
+        "type": "object",
+        "required": [
+          "order_count",
+          "line_count",
+          "qty_sold",
+          "revenue"
+        ],
+        "title": "OrderSalesSummary"
       },
       "OrderSimCartGetOut": {
         "properties": {
@@ -31406,7 +32637,7 @@
             "title": "Platform",
             "description": "可选平台过滤（如 PDD），大写"
           },
-          "shop_id": {
+          "store_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -31415,8 +32646,8 @@
                 "type": "null"
               }
             ],
-            "title": "Shop Id",
-            "description": "可选店铺过滤（字符串，与 orders.shop_id 一致）"
+            "title": "Store Code",
+            "description": "可选店铺过滤（字符串，与 orders.store_code 一致）"
           },
           "orders_created": {
             "type": "integer",
@@ -32516,514 +33747,6 @@
         "type": "object",
         "title": "PasswordResetIn"
       },
-      "PddMockAuthorizeRequest": {
-        "properties": {
-          "granted_identity_display": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Granted Identity Display",
-            "description": "授权展示名；为空时默认使用 shop_id"
-          },
-          "access_token": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Access Token",
-            "description": "可选，默认自动生成 mock token"
-          },
-          "expires_in_days": {
-            "type": "integer",
-            "maximum": 3650.0,
-            "minimum": 1.0,
-            "title": "Expires In Days",
-            "description": "mock token 过期天数",
-            "default": 365
-          }
-        },
-        "type": "object",
-        "title": "PddMockAuthorizeRequest"
-      },
-      "PddMockClearOrdersRequest": {
-        "properties": {
-          "clear_connection": {
-            "type": "boolean",
-            "title": "Clear Connection",
-            "description": "是否同时清理连接状态",
-            "default": false
-          },
-          "clear_credential": {
-            "type": "boolean",
-            "title": "Clear Credential",
-            "description": "是否同时清理凭据",
-            "default": false
-          }
-        },
-        "type": "object",
-        "title": "PddMockClearOrdersRequest"
-      },
-      "PddMockIngestOrdersRequest": {
-        "properties": {
-          "scenario": {
-            "type": "string",
-            "enum": [
-              "normal",
-              "address_missing",
-              "item_abnormal",
-              "mixed"
-            ],
-            "title": "Scenario",
-            "description": "生成场景：normal / address_missing / item_abnormal / mixed",
-            "default": "mixed"
-          },
-          "count": {
-            "type": "integer",
-            "maximum": 100.0,
-            "minimum": 1.0,
-            "title": "Count",
-            "description": "生成订单数量",
-            "default": 6
-          }
-        },
-        "type": "object",
-        "title": "PddMockIngestOrdersRequest"
-      },
-      "PddOrderLedgerDetailEnvelopeOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "$ref": "#/components/schemas/PddOrderLedgerDetailOut"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "PddOrderLedgerDetailEnvelopeOut"
-      },
-      "PddOrderLedgerDetailOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "store_id": {
-            "type": "integer",
-            "title": "Store Id"
-          },
-          "order_sn": {
-            "type": "string",
-            "title": "Order Sn"
-          },
-          "order_status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order Status"
-          },
-          "receiver_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Name"
-          },
-          "receiver_phone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Phone"
-          },
-          "receiver_province": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Province"
-          },
-          "receiver_city": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver City"
-          },
-          "receiver_district": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver District"
-          },
-          "receiver_address": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Address"
-          },
-          "buyer_memo": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Buyer Memo"
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          },
-          "confirm_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Confirm At"
-          },
-          "goods_amount": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Goods Amount"
-          },
-          "pay_amount": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pay Amount"
-          },
-          "raw_summary_payload": {
-            "title": "Raw Summary Payload"
-          },
-          "raw_detail_payload": {
-            "title": "Raw Detail Payload"
-          },
-          "pulled_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pulled At"
-          },
-          "last_synced_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Synced At"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          },
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/PddOrderLedgerItemOut"
-            },
-            "type": "array",
-            "title": "Items"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "store_id",
-          "order_sn",
-          "items"
-        ],
-        "title": "PddOrderLedgerDetailOut"
-      },
-      "PddOrderLedgerItemOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "pdd_order_id": {
-            "type": "integer",
-            "title": "Pdd Order Id"
-          },
-          "order_sn": {
-            "type": "string",
-            "title": "Order Sn"
-          },
-          "platform_goods_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Goods Id"
-          },
-          "platform_sku_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Sku Id"
-          },
-          "outer_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Outer Id"
-          },
-          "goods_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Goods Name"
-          },
-          "goods_count": {
-            "type": "integer",
-            "title": "Goods Count"
-          },
-          "goods_price": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Goods Price"
-          },
-          "raw_item_payload": {
-            "title": "Raw Item Payload"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "pdd_order_id",
-          "order_sn",
-          "goods_count"
-        ],
-        "title": "PddOrderLedgerItemOut"
-      },
-      "PddOrderLedgerListOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/PddOrderLedgerRowOut"
-            },
-            "type": "array",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "PddOrderLedgerListOut"
-      },
-      "PddOrderLedgerRowOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "store_id": {
-            "type": "integer",
-            "title": "Store Id"
-          },
-          "order_sn": {
-            "type": "string",
-            "title": "Order Sn"
-          },
-          "order_status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Order Status"
-          },
-          "confirm_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Confirm At"
-          },
-          "goods_amount": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Goods Amount"
-          },
-          "pay_amount": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pay Amount"
-          },
-          "pulled_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pulled At"
-          },
-          "last_synced_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Synced At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "store_id",
-          "order_sn"
-        ],
-        "title": "PddOrderLedgerRowOut"
-      },
       "PermissionMatrixPageOut": {
         "properties": {
           "page_code": {
@@ -33475,7 +34198,7 @@
             ],
             "title": "Store Id"
           },
-          "shop_id": {
+          "store_code": {
             "anyOf": [
               {
                 "type": "string",
@@ -33485,7 +34208,7 @@
                 "type": "null"
               }
             ],
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "ext_order_no": {
             "type": "string",
@@ -33972,6 +34695,562 @@
         "title": "PlatformOrderLineResult",
         "description": "行级解析结果（Phase N+2 输出）"
       },
+      "PlatformOrderMirrorEnvelopeOut": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok",
+            "default": true
+          },
+          "data": {
+            "$ref": "#/components/schemas/PlatformOrderMirrorOut"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "PlatformOrderMirrorEnvelopeOut"
+      },
+      "PlatformOrderMirrorImportIn": {
+        "properties": {
+          "collector_order_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Collector Order Id"
+          },
+          "collector_store_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Collector Store Id"
+          },
+          "collector_store_code": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Collector Store Code"
+          },
+          "collector_store_name": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Collector Store Name"
+          },
+          "platform": {
+            "type": "string",
+            "enum": [
+              "pdd",
+              "taobao",
+              "jd"
+            ],
+            "title": "Platform"
+          },
+          "platform_order_no": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Platform Order No"
+          },
+          "platform_status": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 64
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform Status"
+          },
+          "source_updated_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Updated At"
+          },
+          "pulled_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pulled At"
+          },
+          "last_synced_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Synced At"
+          },
+          "receiver": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Receiver"
+          },
+          "amounts": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Amounts"
+          },
+          "platform_fields": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Platform Fields"
+          },
+          "raw_refs": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Raw Refs"
+          },
+          "lines": {
+            "items": {
+              "$ref": "#/components/schemas/PlatformOrderMirrorLineImportIn"
+            },
+            "type": "array",
+            "title": "Lines"
+          }
+        },
+        "type": "object",
+        "required": [
+          "collector_order_id",
+          "collector_store_id",
+          "collector_store_code",
+          "collector_store_name",
+          "platform",
+          "platform_order_no"
+        ],
+        "title": "PlatformOrderMirrorImportIn"
+      },
+      "PlatformOrderMirrorLineImportIn": {
+        "properties": {
+          "collector_line_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Collector Line Id"
+          },
+          "collector_order_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Collector Order Id"
+          },
+          "platform_order_no": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Platform Order No"
+          },
+          "merchant_sku": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Merchant Sku"
+          },
+          "platform_item_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform Item Id"
+          },
+          "platform_sku_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform Sku Id"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "quantity": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              }
+            ],
+            "title": "Quantity",
+            "default": "0"
+          },
+          "unit_price": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit Price"
+          },
+          "line_amount": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Line Amount"
+          },
+          "platform_fields": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Platform Fields"
+          },
+          "raw_item_payload": {
+            "title": "Raw Item Payload"
+          }
+        },
+        "type": "object",
+        "required": [
+          "collector_line_id",
+          "collector_order_id",
+          "platform_order_no"
+        ],
+        "title": "PlatformOrderMirrorLineImportIn"
+      },
+      "PlatformOrderMirrorLineOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "collector_line_id": {
+            "type": "integer",
+            "title": "Collector Line Id"
+          },
+          "collector_order_id": {
+            "type": "integer",
+            "title": "Collector Order Id"
+          },
+          "platform_order_no": {
+            "type": "string",
+            "title": "Platform Order No"
+          },
+          "merchant_sku": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Merchant Sku"
+          },
+          "platform_item_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform Item Id"
+          },
+          "platform_sku_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform Sku Id"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "quantity": {
+            "type": "string",
+            "title": "Quantity"
+          },
+          "unit_price": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit Price"
+          },
+          "line_amount": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Line Amount"
+          },
+          "platform_fields": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Platform Fields"
+          },
+          "raw_item_payload": {
+            "title": "Raw Item Payload"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "collector_line_id",
+          "collector_order_id",
+          "platform_order_no",
+          "quantity"
+        ],
+        "title": "PlatformOrderMirrorLineOut"
+      },
+      "PlatformOrderMirrorListOut": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok",
+            "default": true
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/PlatformOrderMirrorOut"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "PlatformOrderMirrorListOut"
+      },
+      "PlatformOrderMirrorOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "collector_order_id": {
+            "type": "integer",
+            "title": "Collector Order Id"
+          },
+          "collector_store_id": {
+            "type": "integer",
+            "title": "Collector Store Id"
+          },
+          "collector_store_code": {
+            "type": "string",
+            "title": "Collector Store Code"
+          },
+          "collector_store_name": {
+            "type": "string",
+            "title": "Collector Store Name"
+          },
+          "wms_store_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wms Store Id"
+          },
+          "platform": {
+            "type": "string",
+            "enum": [
+              "pdd",
+              "taobao",
+              "jd"
+            ],
+            "title": "Platform"
+          },
+          "platform_order_no": {
+            "type": "string",
+            "title": "Platform Order No"
+          },
+          "platform_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform Status"
+          },
+          "import_status": {
+            "type": "string",
+            "title": "Import Status"
+          },
+          "mirror_status": {
+            "type": "string",
+            "title": "Mirror Status"
+          },
+          "source_updated_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Updated At"
+          },
+          "pulled_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pulled At"
+          },
+          "collector_last_synced_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Collector Last Synced At"
+          },
+          "imported_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Imported At"
+          },
+          "last_synced_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Synced At"
+          },
+          "receiver": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Receiver"
+          },
+          "amounts": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Amounts"
+          },
+          "platform_fields": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Platform Fields"
+          },
+          "raw_refs": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Raw Refs"
+          },
+          "lines": {
+            "items": {
+              "$ref": "#/components/schemas/PlatformOrderMirrorLineOut"
+            },
+            "type": "array",
+            "title": "Lines"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "collector_order_id",
+          "collector_store_id",
+          "collector_store_code",
+          "collector_store_name",
+          "platform",
+          "platform_order_no",
+          "import_status",
+          "mirror_status"
+        ],
+        "title": "PlatformOrderMirrorOut"
+      },
       "PlatformOrderReplayIn": {
         "properties": {
           "platform": {
@@ -34090,6 +35369,275 @@
         ],
         "title": "PlatformOrderReplayOut"
       },
+      "PlatformOrderResolvePreviewFactLineOut": {
+        "properties": {
+          "line_no": {
+            "type": "integer",
+            "title": "Line No"
+          },
+          "line_key": {
+            "type": "string",
+            "title": "Line Key"
+          },
+          "locator_kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Locator Kind"
+          },
+          "locator_value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Locator Value"
+          },
+          "filled_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Filled Code"
+          },
+          "qty": {
+            "type": "integer",
+            "title": "Qty"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "spec": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spec"
+          },
+          "extras": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Extras"
+          }
+        },
+        "type": "object",
+        "required": [
+          "line_no",
+          "line_key",
+          "qty"
+        ],
+        "title": "PlatformOrderResolvePreviewFactLineOut"
+      },
+      "PlatformOrderResolvePreviewIn": {
+        "properties": {
+          "platform": {
+            "type": "string",
+            "maxLength": 50,
+            "minLength": 1,
+            "title": "Platform"
+          },
+          "store_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Store Id"
+          },
+          "ext_order_no": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Ext Order No"
+          }
+        },
+        "type": "object",
+        "required": [
+          "platform",
+          "store_id",
+          "ext_order_no"
+        ],
+        "title": "PlatformOrderResolvePreviewIn"
+      },
+      "PlatformOrderResolvePreviewItemQtyOut": {
+        "properties": {
+          "item_id": {
+            "type": "integer",
+            "title": "Item Id"
+          },
+          "qty": {
+            "type": "integer",
+            "title": "Qty"
+          },
+          "sku": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sku"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "item_id",
+          "qty"
+        ],
+        "title": "PlatformOrderResolvePreviewItemQtyOut"
+      },
+      "PlatformOrderResolvePreviewOut": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "ref": {
+            "type": "string",
+            "title": "Ref"
+          },
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "store_id": {
+            "type": "integer",
+            "title": "Store Id"
+          },
+          "ext_order_no": {
+            "type": "string",
+            "title": "Ext Order No"
+          },
+          "facts_n": {
+            "type": "integer",
+            "title": "Facts N"
+          },
+          "fact_lines": {
+            "items": {
+              "$ref": "#/components/schemas/PlatformOrderResolvePreviewFactLineOut"
+            },
+            "type": "array",
+            "title": "Fact Lines"
+          },
+          "resolved": {
+            "items": {
+              "$ref": "#/components/schemas/PlatformOrderResolvePreviewResolvedLineOut"
+            },
+            "type": "array",
+            "title": "Resolved"
+          },
+          "unresolved": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Unresolved"
+          },
+          "item_qty_map": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "type": "object",
+            "title": "Item Qty Map"
+          },
+          "item_qty_items": {
+            "items": {
+              "$ref": "#/components/schemas/PlatformOrderResolvePreviewItemQtyOut"
+            },
+            "type": "array",
+            "title": "Item Qty Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "ref",
+          "platform",
+          "store_id",
+          "ext_order_no",
+          "facts_n",
+          "fact_lines",
+          "resolved",
+          "unresolved",
+          "item_qty_map",
+          "item_qty_items"
+        ],
+        "title": "PlatformOrderResolvePreviewOut"
+      },
+      "PlatformOrderResolvePreviewResolvedLineOut": {
+        "properties": {
+          "filled_code": {
+            "type": "string",
+            "title": "Filled Code"
+          },
+          "qty": {
+            "type": "integer",
+            "title": "Qty"
+          },
+          "fsku_id": {
+            "type": "integer",
+            "title": "Fsku Id"
+          },
+          "expanded_items": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Expanded Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "filled_code",
+          "qty",
+          "fsku_id",
+          "expanded_items"
+        ],
+        "title": "PlatformOrderResolvePreviewResolvedLineOut"
+      },
       "PricingListResponse": {
         "properties": {
           "ok": {
@@ -34117,13 +35665,13 @@
             "type": "integer",
             "title": "Provider Id"
           },
-          "provider_code": {
+          "shipping_provider_code": {
             "type": "string",
-            "title": "Provider Code"
+            "title": "Shipping Provider Code"
           },
-          "provider_name": {
+          "shipping_provider_name": {
             "type": "string",
-            "title": "Provider Name"
+            "title": "Shipping Provider Name"
           },
           "provider_active": {
             "type": "boolean",
@@ -34202,8 +35750,8 @@
         "type": "object",
         "required": [
           "provider_id",
-          "provider_code",
-          "provider_name",
+          "shipping_provider_code",
+          "shipping_provider_name",
           "provider_active",
           "warehouse_id",
           "warehouse_name",
@@ -34675,6 +36223,213 @@
           "barcodes"
         ],
         "title": "PublicItemAggregateOut"
+      },
+      "PurchaseCostDailyRow": {
+        "properties": {
+          "day": {
+            "type": "string",
+            "format": "date",
+            "title": "Day"
+          },
+          "purchase_order_count": {
+            "type": "integer",
+            "title": "Purchase Order Count"
+          },
+          "purchase_amount": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Purchase Amount"
+          }
+        },
+        "type": "object",
+        "required": [
+          "day",
+          "purchase_order_count",
+          "purchase_amount"
+        ],
+        "title": "PurchaseCostDailyRow"
+      },
+      "PurchaseCostItemRow": {
+        "properties": {
+          "item_id": {
+            "type": "integer",
+            "title": "Item Id"
+          },
+          "item_sku": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Item Sku"
+          },
+          "item_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Item Name"
+          },
+          "total_units": {
+            "type": "integer",
+            "title": "Total Units"
+          },
+          "purchase_amount": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Purchase Amount"
+          },
+          "avg_unit_cost": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avg Unit Cost"
+          }
+        },
+        "type": "object",
+        "required": [
+          "item_id",
+          "total_units",
+          "purchase_amount"
+        ],
+        "title": "PurchaseCostItemRow"
+      },
+      "PurchaseCostResponse": {
+        "properties": {
+          "summary": {
+            "$ref": "#/components/schemas/PurchaseCostSummary"
+          },
+          "daily": {
+            "items": {
+              "$ref": "#/components/schemas/PurchaseCostDailyRow"
+            },
+            "type": "array",
+            "title": "Daily"
+          },
+          "by_supplier": {
+            "items": {
+              "$ref": "#/components/schemas/PurchaseCostSupplierRow"
+            },
+            "type": "array",
+            "title": "By Supplier"
+          },
+          "by_item": {
+            "items": {
+              "$ref": "#/components/schemas/PurchaseCostItemRow"
+            },
+            "type": "array",
+            "title": "By Item"
+          }
+        },
+        "type": "object",
+        "required": [
+          "summary",
+          "daily",
+          "by_supplier",
+          "by_item"
+        ],
+        "title": "PurchaseCostResponse"
+      },
+      "PurchaseCostSummary": {
+        "properties": {
+          "purchase_order_count": {
+            "type": "integer",
+            "title": "Purchase Order Count"
+          },
+          "supplier_count": {
+            "type": "integer",
+            "title": "Supplier Count"
+          },
+          "item_count": {
+            "type": "integer",
+            "title": "Item Count"
+          },
+          "purchase_amount": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Purchase Amount"
+          },
+          "avg_unit_cost": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avg Unit Cost"
+          }
+        },
+        "type": "object",
+        "required": [
+          "purchase_order_count",
+          "supplier_count",
+          "item_count",
+          "purchase_amount"
+        ],
+        "title": "PurchaseCostSummary"
+      },
+      "PurchaseCostSupplierRow": {
+        "properties": {
+          "supplier_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Supplier Id"
+          },
+          "supplier_name": {
+            "type": "string",
+            "title": "Supplier Name"
+          },
+          "purchase_order_count": {
+            "type": "integer",
+            "title": "Purchase Order Count"
+          },
+          "purchase_amount": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Purchase Amount"
+          },
+          "avg_unit_cost": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avg Unit Cost"
+          }
+        },
+        "type": "object",
+        "required": [
+          "supplier_name",
+          "purchase_order_count",
+          "purchase_amount"
+        ],
+        "title": "PurchaseCostSupplierRow"
       },
       "PurchaseOrderCloseIn": {
         "properties": {
@@ -35216,31 +36971,6 @@
             ],
             "title": "Supply Price"
           },
-          "discount_amount": {
-            "anyOf": [
-              {
-                "type": "number",
-                "minimum": 0.0
-              },
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              }
-            ],
-            "title": "Discount Amount",
-            "default": "0"
-          },
-          "discount_note": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Discount Note"
-          },
           "remark": {
             "anyOf": [
               {
@@ -35262,7 +36992,7 @@
           "qty_input"
         ],
         "title": "PurchaseOrderCreateLineV2",
-        "description": "PO 创建行输入（V2）——终态合同\n\n严格合同：\n- 必填：line_no / item_id / uom_id / qty_input\n- 可选商业字段：supply_price / discount_amount / discount_note / remark\n- 快照与派生字段（item_name / ratio_to_base / qty_ordered_base）不允许前端直传"
+        "description": "PO 创建行输入（V2）——终态合同\n\n严格合同：\n- 必填：line_no / item_id / uom_id / qty_input\n- 可选商业字段：supply_price / remark\n- 快照与派生字段（item_name / ratio_to_base / qty_ordered_base）不允许前端直传"
       },
       "PurchaseOrderCreateV2": {
         "properties": {
@@ -35395,23 +37125,6 @@
               }
             ],
             "title": "Supply Price"
-          },
-          "discount_amount": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Discount Amount",
-            "default": "0"
-          },
-          "discount_note": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Discount Note"
           },
           "remark": {
             "anyOf": [
@@ -36314,7 +38027,7 @@
             "type": "integer",
             "title": "Provider Id"
           },
-          "carrier_code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -36323,11 +38036,11 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
-          "carrier_name": {
+          "shipping_provider_name": {
             "type": "string",
-            "title": "Carrier Name"
+            "title": "Shipping Provider Name"
           },
           "template_id": {
             "type": "integer",
@@ -36418,7 +38131,7 @@
         "type": "object",
         "required": [
           "provider_id",
-          "carrier_name",
+          "shipping_provider_name",
           "template_id",
           "total_amount",
           "quote_status",
@@ -36528,7 +38241,7 @@
             ],
             "title": "Provider Id"
           },
-          "carrier_code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -36537,9 +38250,9 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
-          "carrier_name": {
+          "shipping_provider_name": {
             "anyOf": [
               {
                 "type": "string"
@@ -36548,7 +38261,7 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Name"
+            "title": "Shipping Provider Name"
           },
           "currency": {
             "anyOf": [
@@ -36623,30 +38336,30 @@
         ],
         "title": "ReasonCanon"
       },
-      "ReconcileCarrierBillIn": {
+      "ReconcileShippingProviderBillIn": {
         "properties": {
-          "carrier_code": {
+          "shipping_provider_code": {
             "type": "string",
-            "title": "Carrier Code",
-            "description": "承运商代码"
+            "title": "Shipping Provider Code",
+            "description": "物流网点编码"
           }
         },
         "type": "object",
         "required": [
-          "carrier_code"
+          "shipping_provider_code"
         ],
-        "title": "ReconcileCarrierBillIn"
+        "title": "ReconcileShippingProviderBillIn"
       },
-      "ReconcileCarrierBillResult": {
+      "ReconcileShippingProviderBillResult": {
         "properties": {
           "ok": {
             "type": "boolean",
             "title": "Ok",
             "default": true
           },
-          "carrier_code": {
+          "shipping_provider_code": {
             "type": "string",
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
           "bill_item_count": {
             "type": "integer",
@@ -36676,14 +38389,14 @@
         },
         "type": "object",
         "required": [
-          "carrier_code",
+          "shipping_provider_code",
           "bill_item_count",
           "matched_count",
           "bill_only_count",
           "diff_count",
           "updated_count"
         ],
-        "title": "ReconcileCarrierBillResult"
+        "title": "ReconcileShippingProviderBillResult"
       },
       "ReconcileSummaryPayload": {
         "properties": {
@@ -36717,7 +38430,7 @@
       },
       "RecordsCostAnalysisByCarrierRowOut": {
         "properties": {
-          "carrier_code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -36726,7 +38439,7 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
           "ticket_count": {
             "type": "integer",
@@ -36835,7 +38548,7 @@
             ],
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -36844,7 +38557,7 @@
                 "type": "null"
               }
             ],
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "ext_order_no": {
             "anyOf": [
@@ -37845,9 +39558,9 @@
             "title": "Platform",
             "description": "平台，例如 PDD"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "title": "Shop Id",
+            "title": "Store Code",
             "description": "店铺 ID，例如 '1'"
           },
           "ext_order_no": {
@@ -37864,7 +39577,7 @@
         "type": "object",
         "required": [
           "platform",
-          "shop_id",
+          "store_code",
           "ext_order_no",
           "address_ready_status"
         ],
@@ -37885,9 +39598,9 @@
             "type": "string",
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "ext_order_no": {
             "type": "string",
@@ -37902,7 +39615,7 @@
         "required": [
           "order_id",
           "platform",
-          "shop_id",
+          "store_code",
           "ext_order_no",
           "address_ready_status"
         ],
@@ -37918,9 +39631,9 @@
             "type": "string",
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "ext_order_no": {
             "type": "string",
@@ -38005,7 +39718,7 @@
         "required": [
           "order_id",
           "platform",
-          "shop_id",
+          "store_code",
           "ext_order_no",
           "address_summary",
           "address_ready_status"
@@ -38039,9 +39752,9 @@
             "type": "string",
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "ext_order_no": {
             "type": "string",
@@ -38122,7 +39835,7 @@
         "required": [
           "order_id",
           "platform",
-          "shop_id",
+          "store_code",
           "ext_order_no",
           "address_summary"
         ],
@@ -38425,7 +40138,7 @@
             "type": "integer",
             "title": "Provider Id"
           },
-          "carrier_code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -38434,11 +40147,11 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
-          "carrier_name": {
+          "shipping_provider_name": {
             "type": "string",
-            "title": "Carrier Name"
+            "title": "Shipping Provider Name"
           },
           "template_id": {
             "type": "integer",
@@ -38515,7 +40228,7 @@
         "type": "object",
         "required": [
           "provider_id",
-          "carrier_name",
+          "shipping_provider_name",
           "template_id",
           "quote_status"
         ],
@@ -38527,7 +40240,7 @@
             "type": "integer",
             "title": "Provider Id"
           },
-          "carrier_code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -38536,11 +40249,11 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
-          "carrier_name": {
+          "shipping_provider_name": {
             "type": "string",
-            "title": "Carrier Name"
+            "title": "Shipping Provider Name"
           },
           "template_id": {
             "type": "integer",
@@ -38617,7 +40330,7 @@
         "type": "object",
         "required": [
           "provider_id",
-          "carrier_name",
+          "shipping_provider_name",
           "template_id",
           "quote_status"
         ],
@@ -38629,7 +40342,7 @@
             "type": "integer",
             "title": "Provider Id"
           },
-          "carrier_code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -38638,7 +40351,7 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
           "template_id": {
             "type": "integer",
@@ -38798,7 +40511,7 @@
             "type": "integer",
             "title": "Shipping Provider Id"
           },
-          "carrier_code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -38807,9 +40520,9 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
-          "carrier_name": {
+          "shipping_provider_name": {
             "anyOf": [
               {
                 "type": "string"
@@ -38818,7 +40531,7 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Name"
+            "title": "Shipping Provider Name"
           },
           "status": {
             "type": "string",
@@ -38906,9 +40619,9 @@
             ],
             "title": "Shipping Record Id"
           },
-          "carrier_code": {
+          "shipping_provider_code": {
             "type": "string",
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
           "tracking_no": {
             "type": "string",
@@ -38986,7 +40699,7 @@
         "required": [
           "id",
           "carrier_bill_item_id",
-          "carrier_code",
+          "shipping_provider_code",
           "tracking_no",
           "result_status",
           "approved_reason_code",
@@ -39008,9 +40721,9 @@
             ],
             "title": "Status"
           },
-          "carrier_code": {
+          "shipping_provider_code": {
             "type": "string",
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
           "tracking_no": {
             "type": "string",
@@ -39113,7 +40826,7 @@
         "required": [
           "reconciliation_id",
           "status",
-          "carrier_code",
+          "shipping_provider_code",
           "tracking_no",
           "carrier_bill_item_id",
           "created_at"
@@ -39169,7 +40882,7 @@
       },
       "ShippingByCarrierRow": {
         "properties": {
-          "carrier_code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -39178,9 +40891,9 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
-          "carrier_name": {
+          "shipping_provider_name": {
             "anyOf": [
               {
                 "type": "string"
@@ -39189,7 +40902,7 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Name"
+            "title": "Shipping Provider Name"
           },
           "ship_cnt": {
             "type": "integer",
@@ -39267,7 +40980,7 @@
         ],
         "title": "ShippingByProvinceRow"
       },
-      "ShippingByShopResponse": {
+      "ShippingByStoreResponse": {
         "properties": {
           "ok": {
             "type": "boolean",
@@ -39276,7 +40989,7 @@
           },
           "rows": {
             "items": {
-              "$ref": "#/components/schemas/ShippingByShopRow"
+              "$ref": "#/components/schemas/ShippingByStoreRow"
             },
             "type": "array",
             "title": "Rows"
@@ -39286,17 +40999,17 @@
         "required": [
           "rows"
         ],
-        "title": "ShippingByShopResponse"
+        "title": "ShippingByStoreResponse"
       },
-      "ShippingByShopRow": {
+      "ShippingByStoreRow": {
         "properties": {
           "platform": {
             "type": "string",
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "ship_cnt": {
             "type": "integer",
@@ -39314,12 +41027,12 @@
         "type": "object",
         "required": [
           "platform",
-          "shop_id",
+          "store_code",
           "ship_cnt",
           "total_cost",
           "avg_cost"
         ],
-        "title": "ShippingByShopRow"
+        "title": "ShippingByStoreRow"
       },
       "ShippingByWarehouseResponse": {
         "properties": {
@@ -39375,6 +41088,530 @@
           "avg_cost"
         ],
         "title": "ShippingByWarehouseRow"
+      },
+      "ShippingCostDailyRow": {
+        "properties": {
+          "day": {
+            "type": "string",
+            "format": "date",
+            "title": "Day"
+          },
+          "shipment_count": {
+            "type": "integer",
+            "title": "Shipment Count"
+          },
+          "estimated_shipping_cost": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Estimated Shipping Cost"
+          },
+          "billed_shipping_cost": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Billed Shipping Cost"
+          },
+          "cost_diff": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Cost Diff"
+          },
+          "adjusted_cost": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Adjusted Cost"
+          }
+        },
+        "type": "object",
+        "required": [
+          "day",
+          "shipment_count",
+          "estimated_shipping_cost",
+          "billed_shipping_cost",
+          "cost_diff",
+          "adjusted_cost"
+        ],
+        "title": "ShippingCostDailyRow"
+      },
+      "ShippingCostLedgerOptionsResponse": {
+        "properties": {
+          "stores": {
+            "items": {
+              "$ref": "#/components/schemas/ShippingCostLedgerShopOption"
+            },
+            "type": "array",
+            "title": "Stores"
+          },
+          "warehouses": {
+            "items": {
+              "$ref": "#/components/schemas/ShippingCostLedgerWarehouseOption"
+            },
+            "type": "array",
+            "title": "Warehouses"
+          },
+          "providers": {
+            "items": {
+              "$ref": "#/components/schemas/ShippingCostLedgerProviderOption"
+            },
+            "type": "array",
+            "title": "Providers"
+          }
+        },
+        "type": "object",
+        "required": [
+          "stores",
+          "warehouses",
+          "providers"
+        ],
+        "title": "ShippingCostLedgerOptionsResponse"
+      },
+      "ShippingCostLedgerProviderOption": {
+        "properties": {
+          "shipping_provider_id": {
+            "type": "integer",
+            "title": "Shipping Provider Id"
+          },
+          "shipping_provider_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shipping Provider Code"
+          },
+          "shipping_provider_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shipping Provider Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "shipping_provider_id"
+        ],
+        "title": "ShippingCostLedgerProviderOption"
+      },
+      "ShippingCostLedgerResponse": {
+        "properties": {
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/ShippingCostLedgerRow"
+            },
+            "type": "array",
+            "title": "Rows"
+          }
+        },
+        "type": "object",
+        "required": [
+          "rows"
+        ],
+        "title": "ShippingCostLedgerResponse"
+      },
+      "ShippingCostLedgerRow": {
+        "properties": {
+          "shipping_record_id": {
+            "type": "integer",
+            "title": "Shipping Record Id"
+          },
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "store_code": {
+            "type": "string",
+            "title": "Store Code"
+          },
+          "store_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Store Name"
+          },
+          "order_ref": {
+            "type": "string",
+            "title": "Order Ref"
+          },
+          "package_no": {
+            "type": "integer",
+            "title": "Package No"
+          },
+          "tracking_no": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tracking No"
+          },
+          "warehouse_id": {
+            "type": "integer",
+            "title": "Warehouse Id"
+          },
+          "warehouse_name": {
+            "type": "string",
+            "title": "Warehouse Name"
+          },
+          "shipping_provider_id": {
+            "type": "integer",
+            "title": "Shipping Provider Id"
+          },
+          "shipping_provider_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shipping Provider Code"
+          },
+          "shipping_provider_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shipping Provider Name"
+          },
+          "shipped_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Shipped Time"
+          },
+          "shipped_date": {
+            "type": "string",
+            "format": "date",
+            "title": "Shipped Date"
+          },
+          "dest_province": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dest Province"
+          },
+          "dest_city": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dest City"
+          },
+          "gross_weight_kg": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gross Weight Kg"
+          },
+          "freight_estimated": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Freight Estimated"
+          },
+          "surcharge_estimated": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Surcharge Estimated"
+          },
+          "cost_estimated": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cost Estimated"
+          }
+        },
+        "type": "object",
+        "required": [
+          "shipping_record_id",
+          "platform",
+          "store_code",
+          "order_ref",
+          "package_no",
+          "warehouse_id",
+          "warehouse_name",
+          "shipping_provider_id",
+          "shipped_time",
+          "shipped_date"
+        ],
+        "title": "ShippingCostLedgerRow"
+      },
+      "ShippingCostLedgerShopOption": {
+        "properties": {
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "store_code": {
+            "type": "string",
+            "title": "Store Code"
+          },
+          "store_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Store Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "platform",
+          "store_code"
+        ],
+        "title": "ShippingCostLedgerShopOption"
+      },
+      "ShippingCostLedgerWarehouseOption": {
+        "properties": {
+          "warehouse_id": {
+            "type": "integer",
+            "title": "Warehouse Id"
+          },
+          "warehouse_name": {
+            "type": "string",
+            "title": "Warehouse Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "warehouse_id",
+          "warehouse_name"
+        ],
+        "title": "ShippingCostLedgerWarehouseOption"
+      },
+      "ShippingCostProviderRow": {
+        "properties": {
+          "shipping_provider_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shipping Provider Id"
+          },
+          "shipping_provider_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shipping Provider Code"
+          },
+          "shipping_provider_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shipping Provider Name"
+          },
+          "shipment_count": {
+            "type": "integer",
+            "title": "Shipment Count"
+          },
+          "estimated_shipping_cost": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Estimated Shipping Cost"
+          },
+          "billed_shipping_cost": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Billed Shipping Cost"
+          }
+        },
+        "type": "object",
+        "required": [
+          "shipment_count",
+          "estimated_shipping_cost",
+          "billed_shipping_cost"
+        ],
+        "title": "ShippingCostProviderRow"
+      },
+      "ShippingCostResponse": {
+        "properties": {
+          "summary": {
+            "$ref": "#/components/schemas/ShippingCostSummary"
+          },
+          "daily": {
+            "items": {
+              "$ref": "#/components/schemas/ShippingCostDailyRow"
+            },
+            "type": "array",
+            "title": "Daily"
+          },
+          "by_carrier": {
+            "items": {
+              "$ref": "#/components/schemas/ShippingCostProviderRow"
+            },
+            "type": "array",
+            "title": "By Carrier"
+          },
+          "by_store": {
+            "items": {
+              "$ref": "#/components/schemas/ShippingCostShopRow"
+            },
+            "type": "array",
+            "title": "By Store"
+          }
+        },
+        "type": "object",
+        "required": [
+          "summary",
+          "daily",
+          "by_carrier",
+          "by_store"
+        ],
+        "title": "ShippingCostResponse"
+      },
+      "ShippingCostShopRow": {
+        "properties": {
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "store_code": {
+            "type": "string",
+            "title": "Store Code"
+          },
+          "store_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Store Name"
+          },
+          "shipment_count": {
+            "type": "integer",
+            "title": "Shipment Count"
+          },
+          "estimated_shipping_cost": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Estimated Shipping Cost"
+          },
+          "billed_shipping_cost": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Billed Shipping Cost"
+          }
+        },
+        "type": "object",
+        "required": [
+          "platform",
+          "store_code",
+          "shipment_count",
+          "estimated_shipping_cost",
+          "billed_shipping_cost"
+        ],
+        "title": "ShippingCostShopRow"
+      },
+      "ShippingCostSummary": {
+        "properties": {
+          "shipment_count": {
+            "type": "integer",
+            "title": "Shipment Count"
+          },
+          "estimated_shipping_cost": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Estimated Shipping Cost"
+          },
+          "billed_shipping_cost": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Billed Shipping Cost"
+          },
+          "cost_diff": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Cost Diff"
+          },
+          "adjusted_cost": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Adjusted Cost"
+          }
+        },
+        "type": "object",
+        "required": [
+          "shipment_count",
+          "estimated_shipping_cost",
+          "billed_shipping_cost",
+          "cost_diff",
+          "adjusted_cost"
+        ],
+        "title": "ShippingCostSummary"
       },
       "ShippingDailyResponse": {
         "properties": {
@@ -39483,7 +41720,7 @@
             ],
             "title": "Shipping Provider Id"
           },
-          "carrier_code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -39492,9 +41729,9 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Code"
+            "title": "Shipping Provider Code"
           },
-          "carrier_name": {
+          "shipping_provider_name": {
             "anyOf": [
               {
                 "type": "string"
@@ -39503,7 +41740,7 @@
                 "type": "null"
               }
             ],
-            "title": "Carrier Name"
+            "title": "Shipping Provider Name"
           },
           "tracking_no": {
             "anyOf": [
@@ -39639,6 +41876,282 @@
           "created_at"
         ],
         "title": "ShippingLedgerRow"
+      },
+      "ShippingProviderBillImportResult": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok",
+            "default": true
+          },
+          "shipping_provider_code": {
+            "type": "string",
+            "title": "Shipping Provider Code"
+          },
+          "imported_count": {
+            "type": "integer",
+            "title": "Imported Count"
+          },
+          "skipped_count": {
+            "type": "integer",
+            "title": "Skipped Count"
+          },
+          "error_count": {
+            "type": "integer",
+            "title": "Error Count"
+          },
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/ShippingProviderBillImportRowError"
+            },
+            "type": "array",
+            "title": "Errors"
+          }
+        },
+        "type": "object",
+        "required": [
+          "shipping_provider_code",
+          "imported_count",
+          "skipped_count",
+          "error_count"
+        ],
+        "title": "ShippingProviderBillImportResult"
+      },
+      "ShippingProviderBillImportRowError": {
+        "properties": {
+          "row_no": {
+            "type": "integer",
+            "title": "Row No",
+            "description": "Excel 行号（从 1 开始）"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message",
+            "description": "错误原因"
+          }
+        },
+        "type": "object",
+        "required": [
+          "row_no",
+          "message"
+        ],
+        "title": "ShippingProviderBillImportRowError"
+      },
+      "ShippingProviderBillItemOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "shipping_provider_code": {
+            "type": "string",
+            "title": "Shipping Provider Code"
+          },
+          "bill_month": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bill Month"
+          },
+          "tracking_no": {
+            "type": "string",
+            "title": "Tracking No"
+          },
+          "business_time": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Business Time"
+          },
+          "destination_province": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destination Province"
+          },
+          "destination_city": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destination City"
+          },
+          "billing_weight_kg": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Billing Weight Kg"
+          },
+          "freight_amount": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Freight Amount"
+          },
+          "surcharge_amount": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Surcharge Amount"
+          },
+          "total_amount": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Amount"
+          },
+          "settlement_object": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Settlement Object"
+          },
+          "order_customer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Order Customer"
+          },
+          "sender_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sender Name"
+          },
+          "network_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Network Name"
+          },
+          "size_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Text"
+          },
+          "parent_customer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Customer"
+          },
+          "raw_payload": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Raw Payload"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "shipping_provider_code",
+          "tracking_no",
+          "raw_payload",
+          "created_at"
+        ],
+        "title": "ShippingProviderBillItemOut"
+      },
+      "ShippingProviderBillItemsResponse": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok",
+            "default": true
+          },
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/ShippingProviderBillItemOut"
+            },
+            "type": "array",
+            "title": "Rows"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
+        },
+        "type": "object",
+        "required": [
+          "rows",
+          "total"
+        ],
+        "title": "ShippingProviderBillItemsResponse"
       },
       "ShippingProviderContactCreateIn": {
         "properties": {
@@ -39886,11 +42399,11 @@
             "minLength": 1,
             "title": "Name"
           },
-          "code": {
+          "shipping_provider_code": {
             "type": "string",
             "maxLength": 64,
             "minLength": 1,
-            "title": "Code"
+            "title": "Shipping Provider Code"
           },
           "company_code": {
             "anyOf": [
@@ -39951,7 +42464,7 @@
         "type": "object",
         "required": [
           "name",
-          "code"
+          "shipping_provider_code"
         ],
         "title": "ShippingProviderCreateIn"
       },
@@ -40020,7 +42533,7 @@
             "type": "string",
             "title": "Name"
           },
-          "code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string"
@@ -40029,7 +42542,7 @@
                 "type": "null"
               }
             ],
-            "title": "Code"
+            "title": "Shipping Provider Code"
           },
           "active": {
             "type": "boolean",
@@ -40054,9 +42567,9 @@
             "type": "string",
             "title": "Name"
           },
-          "code": {
+          "shipping_provider_code": {
             "type": "string",
-            "title": "Code"
+            "title": "Shipping Provider Code"
           },
           "display_label": {
             "type": "string",
@@ -40120,11 +42633,11 @@
         "required": [
           "id",
           "name",
-          "code",
+          "shipping_provider_code",
           "display_label"
         ],
         "title": "ShippingProviderOut",
-        "description": "刚性契约（最新）：\n- 本对象语义为「运输网点实体」（保留表名 shipping_providers）\n- 与仓库为 M:N 关系，通过 warehouse_shipping_providers 表表达\n- code 为内部业务键（允许修改，但保持唯一与规范化）\n- company_code / resource_code 为电子面单固定接入参数"
+        "description": "刚性契约（最新）：\n- 本对象语义为「运输网点实体」（保留表名 shipping_providers）\n- 与仓库为 M:N 关系，通过 warehouse_shipping_providers 表表达\n- shipping_provider_code 为物流网点号码 / 网点编码（由网点提供，保持唯一与规范化）\n- company_code / resource_code 为电子面单固定接入参数"
       },
       "ShippingProviderUpdateIn": {
         "properties": {
@@ -40141,7 +42654,7 @@
             ],
             "title": "Name"
           },
-          "code": {
+          "shipping_provider_code": {
             "anyOf": [
               {
                 "type": "string",
@@ -40152,7 +42665,7 @@
                 "type": "null"
               }
             ],
-            "title": "Code"
+            "title": "Shipping Provider Code"
           },
           "company_code": {
             "anyOf": [
@@ -40234,6 +42747,104 @@
         ],
         "title": "ShippingProviderUpdateOut"
       },
+      "ShippingQuoteFailureDetail": {
+        "properties": {
+          "ref": {
+            "type": "string",
+            "title": "Ref"
+          },
+          "event": {
+            "type": "string",
+            "title": "Event"
+          },
+          "error_code": {
+            "type": "string",
+            "title": "Error Code"
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Message"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ref",
+          "event",
+          "error_code",
+          "created_at"
+        ],
+        "title": "ShippingQuoteFailureDetail"
+      },
+      "ShippingQuoteFailuresMetricsResponse": {
+        "properties": {
+          "day": {
+            "type": "string",
+            "format": "date",
+            "title": "Day"
+          },
+          "platform": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform"
+          },
+          "calc_failed_total": {
+            "type": "integer",
+            "title": "Calc Failed Total"
+          },
+          "recommend_failed_total": {
+            "type": "integer",
+            "title": "Recommend Failed Total"
+          },
+          "calc_failures_by_code": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "type": "object",
+            "title": "Calc Failures By Code",
+            "default": {}
+          },
+          "recommend_failures_by_code": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "type": "object",
+            "title": "Recommend Failures By Code",
+            "default": {}
+          },
+          "details": {
+            "items": {
+              "$ref": "#/components/schemas/ShippingQuoteFailureDetail"
+            },
+            "type": "array",
+            "title": "Details",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "day",
+          "calc_failed_total",
+          "recommend_failed_total"
+        ],
+        "title": "ShippingQuoteFailuresMetricsResponse"
+      },
       "ShippingReportFilterOptions": {
         "properties": {
           "platforms": {
@@ -40243,12 +42854,12 @@
             "type": "array",
             "title": "Platforms"
           },
-          "shop_ids": {
+          "store_codes": {
             "items": {
               "type": "string"
             },
             "type": "array",
-            "title": "Shop Ids"
+            "title": "Store Codes"
           },
           "provinces": {
             "items": {
@@ -40268,11 +42879,1125 @@
         "type": "object",
         "required": [
           "platforms",
-          "shop_ids",
+          "store_codes",
           "provinces",
           "cities"
         ],
         "title": "ShippingReportFilterOptions"
+      },
+      "SimilarItemOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "sku": {
+            "type": "string",
+            "title": "Sku"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "spec": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spec"
+          },
+          "brand": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Brand"
+          },
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "sku",
+          "name",
+          "spec",
+          "brand",
+          "category"
+        ],
+        "title": "SimilarItemOut"
+      },
+      "SkuBusinessCategoryCreate": {
+        "properties": {
+          "parent_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Id"
+          },
+          "level": {
+            "type": "integer",
+            "maximum": 3.0,
+            "minimum": 1.0,
+            "title": "Level"
+          },
+          "product_kind": {
+            "type": "string",
+            "enum": [
+              "FOOD",
+              "SUPPLY"
+            ],
+            "title": "Product Kind"
+          },
+          "category_name": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Category Name"
+          },
+          "category_code": {
+            "type": "string",
+            "maxLength": 32,
+            "minLength": 1,
+            "title": "Category Code"
+          },
+          "is_leaf": {
+            "type": "boolean",
+            "title": "Is Leaf",
+            "default": false
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order",
+            "default": 0
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 500
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          }
+        },
+        "type": "object",
+        "required": [
+          "level",
+          "product_kind",
+          "category_name",
+          "category_code"
+        ],
+        "title": "SkuBusinessCategoryCreate"
+      },
+      "SkuBusinessCategoryOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "parent_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Id"
+          },
+          "level": {
+            "type": "integer",
+            "title": "Level"
+          },
+          "product_kind": {
+            "type": "string",
+            "title": "Product Kind"
+          },
+          "category_name": {
+            "type": "string",
+            "title": "Category Name"
+          },
+          "category_code": {
+            "type": "string",
+            "title": "Category Code"
+          },
+          "path_code": {
+            "type": "string",
+            "title": "Path Code"
+          },
+          "is_leaf": {
+            "type": "boolean",
+            "title": "Is Leaf"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "is_locked": {
+            "type": "boolean",
+            "title": "Is Locked"
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order"
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "parent_id",
+          "level",
+          "product_kind",
+          "category_name",
+          "category_code",
+          "path_code",
+          "is_leaf",
+          "is_active",
+          "is_locked",
+          "sort_order",
+          "remark"
+        ],
+        "title": "SkuBusinessCategoryOut"
+      },
+      "SkuBusinessCategoryUpdate": {
+        "properties": {
+          "category_name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category Name"
+          },
+          "category_code": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 32
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category Code"
+          },
+          "is_leaf": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Leaf"
+          },
+          "sort_order": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sort Order"
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 500
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          }
+        },
+        "type": "object",
+        "title": "SkuBusinessCategoryUpdate"
+      },
+      "SkuCodeBrandCreate": {
+        "properties": {
+          "name_cn": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Name Cn"
+          },
+          "code": {
+            "type": "string",
+            "maxLength": 32,
+            "minLength": 1,
+            "title": "Code"
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order",
+            "default": 0
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 500
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name_cn",
+          "code"
+        ],
+        "title": "SkuCodeBrandCreate"
+      },
+      "SkuCodeBrandOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "name_cn": {
+            "type": "string",
+            "title": "Name Cn"
+          },
+          "code": {
+            "type": "string",
+            "title": "Code"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "is_locked": {
+            "type": "boolean",
+            "title": "Is Locked"
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order"
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name_cn",
+          "code",
+          "is_active",
+          "is_locked",
+          "sort_order",
+          "remark"
+        ],
+        "title": "SkuCodeBrandOut"
+      },
+      "SkuCodeBrandUpdate": {
+        "properties": {
+          "name_cn": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name Cn"
+          },
+          "code": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 32
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Code"
+          },
+          "sort_order": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sort Order"
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 500
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          }
+        },
+        "type": "object",
+        "title": "SkuCodeBrandUpdate"
+      },
+      "SkuCodeTermCreate": {
+        "properties": {
+          "group_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Group Id"
+          },
+          "name_cn": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Name Cn"
+          },
+          "code": {
+            "type": "string",
+            "maxLength": 32,
+            "minLength": 1,
+            "title": "Code"
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order",
+            "default": 0
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 500
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          }
+        },
+        "type": "object",
+        "required": [
+          "group_id",
+          "name_cn",
+          "code"
+        ],
+        "title": "SkuCodeTermCreate"
+      },
+      "SkuCodeTermGroupOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "product_kind": {
+            "type": "string",
+            "title": "Product Kind"
+          },
+          "group_code": {
+            "type": "string",
+            "title": "Group Code"
+          },
+          "group_name": {
+            "type": "string",
+            "title": "Group Name"
+          },
+          "is_multi_select": {
+            "type": "boolean",
+            "title": "Is Multi Select"
+          },
+          "is_required": {
+            "type": "boolean",
+            "title": "Is Required"
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "product_kind",
+          "group_code",
+          "group_name",
+          "is_multi_select",
+          "is_required",
+          "sort_order",
+          "is_active",
+          "remark"
+        ],
+        "title": "SkuCodeTermGroupOut"
+      },
+      "SkuCodeTermOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "group_id": {
+            "type": "integer",
+            "title": "Group Id"
+          },
+          "name_cn": {
+            "type": "string",
+            "title": "Name Cn"
+          },
+          "code": {
+            "type": "string",
+            "title": "Code"
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "is_locked": {
+            "type": "boolean",
+            "title": "Is Locked"
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "group_id",
+          "name_cn",
+          "code",
+          "sort_order",
+          "is_active",
+          "is_locked",
+          "remark"
+        ],
+        "title": "SkuCodeTermOut"
+      },
+      "SkuCodeTermUpdate": {
+        "properties": {
+          "name_cn": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name Cn"
+          },
+          "code": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 32
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Code"
+          },
+          "sort_order": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sort Order"
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 500
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          }
+        },
+        "type": "object",
+        "title": "SkuCodeTermUpdate"
+      },
+      "SkuGenerateDataOut": {
+        "properties": {
+          "sku": {
+            "type": "string",
+            "title": "Sku"
+          },
+          "segments": {
+            "items": {
+              "$ref": "#/components/schemas/SkuGeneratedSegmentOut"
+            },
+            "type": "array",
+            "title": "Segments"
+          },
+          "exists": {
+            "type": "boolean",
+            "title": "Exists"
+          },
+          "similar_items": {
+            "items": {
+              "$ref": "#/components/schemas/SimilarItemOut"
+            },
+            "type": "array",
+            "title": "Similar Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "sku",
+          "segments",
+          "exists",
+          "similar_items"
+        ],
+        "title": "SkuGenerateDataOut"
+      },
+      "SkuGenerateIn": {
+        "properties": {
+          "product_kind": {
+            "type": "string",
+            "enum": [
+              "FOOD",
+              "SUPPLY"
+            ],
+            "title": "Product Kind"
+          },
+          "brand_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Brand Id"
+          },
+          "category_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Category Id"
+          },
+          "term_ids": {
+            "additionalProperties": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "type": "object",
+            "title": "Term Ids"
+          },
+          "text_segments": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Text Segments"
+          },
+          "spec_text": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Spec Text"
+          }
+        },
+        "type": "object",
+        "required": [
+          "product_kind",
+          "brand_id",
+          "category_id",
+          "spec_text"
+        ],
+        "title": "SkuGenerateIn"
+      },
+      "SkuGenerateOut": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok",
+            "default": true
+          },
+          "data": {
+            "$ref": "#/components/schemas/SkuGenerateDataOut"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "SkuGenerateOut"
+      },
+      "SkuGeneratedSegmentOut": {
+        "properties": {
+          "segment_key": {
+            "type": "string",
+            "title": "Segment Key"
+          },
+          "name_cn": {
+            "type": "string",
+            "title": "Name Cn"
+          },
+          "code": {
+            "type": "string",
+            "title": "Code"
+          }
+        },
+        "type": "object",
+        "required": [
+          "segment_key",
+          "name_cn",
+          "code"
+        ],
+        "title": "SkuGeneratedSegmentOut"
+      },
+      "SkuPurchaseLedgerItemOption": {
+        "properties": {
+          "item_id": {
+            "type": "integer",
+            "title": "Item Id"
+          },
+          "item_sku": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Item Sku"
+          },
+          "item_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Item Name"
+          },
+          "spec_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spec Text"
+          }
+        },
+        "type": "object",
+        "required": [
+          "item_id"
+        ],
+        "title": "SkuPurchaseLedgerItemOption"
+      },
+      "SkuPurchaseLedgerOptionsResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/SkuPurchaseLedgerItemOption"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "suppliers": {
+            "items": {
+              "$ref": "#/components/schemas/SkuPurchaseLedgerSupplierOption"
+            },
+            "type": "array",
+            "title": "Suppliers"
+          },
+          "warehouses": {
+            "items": {
+              "$ref": "#/components/schemas/SkuPurchaseLedgerWarehouseOption"
+            },
+            "type": "array",
+            "title": "Warehouses"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "suppliers",
+          "warehouses"
+        ],
+        "title": "SkuPurchaseLedgerOptionsResponse"
+      },
+      "SkuPurchaseLedgerResponse": {
+        "properties": {
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/SkuPurchaseLedgerRow"
+            },
+            "type": "array",
+            "title": "Rows"
+          }
+        },
+        "type": "object",
+        "required": [
+          "rows"
+        ],
+        "title": "SkuPurchaseLedgerResponse"
+      },
+      "SkuPurchaseLedgerRow": {
+        "properties": {
+          "po_line_id": {
+            "type": "integer",
+            "title": "Po Line Id"
+          },
+          "po_id": {
+            "type": "integer",
+            "title": "Po Id"
+          },
+          "po_no": {
+            "type": "string",
+            "title": "Po No"
+          },
+          "line_no": {
+            "type": "integer",
+            "title": "Line No"
+          },
+          "item_id": {
+            "type": "integer",
+            "title": "Item Id"
+          },
+          "item_sku": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Item Sku"
+          },
+          "item_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Item Name"
+          },
+          "spec_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spec Text"
+          },
+          "supplier_id": {
+            "type": "integer",
+            "title": "Supplier Id"
+          },
+          "supplier_name": {
+            "type": "string",
+            "title": "Supplier Name"
+          },
+          "warehouse_id": {
+            "type": "integer",
+            "title": "Warehouse Id"
+          },
+          "warehouse_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Warehouse Name"
+          },
+          "purchase_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Purchase Time"
+          },
+          "purchase_date": {
+            "type": "string",
+            "format": "date",
+            "title": "Purchase Date"
+          },
+          "qty_ordered_input": {
+            "type": "integer",
+            "title": "Qty Ordered Input"
+          },
+          "purchase_uom_name_snapshot": {
+            "type": "string",
+            "title": "Purchase Uom Name Snapshot"
+          },
+          "purchase_ratio_to_base_snapshot": {
+            "type": "integer",
+            "title": "Purchase Ratio To Base Snapshot"
+          },
+          "qty_ordered_base": {
+            "type": "integer",
+            "title": "Qty Ordered Base"
+          },
+          "purchase_unit_price": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Purchase Unit Price"
+          },
+          "planned_line_amount": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Planned Line Amount"
+          },
+          "accounting_unit_price": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Accounting Unit Price"
+          }
+        },
+        "type": "object",
+        "required": [
+          "po_line_id",
+          "po_id",
+          "po_no",
+          "line_no",
+          "item_id",
+          "supplier_id",
+          "supplier_name",
+          "warehouse_id",
+          "purchase_time",
+          "purchase_date",
+          "qty_ordered_input",
+          "purchase_uom_name_snapshot",
+          "purchase_ratio_to_base_snapshot",
+          "qty_ordered_base",
+          "planned_line_amount"
+        ],
+        "title": "SkuPurchaseLedgerRow"
+      },
+      "SkuPurchaseLedgerSupplierOption": {
+        "properties": {
+          "supplier_id": {
+            "type": "integer",
+            "title": "Supplier Id"
+          },
+          "supplier_name": {
+            "type": "string",
+            "title": "Supplier Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "supplier_id",
+          "supplier_name"
+        ],
+        "title": "SkuPurchaseLedgerSupplierOption"
+      },
+      "SkuPurchaseLedgerWarehouseOption": {
+        "properties": {
+          "warehouse_id": {
+            "type": "integer",
+            "title": "Warehouse Id"
+          },
+          "warehouse_name": {
+            "type": "string",
+            "title": "Warehouse Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "warehouse_id",
+          "warehouse_name"
+        ],
+        "title": "SkuPurchaseLedgerWarehouseOption"
       },
       "StockRecountRequest": {
         "properties": {
@@ -40335,13 +44060,13 @@
             "minLength": 2,
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
             "maxLength": 128,
             "minLength": 1,
-            "title": "Shop Id"
+            "title": "Store Code"
           },
-          "name": {
+          "store_name": {
             "anyOf": [
               {
                 "type": "string",
@@ -40352,22 +44077,22 @@
                 "type": "null"
               }
             ],
-            "title": "Name"
+            "title": "Store Name"
           },
-          "shop_type": {
+          "store_type": {
             "type": "string",
             "enum": [
               "TEST",
               "PROD"
             ],
-            "title": "Shop Type",
+            "title": "Store Type",
             "default": "PROD"
           }
         },
         "type": "object",
         "required": [
           "platform",
-          "shop_id"
+          "store_code"
         ],
         "title": "StoreCreateIn"
       },
@@ -40419,13 +44144,13 @@
             "type": "string",
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "title": "Shop Id"
+            "title": "Store Code"
           },
-          "name": {
+          "store_name": {
             "type": "string",
-            "title": "Name"
+            "title": "Store Name"
           },
           "active": {
             "type": "boolean",
@@ -40435,9 +44160,9 @@
             "type": "string",
             "title": "Route Mode"
           },
-          "shop_type": {
+          "store_type": {
             "type": "string",
-            "title": "Shop Type",
+            "title": "Store Type",
             "default": "PROD"
           },
           "email": {
@@ -40478,8 +44203,8 @@
         "required": [
           "id",
           "platform",
-          "shop_id",
-          "name",
+          "store_code",
+          "store_name",
           "active",
           "route_mode"
         ],
@@ -40512,21 +44237,21 @@
             "type": "integer",
             "title": "Id"
           },
-          "name": {
+          "store_name": {
             "type": "string",
-            "title": "Name"
+            "title": "Store Name"
           }
         },
         "type": "object",
         "required": [
           "id",
-          "name"
+          "store_name"
         ],
         "title": "StoreLiteOut"
       },
       "StoreUpdateIn": {
         "properties": {
-          "name": {
+          "store_name": {
             "anyOf": [
               {
                 "type": "string",
@@ -40537,7 +44262,7 @@
                 "type": "null"
               }
             ],
-            "title": "Name"
+            "title": "Store Name"
           },
           "active": {
             "anyOf": [
@@ -41570,214 +45295,9 @@
         "type": "object",
         "title": "SurchargeConfigUpdateIn"
       },
-      "TaobaoOrderLedgerDetailEnvelopeOut": {
+      "SyncPlatformOrderMirrorErrorOut": {
         "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "$ref": "#/components/schemas/TaobaoOrderLedgerDetailOut"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "TaobaoOrderLedgerDetailEnvelopeOut"
-      },
-      "TaobaoOrderLedgerDetailOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "store_id": {
-            "type": "integer",
-            "title": "Store Id"
-          },
-          "tid": {
-            "type": "string",
-            "title": "Tid"
-          },
-          "status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Status"
-          },
-          "type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Type"
-          },
-          "buyer_nick": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Buyer Nick"
-          },
-          "buyer_open_uid": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Buyer Open Uid"
-          },
-          "receiver_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Name"
-          },
-          "receiver_mobile": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Mobile"
-          },
-          "receiver_phone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Phone"
-          },
-          "receiver_state": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver State"
-          },
-          "receiver_city": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver City"
-          },
-          "receiver_district": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver District"
-          },
-          "receiver_town": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Town"
-          },
-          "receiver_address": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Address"
-          },
-          "receiver_zip": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Zip"
-          },
-          "buyer_memo": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Buyer Memo"
-          },
-          "buyer_message": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Buyer Message"
-          },
-          "seller_memo": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Seller Memo"
-          },
-          "seller_flag": {
+          "collector_order_id": {
             "anyOf": [
               {
                 "type": "integer"
@@ -41786,418 +45306,168 @@
                 "type": "null"
               }
             ],
-            "title": "Seller Flag"
+            "title": "Collector Order Id"
           },
-          "payment": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Payment"
+          "error_code": {
+            "type": "string",
+            "title": "Error Code"
           },
-          "total_fee": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Total Fee"
-          },
-          "post_fee": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Post Fee"
-          },
-          "coupon_fee": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Coupon Fee"
-          },
-          "created": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created"
-          },
-          "pay_time": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pay Time"
-          },
-          "modified": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Modified"
-          },
-          "raw_summary_payload": {
-            "title": "Raw Summary Payload"
-          },
-          "raw_detail_payload": {
-            "title": "Raw Detail Payload"
-          },
-          "pulled_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pulled At"
-          },
-          "last_synced_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Synced At"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          },
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/TaobaoOrderLedgerItemOut"
-            },
-            "type": "array",
-            "title": "Items"
+          "message": {
+            "type": "string",
+            "title": "Message"
           }
         },
         "type": "object",
         "required": [
-          "id",
-          "store_id",
-          "tid",
-          "items"
+          "error_code",
+          "message"
         ],
-        "title": "TaobaoOrderLedgerDetailOut"
+        "title": "SyncPlatformOrderMirrorErrorOut"
       },
-      "TaobaoOrderLedgerItemOut": {
+      "SyncPlatformOrderMirrorItemOut": {
         "properties": {
-          "id": {
+          "collector_order_id": {
             "type": "integer",
-            "title": "Id"
+            "title": "Collector Order Id"
           },
-          "taobao_order_id": {
+          "mirror_id": {
             "type": "integer",
-            "title": "Taobao Order Id"
+            "title": "Mirror Id"
           },
-          "tid": {
-            "type": "string",
-            "title": "Tid"
-          },
-          "oid": {
-            "type": "string",
-            "title": "Oid"
-          },
-          "num_iid": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Num Iid"
-          },
-          "sku_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sku Id"
-          },
-          "outer_iid": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Outer Iid"
-          },
-          "outer_sku_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Outer Sku Id"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title"
-          },
-          "price": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Price"
-          },
-          "num": {
-            "type": "integer",
-            "title": "Num"
-          },
-          "payment": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Payment"
-          },
-          "total_fee": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Total Fee"
-          },
-          "sku_properties_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sku Properties Name"
-          },
-          "raw_item_payload": {
-            "title": "Raw Item Payload"
+          "imported": {
+            "type": "boolean",
+            "title": "Imported",
+            "default": true
           }
         },
         "type": "object",
         "required": [
-          "id",
-          "taobao_order_id",
-          "tid",
-          "oid",
-          "num"
+          "collector_order_id",
+          "mirror_id"
         ],
-        "title": "TaobaoOrderLedgerItemOut"
+        "title": "SyncPlatformOrderMirrorItemOut"
       },
-      "TaobaoOrderLedgerListOut": {
+      "SyncPlatformOrderMirrorsFromCollectorIn": {
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "maximum": 1000.0,
+            "minimum": 1.0,
+            "title": "Limit",
+            "default": 50
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Offset",
+            "default": 0
+          },
+          "since": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Since",
+            "description": "Inclusive lower bound for Collector Export source update time."
+          },
+          "until": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Until",
+            "description": "Exclusive upper bound for Collector Export source update time."
+          }
+        },
+        "type": "object",
+        "title": "SyncPlatformOrderMirrorsFromCollectorIn"
+      },
+      "SyncPlatformOrderMirrorsFromCollectorOut": {
         "properties": {
           "ok": {
             "type": "boolean",
             "title": "Ok",
             "default": true
           },
-          "data": {
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          },
+          "since": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Since"
+          },
+          "until": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Until"
+          },
+          "fetched_count": {
+            "type": "integer",
+            "title": "Fetched Count"
+          },
+          "imported_count": {
+            "type": "integer",
+            "title": "Imported Count"
+          },
+          "failed_count": {
+            "type": "integer",
+            "title": "Failed Count"
+          },
+          "items": {
             "items": {
-              "$ref": "#/components/schemas/TaobaoOrderLedgerRowOut"
+              "$ref": "#/components/schemas/SyncPlatformOrderMirrorItemOut"
             },
             "type": "array",
-            "title": "Data"
+            "title": "Items"
+          },
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/SyncPlatformOrderMirrorErrorOut"
+            },
+            "type": "array",
+            "title": "Errors"
           }
         },
         "type": "object",
         "required": [
-          "data"
+          "platform",
+          "limit",
+          "offset",
+          "fetched_count",
+          "imported_count",
+          "failed_count"
         ],
-        "title": "TaobaoOrderLedgerListOut"
-      },
-      "TaobaoOrderLedgerRowOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "store_id": {
-            "type": "integer",
-            "title": "Store Id"
-          },
-          "tid": {
-            "type": "string",
-            "title": "Tid"
-          },
-          "status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Status"
-          },
-          "type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Type"
-          },
-          "created": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created"
-          },
-          "pay_time": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pay Time"
-          },
-          "payment": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Payment"
-          },
-          "total_fee": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Total Fee"
-          },
-          "pulled_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pulled At"
-          },
-          "last_synced_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Synced At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "store_id",
-          "tid"
-        ],
-        "title": "TaobaoOrderLedgerRowOut"
+        "title": "SyncPlatformOrderMirrorsFromCollectorOut"
       },
       "TemplateCapabilitiesOut": {
         "properties": {
@@ -42833,6 +46103,13 @@
           "type": {
             "type": "string",
             "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
           }
         },
         "type": "object",
@@ -43842,11 +47119,11 @@
             "minLength": 1,
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
             "maxLength": 64,
             "minLength": 1,
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "shipping_provider_id": {
             "type": "integer",
@@ -43952,7 +47229,7 @@
         "type": "object",
         "required": [
           "platform",
-          "shop_id",
+          "store_code",
           "shipping_provider_id",
           "customer_code"
         ],
@@ -44023,9 +47300,9 @@
             "type": "string",
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "type": "string",
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "shipping_provider_id": {
             "type": "integer",
@@ -44140,7 +47417,7 @@
         "required": [
           "id",
           "platform",
-          "shop_id",
+          "store_code",
           "shipping_provider_id",
           "customer_code"
         ],
@@ -44161,7 +47438,7 @@
             ],
             "title": "Platform"
           },
-          "shop_id": {
+          "store_code": {
             "anyOf": [
               {
                 "type": "string",
@@ -44172,7 +47449,7 @@
                 "type": "null"
               }
             ],
-            "title": "Shop Id"
+            "title": "Store Code"
           },
           "shipping_provider_id": {
             "anyOf": [


### PR DESCRIPTION
## Summary

- Refresh static OpenAPI files after SKU and item test set cleanup.
- Remove stale /items/sku/next from static OpenAPI.
- Remove stale item test set routes and is_test schema from static OpenAPI.
- Clean misleading retired item-test-set comments.
- Keep platform_test_stores / is_test_store as the test-store marker.

## Validation

- strict residue scans for next_sku and retired item test set markers
- python3 -m compileall selected files
- make test TESTS="tests/api/test_items_main_contract_api.py tests/api/test_item_owner_aggregate_api.py tests/ci/test_pms_item_openapi_contract.py"

## Notes

- No DB schema change.
- Runtime /items routes were already clean.