### PR TITLE
refactor(pms): refine item attribute definition contract

### DIFF
--- a/alembic/versions/20260430101727_refine_item_attribute_defs_contract.py
+++ b/alembic/versions/20260430101727_refine_item_attribute_defs_contract.py
@@ -1,0 +1,111 @@
+"""Refine PMS item attribute definition contract.
+
+Revision ID: 20260430101727
+Revises: 20260429233831
+Create Date: 2026-04-30
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "20260430101727"
+down_revision: Union[str, Sequence[str], None] = "20260429233831"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "item_attribute_defs",
+        sa.Column("selection_mode", sa.String(length=16), server_default="SINGLE", nullable=False),
+    )
+    op.add_column(
+        "item_attribute_defs",
+        sa.Column("is_item_required", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+    )
+    op.add_column(
+        "item_attribute_defs",
+        sa.Column("is_sku_required", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+    )
+    op.add_column(
+        "item_attribute_defs",
+        sa.Column("is_locked", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+    )
+
+    op.execute(
+        """
+        UPDATE item_attribute_defs
+           SET is_item_required = is_required
+        """
+    )
+
+    op.execute(
+        """
+        UPDATE item_attribute_defs
+           SET selection_mode = 'MULTI'
+         WHERE value_type = 'OPTION'
+           AND is_sku_segment IS TRUE
+        """
+    )
+
+    op.drop_constraint("fk_item_attribute_defs_category", "item_attribute_defs", type_="foreignkey")
+    op.drop_constraint("uq_item_attribute_defs_category_code", "item_attribute_defs", type_="unique")
+    op.drop_index("ix_item_attribute_defs_category_id", table_name="item_attribute_defs")
+
+    op.drop_column("item_attribute_defs", "category_id")
+    op.drop_column("item_attribute_defs", "is_required")
+    op.drop_column("item_attribute_defs", "is_searchable")
+    op.drop_column("item_attribute_defs", "is_filterable")
+
+    op.create_check_constraint(
+        "ck_item_attribute_defs_selection_mode",
+        "item_attribute_defs",
+        "selection_mode in ('SINGLE', 'MULTI')",
+    )
+    op.create_unique_constraint(
+        "uq_item_attribute_defs_product_kind_code",
+        "item_attribute_defs",
+        ["product_kind", "code"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_item_attribute_defs_product_kind_code", "item_attribute_defs", type_="unique")
+    op.drop_constraint("ck_item_attribute_defs_selection_mode", "item_attribute_defs", type_="check")
+
+    op.add_column("item_attribute_defs", sa.Column("is_filterable", sa.Boolean(), server_default=sa.text("false"), nullable=False))
+    op.add_column("item_attribute_defs", sa.Column("is_searchable", sa.Boolean(), server_default=sa.text("false"), nullable=False))
+    op.add_column("item_attribute_defs", sa.Column("is_required", sa.Boolean(), server_default=sa.text("false"), nullable=False))
+    op.add_column("item_attribute_defs", sa.Column("category_id", sa.Integer(), nullable=True))
+
+    op.execute(
+        """
+        UPDATE item_attribute_defs
+           SET is_required = is_item_required
+        """
+    )
+
+    op.create_foreign_key(
+        "fk_item_attribute_defs_category",
+        "item_attribute_defs",
+        "pms_business_categories",
+        ["category_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.create_unique_constraint(
+        "uq_item_attribute_defs_category_code",
+        "item_attribute_defs",
+        ["category_id", "code"],
+    )
+    op.create_index("ix_item_attribute_defs_category_id", "item_attribute_defs", ["category_id"])
+
+    op.drop_column("item_attribute_defs", "is_locked")
+    op.drop_column("item_attribute_defs", "is_sku_required")
+    op.drop_column("item_attribute_defs", "is_item_required")
+    op.drop_column("item_attribute_defs", "selection_mode")

--- a/app/pms/items/contracts/item_master.py
+++ b/app/pms/items/contracts/item_master.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 ProductKind = Literal["FOOD", "SUPPLY", "OTHER"]
 AttributeProductKind = Literal["FOOD", "SUPPLY", "OTHER", "COMMON"]
 AttributeValueType = Literal["TEXT", "NUMBER", "OPTION", "BOOL"]
+AttributeSelectionMode = Literal["SINGLE", "MULTI"]
 
 
 class _Base(BaseModel):
@@ -132,12 +133,11 @@ class ItemAttributeDefCreate(_Base):
     name_cn: Annotated[str, Field(min_length=1, max_length=128)]
     name_en: Annotated[str | None, Field(default=None, max_length=128)] = None
     product_kind: AttributeProductKind
-    category_id: int | None = None
     value_type: AttributeValueType
+    selection_mode: AttributeSelectionMode = "SINGLE"
     unit: Annotated[str | None, Field(default=None, max_length=16)] = None
-    is_required: bool = False
-    is_searchable: bool = False
-    is_filterable: bool = False
+    is_item_required: bool = False
+    is_sku_required: bool = False
     is_sku_segment: bool = False
     sort_order: int = 0
     remark: Annotated[str | None, Field(default=None, max_length=500)] = None
@@ -147,19 +147,25 @@ class ItemAttributeDefCreate(_Base):
     def _trim_text(cls, v: object) -> object:
         return _trim(v)
 
-    @field_validator("code", "product_kind", "value_type", mode="before")
+    @field_validator("code", "product_kind", "value_type", "selection_mode", mode="before")
     @classmethod
     def _upper_text(cls, v: object) -> object:
         return _upper(v)
+
+    @model_validator(mode="after")
+    def _selection_mode_matches_value_type(self) -> "ItemAttributeDefCreate":
+        if self.value_type != "OPTION" and self.selection_mode != "SINGLE":
+            raise ValueError("非 OPTION 属性只允许 selection_mode=SINGLE")
+        return self
 
 
 class ItemAttributeDefUpdate(_Base):
     name_cn: Annotated[str | None, Field(default=None, max_length=128)] = None
     name_en: Annotated[str | None, Field(default=None, max_length=128)] = None
+    selection_mode: AttributeSelectionMode | None = None
     unit: Annotated[str | None, Field(default=None, max_length=16)] = None
-    is_required: bool | None = None
-    is_searchable: bool | None = None
-    is_filterable: bool | None = None
+    is_item_required: bool | None = None
+    is_sku_required: bool | None = None
     is_sku_segment: bool | None = None
     sort_order: int | None = None
     remark: Annotated[str | None, Field(default=None, max_length=500)] = None
@@ -169,6 +175,11 @@ class ItemAttributeDefUpdate(_Base):
     def _trim_text(cls, v: object) -> object:
         return _trim(v)
 
+    @field_validator("selection_mode", mode="before")
+    @classmethod
+    def _upper_selection_mode(cls, v: object) -> object:
+        return _upper(v)
+
 
 class ItemAttributeDefOut(_Base):
     id: int
@@ -176,14 +187,14 @@ class ItemAttributeDefOut(_Base):
     name_cn: str
     name_en: str | None = None
     product_kind: str
-    category_id: int | None = None
     value_type: str
+    selection_mode: str
     unit: str | None = None
-    is_required: bool
-    is_searchable: bool
-    is_filterable: bool
+    is_item_required: bool
+    is_sku_required: bool
     is_sku_segment: bool
     is_active: bool
+    is_locked: bool
     sort_order: int
     remark: str | None = None
     created_at: datetime | None = None

--- a/app/pms/items/models/item_master.py
+++ b/app/pms/items/models/item_master.py
@@ -74,11 +74,6 @@ class PmsBusinessCategory(Base):
         lazy="joined",
     )
     items: Mapped[list["Item"]] = relationship("Item", back_populates="category_ref", lazy="selectin")
-    attribute_defs: Mapped[list["ItemAttributeDef"]] = relationship(
-        "ItemAttributeDef",
-        back_populates="category",
-        lazy="selectin",
-    )
 
     __table_args__ = (
         sa.CheckConstraint("level in (1, 2, 3)", name="ck_pms_business_categories_level"),
@@ -101,18 +96,14 @@ class ItemAttributeDef(Base):
     name_cn: Mapped[str] = mapped_column(sa.String(128), nullable=False)
     name_en: Mapped[str | None] = mapped_column(sa.String(128), nullable=True)
     product_kind: Mapped[str] = mapped_column(sa.String(16), nullable=False)
-    category_id: Mapped[int | None] = mapped_column(
-        sa.Integer,
-        sa.ForeignKey("pms_business_categories.id", name="fk_item_attribute_defs_category", ondelete="RESTRICT"),
-        nullable=True,
-    )
     value_type: Mapped[str] = mapped_column(sa.String(16), nullable=False)
+    selection_mode: Mapped[str] = mapped_column(sa.String(16), nullable=False, server_default=sa.text("'SINGLE'"))
     unit: Mapped[str | None] = mapped_column(sa.String(16), nullable=True)
-    is_required: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"))
-    is_searchable: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"))
-    is_filterable: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"))
+    is_item_required: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"))
+    is_sku_required: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"))
     is_sku_segment: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"))
     is_active: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("true"))
+    is_locked: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"))
     sort_order: Mapped[int] = mapped_column(sa.Integer, nullable=False, server_default=sa.text("0"))
     remark: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(sa.DateTime(timezone=True), nullable=False, server_default=func.now())
@@ -123,11 +114,6 @@ class ItemAttributeDef(Base):
         onupdate=func.now(),
     )
 
-    category: Mapped[PmsBusinessCategory | None] = relationship(
-        "PmsBusinessCategory",
-        back_populates="attribute_defs",
-        lazy="joined",
-    )
     options: Mapped[list["ItemAttributeOption"]] = relationship(
         "ItemAttributeOption",
         back_populates="attribute_def",
@@ -144,8 +130,11 @@ class ItemAttributeDef(Base):
             "value_type in ('TEXT', 'NUMBER', 'OPTION', 'BOOL')",
             name="ck_item_attribute_defs_value_type",
         ),
-        sa.UniqueConstraint("category_id", "code", name="uq_item_attribute_defs_category_code"),
-        sa.Index("ix_item_attribute_defs_category_id", "category_id"),
+        sa.CheckConstraint(
+            "selection_mode in ('SINGLE', 'MULTI')",
+            name="ck_item_attribute_defs_selection_mode",
+        ),
+        sa.UniqueConstraint("product_kind", "code", name="uq_item_attribute_defs_product_kind_code"),
         sa.Index("ix_item_attribute_defs_product_kind", "product_kind"),
     )
 

--- a/app/pms/items/routers/item_master.py
+++ b/app/pms/items/routers/item_master.py
@@ -254,7 +254,6 @@ def unlock_pms_category(category_id: int, db: Session = Depends(get_db)):
 @router.get("/pms/item-attribute-defs", response_model=ListOut[ItemAttributeDefOut])
 def list_item_attribute_defs(
     product_kind: str | None = Query(None),
-    category_id: int | None = Query(None, ge=1),
     active_only: bool = Query(False),
     db: Session = Depends(get_db),
 ):
@@ -265,8 +264,6 @@ def list_item_attribute_defs(
     )
     if product_kind:
         stmt = stmt.where(ItemAttributeDef.product_kind == product_kind.strip().upper())
-    if category_id is not None:
-        stmt = stmt.where(ItemAttributeDef.category_id == int(category_id))
     if active_only:
         stmt = stmt.where(ItemAttributeDef.is_active.is_(True))
     return {"ok": True, "data": list(db.execute(stmt).scalars().all())}
@@ -274,22 +271,16 @@ def list_item_attribute_defs(
 
 @router.post("/pms/item-attribute-defs", response_model=ItemAttributeDefOut, status_code=status.HTTP_201_CREATED)
 def create_item_attribute_def(payload: ItemAttributeDefCreate, db: Session = Depends(get_db)):
-    if payload.category_id is not None:
-        cat = db.get(PmsBusinessCategory, int(payload.category_id))
-        if cat is None:
-            raise _bad_request("内部分类不存在")
-
     obj = ItemAttributeDef(
         code=payload.code.upper(),
         name_cn=payload.name_cn,
         name_en=payload.name_en,
         product_kind=payload.product_kind,
-        category_id=payload.category_id,
         value_type=payload.value_type,
+        selection_mode=payload.selection_mode,
         unit=payload.unit,
-        is_required=bool(payload.is_required),
-        is_searchable=bool(payload.is_searchable),
-        is_filterable=bool(payload.is_filterable),
+        is_item_required=bool(payload.is_item_required),
+        is_sku_required=bool(payload.is_sku_required),
         is_sku_segment=bool(payload.is_sku_segment),
         sort_order=int(payload.sort_order),
         remark=payload.remark,
@@ -310,6 +301,10 @@ def update_item_attribute_def(attribute_def_id: int, payload: ItemAttributeDefUp
     if obj is None:
         raise _not_found("属性模板不存在")
     data = payload.model_dump(exclude_unset=True)
+    if "selection_mode" in data and obj.is_locked:
+        raise HTTPException(status_code=409, detail="属性模板已锁定，不能修改 selection_mode")
+    if "selection_mode" in data and obj.value_type != "OPTION" and data["selection_mode"] != "SINGLE":
+        raise _bad_request("非 OPTION 属性只允许 selection_mode=SINGLE")
     for k, v in data.items():
         setattr(obj, k, v)
     db.commit()
@@ -334,6 +329,28 @@ def disable_item_attribute_def(attribute_def_id: int, db: Session = Depends(get_
     if obj is None:
         raise _not_found("属性模板不存在")
     obj.is_active = False
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+
+@router.post("/pms/item-attribute-defs/{attribute_def_id}/lock", response_model=ItemAttributeDefOut)
+def lock_item_attribute_def(attribute_def_id: int, db: Session = Depends(get_db)):
+    obj = db.get(ItemAttributeDef, int(attribute_def_id))
+    if obj is None:
+        raise _not_found("属性模板不存在")
+    obj.is_locked = True
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+
+@router.post("/pms/item-attribute-defs/{attribute_def_id}/unlock", response_model=ItemAttributeDefOut)
+def unlock_item_attribute_def(attribute_def_id: int, db: Session = Depends(get_db)):
+    obj = db.get(ItemAttributeDef, int(attribute_def_id))
+    if obj is None:
+        raise _not_found("属性模板不存在")
+    obj.is_locked = False
     db.commit()
     db.refresh(obj)
     return obj
@@ -465,13 +482,13 @@ def replace_item_attribute_values(
 
         if attr.value_type == "TEXT":
             if incoming.value_text is None or not str(incoming.value_text).strip():
-                if attr.is_required:
+                if attr.is_item_required:
                     raise _bad_request(f"必填文本属性不能为空：{attr.code}")
         elif attr.value_type == "NUMBER":
-            if incoming.value_number is None and attr.is_required:
+            if incoming.value_number is None and attr.is_item_required:
                 raise _bad_request(f"必填数值属性不能为空：{attr.code}")
         elif attr.value_type == "BOOL":
-            if incoming.value_bool is None and attr.is_required:
+            if incoming.value_bool is None and attr.is_item_required:
                 raise _bad_request(f"必填布尔属性不能为空：{attr.code}")
 
         row = ItemAttributeValue(

--- a/tests/api/test_pms_master_data_api.py
+++ b/tests/api/test_pms_master_data_api.py
@@ -169,10 +169,11 @@ async def test_pms_attribute_template_options_and_item_values_contract(client: h
             "code": f"COLOR_{sfx}",
             "name_cn": "颜色",
             "product_kind": "OTHER",
-            "category_id": category_id,
             "value_type": "OPTION",
-            "is_required": True,
-            "is_filterable": True,
+            "selection_mode": "SINGLE",
+            "is_item_required": True,
+            "is_sku_required": True,
+            "is_sku_segment": True,
             "sort_order": 10,
         },
         headers=headers,
@@ -181,6 +182,34 @@ async def test_pms_attribute_template_options_and_item_values_contract(client: h
     attr = r_attr.json()
     assert attr["code"] == f"COLOR_{sfx}"
     assert attr["value_type"] == "OPTION"
+    assert attr["selection_mode"] == "SINGLE"
+    assert attr["is_item_required"] is True
+    assert attr["is_sku_required"] is True
+    assert attr["is_sku_segment"] is True
+    assert attr["is_locked"] is False
+
+    r_attr_lock = await client.post(f"/pms/item-attribute-defs/{attr['id']}/lock", headers=headers)
+    assert r_attr_lock.status_code == 200, r_attr_lock.text
+    assert r_attr_lock.json()["is_locked"] is True
+
+    r_attr_locked_patch = await client.patch(
+        f"/pms/item-attribute-defs/{attr['id']}",
+        json={"selection_mode": "MULTI"},
+        headers=headers,
+    )
+    assert r_attr_locked_patch.status_code == 409, r_attr_locked_patch.text
+
+    r_attr_unlock = await client.post(f"/pms/item-attribute-defs/{attr['id']}/unlock", headers=headers)
+    assert r_attr_unlock.status_code == 200, r_attr_unlock.text
+    assert r_attr_unlock.json()["is_locked"] is False
+
+    r_attr_patch = await client.patch(
+        f"/pms/item-attribute-defs/{attr['id']}",
+        json={"selection_mode": "MULTI"},
+        headers=headers,
+    )
+    assert r_attr_patch.status_code == 200, r_attr_patch.text
+    assert r_attr_patch.json()["selection_mode"] == "MULTI"
 
     r_option = await client.post(
         f"/pms/item-attribute-defs/{attr['id']}/options",


### PR DESCRIPTION
## Summary
- Refine item_attribute_defs contract.
- Remove category_id, is_required, is_searchable and is_filterable from attribute definitions.
- Add selection_mode, is_item_required, is_sku_required and is_locked.
- Backfill OPTION + SKU segment templates to selection_mode=MULTI.
- Add attribute definition lock/unlock endpoints.
- Update item attribute value required validation to use is_item_required.

## Validation
- make test TESTS=tests/api/test_pms_master_data_api.py

Result:
- 2 tests passed.