### PR TITLE
feat(pms): add attribute option lock

### DIFF
--- a/alembic/versions/20260430111143_pms_attribute_options_lock.py
+++ b/alembic/versions/20260430111143_pms_attribute_options_lock.py
@@ -1,0 +1,30 @@
+"""Add lock flag to PMS item attribute options.
+
+Revision ID: 20260430111143
+Revises: 20260430101727
+Create Date: 2026-04-30
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "20260430111143"
+down_revision: Union[str, Sequence[str], None] = "20260430101727"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "item_attribute_options",
+        sa.Column("is_locked", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("item_attribute_options", "is_locked")

--- a/app/pms/items/contracts/item_master.py
+++ b/app/pms/items/contracts/item_master.py
@@ -233,6 +233,7 @@ class ItemAttributeOptionOut(_Base):
     option_code: str
     option_name: str
     is_active: bool
+    is_locked: bool
     sort_order: int
     created_at: datetime | None = None
     updated_at: datetime | None = None

--- a/app/pms/items/models/item_master.py
+++ b/app/pms/items/models/item_master.py
@@ -151,6 +151,7 @@ class ItemAttributeOption(Base):
     option_code: Mapped[str] = mapped_column(sa.String(64), nullable=False)
     option_name: Mapped[str] = mapped_column(sa.String(128), nullable=False)
     is_active: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("true"))
+    is_locked: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"))
     sort_order: Mapped[int] = mapped_column(sa.Integer, nullable=False, server_default=sa.text("0"))
     created_at: Mapped[datetime] = mapped_column(sa.DateTime(timezone=True), nullable=False, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(

--- a/app/pms/items/routers/item_master.py
+++ b/app/pms/items/routers/item_master.py
@@ -406,8 +406,32 @@ def update_item_attribute_option(option_id: int, payload: ItemAttributeOptionUpd
     if obj is None:
         raise _not_found("属性选项不存在")
     data = payload.model_dump(exclude_unset=True)
+    if obj.is_locked and data:
+        raise HTTPException(status_code=409, detail="属性选项已锁定，不能修改 option_name 或 sort_order")
     for k, v in data.items():
         setattr(obj, k, v)
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+
+@router.post("/pms/item-attribute-options/{option_id}/lock", response_model=ItemAttributeOptionOut)
+def lock_item_attribute_option(option_id: int, db: Session = Depends(get_db)):
+    obj = db.get(ItemAttributeOption, int(option_id))
+    if obj is None:
+        raise _not_found("属性选项不存在")
+    obj.is_locked = True
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+
+@router.post("/pms/item-attribute-options/{option_id}/unlock", response_model=ItemAttributeOptionOut)
+def unlock_item_attribute_option(option_id: int, db: Session = Depends(get_db)):
+    obj = db.get(ItemAttributeOption, int(option_id))
+    if obj is None:
+        raise _not_found("属性选项不存在")
+    obj.is_locked = False
     db.commit()
     db.refresh(obj)
     return obj

--- a/tests/api/test_pms_master_data_api.py
+++ b/tests/api/test_pms_master_data_api.py
@@ -219,6 +219,32 @@ async def test_pms_attribute_template_options_and_item_values_contract(client: h
     assert r_option.status_code == 201, r_option.text
     option = r_option.json()
     assert option["option_code"] == f"WHT{sfx}"
+    assert option["is_locked"] is False
+
+    r_option_lock = await client.post(f"/pms/item-attribute-options/{option['id']}/lock", headers=headers)
+    assert r_option_lock.status_code == 200, r_option_lock.text
+    assert r_option_lock.json()["is_locked"] is True
+
+    r_option_locked_patch = await client.patch(
+        f"/pms/item-attribute-options/{option['id']}",
+        json={"option_name": "锁定后不允许修改", "sort_order": 20},
+        headers=headers,
+    )
+    assert r_option_locked_patch.status_code == 409, r_option_locked_patch.text
+
+    r_option_unlock = await client.post(f"/pms/item-attribute-options/{option['id']}/unlock", headers=headers)
+    assert r_option_unlock.status_code == 200, r_option_unlock.text
+    assert r_option_unlock.json()["is_locked"] is False
+
+    r_option_patch = await client.patch(
+        f"/pms/item-attribute-options/{option['id']}",
+        json={"option_name": f"白色更新-{sfx}", "sort_order": 11},
+        headers=headers,
+    )
+    assert r_option_patch.status_code == 200, r_option_patch.text
+    assert r_option_patch.json()["option_name"] == f"白色更新-{sfx}"
+    assert r_option_patch.json()["sort_order"] == 11
+    option = r_option_patch.json()
 
     r_item = await client.post(
         "/items",


### PR DESCRIPTION
## Summary
- Add is_locked to item_attribute_options.
- Return is_locked in attribute option contract.
- Add lock/unlock endpoints for attribute options.
- Block option_name and sort_order updates when an option is locked.
- Keep enable/disable independent from lock state.

## Validation
- make test TESTS=tests/api/test_pms_master_data_api.py

Result:
- 2 tests passed.