### PR TITLE
chore(pms): clean sku generation comment residue

### DIFF
--- a/app/pms/items/services/item_service.py
+++ b/app/pms/items/services/item_service.py
@@ -30,7 +30,7 @@ class ItemService:
     - PMS 主合同的净重读写转移到 base item_uom.net_weight_kg
 
     SKU coding：
-    - 主合同 POST /items 不再自动生成 SKU
+    - 主合同 POST /items 必须显式传 sku
     - items.sku 必须由调用方显式输入，通常来自 SKU 编码页生成候选后人工确认
 
     """


### PR DESCRIPTION
## Summary

- Clean stale comment wording about SKU generation.
- Keep the contract wording aligned with current behavior: POST /items requires explicit sku.

## Validation

- python3 -m compileall app/pms/items/services/item_service.py
- strict next_sku residue scan

## Notes

- Comment-only cleanup.
- No runtime behavior change.