### PR TITLE
chore(pms): rename category navigation label

### DIFF
--- a/alembic/versions/20260429233831_pms_categories_nav_name_product_category_code.py
+++ b/alembic/versions/20260429233831_pms_categories_nav_name_product_category_code.py
@@ -1,0 +1,43 @@
+"""Rename PMS categories navigation label.
+
+Revision ID: 20260429233831
+Revises: e4b8c31f7a2d
+Create Date: 2026-04-29
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20260429233831"
+down_revision: Union[str, Sequence[str], None] = "e4b8c31f7a2d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Rename pms.categories sidebar label to match the frontend page."""
+    op.execute(
+        """
+        UPDATE page_registry
+           SET name = '商品分类编码'
+         WHERE code = 'pms.categories'
+           AND name = '内部分类'
+        """
+    )
+
+
+def downgrade() -> None:
+    """Restore previous pms.categories sidebar label."""
+    op.execute(
+        """
+        UPDATE page_registry
+           SET name = '内部分类'
+         WHERE code = 'pms.categories'
+           AND name = '商品分类编码'
+        """
+    )

--- a/tests/api/test_pms_master_data_navigation_api.py
+++ b/tests/api/test_pms_master_data_navigation_api.py
@@ -59,7 +59,7 @@ async def test_pms_master_data_page_tree_and_routes(client: httpx.AsyncClient) -
 
     assert nodes["pms.items"]["name"] == "商品列表"
     assert nodes["pms.brands"]["name"] == "品牌管理"
-    assert nodes["pms.categories"]["name"] == "内部分类"
+    assert nodes["pms.categories"]["name"] == "商品分类编码"
     assert nodes["pms.item_attributes"]["name"] == "属性模板"
     assert nodes["pms.item_uoms"]["name"] == "包装单位"
     assert nodes["pms.suppliers"]["name"] == "供应商管理"


### PR DESCRIPTION
## Summary
- Rename PMS sidebar label pms.categories from 内部分类 to 商品分类编码.
- Add Alembic migration for page_registry.
- Update navigation contract test.

## Validation
- make test TESTS=tests/api/test_pms_master_data_navigation_api.py

Result:
- 1 test passed.