### PR TITLE
feat(pms): add item sku code governance

### DIFF
--- a/alembic/versions/b6d3e914a8c2_pms_item_sku_codes_governance.py
+++ b/alembic/versions/b6d3e914a8c2_pms_item_sku_codes_governance.py
@@ -1,0 +1,127 @@
+"""pms_item_sku_codes_governance
+
+Revision ID: b6d3e914a8c2
+Revises: a52459bdb9ed
+Create Date: 2026-04-29 18:40:00.000000
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "b6d3e914a8c2"
+down_revision: Union[str, Sequence[str], None] = "a52459bdb9ed"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+
+    op.create_table(
+        "item_sku_codes",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("item_id", sa.Integer(), nullable=False),
+        sa.Column("code", sa.String(length=128), nullable=False),
+        sa.Column("code_type", sa.String(length=16), nullable=False),
+        sa.Column("is_primary", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.Column("is_active", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.Column("effective_from", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("effective_to", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("remark", sa.String(length=255), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.CheckConstraint("length(trim(code)) > 0", name="ck_item_sku_codes_code_non_empty"),
+        sa.CheckConstraint(
+            "code_type in ('PRIMARY', 'ALIAS', 'LEGACY', 'MANUAL')",
+            name="ck_item_sku_codes_code_type",
+        ),
+        sa.CheckConstraint(
+            "(is_primary = false) OR (is_active = true)",
+            name="ck_item_sku_codes_primary_active",
+        ),
+        sa.CheckConstraint(
+            "(is_primary = false) OR (effective_to IS NULL)",
+            name="ck_item_sku_codes_primary_no_effective_to",
+        ),
+        sa.CheckConstraint(
+            "((code_type = 'PRIMARY') = (is_primary = true))",
+            name="ck_item_sku_codes_primary_type_matches_flag",
+        ),
+        sa.ForeignKeyConstraint(
+            ["item_id"],
+            ["items.id"],
+            name="fk_item_sku_codes_item",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("code", name="uq_item_sku_codes_code"),
+    )
+
+    op.create_index(
+        "ix_item_sku_codes_item_id",
+        "item_sku_codes",
+        ["item_id"],
+        unique=False,
+    )
+    op.create_index(
+        "uq_item_sku_codes_one_primary_per_item",
+        "item_sku_codes",
+        ["item_id"],
+        unique=True,
+        postgresql_where=sa.text("is_primary = true"),
+    )
+
+    # Backfill：现有 items.sku 全部成为当前 PRIMARY 编码。
+    op.execute(
+        """
+        INSERT INTO item_sku_codes (
+          item_id,
+          code,
+          code_type,
+          is_primary,
+          is_active,
+          effective_from,
+          effective_to,
+          remark,
+          created_at,
+          updated_at
+        )
+        SELECT
+          i.id,
+          upper(trim(i.sku)),
+          'PRIMARY',
+          TRUE,
+          TRUE,
+          COALESCE(i.created_at, CURRENT_TIMESTAMP),
+          NULL,
+          'backfilled from items.sku',
+          CURRENT_TIMESTAMP,
+          CURRENT_TIMESTAMP
+        FROM items i
+        WHERE trim(i.sku) <> ''
+        ON CONFLICT (code) DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+
+    op.drop_index("uq_item_sku_codes_one_primary_per_item", table_name="item_sku_codes")
+    op.drop_index("ix_item_sku_codes_item_id", table_name="item_sku_codes")
+    op.drop_table("item_sku_codes")

--- a/app/pms/items/contracts/item_sku_code.py
+++ b/app/pms/items/contracts/item_sku_code.py
@@ -1,0 +1,63 @@
+# app/pms/items/contracts/item_sku_code.py
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+ItemSkuCodeType = Literal["PRIMARY", "ALIAS", "LEGACY", "MANUAL"]
+
+
+def _norm_text(v: object) -> object:
+    return v.strip() if isinstance(v, str) else v
+
+
+class ItemSkuCodeCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    code: Annotated[str, Field(min_length=1, max_length=128)]
+    code_type: ItemSkuCodeType = "ALIAS"
+    is_active: bool = True
+    effective_from: datetime | None = None
+    effective_to: datetime | None = None
+    remark: Annotated[str | None, Field(default=None, max_length=255)] = None
+
+    @field_validator("code", "remark", mode="before")
+    @classmethod
+    def _trim_text(cls, v: object) -> object:
+        return _norm_text(v)
+
+    @model_validator(mode="after")
+    def _no_primary_via_create_alias(self) -> "ItemSkuCodeCreate":
+        if self.code_type == "PRIMARY":
+            raise ValueError("PRIMARY code must be changed via change-primary action")
+        return self
+
+
+class ItemSkuCodeChangePrimary(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    code: Annotated[str, Field(min_length=1, max_length=128)]
+    remark: Annotated[str | None, Field(default=None, max_length=255)] = None
+
+    @field_validator("code", "remark", mode="before")
+    @classmethod
+    def _trim_text(cls, v: object) -> object:
+        return _norm_text(v)
+
+
+class ItemSkuCodeOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    item_id: int
+    code: str
+    code_type: ItemSkuCodeType
+    is_primary: bool
+    is_active: bool
+    effective_from: datetime | None = None
+    effective_to: datetime | None = None
+    remark: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None

--- a/app/pms/items/models/__init__.py
+++ b/app/pms/items/models/__init__.py
@@ -1,6 +1,7 @@
 # app/pms/items/models/__init__.py
 from app.pms.items.models.item import ExpiryPolicy, Item, LotSourcePolicy
 from app.pms.items.models.item_barcode import ItemBarcode
+from app.pms.items.models.item_sku_code import ItemSkuCode, ItemSkuCodeType
 from app.pms.items.models.item_uom import ItemUOM
 
 __all__ = [
@@ -9,4 +10,6 @@ __all__ = [
     "ExpiryPolicy",
     "ItemUOM",
     "ItemBarcode",
+    "ItemSkuCode",
+    "ItemSkuCodeType",
 ]

--- a/app/pms/items/models/item.py
+++ b/app/pms/items/models/item.py
@@ -11,14 +11,16 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.db.base import Base
 from app.oms.orders.models.order import Order  # noqa: F401
 from app.oms.orders.models.order_item import OrderItem  # noqa: F401
+from app.pms.items.models.item_sku_code import ItemSkuCode  # noqa: F401
 from app.pms.items.models.item_uom import ItemUOM  # noqa: F401
 from app.pms.suppliers.models.supplier import Supplier  # noqa: F401
 
 if TYPE_CHECKING:
     from app.oms.orders.models.order import Order
     from app.oms.orders.models.order_item import OrderItem
-    from app.pms.suppliers.models.supplier import Supplier
+    from app.pms.items.models.item_sku_code import ItemSkuCode
     from app.pms.items.models.item_uom import ItemUOM
+    from app.pms.suppliers.models.supplier import Supplier
 
 
 class LotSourcePolicy(str, enum.Enum):
@@ -49,6 +51,11 @@ class Item(Base):
     Phase M-6（item weight cutover）：
     - items.weight_kg 已物理删除
     - 运行时 weight_kg = base item_uom.net_weight_kg
+
+    SKU governance：
+    - item_id 是商品内部身份真相
+    - items.sku 是当前主 SKU 投影
+    - item_sku_codes 是商品编码治理真相表
     """
 
     __tablename__ = "items"
@@ -107,6 +114,14 @@ class Item(Base):
         back_populates="item",
         lazy="selectin",
         order_by="ItemUOM.id.asc()",
+    )
+
+    sku_codes: Mapped[List["ItemSkuCode"]] = relationship(
+        "ItemSkuCode",
+        back_populates="item",
+        lazy="selectin",
+        order_by=lambda: (ItemSkuCode.is_primary.desc(), ItemSkuCode.id.asc()),
+        cascade="all, delete-orphan",
     )
 
     @property

--- a/app/pms/items/models/item_sku_code.py
+++ b/app/pms/items/models/item_sku_code.py
@@ -1,0 +1,101 @@
+# app/pms/items/models/item_sku_code.py
+from __future__ import annotations
+
+import enum
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+if TYPE_CHECKING:
+    from app.pms.items.models.item import Item
+
+
+class ItemSkuCodeType(str, enum.Enum):
+    PRIMARY = "PRIMARY"
+    ALIAS = "ALIAS"
+    LEGACY = "LEGACY"
+    MANUAL = "MANUAL"
+
+
+class ItemSkuCode(Base):
+    """
+    商品 SKU 多编码治理表。
+
+    设计原则：
+    - item_id 是商品内部身份真相；
+    - items.sku 是当前主 SKU 投影；
+    - item_sku_codes 是商品编码治理真相表；
+    - 历史采购 / 入库 / 财务单据里的 item_sku 是当时展示快照，不追改。
+    """
+
+    __tablename__ = "item_sku_codes"
+
+    __table_args__ = (
+        sa.UniqueConstraint("code", name="uq_item_sku_codes_code"),
+        sa.Index(
+            "uq_item_sku_codes_one_primary_per_item",
+            "item_id",
+            unique=True,
+            postgresql_where=sa.text("is_primary = true"),
+        ),
+        sa.CheckConstraint("length(trim(code)) > 0", name="ck_item_sku_codes_code_non_empty"),
+        sa.CheckConstraint(
+            "code_type in ('PRIMARY', 'ALIAS', 'LEGACY', 'MANUAL')",
+            name="ck_item_sku_codes_code_type",
+        ),
+        sa.CheckConstraint(
+            "(is_primary = false) OR (is_active = true)",
+            name="ck_item_sku_codes_primary_active",
+        ),
+        sa.CheckConstraint(
+            "(is_primary = false) OR (effective_to IS NULL)",
+            name="ck_item_sku_codes_primary_no_effective_to",
+        ),
+        sa.CheckConstraint(
+            "((code_type = 'PRIMARY') = (is_primary = true))",
+            name="ck_item_sku_codes_primary_type_matches_flag",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(sa.Integer, primary_key=True)
+
+    item_id: Mapped[int] = mapped_column(
+        sa.Integer,
+        sa.ForeignKey("items.id", name="fk_item_sku_codes_item", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    code: Mapped[str] = mapped_column(sa.String(128), nullable=False)
+    code_type: Mapped[str] = mapped_column(sa.String(16), nullable=False)
+
+    is_primary: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"))
+    is_active: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("true"))
+
+    effective_from: Mapped[datetime | None] = mapped_column(sa.DateTime(timezone=True), nullable=True)
+    effective_to: Mapped[datetime | None] = mapped_column(sa.DateTime(timezone=True), nullable=True)
+    remark: Mapped[str | None] = mapped_column(sa.String(255), nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("CURRENT_TIMESTAMP"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("CURRENT_TIMESTAMP"),
+    )
+
+    item: Mapped["Item"] = relationship("Item", back_populates="sku_codes")
+
+    def __repr__(self) -> str:
+        return (
+            f"<ItemSkuCode id={self.id} item_id={self.item_id} "
+            f"code={self.code!r} code_type={self.code_type!r} "
+            f"is_primary={self.is_primary} is_active={self.is_active}>"
+        )

--- a/app/pms/items/repos/item_repo.py
+++ b/app/pms/items/repos/item_repo.py
@@ -8,6 +8,18 @@ from sqlalchemy.orm import Session
 
 from app.pms.items.models.item import Item
 from app.pms.items.models.item_barcode import ItemBarcode
+from app.pms.items.models.item_sku_code import ItemSkuCode
+
+
+def _active_sku_code_match_exists(*, q_like: str):
+    return (
+        select(ItemSkuCode.id)
+        .where(ItemSkuCode.item_id == Item.id)
+        .where(ItemSkuCode.is_active.is_(True))
+        .where(func.lower(ItemSkuCode.code).like(q_like))
+        .limit(1)
+        .exists()
+    )
 
 
 def get_items(
@@ -42,6 +54,7 @@ def get_items(
 
         conds = [
             func.lower(Item.sku).like(q_like),
+            _active_sku_code_match_exists(q_like=q_like),
             func.lower(Item.name).like(q_like),
             cast(Item.id, String).like(q_like),
             func.lower(func.coalesce(primary_barcode_expr, "")).like(q_like),
@@ -80,7 +93,22 @@ def get_item_by_id(db: Session, id: int) -> Optional[Item]:
 
 
 def get_item_by_sku(db: Session, sku: str) -> Optional[Item]:
-    s = (sku or "").strip()
+    s = (sku or "").strip().upper()
     if not s:
         return None
-    return db.execute(select(Item).where(Item.sku == s)).scalar_one_or_none()
+
+    row = (
+        db.execute(
+            select(ItemSkuCode)
+            .where(func.lower(ItemSkuCode.code) == s.lower())
+            .where(ItemSkuCode.is_active.is_(True))
+            .order_by(ItemSkuCode.is_primary.desc(), ItemSkuCode.id.asc())
+            .limit(1)
+        )
+        .scalars()
+        .first()
+    )
+    if row is not None:
+        return db.get(Item, int(row.item_id))
+
+    return None

--- a/app/pms/items/repos/item_sku_code_repo.py
+++ b/app/pms/items/repos/item_sku_code_repo.py
@@ -1,0 +1,133 @@
+# app/pms/items/repos/item_sku_code_repo.py
+from __future__ import annotations
+
+from typing import Iterable
+
+from sqlalchemy import exists, func, or_, select
+from sqlalchemy.orm import Session
+
+from app.pms.items.models.item import Item
+from app.pms.items.models.item_sku_code import ItemSkuCode
+
+
+def list_sku_codes_by_item_id(db: Session, *, item_id: int) -> list[ItemSkuCode]:
+    return (
+        db.execute(
+            select(ItemSkuCode)
+            .where(ItemSkuCode.item_id == int(item_id))
+            .order_by(
+                ItemSkuCode.is_primary.desc(),
+                ItemSkuCode.is_active.desc(),
+                ItemSkuCode.id.asc(),
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+def get_sku_code_by_id(db: Session, *, code_id: int) -> ItemSkuCode | None:
+    return db.get(ItemSkuCode, int(code_id))
+
+
+def get_sku_code_by_code(db: Session, *, code: str) -> ItemSkuCode | None:
+    s = str(code or "").strip().upper()
+    if not s:
+        return None
+    return (
+        db.execute(select(ItemSkuCode).where(func.lower(ItemSkuCode.code) == s.lower()))
+        .scalars()
+        .first()
+    )
+
+
+def get_active_sku_code_by_code(db: Session, *, code: str) -> ItemSkuCode | None:
+    s = str(code or "").strip().upper()
+    if not s:
+        return None
+    return (
+        db.execute(
+            select(ItemSkuCode)
+            .where(func.lower(ItemSkuCode.code) == s.lower())
+            .where(ItemSkuCode.is_active.is_(True))
+            .order_by(ItemSkuCode.is_primary.desc(), ItemSkuCode.id.asc())
+            .limit(1)
+        )
+        .scalars()
+        .first()
+    )
+
+
+def get_primary_sku_code_by_item_id(db: Session, *, item_id: int) -> ItemSkuCode | None:
+    return (
+        db.execute(
+            select(ItemSkuCode)
+            .where(ItemSkuCode.item_id == int(item_id))
+            .where(ItemSkuCode.is_primary.is_(True))
+            .limit(1)
+        )
+        .scalars()
+        .first()
+    )
+
+
+def item_sku_code_exists_expr(*, item_id_col) -> object:
+    return (
+        select(ItemSkuCode.id)
+        .where(ItemSkuCode.item_id == item_id_col)
+        .where(ItemSkuCode.is_active.is_(True))
+        .exists()
+    )
+
+
+def active_code_match_exists_expr(*, item_id_col, q_like: str) -> object:
+    return (
+        select(ItemSkuCode.id)
+        .where(ItemSkuCode.item_id == item_id_col)
+        .where(ItemSkuCode.is_active.is_(True))
+        .where(func.lower(ItemSkuCode.code).like(q_like))
+        .exists()
+    )
+
+
+def find_items_by_active_sku_code(db: Session, *, code: str) -> Item | None:
+    row = get_active_sku_code_by_code(db, code=code)
+    if row is None:
+        return None
+    return db.get(Item, int(row.item_id))
+
+
+def add_sku_code(db: Session, obj: ItemSkuCode) -> None:
+    db.add(obj)
+
+
+def add_all_sku_codes(db: Session, rows: Iterable[ItemSkuCode]) -> None:
+    db.add_all(list(rows))
+
+
+def has_active_code_for_item(db: Session, *, item_id: int, code: str) -> bool:
+    s = str(code or "").strip().upper()
+    if not s:
+        return False
+    return bool(
+        db.execute(
+            select(
+                exists().where(
+                    ItemSkuCode.item_id == int(item_id),
+                    func.lower(ItemSkuCode.code) == s.lower(),
+                    ItemSkuCode.is_active.is_(True),
+                )
+            )
+        ).scalar()
+    )
+
+
+def search_items_by_code_or_projection(
+    db: Session,
+    *,
+    q_like: str,
+    base_stmt,
+    item_id_col,
+):
+    code_exists = active_code_match_exists_expr(item_id_col=item_id_col, q_like=q_like)
+    return base_stmt.where(or_(code_exists, func.lower(Item.sku).like(q_like)))

--- a/app/pms/items/repos/item_write_repo.py
+++ b/app/pms/items/repos/item_write_repo.py
@@ -8,6 +8,18 @@ from sqlalchemy.orm import Session
 
 from app.pms.items.models.item import Item
 from app.pms.items.models.item_barcode import ItemBarcode
+from app.pms.items.models.item_sku_code import ItemSkuCode
+
+
+def _active_sku_code_match_exists(*, q_like: str):
+    return (
+        select(ItemSkuCode.id)
+        .where(ItemSkuCode.item_id == Item.id)
+        .where(ItemSkuCode.is_active.is_(True))
+        .where(func.lower(ItemSkuCode.code).like(q_like))
+        .limit(1)
+        .exists()
+    )
 
 
 def list_items(
@@ -41,6 +53,7 @@ def list_items(
 
         conds = [
             func.lower(Item.sku).like(q_like),
+            _active_sku_code_match_exists(q_like=q_like),
             func.lower(Item.name).like(q_like),
             cast(Item.id, String).like(q_like),
             func.lower(func.coalesce(primary_barcode_expr, "")).like(q_like),
@@ -85,10 +98,25 @@ def get_item_by_id_for_update(db: Session, item_id: int) -> Item | None:
 
 
 def get_item_by_sku(db: Session, sku: str) -> Item | None:
-    s = (sku or "").strip()
+    s = (sku or "").strip().upper()
     if not s:
         return None
-    return db.execute(select(Item).where(Item.sku == s)).scalar_one_or_none()
+
+    row = (
+        db.execute(
+            select(ItemSkuCode)
+            .where(func.lower(ItemSkuCode.code) == s.lower())
+            .where(ItemSkuCode.is_active.is_(True))
+            .order_by(ItemSkuCode.is_primary.desc(), ItemSkuCode.id.asc())
+            .limit(1)
+        )
+        .scalars()
+        .first()
+    )
+    if row is not None:
+        return db.get(Item, int(row.item_id))
+
+    return None
 
 
 def add_item(db: Session, item: Item) -> None:

--- a/app/pms/items/routers/item_sku_codes.py
+++ b/app/pms/items/routers/item_sku_codes.py
@@ -1,0 +1,102 @@
+# app/pms/items/routers/item_sku_codes.py
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.db.deps import get_db
+from app.pms.items.contracts.item_sku_code import (
+    ItemSkuCodeChangePrimary,
+    ItemSkuCodeCreate,
+    ItemSkuCodeOut,
+)
+from app.pms.items.services.item_sku_code_service import ItemSkuCodeService
+
+
+router = APIRouter(prefix="/items/{item_id}/sku-codes", tags=["item-sku-codes"])
+
+
+def get_item_sku_code_service(db: Session = Depends(get_db)) -> ItemSkuCodeService:
+    return ItemSkuCodeService(db)
+
+
+def _raise_http_from_value_error(e: ValueError) -> None:
+    detail = str(e)
+    if detail in {"Item not found", "SKU code not found"}:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail)
+    if detail in {"SKU code duplicate"}:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=detail)
+    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
+
+
+@router.get("", response_model=List[ItemSkuCodeOut])
+def list_item_sku_codes(
+    item_id: int,
+    service: ItemSkuCodeService = Depends(get_item_sku_code_service),
+):
+    try:
+        return service.list_codes(item_id=int(item_id))
+    except ValueError as e:
+        _raise_http_from_value_error(e)
+
+
+@router.post("", response_model=ItemSkuCodeOut, status_code=status.HTTP_201_CREATED)
+def create_item_sku_code(
+    item_id: int,
+    payload: ItemSkuCodeCreate,
+    service: ItemSkuCodeService = Depends(get_item_sku_code_service),
+):
+    try:
+        return service.create_code(
+            item_id=int(item_id),
+            code=payload.code,
+            code_type=payload.code_type,
+            is_active=payload.is_active,
+            effective_from=payload.effective_from,
+            effective_to=payload.effective_to,
+            remark=payload.remark,
+        )
+    except ValueError as e:
+        _raise_http_from_value_error(e)
+
+
+@router.post("/{code_id}/disable", response_model=ItemSkuCodeOut)
+def disable_item_sku_code(
+    item_id: int,
+    code_id: int,
+    service: ItemSkuCodeService = Depends(get_item_sku_code_service),
+):
+    try:
+        return service.disable_code(item_id=int(item_id), code_id=int(code_id))
+    except ValueError as e:
+        _raise_http_from_value_error(e)
+
+
+@router.post("/{code_id}/enable", response_model=ItemSkuCodeOut)
+def enable_item_sku_code(
+    item_id: int,
+    code_id: int,
+    service: ItemSkuCodeService = Depends(get_item_sku_code_service),
+):
+    try:
+        return service.enable_code(item_id=int(item_id), code_id=int(code_id))
+    except ValueError as e:
+        _raise_http_from_value_error(e)
+
+
+@router.post("/change-primary", response_model=ItemSkuCodeOut)
+def change_primary_item_sku_code(
+    item_id: int,
+    payload: ItemSkuCodeChangePrimary,
+    service: ItemSkuCodeService = Depends(get_item_sku_code_service),
+):
+    try:
+        return service.change_primary(
+            item_id=int(item_id),
+            code=payload.code,
+            remark=payload.remark,
+        )
+    except ValueError as e:
+        _raise_http_from_value_error(e)

--- a/app/pms/items/services/item_owner_aggregate_service.py
+++ b/app/pms/items/services/item_owner_aggregate_service.py
@@ -46,6 +46,7 @@ from app.pms.items.repos.item_write_repo import (
     rollback as repo_rollback,
 )
 from app.pms.items.services.item_presenter import ItemPresenter
+from app.pms.items.services.item_sku_code_service import ItemSkuCodeService
 
 
 _ALLOWED_LOT_SOURCE_POLICIES = {"INTERNAL_ONLY", "SUPPLIER_ONLY"}
@@ -202,6 +203,12 @@ class ItemOwnerAggregateService:
         try:
             repo_flush(self.db)
 
+            ItemSkuCodeService(self.db).create_primary_code_in_current_tx(
+                item_id=int(obj.id),
+                code=str(item_fields["sku"]),
+                remark="created with item aggregate",
+            )
+
             uom_key_to_id, _keep_uom_ids = self._upsert_uoms(
                 item_id=int(obj.id),
                 payload_uoms=list(payload.uoms),
@@ -222,8 +229,10 @@ class ItemOwnerAggregateService:
             if "items_sku_key" in raw or ("unique" in raw and "sku" in raw):
                 raise ValueError("SKU duplicate") from e
             raise ValueError(f"DB integrity error: {getattr(e, 'orig', e)}") from e
-        except ValueError:
+        except ValueError as e:
             repo_rollback(self.db)
+            if str(e) == "SKU code duplicate":
+                raise ValueError("SKU duplicate") from e
             raise
 
         refresh_item(self.db, obj)

--- a/app/pms/items/services/item_sku_code_service.py
+++ b/app/pms/items/services/item_sku_code_service.py
@@ -1,0 +1,283 @@
+# app/pms/items/services/item_sku_code_service.py
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.pms.items.models.item import Item
+from app.pms.items.models.item_sku_code import ItemSkuCode
+from app.pms.items.repos.item_sku_code_repo import (
+    add_sku_code,
+    get_active_sku_code_by_code,
+    get_primary_sku_code_by_item_id,
+    get_sku_code_by_code,
+    get_sku_code_by_id,
+    list_sku_codes_by_item_id,
+)
+
+
+_SKU_PATTERN = re.compile(r"^[A-Z0-9][A-Z0-9._-]{0,127}$")
+_NON_PRIMARY_TYPES = {"ALIAS", "LEGACY", "MANUAL"}
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def normalize_sku_code(v: object) -> str:
+    s = str(v or "").strip().upper()
+    if not s:
+        raise ValueError("sku code 不能为空")
+    if len(s) > 128:
+        raise ValueError("sku code 长度不能超过 128")
+    if not _SKU_PATTERN.fullmatch(s):
+        raise ValueError("invalid sku code")
+    return s
+
+
+def normalize_sku_code_or_none(v: object) -> str | None:
+    s = str(v or "").strip()
+    if not s:
+        return None
+    return normalize_sku_code(s)
+
+
+def normalize_code_type(v: object) -> str:
+    raw = getattr(v, "value", v)
+    s = str(raw or "").strip().upper()
+    if s not in {"PRIMARY", "ALIAS", "LEGACY", "MANUAL"}:
+        raise ValueError("invalid sku code type")
+    return s
+
+
+class ItemSkuCodeService:
+    """
+    商品 SKU 多编码治理服务。
+
+    边界：
+    - item_id 是商品内部身份真相；
+    - items.sku 是当前主 SKU 投影；
+    - item_sku_codes 是编码治理真相表；
+    - 历史单据里的 item_sku / item_sku_snapshot 是当时展示快照，不追改。
+    """
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def list_codes(self, *, item_id: int) -> list[ItemSkuCode]:
+        item = self.db.get(Item, int(item_id))
+        if item is None:
+            raise ValueError("Item not found")
+        return list_sku_codes_by_item_id(self.db, item_id=int(item_id))
+
+    def create_primary_code_in_current_tx(
+        self,
+        *,
+        item_id: int,
+        code: object,
+        effective_from: datetime | None = None,
+        remark: str | None = None,
+    ) -> ItemSkuCode:
+        """
+        在当前事务里为新建商品同步 PRIMARY 编码。
+
+        注意：
+        - 不 commit，由调用方控制事务；
+        - 用于 POST /items 与 POST /items/aggregate；
+        - 不能被普通 alias 创建入口调用。
+        """
+        item = self.db.get(Item, int(item_id))
+        if item is None:
+            raise ValueError("Item not found")
+
+        code_val = normalize_sku_code(code)
+        existing = get_sku_code_by_code(self.db, code=code_val)
+        if existing is not None:
+            if int(existing.item_id) == int(item_id) and bool(existing.is_primary):
+                return existing
+            raise ValueError("SKU code duplicate")
+
+        now = utc_now()
+        obj = ItemSkuCode(
+            item_id=int(item_id),
+            code=code_val,
+            code_type="PRIMARY",
+            is_primary=True,
+            is_active=True,
+            effective_from=effective_from or now,
+            effective_to=None,
+            remark=remark,
+            created_at=now,
+            updated_at=now,
+        )
+        add_sku_code(self.db, obj)
+        self.db.flush()
+        return obj
+
+    def create_code(
+        self,
+        *,
+        item_id: int,
+        code: object,
+        code_type: object = "ALIAS",
+        is_active: bool = True,
+        effective_from: datetime | None = None,
+        effective_to: datetime | None = None,
+        remark: str | None = None,
+    ) -> ItemSkuCode:
+        item = self.db.get(Item, int(item_id))
+        if item is None:
+            raise ValueError("Item not found")
+
+        code_val = normalize_sku_code(code)
+        code_type_val = normalize_code_type(code_type)
+        if code_type_val not in _NON_PRIMARY_TYPES:
+            raise ValueError("PRIMARY code must be changed via change-primary action")
+
+        existing = get_sku_code_by_code(self.db, code=code_val)
+        if existing is not None:
+            raise ValueError("SKU code duplicate")
+
+        now = utc_now()
+        obj = ItemSkuCode(
+            item_id=int(item_id),
+            code=code_val,
+            code_type=code_type_val,
+            is_primary=False,
+            is_active=bool(is_active),
+            effective_from=effective_from,
+            effective_to=effective_to,
+            remark=remark,
+            created_at=now,
+            updated_at=now,
+        )
+        add_sku_code(self.db, obj)
+
+        try:
+            self.db.commit()
+        except IntegrityError as e:
+            self.db.rollback()
+            raise ValueError("SKU code duplicate") from e
+
+        self.db.refresh(obj)
+        return obj
+
+    def disable_code(self, *, item_id: int, code_id: int) -> ItemSkuCode:
+        obj = get_sku_code_by_id(self.db, code_id=int(code_id))
+        if obj is None or int(obj.item_id) != int(item_id):
+            raise ValueError("SKU code not found")
+        if bool(obj.is_primary):
+            raise ValueError("primary sku code cannot be disabled")
+
+        now = utc_now()
+        obj.is_active = False
+        obj.updated_at = now
+        if obj.effective_to is None:
+            obj.effective_to = now
+
+        self.db.commit()
+        self.db.refresh(obj)
+        return obj
+
+    def enable_code(self, *, item_id: int, code_id: int) -> ItemSkuCode:
+        obj = get_sku_code_by_id(self.db, code_id=int(code_id))
+        if obj is None or int(obj.item_id) != int(item_id):
+            raise ValueError("SKU code not found")
+
+        obj.is_active = True
+        obj.updated_at = utc_now()
+
+        self.db.commit()
+        self.db.refresh(obj)
+        return obj
+
+    def change_primary(
+        self,
+        *,
+        item_id: int,
+        code: object,
+        remark: str | None = None,
+    ) -> ItemSkuCode:
+        item = self.db.get(Item, int(item_id))
+        if item is None:
+            raise ValueError("Item not found")
+
+        code_val = normalize_sku_code(code)
+        now = utc_now()
+
+        existing = get_sku_code_by_code(self.db, code=code_val)
+        if existing is not None and int(existing.item_id) != int(item_id):
+            raise ValueError("SKU code duplicate")
+
+        old_primary = get_primary_sku_code_by_item_id(self.db, item_id=int(item_id))
+
+        if old_primary is not None and str(old_primary.code) == code_val:
+            old_primary.code_type = "PRIMARY"
+            old_primary.is_primary = True
+            old_primary.is_active = True
+            old_primary.effective_to = None
+            old_primary.updated_at = now
+            item.sku = code_val
+            item.updated_at = now
+            self.db.commit()
+            self.db.refresh(old_primary)
+            return old_primary
+
+        if old_primary is not None:
+            old_primary.code_type = "ALIAS"
+            old_primary.is_primary = False
+            old_primary.is_active = True
+            old_primary.effective_to = now
+            old_primary.updated_at = now
+            self.db.flush()
+
+        if existing is None:
+            new_primary = ItemSkuCode(
+                item_id=int(item_id),
+                code=code_val,
+                code_type="PRIMARY",
+                is_primary=True,
+                is_active=True,
+                effective_from=now,
+                effective_to=None,
+                remark=remark,
+                created_at=now,
+                updated_at=now,
+            )
+            add_sku_code(self.db, new_primary)
+        else:
+            new_primary = existing
+            new_primary.code_type = "PRIMARY"
+            new_primary.is_primary = True
+            new_primary.is_active = True
+            new_primary.effective_from = new_primary.effective_from or now
+            new_primary.effective_to = None
+            new_primary.remark = remark if remark is not None else new_primary.remark
+            new_primary.updated_at = now
+
+        item.sku = code_val
+        item.updated_at = now
+
+        try:
+            self.db.commit()
+        except IntegrityError as e:
+            self.db.rollback()
+            raw = str(getattr(e, "orig", e)).lower()
+            if "item_sku_codes" in raw or "items_sku_key" in raw or "unique" in raw:
+                raise ValueError("SKU code duplicate") from e
+            raise ValueError(f"DB integrity error: {getattr(e, 'orig', e)}") from e
+
+        self.db.refresh(new_primary)
+        return new_primary
+
+    def get_item_by_active_code(self, *, code: object) -> Item | None:
+        code_val = normalize_sku_code_or_none(code)
+        if code_val is None:
+            return None
+        row = get_active_sku_code_by_code(self.db, code=code_val)
+        if row is None:
+            return None
+        return self.db.get(Item, int(row.item_id))

--- a/app/pms/items/services/item_write_service.py
+++ b/app/pms/items/services/item_write_service.py
@@ -17,6 +17,7 @@ from app.pms.items.repos.item_write_repo import (
     refresh_item,
     rollback as repo_rollback,
 )
+from app.pms.items.services.item_sku_code_service import ItemSkuCodeService
 
 
 _ALLOWED_LOT_SOURCE_POLICIES = {"INTERNAL_ONLY", "SUPPLIER_ONLY"}
@@ -132,6 +133,7 @@ class ItemWriteService:
     主合同语义：
     - POST /items 必须显式传 sku
     - 创建 item 时仍自动补最小 base item_uom
+    - 创建 item 时同步写 item_sku_codes PRIMARY，items.sku 仅作为当前主 SKU 投影
     """
 
     def __init__(self, db: Session) -> None:
@@ -208,6 +210,12 @@ class ItemWriteService:
         try:
             repo_flush(self.db)
 
+            ItemSkuCodeService(self.db).create_primary_code_in_current_tx(
+                item_id=int(obj.id),
+                code=sku_val,
+                remark="created with item",
+            )
+
             # 维持当前主合同语义：创建 item 时自动补最小 base item_uom
             create_item_uom(
                 self.db,
@@ -227,9 +235,18 @@ class ItemWriteService:
         except IntegrityError as e:
             repo_rollback(self.db)
             raw = str(getattr(e, "orig", e)).lower()
-            if "items_sku_key" in raw or ("unique" in raw and "sku" in raw):
+            if (
+                "items_sku_key" in raw
+                or "uq_item_sku_codes_code" in raw
+                or ("unique" in raw and "sku" in raw)
+            ):
                 raise ValueError("SKU duplicate") from e
             raise ValueError(f"DB integrity error: {getattr(e, 'orig', e)}") from e
+        except ValueError as e:
+            repo_rollback(self.db)
+            if str(e) == "SKU code duplicate":
+                raise ValueError("SKU duplicate") from e
+            raise
 
         refresh_item(self.db, obj)
         return obj

--- a/app/pms/public/items/services/item_read_service.py
+++ b/app/pms/public/items/services/item_read_service.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 
 from app.pms.items.models.item import Item
 from app.pms.items.models.item_barcode import ItemBarcode
+from app.pms.items.models.item_sku_code import ItemSkuCode
 from app.pms.items.repos.item_repo import get_item_by_id as repo_get_item_by_id
 from app.pms.items.repos.item_repo import get_item_by_sku as repo_get_item_by_sku
 from app.pms.items.repos.item_repo import get_items as repo_get_items
@@ -158,7 +159,8 @@ class ItemReadService:
         """
         面向跨域报表/台账的最小异步搜索能力：
         - 匹配 item.name
-        - 匹配 item.sku
+        - 匹配 item.sku 当前主投影
+        - 匹配 active item_sku_codes
         - 匹配 active barcode
         返回 item_id 列表，不暴露 ORM。
         """
@@ -178,6 +180,16 @@ class ItemReadService:
             .limit(1)
             .exists()
         )
+        sku_code_exists = (
+            select(ItemSkuCode.id)
+            .where(
+                ItemSkuCode.item_id == Item.id,
+                ItemSkuCode.is_active.is_(True),
+                ItemSkuCode.code.ilike(like_kw),
+            )
+            .limit(1)
+            .exists()
+        )
 
         stmt = (
             select(Item.id)
@@ -185,6 +197,7 @@ class ItemReadService:
                 or_(
                     Item.name.ilike(like_kw),
                     Item.sku.ilike(like_kw),
+                    sku_code_exists,
                     barcode_exists,
                 )
             )

--- a/app/pms/sku_coding/services/sku_coding_service.py
+++ b/app/pms/sku_coding/services/sku_coding_service.py
@@ -9,6 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
 
 from app.pms.items.models.item import Item
+from app.pms.items.models.item_sku_code import ItemSkuCode
 from app.pms.sku_coding.models.sku_coding import (
     SkuBusinessCategory,
     SkuCodeBrand,
@@ -202,11 +203,17 @@ class SkuCodingService:
 
         sku = str(template.separator).join([p for p in parts if p])
 
-        exists = self.db.execute(select(Item.id).where(Item.sku == sku).limit(1)).first() is not None
+        matched_code_item_ids = select(ItemSkuCode.item_id).where(ItemSkuCode.code == sku)
+        exists = self.db.execute(select(ItemSkuCode.id).where(ItemSkuCode.code == sku).limit(1)).first() is not None
         similar_rows = (
             self.db.execute(
                 select(Item)
-                .where((Item.brand == brand.name_cn) | (Item.category == category.category_name) | (Item.sku == sku))
+                .where(
+                    (Item.brand == brand.name_cn)
+                    | (Item.category == category.category_name)
+                    | (Item.sku == sku)
+                    | (Item.id.in_(matched_code_item_ids))
+                )
                 .order_by(Item.id.desc())
                 .limit(10)
             )

--- a/app/router_mount.py
+++ b/app/router_mount.py
@@ -19,6 +19,7 @@ def mount_routers(app: FastAPI) -> None:
     from app.shipping_assist.routers.geo_cn import router as geo_router
     from app.pms.items.routers.item_aggregate import router as item_aggregate_router
     from app.pms.items.routers.item_barcodes import router as item_barcodes_router
+    from app.pms.items.routers.item_sku_codes import router as item_sku_codes_router
     from app.pms.items.routers.item_uoms import router as item_uoms_router
     from app.pms.items.routers.items import router as items_router
     from app.pms.sku_coding.routers.sku_coding import router as sku_coding_router
@@ -141,6 +142,7 @@ def mount_routers(app: FastAPI) -> None:
     app.include_router(pms_public_suppliers_read_router)
     app.include_router(item_aggregate_router)
     app.include_router(items_router)
+    app.include_router(item_sku_codes_router)
     app.include_router(sku_coding_router)
     app.include_router(item_barcodes_router)
     app.include_router(item_uoms_router)

--- a/app/wms/scan/services/scan_orchestrator_item_resolver.py
+++ b/app/wms/scan/services/scan_orchestrator_item_resolver.py
@@ -72,13 +72,23 @@ async def resolve_item_id_from_barcode(
 
 
 async def resolve_item_id_from_sku(session: AsyncSession, sku: str) -> Optional[int]:
-    s = (sku or "").strip()
+    s = (sku or "").strip().upper()
     if not s:
         return None
 
     try:
         row = await session.execute(
-            SA("SELECT id FROM items WHERE sku = :s LIMIT 1"),
+            SA(
+                """
+                SELECT i.id
+                  FROM item_sku_codes c
+                  JOIN items i ON i.id = c.item_id
+                 WHERE lower(c.code) = lower(:s)
+                   AND c.is_active = TRUE
+                 ORDER BY c.is_primary DESC, c.id ASC
+                 LIMIT 1
+                """
+            ),
             {"s": s},
         )
         item_id = row.scalar_one_or_none()

--- a/openapi/_current.json
+++ b/openapi/_current.json
@@ -10078,6 +10078,256 @@
         }
       }
     },
+    "/items/{item_id}/sku-codes": {
+      "get": {
+        "tags": [
+          "item-sku-codes"
+        ],
+        "summary": "List Item Sku Codes",
+        "operationId": "list_item_sku_codes_items__item_id__sku_codes_get",
+        "parameters": [
+          {
+            "name": "item_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Item Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ItemSkuCodeOut"
+                  },
+                  "title": "Response List Item Sku Codes Items  Item Id  Sku Codes Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "item-sku-codes"
+        ],
+        "summary": "Create Item Sku Code",
+        "operationId": "create_item_sku_code_items__item_id__sku_codes_post",
+        "parameters": [
+          {
+            "name": "item_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Item Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ItemSkuCodeCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemSkuCodeOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/items/{item_id}/sku-codes/{code_id}/disable": {
+      "post": {
+        "tags": [
+          "item-sku-codes"
+        ],
+        "summary": "Disable Item Sku Code",
+        "operationId": "disable_item_sku_code_items__item_id__sku_codes__code_id__disable_post",
+        "parameters": [
+          {
+            "name": "item_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Item Id"
+            }
+          },
+          {
+            "name": "code_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Code Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemSkuCodeOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/items/{item_id}/sku-codes/{code_id}/enable": {
+      "post": {
+        "tags": [
+          "item-sku-codes"
+        ],
+        "summary": "Enable Item Sku Code",
+        "operationId": "enable_item_sku_code_items__item_id__sku_codes__code_id__enable_post",
+        "parameters": [
+          {
+            "name": "item_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Item Id"
+            }
+          },
+          {
+            "name": "code_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Code Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemSkuCodeOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/items/{item_id}/sku-codes/change-primary": {
+      "post": {
+        "tags": [
+          "item-sku-codes"
+        ],
+        "summary": "Change Primary Item Sku Code",
+        "operationId": "change_primary_item_sku_code_items__item_id__sku_codes_change_primary_post",
+        "parameters": [
+          {
+            "name": "item_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Item Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ItemSkuCodeChangePrimary"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemSkuCodeOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/pms/sku-coding/brands": {
       "get": {
         "tags": [
@@ -28210,6 +28460,205 @@
           "planned_line_amount"
         ],
         "title": "ItemPurchaseReportLineItem"
+      },
+      "ItemSkuCodeChangePrimary": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Code"
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "code"
+        ],
+        "title": "ItemSkuCodeChangePrimary"
+      },
+      "ItemSkuCodeCreate": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Code"
+          },
+          "code_type": {
+            "type": "string",
+            "enum": [
+              "PRIMARY",
+              "ALIAS",
+              "LEGACY",
+              "MANUAL"
+            ],
+            "title": "Code Type",
+            "default": "ALIAS"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active",
+            "default": true
+          },
+          "effective_from": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Effective From"
+          },
+          "effective_to": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Effective To"
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "code"
+        ],
+        "title": "ItemSkuCodeCreate"
+      },
+      "ItemSkuCodeOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "item_id": {
+            "type": "integer",
+            "title": "Item Id"
+          },
+          "code": {
+            "type": "string",
+            "title": "Code"
+          },
+          "code_type": {
+            "type": "string",
+            "enum": [
+              "PRIMARY",
+              "ALIAS",
+              "LEGACY",
+              "MANUAL"
+            ],
+            "title": "Code Type"
+          },
+          "is_primary": {
+            "type": "boolean",
+            "title": "Is Primary"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "effective_from": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Effective From"
+          },
+          "effective_to": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Effective To"
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "item_id",
+          "code",
+          "code_type",
+          "is_primary",
+          "is_active"
+        ],
+        "title": "ItemSkuCodeOut"
       },
       "ItemUomBarcodeRowOut": {
         "properties": {

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -10078,6 +10078,256 @@
         }
       }
     },
+    "/items/{item_id}/sku-codes": {
+      "get": {
+        "tags": [
+          "item-sku-codes"
+        ],
+        "summary": "List Item Sku Codes",
+        "operationId": "list_item_sku_codes_items__item_id__sku_codes_get",
+        "parameters": [
+          {
+            "name": "item_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Item Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ItemSkuCodeOut"
+                  },
+                  "title": "Response List Item Sku Codes Items  Item Id  Sku Codes Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "item-sku-codes"
+        ],
+        "summary": "Create Item Sku Code",
+        "operationId": "create_item_sku_code_items__item_id__sku_codes_post",
+        "parameters": [
+          {
+            "name": "item_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Item Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ItemSkuCodeCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemSkuCodeOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/items/{item_id}/sku-codes/{code_id}/disable": {
+      "post": {
+        "tags": [
+          "item-sku-codes"
+        ],
+        "summary": "Disable Item Sku Code",
+        "operationId": "disable_item_sku_code_items__item_id__sku_codes__code_id__disable_post",
+        "parameters": [
+          {
+            "name": "item_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Item Id"
+            }
+          },
+          {
+            "name": "code_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Code Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemSkuCodeOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/items/{item_id}/sku-codes/{code_id}/enable": {
+      "post": {
+        "tags": [
+          "item-sku-codes"
+        ],
+        "summary": "Enable Item Sku Code",
+        "operationId": "enable_item_sku_code_items__item_id__sku_codes__code_id__enable_post",
+        "parameters": [
+          {
+            "name": "item_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Item Id"
+            }
+          },
+          {
+            "name": "code_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Code Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemSkuCodeOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/items/{item_id}/sku-codes/change-primary": {
+      "post": {
+        "tags": [
+          "item-sku-codes"
+        ],
+        "summary": "Change Primary Item Sku Code",
+        "operationId": "change_primary_item_sku_code_items__item_id__sku_codes_change_primary_post",
+        "parameters": [
+          {
+            "name": "item_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Item Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ItemSkuCodeChangePrimary"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemSkuCodeOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/pms/sku-coding/brands": {
       "get": {
         "tags": [
@@ -28210,6 +28460,205 @@
           "planned_line_amount"
         ],
         "title": "ItemPurchaseReportLineItem"
+      },
+      "ItemSkuCodeChangePrimary": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Code"
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "code"
+        ],
+        "title": "ItemSkuCodeChangePrimary"
+      },
+      "ItemSkuCodeCreate": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Code"
+          },
+          "code_type": {
+            "type": "string",
+            "enum": [
+              "PRIMARY",
+              "ALIAS",
+              "LEGACY",
+              "MANUAL"
+            ],
+            "title": "Code Type",
+            "default": "ALIAS"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active",
+            "default": true
+          },
+          "effective_from": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Effective From"
+          },
+          "effective_to": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Effective To"
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "code"
+        ],
+        "title": "ItemSkuCodeCreate"
+      },
+      "ItemSkuCodeOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "item_id": {
+            "type": "integer",
+            "title": "Item Id"
+          },
+          "code": {
+            "type": "string",
+            "title": "Code"
+          },
+          "code_type": {
+            "type": "string",
+            "enum": [
+              "PRIMARY",
+              "ALIAS",
+              "LEGACY",
+              "MANUAL"
+            ],
+            "title": "Code Type"
+          },
+          "is_primary": {
+            "type": "boolean",
+            "title": "Is Primary"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "effective_from": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Effective From"
+          },
+          "effective_to": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Effective To"
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "item_id",
+          "code",
+          "code_type",
+          "is_primary",
+          "is_active"
+        ],
+        "title": "ItemSkuCodeOut"
       },
       "ItemUomBarcodeRowOut": {
         "properties": {

--- a/tests/api/test_item_sku_codes_api.py
+++ b/tests/api/test_item_sku_codes_api.py
@@ -1,0 +1,259 @@
+# tests/api/test_item_sku_codes_api.py
+from __future__ import annotations
+
+from typing import Any, Dict
+from uuid import uuid4
+
+import httpx
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def _sku(prefix: str = "UT-SKU-CODE") -> str:
+    return f"{prefix}-{uuid4().hex[:8].upper()}"
+
+
+async def _login_admin_headers(client: httpx.AsyncClient) -> Dict[str, str]:
+    r = await client.post("/users/login", json={"username": "admin", "password": "admin123"})
+    assert r.status_code == 200, r.text
+    token = r.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _create_item(
+    client: httpx.AsyncClient,
+    headers: Dict[str, str],
+    *,
+    sku: str | None = None,
+) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "sku": sku or _sku(),
+        "name": f"UT-SKU-CODE-ITEM-{uuid4().hex[:8].upper()}",
+        "spec": "SPEC-A",
+        "brand": "BRAND-A",
+        "category": "CATEGORY-A",
+        "enabled": True,
+        "supplier_id": 1,
+        "lot_source_policy": "SUPPLIER_ONLY",
+        "expiry_policy": "NONE",
+        "derivation_allowed": True,
+        "uom_governance_enabled": False,
+    }
+    r = await client.post("/items", json=payload, headers=headers)
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+@pytest.mark.asyncio
+async def test_create_item_syncs_primary_sku_code(
+    client: httpx.AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    sku = _sku("UT-PRIMARY")
+    created = await _create_item(client, headers, sku=sku)
+    item_id = int(created["id"])
+
+    r = await client.get(f"/items/{item_id}/sku-codes", headers=headers)
+    assert r.status_code == 200, r.text
+    codes = r.json()
+
+    assert len(codes) == 1
+    primary = codes[0]
+    assert primary["item_id"] == item_id
+    assert primary["code"] == sku
+    assert primary["code_type"] == "PRIMARY"
+    assert primary["is_primary"] is True
+    assert primary["is_active"] is True
+
+    db_count = await session.execute(
+        text(
+            """
+            SELECT COUNT(*)
+              FROM item_sku_codes
+             WHERE item_id = :item_id
+               AND code = :sku
+               AND code_type = 'PRIMARY'
+               AND is_primary = TRUE
+               AND is_active = TRUE
+            """
+        ),
+        {"item_id": item_id, "sku": sku},
+    )
+    assert int(db_count.scalar_one()) == 1
+
+
+@pytest.mark.asyncio
+async def test_alias_sku_code_can_resolve_item_then_disable_and_enable(client: httpx.AsyncClient) -> None:
+    headers = await _login_admin_headers(client)
+    created = await _create_item(client, headers, sku=_sku("UT-ALIAS-PRIMARY"))
+    item_id = int(created["id"])
+
+    alias = _sku("ut-alias").lower()
+    r_create = await client.post(
+        f"/items/{item_id}/sku-codes",
+        json={"code": alias, "code_type": "ALIAS", "remark": "历史别名"},
+        headers=headers,
+    )
+    assert r_create.status_code == 201, r_create.text
+    alias_row = r_create.json()
+    assert alias_row["code"] == alias.upper()
+    assert alias_row["code_type"] == "ALIAS"
+    assert alias_row["is_primary"] is False
+    assert alias_row["is_active"] is True
+
+    r_by_alias = await client.get(f"/items/sku/{alias}", headers=headers)
+    assert r_by_alias.status_code == 200, r_by_alias.text
+    assert int(r_by_alias.json()["id"]) == item_id
+
+    r_disable = await client.post(
+        f"/items/{item_id}/sku-codes/{int(alias_row['id'])}/disable",
+        headers=headers,
+    )
+    assert r_disable.status_code == 200, r_disable.text
+    assert r_disable.json()["is_active"] is False
+
+    r_disabled_lookup = await client.get(f"/items/sku/{alias}", headers=headers)
+    assert r_disabled_lookup.status_code == 404, r_disabled_lookup.text
+
+    r_enable = await client.post(
+        f"/items/{item_id}/sku-codes/{int(alias_row['id'])}/enable",
+        headers=headers,
+    )
+    assert r_enable.status_code == 200, r_enable.text
+    assert r_enable.json()["is_active"] is True
+
+    r_enabled_lookup = await client.get(f"/items/sku/{alias}", headers=headers)
+    assert r_enabled_lookup.status_code == 200, r_enabled_lookup.text
+    assert int(r_enabled_lookup.json()["id"]) == item_id
+
+
+@pytest.mark.asyncio
+async def test_change_primary_keeps_old_sku_as_alias_and_updates_items_projection(
+    client: httpx.AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    old_sku = _sku("UT-OLD")
+    new_sku = _sku("UT-NEW")
+
+    created = await _create_item(client, headers, sku=old_sku)
+    item_id = int(created["id"])
+
+    r_change = await client.post(
+        f"/items/{item_id}/sku-codes/change-primary",
+        json={"code": new_sku, "remark": "规则调整"},
+        headers=headers,
+    )
+    assert r_change.status_code == 200, r_change.text
+    primary = r_change.json()
+    assert primary["code"] == new_sku
+    assert primary["code_type"] == "PRIMARY"
+    assert primary["is_primary"] is True
+    assert primary["is_active"] is True
+
+    r_get = await client.get(f"/items/{item_id}", headers=headers)
+    assert r_get.status_code == 200, r_get.text
+    assert r_get.json()["sku"] == new_sku
+
+    r_old = await client.get(f"/items/sku/{old_sku}", headers=headers)
+    assert r_old.status_code == 200, r_old.text
+    assert int(r_old.json()["id"]) == item_id
+
+    r_new = await client.get(f"/items/sku/{new_sku}", headers=headers)
+    assert r_new.status_code == 200, r_new.text
+    assert int(r_new.json()["id"]) == item_id
+
+    rows = (
+        await session.execute(
+            text(
+                """
+                SELECT code, code_type, is_primary, is_active
+                  FROM item_sku_codes
+                 WHERE item_id = :item_id
+                 ORDER BY is_primary DESC, code ASC
+                """
+            ),
+            {"item_id": item_id},
+        )
+    ).mappings().all()
+
+    by_code = {str(r["code"]): r for r in rows}
+    assert by_code[new_sku]["code_type"] == "PRIMARY"
+    assert bool(by_code[new_sku]["is_primary"]) is True
+    assert by_code[old_sku]["code_type"] == "ALIAS"
+    assert bool(by_code[old_sku]["is_primary"]) is False
+    assert bool(by_code[old_sku]["is_active"]) is True
+
+
+@pytest.mark.asyncio
+async def test_primary_sku_code_cannot_be_disabled(client: httpx.AsyncClient) -> None:
+    headers = await _login_admin_headers(client)
+    created = await _create_item(client, headers, sku=_sku("UT-NO-DISABLE"))
+    item_id = int(created["id"])
+
+    r_list = await client.get(f"/items/{item_id}/sku-codes", headers=headers)
+    assert r_list.status_code == 200, r_list.text
+    primary = next(x for x in r_list.json() if x["is_primary"] is True)
+
+    r_disable = await client.post(
+        f"/items/{item_id}/sku-codes/{int(primary['id'])}/disable",
+        headers=headers,
+    )
+    assert r_disable.status_code == 400, r_disable.text
+    assert "primary sku code cannot be disabled" in r_disable.text
+
+
+@pytest.mark.asyncio
+async def test_create_item_aggregate_syncs_primary_sku_code(client: httpx.AsyncClient) -> None:
+    headers = await _login_admin_headers(client)
+    suffix = uuid4().hex[:8].upper()
+    sku = f"UT-AGG-SKU-CODE-{suffix}"
+
+    payload = {
+        "item": {
+            "sku": sku,
+            "name": f"UT-AGG-SKU-CODE-ITEM-{suffix}",
+            "spec": "500g",
+            "brand": "BRAND-A",
+            "category": "CATEGORY-A",
+            "enabled": True,
+            "supplier_id": 1,
+            "lot_source_policy": "SUPPLIER_ONLY",
+            "expiry_policy": "NONE",
+            "derivation_allowed": True,
+            "uom_governance_enabled": True,
+            "shelf_life_value": None,
+            "shelf_life_unit": None,
+        },
+        "uoms": [
+            {
+                "id": None,
+                "uom_key": "BASE",
+                "uom": "PCS",
+                "ratio_to_base": 1,
+                "display_name": "PCS",
+                "net_weight_kg": None,
+                "is_base": True,
+                "is_purchase_default": True,
+                "is_inbound_default": True,
+                "is_outbound_default": True,
+            }
+        ],
+        "barcodes": [],
+    }
+
+    r = await client.post("/items/aggregate", json=payload, headers=headers)
+    assert r.status_code == 201, r.text
+    item_id = int(r.json()["item"]["id"])
+
+    r_codes = await client.get(f"/items/{item_id}/sku-codes", headers=headers)
+    assert r_codes.status_code == 200, r_codes.text
+    codes = r_codes.json()
+
+    assert len(codes) == 1
+    assert codes[0]["code"] == sku
+    assert codes[0]["code_type"] == "PRIMARY"
+    assert codes[0]["is_primary"] is True
+    assert codes[0]["is_active"] is True

--- a/tests/ci/test_db_invariants.py
+++ b/tests/ci/test_db_invariants.py
@@ -150,3 +150,89 @@ async def test_ledger_row_consistent_with_stock_slot(session: AsyncSession):
     assert int(r["l_item"]) == int(r["s_item"]) == int(item_id)
     assert int(r["l_lot"]) == int(r["s_lot"]) == int(lot_id)
     assert str(r["l_code"]) == str(r["s_code"]) == str(lot_code)
+
+
+@pytest.mark.asyncio
+async def test_item_sku_codes_primary_invariant(session: AsyncSession):
+    """
+    SKU 多编码治理 invariant：
+
+    - 每个 item 必须且只能有一个 PRIMARY code；
+    - PRIMARY code 必须 active；
+    - PRIMARY code 不允许 effective_to；
+    - PRIMARY code 必须等于 items.sku 当前主投影；
+    - code 统一按大写治理，不允许 lower(code) 维度重复。
+    """
+    await ensure_item(
+        session,
+        id=99902,
+        sku="SKU-99902",
+        name="Item-99902",
+        expiry_required=False,
+    )
+    await session.commit()
+
+    missing_or_duplicate_primary = await session.execute(
+        text(
+            """
+            SELECT i.id, COUNT(c.id) AS primary_count
+              FROM items i
+              LEFT JOIN item_sku_codes c
+                ON c.item_id = i.id
+               AND c.is_primary = TRUE
+             GROUP BY i.id
+            HAVING COUNT(c.id) <> 1
+            ORDER BY i.id
+            """
+        )
+    )
+    bad_primary_count = missing_or_duplicate_primary.mappings().all()
+    assert bad_primary_count == []
+
+    inactive_or_closed_primary = await session.execute(
+        text(
+            """
+            SELECT id, item_id, code, is_active, effective_to
+              FROM item_sku_codes
+             WHERE is_primary = TRUE
+               AND (
+                 is_active IS DISTINCT FROM TRUE
+                 OR effective_to IS NOT NULL
+                 OR code_type <> 'PRIMARY'
+               )
+             ORDER BY item_id, id
+            """
+        )
+    )
+    bad_primary_rows = inactive_or_closed_primary.mappings().all()
+    assert bad_primary_rows == []
+
+    projection_mismatch = await session.execute(
+        text(
+            """
+            SELECT i.id, i.sku, c.code
+              FROM items i
+              JOIN item_sku_codes c
+                ON c.item_id = i.id
+               AND c.is_primary = TRUE
+             WHERE c.code <> upper(trim(i.sku))
+             ORDER BY i.id
+            """
+        )
+    )
+    mismatches = projection_mismatch.mappings().all()
+    assert mismatches == []
+
+    case_duplicates = await session.execute(
+        text(
+            """
+            SELECT lower(code) AS norm_code, COUNT(*) AS cnt
+              FROM item_sku_codes
+             GROUP BY lower(code)
+            HAVING COUNT(*) > 1
+             ORDER BY lower(code)
+            """
+        )
+    )
+    duplicate_rows = case_duplicates.mappings().all()
+    assert duplicate_rows == []

--- a/tests/ci/test_pms_item_openapi_contract.py
+++ b/tests/ci/test_pms_item_openapi_contract.py
@@ -83,11 +83,12 @@ def test_static_openapi_pms_item_write_contract_matches_runtime_boundary() -> No
 
 def test_runtime_openapi_pms_item_create_requires_manual_sku_and_update_keeps_sku_closed() -> None:
     """
-    SKU 编码终态合同：
+    SKU 编码治理合同：
 
     - ItemCreate 必须显式输入 sku；
     - ItemUpdate 仍然不开放 sku 变更；
-    - sku 的最终真相仍是 items.sku，不再由 POST /items 自动生成。
+    - items.sku 是当前主 SKU 投影；
+    - item_sku_codes 是商品编码治理真相表。
     """
     spec = app.openapi()
 
@@ -101,3 +102,25 @@ def test_runtime_openapi_pms_item_create_requires_manual_sku_and_update_keeps_sk
     assert "sku" in create_props
     assert "sku" in create_required
     assert "sku" not in update_props
+
+
+def test_runtime_openapi_exposes_item_sku_codes_owner_governance_routes() -> None:
+    """
+    SKU 多编码治理入口必须是独立 owner surface，
+    不能通过 PATCH /items/{id} 偷开 sku 变更。
+    """
+    spec = app.openapi()
+    paths = spec.get("paths") or {}
+
+    assert "/items/{item_id}/sku-codes" in paths
+    assert "get" in paths["/items/{item_id}/sku-codes"]
+    assert "post" in paths["/items/{item_id}/sku-codes"]
+
+    assert "/items/{item_id}/sku-codes/{code_id}/disable" in paths
+    assert "post" in paths["/items/{item_id}/sku-codes/{code_id}/disable"]
+
+    assert "/items/{item_id}/sku-codes/{code_id}/enable" in paths
+    assert "post" in paths["/items/{item_id}/sku-codes/{code_id}/enable"]
+
+    assert "/items/{item_id}/sku-codes/change-primary" in paths
+    assert "post" in paths["/items/{item_id}/sku-codes/change-primary"]

--- a/tests/fixtures/base_seed.sql
+++ b/tests/fixtures/base_seed.sql
@@ -213,6 +213,52 @@ VALUES
    'SUPPLIER_ONLY'::lot_source_policy, 'NONE'::expiry_policy, true, true)
 ON CONFLICT (id) DO NOTHING;
 
+
+-- ===== item_sku_codes (SKU governance truth) =====
+UPDATE item_sku_codes c
+   SET code_type = 'ALIAS',
+       is_primary = false,
+       is_active = true,
+       effective_to = COALESCE(c.effective_to, CURRENT_TIMESTAMP),
+       updated_at = CURRENT_TIMESTAMP
+  FROM items i
+ WHERE c.item_id = i.id
+   AND c.is_primary = true
+   AND c.code <> upper(trim(i.sku));
+
+INSERT INTO item_sku_codes (
+  item_id,
+  code,
+  code_type,
+  is_primary,
+  is_active,
+  effective_from,
+  effective_to,
+  remark,
+  created_at,
+  updated_at
+)
+SELECT
+  i.id,
+  upper(trim(i.sku)),
+  'PRIMARY',
+  true,
+  true,
+  COALESCE(i.created_at, CURRENT_TIMESTAMP),
+  NULL,
+  'base seed primary sku',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+FROM items i
+WHERE trim(i.sku) <> ''
+ON CONFLICT (code) DO UPDATE SET
+  code_type = 'PRIMARY',
+  is_primary = true,
+  is_active = true,
+  effective_to = NULL,
+  updated_at = CURRENT_TIMESTAMP
+WHERE item_sku_codes.item_id = EXCLUDED.item_id;
+
 -- ===== item_uoms (unit truth source) =====
 INSERT INTO item_uoms (
   item_id, uom, ratio_to_base, display_name,

--- a/tests/utils/ensure_minimal.py
+++ b/tests/utils/ensure_minimal.py
@@ -132,6 +132,64 @@ async def ensure_item(
     )
 
 
+    sku_code = str(sku).strip().upper()
+    await session.execute(
+        text(
+            """
+            UPDATE item_sku_codes
+               SET code_type = 'ALIAS',
+                   is_primary = FALSE,
+                   is_active = TRUE,
+                   effective_to = COALESCE(effective_to, CURRENT_TIMESTAMP),
+                   updated_at = CURRENT_TIMESTAMP
+             WHERE item_id = :id
+               AND is_primary = TRUE
+               AND code <> :sku
+            """
+        ),
+        {"id": int(id), "sku": sku_code},
+    )
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO item_sku_codes (
+              item_id,
+              code,
+              code_type,
+              is_primary,
+              is_active,
+              effective_from,
+              effective_to,
+              remark,
+              created_at,
+              updated_at
+            )
+            VALUES (
+              :id,
+              :sku,
+              'PRIMARY',
+              TRUE,
+              TRUE,
+              CURRENT_TIMESTAMP,
+              NULL,
+              'tests ensure_item primary sku',
+              CURRENT_TIMESTAMP,
+              CURRENT_TIMESTAMP
+            )
+            ON CONFLICT (code) DO UPDATE SET
+              code_type = 'PRIMARY',
+              is_primary = TRUE,
+              is_active = TRUE,
+              effective_to = NULL,
+              updated_at = CURRENT_TIMESTAMP
+            WHERE item_sku_codes.item_id = EXCLUDED.item_id
+            """
+        ),
+        {"id": int(id), "sku": sku_code},
+    )
+
+
 def _norm_lot_key(code_raw: str) -> str:
     # tests baseline normalize: trim + lower (DB unique key is text; service uses upper, but tests just need stable key)
     return str(code_raw).strip().lower()


### PR DESCRIPTION
## Summary

- add `item_sku_codes` as PMS SKU governance truth table
- backfill existing `items.sku` as PRIMARY code
- keep `items.sku` as current primary SKU projection
- add owner APIs for listing codes, adding aliases, enable/disable, and changing primary SKU
- make item creation and aggregate creation sync PRIMARY SKU code
- make SKU lookup/search/scan/SKU-coding existence checks use `item_sku_codes`
- sync test seed/helper direct item inserts with PRIMARY SKU codes
- add API, OpenAPI, and DB invariant coverage

## Validation

- `python3 -m compileall app tests`
- `make upgrade-dev`
- `make alembic-check`
- `make openapi`
- targeted validation:
  - `tests/api/test_item_sku_codes_api.py`
  - `tests/api/test_items_main_contract_api.py`
  - `tests/api/test_item_owner_aggregate_api.py`
  - `tests/ci/test_db_invariants.py`
  - `tests/ci/test_pms_item_openapi_contract.py`
  - `tests/api/test_stock_inventory_read_api.py`
  - `tests/services/test_pms_public_item_read_service.py`
  - `tests/api/test_no_duplicate_routes.py`
- SKU stale fallback / wording scan clean