### PR TITLE
feat(pms): add category lock endpoints

### DIFF
--- a/app/pms/items/routers/item_master.py
+++ b/app/pms/items/routers/item_master.py
@@ -229,6 +229,28 @@ def disable_pms_category(category_id: int, db: Session = Depends(get_db)):
     return obj
 
 
+@router.post("/pms/categories/{category_id}/lock", response_model=PmsCategoryOut)
+def lock_pms_category(category_id: int, db: Session = Depends(get_db)):
+    obj = db.get(PmsBusinessCategory, int(category_id))
+    if obj is None:
+        raise _not_found("内部分类不存在")
+    obj.is_locked = True
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+
+@router.post("/pms/categories/{category_id}/unlock", response_model=PmsCategoryOut)
+def unlock_pms_category(category_id: int, db: Session = Depends(get_db)):
+    obj = db.get(PmsBusinessCategory, int(category_id))
+    if obj is None:
+        raise _not_found("内部分类不存在")
+    obj.is_locked = False
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+
 @router.get("/pms/item-attribute-defs", response_model=ListOut[ItemAttributeDefOut])
 def list_item_attribute_defs(
     product_kind: str | None = Query(None),

--- a/tests/api/test_pms_master_data_api.py
+++ b/tests/api/test_pms_master_data_api.py
@@ -109,6 +109,32 @@ async def test_pms_brand_and_category_owner_contract(client: httpx.AsyncClient) 
     assert r_category_patch.json()["path_code"] == f"CATX{sfx}"
 
 
+    r_category_lock = await client.post(f"/pms/categories/{category['id']}/lock", headers=headers)
+    assert r_category_lock.status_code == 200, r_category_lock.text
+    assert r_category_lock.json()["is_locked"] is True
+
+    r_category_locked_patch = await client.patch(
+        f"/pms/categories/{category['id']}",
+        json={"category_code": f"CATLOCK{sfx}"},
+        headers=headers,
+    )
+    assert r_category_locked_patch.status_code == 409, r_category_locked_patch.text
+    assert "category_code" in r_category_locked_patch.text
+
+    r_category_unlock = await client.post(f"/pms/categories/{category['id']}/unlock", headers=headers)
+    assert r_category_unlock.status_code == 200, r_category_unlock.text
+    assert r_category_unlock.json()["is_locked"] is False
+
+    r_category_unlock_patch = await client.patch(
+        f"/pms/categories/{category['id']}",
+        json={"category_code": f"CATU{sfx}"},
+        headers=headers,
+    )
+    assert r_category_unlock_patch.status_code == 200, r_category_unlock_patch.text
+    assert r_category_unlock_patch.json()["category_code"] == f"CATU{sfx}"
+    assert r_category_unlock_patch.json()["path_code"] == f"CATU{sfx}"
+
+
 @pytest.mark.asyncio
 async def test_pms_attribute_template_options_and_item_values_contract(client: httpx.AsyncClient) -> None:
     headers = await _headers(client)


### PR DESCRIPTION
## Summary
- Add PMS category lock/unlock endpoints.
- Keep existing locked category_code guard unchanged.
- Add API coverage for lock, locked category_code rejection, unlock, and unlocked category_code update.

## Validation
- make test TESTS=tests/api/test_pms_master_data_api.py

Result:
- 2 tests passed.