### PR TITLE
feat(pms): add brand lock endpoints

### DIFF
--- a/app/pms/items/routers/item_master.py
+++ b/app/pms/items/routers/item_master.py
@@ -120,6 +120,28 @@ def disable_pms_brand(brand_id: int, db: Session = Depends(get_db)):
     return obj
 
 
+@router.post("/pms/brands/{brand_id}/lock", response_model=PmsBrandOut)
+def lock_pms_brand(brand_id: int, db: Session = Depends(get_db)):
+    obj = db.get(PmsBrand, int(brand_id))
+    if obj is None:
+        raise _not_found("品牌不存在")
+    obj.is_locked = True
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+
+@router.post("/pms/brands/{brand_id}/unlock", response_model=PmsBrandOut)
+def unlock_pms_brand(brand_id: int, db: Session = Depends(get_db)):
+    obj = db.get(PmsBrand, int(brand_id))
+    if obj is None:
+        raise _not_found("品牌不存在")
+    obj.is_locked = False
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+
 @router.get("/pms/categories", response_model=ListOut[PmsCategoryOut])
 def list_pms_categories(
     product_kind: str | None = Query(None),

--- a/tests/api/test_pms_master_data_api.py
+++ b/tests/api/test_pms_master_data_api.py
@@ -50,6 +50,32 @@ async def test_pms_brand_and_category_owner_contract(client: httpx.AsyncClient) 
     assert r_enable.status_code == 200, r_enable.text
     assert r_enable.json()["is_active"] is True
 
+
+    # ===== lock / unlock =====
+    r_lock = await client.post(f"/pms/brands/{brand['id']}/lock", headers=headers)
+    assert r_lock.status_code == 200, r_lock.text
+    assert r_lock.json()["is_locked"] is True
+
+    # locked 后禁止改 code
+    r_locked_patch = await client.patch(
+        f"/pms/brands/{brand['id']}",
+        json={"code": f"BRLOCK{sfx}"},
+        headers=headers,
+    )
+    assert r_locked_patch.status_code == 409, r_locked_patch.text
+
+    r_unlock = await client.post(f"/pms/brands/{brand['id']}/unlock", headers=headers)
+    assert r_unlock.status_code == 200, r_unlock.text
+    assert r_unlock.json()["is_locked"] is False
+
+    # 解锁后允许改 code
+    r_unlock_patch = await client.patch(
+        f"/pms/brands/{brand['id']}",
+        json={"code": f"BRU{sfx}"},
+        headers=headers,
+    )
+    assert r_unlock_patch.status_code == 200, r_unlock_patch.text
+
     r_category = await client.post(
         "/pms/categories",
         json={


### PR DESCRIPTION
## Summary
- Add PMS brand lock/unlock endpoints.
- Keep existing locked-code guard unchanged.
- Add API coverage for lock, locked-code rejection, unlock, and unlocked-code update.

## Validation
- make test TESTS=tests/api/test_pms_master_data_api.py