### PR TITLE
refactor(pms): use attribute options for sku coding

### DIFF
--- a/alembic/versions/20260430113408_sku_coding_segments_use_attribute_options.py
+++ b/alembic/versions/20260430113408_sku_coding_segments_use_attribute_options.py
@@ -1,0 +1,553 @@
+"""Cut SKU coding segments over to PMS attribute options.
+
+Revision ID: 20260430113408
+Revises: 20260430111143
+Create Date: 2026-04-30
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "20260430113408"
+down_revision: Union[str, Sequence[str], None] = "20260430111143"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1) 先把旧 SKU 字典完整升迁到 PMS 属性模板 / 预设选项。
+    op.execute(
+        """
+        INSERT INTO item_attribute_defs (
+            code,
+            name_cn,
+            name_en,
+            product_kind,
+            value_type,
+            selection_mode,
+            unit,
+            is_item_required,
+            is_sku_required,
+            is_sku_segment,
+            is_active,
+            is_locked,
+            sort_order,
+            remark
+        )
+        SELECT
+            g.group_code,
+            CASE g.group_code
+                WHEN 'LIFE_STAGE' THEN '适用阶段'
+                WHEN 'PROCESS' THEN '工艺类型'
+                WHEN 'FLAVOR' THEN '口味'
+                WHEN 'FUNCTION' THEN '功能属性'
+                WHEN 'MODEL' THEN '型号/系列'
+                WHEN 'MATERIAL' THEN '材质'
+                WHEN 'COLOR' THEN '颜色'
+                WHEN 'STRUCTURE' THEN '结构'
+                WHEN 'FEATURE' THEN '功能特性'
+                ELSE g.group_name
+            END AS name_cn,
+            NULL AS name_en,
+            g.product_kind,
+            'OPTION' AS value_type,
+            CASE WHEN g.is_multi_select THEN 'MULTI' ELSE 'SINGLE' END AS selection_mode,
+            NULL AS unit,
+            FALSE AS is_item_required,
+            g.is_required AS is_sku_required,
+            TRUE AS is_sku_segment,
+            g.is_active AS is_active,
+            FALSE AS is_locked,
+            g.sort_order AS sort_order,
+            '由 SKU 编码字典升迁为属性模板预设选项真相源' AS remark
+        FROM sku_code_term_groups g
+        WHERE g.product_kind IN ('FOOD', 'SUPPLY')
+        ON CONFLICT (product_kind, code) DO UPDATE
+           SET value_type = 'OPTION',
+               selection_mode = EXCLUDED.selection_mode,
+               is_sku_required = EXCLUDED.is_sku_required,
+               is_sku_segment = TRUE,
+               updated_at = now()
+        """
+    )
+
+    op.execute(
+        """
+        INSERT INTO item_attribute_options (
+            attribute_def_id,
+            option_code,
+            option_name,
+            is_active,
+            is_locked,
+            sort_order
+        )
+        SELECT
+            d.id,
+            t.code,
+            t.name_cn,
+            t.is_active,
+            t.is_locked,
+            t.sort_order
+        FROM sku_code_terms t
+        JOIN sku_code_term_groups g ON g.id = t.group_id
+        JOIN item_attribute_defs d
+          ON d.product_kind = g.product_kind
+         AND d.code = g.group_code
+        WHERE g.product_kind IN ('FOOD', 'SUPPLY')
+        ON CONFLICT (attribute_def_id, option_code) DO NOTHING
+        """
+    )
+
+    # 2) SKU 模板段从旧 term_group_id 改为 attribute_def_id。
+    op.add_column("sku_code_template_segments", sa.Column("attribute_def_id", sa.Integer(), nullable=True))
+    op.create_foreign_key(
+        "fk_sku_code_template_segments_attribute_def",
+        "sku_code_template_segments",
+        "item_attribute_defs",
+        ["attribute_def_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.create_index(
+        "ix_sku_code_template_segments_attribute_def_id",
+        "sku_code_template_segments",
+        ["attribute_def_id"],
+    )
+
+    # 先删除旧 check，否则 ATTRIBUTE_OPTION 写不进去。
+    op.drop_constraint("ck_sku_code_template_segments_source_type", "sku_code_template_segments", type_="check")
+
+    op.execute(
+        """
+        UPDATE sku_code_template_segments s
+           SET attribute_def_id = d.id,
+               source_type = 'ATTRIBUTE_OPTION'
+          FROM sku_code_templates t,
+               sku_code_term_groups g,
+               item_attribute_defs d
+         WHERE s.template_id = t.id
+           AND s.term_group_id = g.id
+           AND s.source_type = 'TERM'
+           AND d.product_kind = t.product_kind
+           AND d.code = g.group_code
+           AND d.value_type = 'OPTION'
+           AND d.is_sku_segment IS TRUE
+        """
+    )
+
+    op.execute(
+        """
+        DO $sku_cutover$
+        BEGIN
+            IF EXISTS (
+                SELECT 1
+                  FROM sku_code_template_segments
+                 WHERE source_type = 'TERM'
+                   AND attribute_def_id IS NULL
+            ) THEN
+                RAISE EXCEPTION 'Migration blocked: some SKU TERM segments could not be mapped to item_attribute_defs';
+            END IF;
+        END
+        $sku_cutover$;
+        """
+    )
+
+    op.create_check_constraint(
+        "ck_sku_code_template_segments_source_type",
+        "sku_code_template_segments",
+        "source_type in ('BRAND', 'CATEGORY', 'ATTRIBUTE_OPTION', 'TEXT', 'SPEC')",
+    )
+    op.create_check_constraint(
+        "ck_sku_code_template_segments_attribute_def",
+        "sku_code_template_segments",
+        "((source_type = 'ATTRIBUTE_OPTION' and attribute_def_id is not null) or (source_type <> 'ATTRIBUTE_OPTION' and attribute_def_id is null))",
+    )
+
+    op.drop_constraint("sku_code_template_segments_term_group_id_fkey", "sku_code_template_segments", type_="foreignkey")
+    op.drop_column("sku_code_template_segments", "term_group_id")
+
+    # 3) SKU 编码页面注册收口：只有一个页面时，直接提升为 PMS 二级页。
+    op.execute(
+        """
+        DELETE FROM page_route_prefixes
+        WHERE route_prefix IN (
+          '/items/sku-coding/generator',
+          '/items/sku-coding/dictionaries'
+        )
+        """
+    )
+    op.execute(
+        """
+        DELETE FROM page_registry
+        WHERE code IN (
+          'pms.sku_coding.generator',
+          'pms.sku_coding.dictionaries'
+        )
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO page_registry (
+          code,
+          name,
+          parent_code,
+          level,
+          domain_code,
+          show_in_topbar,
+          show_in_sidebar,
+          inherit_permissions,
+          read_permission_id,
+          write_permission_id,
+          sort_order,
+          is_active
+        )
+        VALUES (
+          'pms.sku_coding',
+          'SKU 编码',
+          'pms',
+          2,
+          'pms',
+          FALSE,
+          TRUE,
+          TRUE,
+          NULL,
+          NULL,
+          50,
+          TRUE
+        )
+        ON CONFLICT (code) DO UPDATE
+        SET
+          name = EXCLUDED.name,
+          parent_code = EXCLUDED.parent_code,
+          level = EXCLUDED.level,
+          domain_code = EXCLUDED.domain_code,
+          show_in_topbar = EXCLUDED.show_in_topbar,
+          show_in_sidebar = EXCLUDED.show_in_sidebar,
+          inherit_permissions = EXCLUDED.inherit_permissions,
+          read_permission_id = EXCLUDED.read_permission_id,
+          write_permission_id = EXCLUDED.write_permission_id,
+          sort_order = EXCLUDED.sort_order,
+          is_active = EXCLUDED.is_active
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO page_route_prefixes (
+          route_prefix,
+          page_code,
+          sort_order,
+          is_active
+        )
+        VALUES (
+          '/items/sku-coding',
+          'pms.sku_coding',
+          10,
+          TRUE
+        )
+        ON CONFLICT (route_prefix) DO UPDATE
+        SET
+          page_code = EXCLUDED.page_code,
+          sort_order = EXCLUDED.sort_order,
+          is_active = EXCLUDED.is_active
+        """
+    )
+
+    # 4) 一步到位：旧 SKU 字典表退役，不再保留双字典。
+    op.drop_table("sku_code_term_aliases")
+    op.drop_table("sku_code_terms")
+    op.drop_table("sku_code_term_groups")
+
+
+def downgrade() -> None:
+    # 可逆恢复旧三级页结构。
+    op.execute(
+        """
+        DELETE FROM page_route_prefixes
+        WHERE route_prefix = '/items/sku-coding'
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO page_registry (
+          code,
+          name,
+          parent_code,
+          level,
+          domain_code,
+          show_in_topbar,
+          show_in_sidebar,
+          inherit_permissions,
+          read_permission_id,
+          write_permission_id,
+          sort_order,
+          is_active
+        )
+        VALUES (
+          'pms.sku_coding',
+          'SKU编码',
+          'pms',
+          2,
+          'pms',
+          FALSE,
+          TRUE,
+          TRUE,
+          NULL,
+          NULL,
+          50,
+          TRUE
+        )
+        ON CONFLICT (code) DO UPDATE
+        SET
+          name = EXCLUDED.name,
+          parent_code = EXCLUDED.parent_code,
+          level = EXCLUDED.level,
+          domain_code = EXCLUDED.domain_code,
+          show_in_topbar = EXCLUDED.show_in_topbar,
+          show_in_sidebar = EXCLUDED.show_in_sidebar,
+          inherit_permissions = EXCLUDED.inherit_permissions,
+          read_permission_id = EXCLUDED.read_permission_id,
+          write_permission_id = EXCLUDED.write_permission_id,
+          sort_order = EXCLUDED.sort_order,
+          is_active = EXCLUDED.is_active
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO page_registry (
+          code,
+          name,
+          parent_code,
+          level,
+          domain_code,
+          show_in_topbar,
+          show_in_sidebar,
+          inherit_permissions,
+          read_permission_id,
+          write_permission_id,
+          sort_order,
+          is_active
+        )
+        VALUES
+          (
+            'pms.sku_coding.generator',
+            '编码生成',
+            'pms.sku_coding',
+            3,
+            'pms',
+            FALSE,
+            TRUE,
+            TRUE,
+            NULL,
+            NULL,
+            10,
+            TRUE
+          ),
+          (
+            'pms.sku_coding.dictionaries',
+            '字典维护',
+            'pms.sku_coding',
+            3,
+            'pms',
+            FALSE,
+            TRUE,
+            TRUE,
+            NULL,
+            NULL,
+            20,
+            TRUE
+          )
+        ON CONFLICT (code) DO UPDATE
+        SET
+          name = EXCLUDED.name,
+          parent_code = EXCLUDED.parent_code,
+          level = EXCLUDED.level,
+          domain_code = EXCLUDED.domain_code,
+          show_in_topbar = EXCLUDED.show_in_topbar,
+          show_in_sidebar = EXCLUDED.show_in_sidebar,
+          inherit_permissions = EXCLUDED.inherit_permissions,
+          read_permission_id = EXCLUDED.read_permission_id,
+          write_permission_id = EXCLUDED.write_permission_id,
+          sort_order = EXCLUDED.sort_order,
+          is_active = EXCLUDED.is_active
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO page_route_prefixes (
+          route_prefix,
+          page_code,
+          sort_order,
+          is_active
+        )
+        VALUES
+          (
+            '/items/sku-coding/generator',
+            'pms.sku_coding.generator',
+            10,
+            TRUE
+          ),
+          (
+            '/items/sku-coding/dictionaries',
+            'pms.sku_coding.dictionaries',
+            20,
+            TRUE
+          )
+        ON CONFLICT (route_prefix) DO UPDATE
+        SET
+          page_code = EXCLUDED.page_code,
+          sort_order = EXCLUDED.sort_order,
+          is_active = EXCLUDED.is_active
+        """
+    )
+
+    op.create_table(
+        "sku_code_term_groups",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("product_kind", sa.String(length=16), nullable=False),
+        sa.Column("group_code", sa.String(length=32), nullable=False),
+        sa.Column("group_name", sa.String(length=64), nullable=False),
+        sa.Column("is_multi_select", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.Column("is_required", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.Column("sort_order", sa.Integer(), server_default=sa.text("0"), nullable=False),
+        sa.Column("is_active", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.Column("remark", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.CheckConstraint("product_kind in ('FOOD', 'SUPPLY', 'COMMON')", name="ck_sku_code_term_groups_product_kind"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("product_kind", "group_code", name="uq_sku_code_term_groups_kind_code"),
+    )
+
+    op.create_table(
+        "sku_code_terms",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("group_id", sa.Integer(), nullable=False),
+        sa.Column("name_cn", sa.String(length=128), nullable=False),
+        sa.Column("code", sa.String(length=32), nullable=False),
+        sa.Column("sort_order", sa.Integer(), server_default=sa.text("0"), nullable=False),
+        sa.Column("is_active", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.Column("is_locked", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.Column("remark", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["group_id"], ["sku_code_term_groups.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("group_id", "name_cn", name="uq_sku_code_terms_group_name_cn"),
+        sa.UniqueConstraint("group_id", "code", name="uq_sku_code_terms_group_code"),
+    )
+    op.create_index("ix_sku_code_terms_group_id", "sku_code_terms", ["group_id"])
+
+    op.create_table(
+        "sku_code_term_aliases",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("term_id", sa.Integer(), nullable=False),
+        sa.Column("alias_name", sa.String(length=128), nullable=False),
+        sa.Column("normalized_alias", sa.String(length=128), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["term_id"], ["sku_code_terms.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("normalized_alias", name="uq_sku_code_term_aliases_normalized"),
+    )
+    op.create_index("ix_sku_code_term_aliases_term_id", "sku_code_term_aliases", ["term_id"])
+
+    op.execute(
+        """
+        INSERT INTO sku_code_term_groups (
+            product_kind,
+            group_code,
+            group_name,
+            is_multi_select,
+            is_required,
+            sort_order,
+            is_active,
+            remark
+        )
+        SELECT
+            d.product_kind,
+            d.code,
+            d.name_cn,
+            d.selection_mode = 'MULTI',
+            d.is_sku_required,
+            d.sort_order,
+            d.is_active,
+            d.remark
+        FROM item_attribute_defs d
+        WHERE d.product_kind IN ('FOOD', 'SUPPLY')
+          AND d.value_type = 'OPTION'
+          AND d.is_sku_segment IS TRUE
+        ON CONFLICT (product_kind, group_code) DO NOTHING
+        """
+    )
+
+    op.execute(
+        """
+        INSERT INTO sku_code_terms (
+            group_id,
+            name_cn,
+            code,
+            sort_order,
+            is_active,
+            is_locked
+        )
+        SELECT
+            g.id,
+            o.option_name,
+            o.option_code,
+            o.sort_order,
+            o.is_active,
+            o.is_locked
+        FROM item_attribute_options o
+        JOIN item_attribute_defs d ON d.id = o.attribute_def_id
+        JOIN sku_code_term_groups g
+          ON g.product_kind = d.product_kind
+         AND g.group_code = d.code
+        WHERE d.product_kind IN ('FOOD', 'SUPPLY')
+          AND d.value_type = 'OPTION'
+          AND d.is_sku_segment IS TRUE
+        ON CONFLICT (group_id, code) DO NOTHING
+        """
+    )
+
+    op.add_column("sku_code_template_segments", sa.Column("term_group_id", sa.Integer(), nullable=True))
+    op.create_foreign_key(
+        "sku_code_template_segments_term_group_id_fkey",
+        "sku_code_template_segments",
+        "sku_code_term_groups",
+        ["term_group_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+
+    op.drop_constraint("ck_sku_code_template_segments_attribute_def", "sku_code_template_segments", type_="check")
+    op.drop_constraint("ck_sku_code_template_segments_source_type", "sku_code_template_segments", type_="check")
+
+    op.execute(
+        """
+        UPDATE sku_code_template_segments s
+           SET term_group_id = g.id,
+               source_type = 'TERM'
+          FROM sku_code_templates t,
+               item_attribute_defs d,
+               sku_code_term_groups g
+         WHERE s.template_id = t.id
+           AND s.attribute_def_id = d.id
+           AND s.source_type = 'ATTRIBUTE_OPTION'
+           AND g.product_kind = t.product_kind
+           AND g.group_code = d.code
+        """
+    )
+
+    op.create_check_constraint(
+        "ck_sku_code_template_segments_source_type",
+        "sku_code_template_segments",
+        "source_type in ('BRAND', 'CATEGORY', 'TERM', 'TEXT', 'SPEC')",
+    )
+
+    op.drop_index("ix_sku_code_template_segments_attribute_def_id", table_name="sku_code_template_segments")
+    op.drop_constraint("fk_sku_code_template_segments_attribute_def", "sku_code_template_segments", type_="foreignkey")
+    op.drop_column("sku_code_template_segments", "attribute_def_id")

--- a/app/pms/sku_coding/contracts/sku_coding.py
+++ b/app/pms/sku_coding/contracts/sku_coding.py
@@ -1,14 +1,12 @@
 # app/pms/sku_coding/contracts/sku_coding.py
 from __future__ import annotations
 
-from datetime import datetime
 from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 ProductKind = Literal["FOOD", "SUPPLY"]
-TermProductKind = Literal["FOOD", "SUPPLY", "COMMON"]
 
 
 class _Base(BaseModel):
@@ -19,71 +17,11 @@ def _trim(v: object) -> object:
     return v.strip() if isinstance(v, str) else v
 
 
-class SkuCodeTermGroupOut(_Base):
-    id: int
-    product_kind: str
-    group_code: str
-    group_name: str
-    is_multi_select: bool
-    is_required: bool
-    sort_order: int
-    is_active: bool
-    remark: str | None
-
-
-class SkuCodeTermCreate(_Base):
-    group_id: Annotated[int, Field(ge=1)]
-    name_cn: Annotated[str, Field(min_length=1, max_length=128)]
-    code: Annotated[str, Field(min_length=1, max_length=32)]
-    sort_order: int = 0
-    remark: Annotated[str | None, Field(default=None, max_length=500)] = None
-
-    @field_validator("name_cn", "code", "remark", mode="before")
-    @classmethod
-    def _trim_text(cls, v: object) -> object:
-        return _trim(v)
-
-    @field_validator("code", mode="before")
-    @classmethod
-    def _upper_text(cls, v: object) -> object:
-        return v.strip().upper() if isinstance(v, str) else v
-
-
-class SkuCodeTermUpdate(_Base):
-    name_cn: Annotated[str | None, Field(default=None, max_length=128)] = None
-    code: Annotated[str | None, Field(default=None, max_length=32)] = None
-    sort_order: int | None = None
-    remark: Annotated[str | None, Field(default=None, max_length=500)] = None
-
-    @field_validator("name_cn", "code", "remark", mode="before")
-    @classmethod
-    def _trim_text(cls, v: object) -> object:
-        return _trim(v)
-
-    @field_validator("code", mode="before")
-    @classmethod
-    def _upper_text(cls, v: object) -> object:
-        return v.strip().upper() if isinstance(v, str) else v
-
-
-class SkuCodeTermOut(_Base):
-    id: int
-    group_id: int
-    name_cn: str
-    code: str
-    sort_order: int
-    is_active: bool
-    is_locked: bool
-    remark: str | None
-    created_at: datetime | None = None
-    updated_at: datetime | None = None
-
-
 class SkuGenerateIn(_Base):
     product_kind: ProductKind
     brand_id: Annotated[int, Field(ge=1)]
     category_id: Annotated[int, Field(ge=1)]
-    term_ids: dict[str, list[int]] = Field(default_factory=dict)
+    attribute_option_ids: dict[str, list[int]] = Field(default_factory=dict)
     text_segments: dict[str, str] = Field(default_factory=dict)
     spec_text: Annotated[str, Field(min_length=1, max_length=64)]
 
@@ -125,8 +63,3 @@ class SkuGenerateDataOut(_Base):
 class SkuGenerateOut(_Base):
     ok: bool = True
     data: SkuGenerateDataOut
-
-
-class ListOut[T](_Base):
-    ok: bool = True
-    data: list[T]

--- a/app/pms/sku_coding/models/__init__.py
+++ b/app/pms/sku_coding/models/__init__.py
@@ -1,21 +1,7 @@
 # app/pms/sku_coding/models/__init__.py
-# SKU coding domain only owns term dictionaries and SKU templates.
-#
-# Brand / business category have moved to PMS master data:
-# - app.pms.items.models.item_master.PmsBrand
-# - app.pms.items.models.item_master.PmsBusinessCategory
-from app.pms.sku_coding.models.sku_coding import (
-    SkuCodeTemplate,
-    SkuCodeTemplateSegment,
-    SkuCodeTerm,
-    SkuCodeTermAlias,
-    SkuCodeTermGroup,
-)
+from app.pms.sku_coding.models.sku_coding import SkuCodeTemplate, SkuCodeTemplateSegment
 
 __all__ = [
-    "SkuCodeTermGroup",
-    "SkuCodeTerm",
-    "SkuCodeTermAlias",
     "SkuCodeTemplate",
     "SkuCodeTemplateSegment",
 ]

--- a/app/pms/sku_coding/models/sku_coding.py
+++ b/app/pms/sku_coding/models/sku_coding.py
@@ -1,11 +1,13 @@
 # app/pms/sku_coding/models/sku_coding.py
-# SKU coding domain models: term dictionaries, templates and template segments.
+# SKU coding domain models: templates and template segments.
 #
-# 品牌 / 内部分类已提升到 PMS 商品主数据：
+# 品牌 / 内部分类 / 属性预设选项已提升到 PMS 商品主数据：
 # - pms_brands
 # - pms_business_categories
+# - item_attribute_defs
+# - item_attribute_options
 #
-# SKU 编码域不再拥有品牌 / 分类表，只引用 PMS 主数据。
+# SKU 编码域不再拥有属性词典，只负责 SKU 拼接模板。
 from __future__ import annotations
 
 from datetime import datetime
@@ -16,70 +18,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
 
 from app.db.base import Base
-
-
-class SkuCodeTermGroup(Base):
-    __tablename__ = "sku_code_term_groups"
-
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    product_kind: Mapped[str] = mapped_column(String(16), nullable=False)
-    group_code: Mapped[str] = mapped_column(String(32), nullable=False)
-    group_name: Mapped[str] = mapped_column(String(64), nullable=False)
-    is_multi_select: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
-    is_required: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
-    sort_order: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
-    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
-    remark: Mapped[str | None] = mapped_column(Text, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
-
-    terms: Mapped[list["SkuCodeTerm"]] = relationship("SkuCodeTerm", back_populates="group", lazy="selectin")
-
-    __table_args__ = (
-        sa.CheckConstraint("product_kind in ('FOOD', 'SUPPLY', 'COMMON')", name="ck_sku_code_term_groups_product_kind"),
-        UniqueConstraint("product_kind", "group_code", name="uq_sku_code_term_groups_kind_code"),
-    )
-
-
-class SkuCodeTerm(Base):
-    __tablename__ = "sku_code_terms"
-
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    group_id: Mapped[int] = mapped_column(Integer, ForeignKey("sku_code_term_groups.id", ondelete="RESTRICT"), nullable=False)
-    name_cn: Mapped[str] = mapped_column(String(128), nullable=False)
-    code: Mapped[str] = mapped_column(String(32), nullable=False)
-    sort_order: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
-    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
-    is_locked: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
-    remark: Mapped[str | None] = mapped_column(Text, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
-
-    group: Mapped[SkuCodeTermGroup] = relationship("SkuCodeTermGroup", back_populates="terms", lazy="joined")
-    aliases: Mapped[list["SkuCodeTermAlias"]] = relationship("SkuCodeTermAlias", back_populates="term", lazy="selectin", cascade="all, delete-orphan")
-
-    __table_args__ = (
-        UniqueConstraint("group_id", "name_cn", name="uq_sku_code_terms_group_name_cn"),
-        UniqueConstraint("group_id", "code", name="uq_sku_code_terms_group_code"),
-        sa.Index("ix_sku_code_terms_group_id", "group_id"),
-    )
-
-
-class SkuCodeTermAlias(Base):
-    __tablename__ = "sku_code_term_aliases"
-
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    term_id: Mapped[int] = mapped_column(Integer, ForeignKey("sku_code_terms.id", ondelete="CASCADE"), nullable=False)
-    alias_name: Mapped[str] = mapped_column(String(128), nullable=False)
-    normalized_alias: Mapped[str] = mapped_column(String(128), nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
-
-    term: Mapped[SkuCodeTerm] = relationship("SkuCodeTerm", back_populates="aliases", lazy="joined")
-
-    __table_args__ = (
-        UniqueConstraint("normalized_alias", name="uq_sku_code_term_aliases_normalized"),
-        sa.Index("ix_sku_code_term_aliases_term_id", "term_id"),
-    )
+from app.pms.items.models.item_master import ItemAttributeDef
 
 
 class SkuCodeTemplate(Base):
@@ -111,7 +50,7 @@ class SkuCodeTemplateSegment(Base):
     template_id: Mapped[int] = mapped_column(Integer, ForeignKey("sku_code_templates.id", ondelete="CASCADE"), nullable=False)
     segment_key: Mapped[str] = mapped_column(String(32), nullable=False)
     source_type: Mapped[str] = mapped_column(String(16), nullable=False)
-    term_group_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("sku_code_term_groups.id", ondelete="RESTRICT"), nullable=True)
+    attribute_def_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("item_attribute_defs.id", ondelete="RESTRICT"), nullable=True)
     is_required: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
     is_multi_select: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
     sort_order: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
@@ -119,10 +58,15 @@ class SkuCodeTemplateSegment(Base):
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
 
     template: Mapped[SkuCodeTemplate] = relationship("SkuCodeTemplate", back_populates="segments", lazy="joined")
-    term_group: Mapped[SkuCodeTermGroup | None] = relationship("SkuCodeTermGroup", lazy="joined")
+    attribute_def: Mapped[ItemAttributeDef | None] = relationship("ItemAttributeDef", lazy="joined")
 
     __table_args__ = (
-        sa.CheckConstraint("source_type in ('BRAND', 'CATEGORY', 'TERM', 'TEXT', 'SPEC')", name="ck_sku_code_template_segments_source_type"),
+        sa.CheckConstraint("source_type in ('BRAND', 'CATEGORY', 'ATTRIBUTE_OPTION', 'TEXT', 'SPEC')", name="ck_sku_code_template_segments_source_type"),
+        sa.CheckConstraint(
+            "((source_type = 'ATTRIBUTE_OPTION' and attribute_def_id is not null) or (source_type <> 'ATTRIBUTE_OPTION' and attribute_def_id is null))",
+            name="ck_sku_code_template_segments_attribute_def",
+        ),
         UniqueConstraint("template_id", "segment_key", name="uq_sku_code_template_segments_template_key"),
         sa.Index("ix_sku_code_template_segments_template_id", "template_id"),
+        sa.Index("ix_sku_code_template_segments_attribute_def_id", "attribute_def_id"),
     )

--- a/app/pms/sku_coding/routers/sku_coding.py
+++ b/app/pms/sku_coding/routers/sku_coding.py
@@ -1,128 +1,17 @@
 # app/pms/sku_coding/routers/sku_coding.py
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy import select
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from app.db.deps import get_db
 from app.pms.sku_coding.contracts.sku_coding import (
-    ListOut,
-    SkuCodeTermCreate,
-    SkuCodeTermGroupOut,
-    SkuCodeTermOut,
-    SkuCodeTermUpdate,
     SkuGenerateIn,
     SkuGenerateOut,
-)
-from app.pms.sku_coding.models.sku_coding import (
-    SkuCodeTerm,
-    SkuCodeTermGroup,
 )
 from app.pms.sku_coding.services.sku_coding_service import SkuCodingService
 
 router = APIRouter(prefix="/pms/sku-coding", tags=["pms-sku-coding"])
-
-
-def _problem_400(message: str) -> HTTPException:
-    return HTTPException(status_code=400, detail=message)
-
-
-def _not_found(message: str) -> HTTPException:
-    return HTTPException(status_code=404, detail=message)
-
-
-@router.get("/term-groups", response_model=ListOut[SkuCodeTermGroupOut])
-def list_term_groups(
-    product_kind: str | None = Query(None),
-    active_only: bool = Query(False),
-    db: Session = Depends(get_db),
-):
-    stmt = select(SkuCodeTermGroup).order_by(
-        SkuCodeTermGroup.product_kind.asc(),
-        SkuCodeTermGroup.sort_order.asc(),
-        SkuCodeTermGroup.group_code.asc(),
-    )
-    if product_kind:
-        stmt = stmt.where(SkuCodeTermGroup.product_kind == product_kind.strip().upper())
-    if active_only:
-        stmt = stmt.where(SkuCodeTermGroup.is_active.is_(True))
-    return {"ok": True, "data": list(db.execute(stmt).scalars().all())}
-
-
-@router.get("/terms", response_model=ListOut[SkuCodeTermOut])
-def list_terms(
-    group_id: int | None = Query(None, ge=1),
-    active_only: bool = Query(False),
-    db: Session = Depends(get_db),
-):
-    stmt = select(SkuCodeTerm).order_by(SkuCodeTerm.group_id.asc(), SkuCodeTerm.sort_order.asc(), SkuCodeTerm.code.asc())
-    if group_id is not None:
-        stmt = stmt.where(SkuCodeTerm.group_id == int(group_id))
-    if active_only:
-        stmt = stmt.where(SkuCodeTerm.is_active.is_(True))
-    return {"ok": True, "data": list(db.execute(stmt).scalars().all())}
-
-
-@router.post("/terms", response_model=SkuCodeTermOut, status_code=status.HTTP_201_CREATED)
-def create_term(payload: SkuCodeTermCreate, db: Session = Depends(get_db)):
-    group = db.get(SkuCodeTermGroup, int(payload.group_id))
-    if group is None or not bool(group.is_active):
-        raise _problem_400("字典分组不存在或已停用")
-    obj = SkuCodeTerm(
-        group_id=int(payload.group_id),
-        name_cn=payload.name_cn,
-        code=payload.code.upper(),
-        sort_order=int(payload.sort_order),
-        remark=payload.remark,
-    )
-    db.add(obj)
-    try:
-        db.commit()
-    except Exception as e:
-        db.rollback()
-        raise _problem_400(f"字典项写入失败：{str(e)}") from e
-    db.refresh(obj)
-    return obj
-
-
-@router.patch("/terms/{term_id}", response_model=SkuCodeTermOut)
-def update_term(term_id: int, payload: SkuCodeTermUpdate, db: Session = Depends(get_db)):
-    obj = db.get(SkuCodeTerm, int(term_id))
-    if obj is None:
-        raise _not_found("字典项不存在")
-    data = payload.model_dump(exclude_unset=True)
-    if "code" in data and obj.is_locked:
-        raise HTTPException(status_code=409, detail="字典项编码已锁定，不能修改 code")
-    for k, v in data.items():
-        if k == "code" and v is not None:
-            v = str(v).upper()
-        setattr(obj, k, v)
-    db.commit()
-    db.refresh(obj)
-    return obj
-
-
-@router.post("/terms/{term_id}/enable", response_model=SkuCodeTermOut)
-def enable_term(term_id: int, db: Session = Depends(get_db)):
-    obj = db.get(SkuCodeTerm, int(term_id))
-    if obj is None:
-        raise _not_found("字典项不存在")
-    obj.is_active = True
-    db.commit()
-    db.refresh(obj)
-    return obj
-
-
-@router.post("/terms/{term_id}/disable", response_model=SkuCodeTermOut)
-def disable_term(term_id: int, db: Session = Depends(get_db)):
-    obj = db.get(SkuCodeTerm, int(term_id))
-    if obj is None:
-        raise _not_found("字典项不存在")
-    obj.is_active = False
-    db.commit()
-    db.refresh(obj)
-    return obj
 
 
 @router.post("/generate", response_model=SkuGenerateOut)
@@ -132,7 +21,7 @@ def generate_sku(payload: SkuGenerateIn, db: Session = Depends(get_db)):
             product_kind=payload.product_kind,
             brand_id=int(payload.brand_id),
             category_id=int(payload.category_id),
-            term_ids=payload.term_ids,
+            attribute_option_ids=payload.attribute_option_ids,
             text_segments=payload.text_segments,
             spec_text=payload.spec_text,
         )

--- a/app/pms/sku_coding/services/sku_coding_service.py
+++ b/app/pms/sku_coding/services/sku_coding_service.py
@@ -9,13 +9,9 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
 
 from app.pms.items.models.item import Item
-from app.pms.items.models.item_master import PmsBrand, PmsBusinessCategory
+from app.pms.items.models.item_master import ItemAttributeDef, ItemAttributeOption, PmsBrand, PmsBusinessCategory
 from app.pms.items.models.item_sku_code import ItemSkuCode
-from app.pms.sku_coding.models.sku_coding import (
-    SkuCodeTemplate,
-    SkuCodeTerm,
-    SkuCodeTermGroup,
-)
+from app.pms.sku_coding.models.sku_coding import SkuCodeTemplate
 
 
 def _norm_code(v: str) -> str:
@@ -109,27 +105,35 @@ class SkuCodingService:
             raise ValueError(f"缺少 SKU 编码模板：{product_kind}")
         return obj
 
-    def _load_terms_by_group(self, *, group_code: str, ids: list[int]) -> list[SkuCodeTerm]:
+    def _load_attribute_options(
+        self,
+        *,
+        attribute_def: ItemAttributeDef,
+        ids: list[int],
+    ) -> list[ItemAttributeOption]:
         normalized_ids = sorted({int(x) for x in ids if x is not None})
         if not normalized_ids:
             return []
 
         rows = (
             self.db.execute(
-                select(SkuCodeTerm)
-                .join(SkuCodeTermGroup, SkuCodeTermGroup.id == SkuCodeTerm.group_id)
+                select(ItemAttributeOption)
                 .where(
-                    SkuCodeTerm.id.in_(normalized_ids),
-                    SkuCodeTerm.is_active.is_(True),
-                    SkuCodeTermGroup.group_code == group_code,
+                    ItemAttributeOption.id.in_(normalized_ids),
+                    ItemAttributeOption.attribute_def_id == int(attribute_def.id),
+                    ItemAttributeOption.is_active.is_(True),
                 )
-                .order_by(SkuCodeTerm.sort_order.asc(), SkuCodeTerm.code.asc(), SkuCodeTerm.id.asc())
+                .order_by(
+                    ItemAttributeOption.sort_order.asc(),
+                    ItemAttributeOption.option_code.asc(),
+                    ItemAttributeOption.id.asc(),
+                )
             )
             .scalars()
             .all()
         )
         if len(rows) != len(normalized_ids):
-            raise ValueError(f"字典项不存在、已停用或分组不匹配：{group_code}")
+            raise ValueError(f"属性选项不存在、已停用或属性不匹配：{attribute_def.code}")
         return list(rows)
 
     def generate(
@@ -138,7 +142,7 @@ class SkuCodingService:
         product_kind: str,
         brand_id: int,
         category_id: int,
-        term_ids: dict[str, list[int]],
+        attribute_option_ids: dict[str, list[int]],
         text_segments: dict[str, str],
         spec_text: str,
     ) -> dict:
@@ -181,21 +185,28 @@ class SkuCodingService:
                 segments.append(GeneratedSegment(key, str(raw).strip(), code))
                 continue
 
-            if source == "TERM":
-                group = segment.term_group
-                if group is None:
-                    raise ValueError(f"模板段缺少 term_group：{key}")
-                ids = (term_ids or {}).get(str(group.group_code), [])
-                terms = self._load_terms_by_group(group_code=str(group.group_code), ids=ids)
-                if not terms:
-                    if bool(segment.is_required):
-                        raise ValueError(f"缺少必填字典段：{group.group_code}")
+            if source == "ATTRIBUTE_OPTION":
+                attribute_def = segment.attribute_def
+                if attribute_def is None:
+                    raise ValueError(f"模板段缺少 attribute_def：{key}")
+                if not bool(attribute_def.is_active):
+                    raise ValueError(f"属性模板已停用：{attribute_def.code}")
+                if attribute_def.product_kind != kind:
+                    raise ValueError(f"属性模板商品类型不匹配：{attribute_def.code}")
+                if attribute_def.value_type != "OPTION" or not bool(attribute_def.is_sku_segment):
+                    raise ValueError(f"属性模板不是 SKU 预设选项段：{attribute_def.code}")
+
+                ids = (attribute_option_ids or {}).get(str(attribute_def.code), [])
+                options = self._load_attribute_options(attribute_def=attribute_def, ids=ids)
+                if not options:
+                    if bool(attribute_def.is_sku_required):
+                        raise ValueError(f"缺少必填属性段：{attribute_def.code}")
                     continue
-                if not bool(segment.is_multi_select) and len(terms) > 1:
-                    raise ValueError(f"字典段不允许多选：{group.group_code}")
-                for term in terms:
-                    parts.append(_norm_code(term.code))
-                    segments.append(GeneratedSegment(key, term.name_cn, _norm_code(term.code)))
+                if attribute_def.selection_mode != "MULTI" and len(options) > 1:
+                    raise ValueError(f"属性段不允许多选：{attribute_def.code}")
+                for option in options:
+                    parts.append(_norm_code(option.option_code))
+                    segments.append(GeneratedSegment(key, option.option_name, _norm_code(option.option_code)))
                 continue
 
             raise ValueError(f"不支持的模板段来源：{source}")

--- a/tests/api/test_pms_master_data_navigation_api.py
+++ b/tests/api/test_pms_master_data_navigation_api.py
@@ -64,18 +64,15 @@ async def test_pms_master_data_page_tree_and_routes(client: httpx.AsyncClient) -
     assert nodes["pms.item_uoms"]["name"] == "包装单位"
     assert nodes["pms.suppliers"]["name"] == "供应商管理"
 
-    assert [x["code"] for x in nodes["pms.sku_coding"]["children"]] == [
-        "pms.sku_coding.generator",
-        "pms.sku_coding.dictionaries",
-    ]
+    assert nodes["pms.sku_coding"]["name"] == "SKU 编码"
+    assert [x["code"] for x in nodes["pms.sku_coding"].get("children", [])] == []
 
     expected_routes = {
         "/items": "pms.items",
         "/pms/brands": "pms.brands",
         "/pms/categories": "pms.categories",
         "/pms/item-attribute-defs": "pms.item_attributes",
-        "/items/sku-coding/generator": "pms.sku_coding.generator",
-        "/items/sku-coding/dictionaries": "pms.sku_coding.dictionaries",
+        "/items/sku-coding": "pms.sku_coding",
         "/item-barcodes": "pms.item_barcodes",
         "/item-uoms": "pms.item_uoms",
         "/suppliers": "pms.suppliers",

--- a/tests/api/test_pms_sku_coding_api.py
+++ b/tests/api/test_pms_sku_coding_api.py
@@ -46,28 +46,33 @@ async def _create_category(
     )
 
 
-async def _group_id(client: httpx.AsyncClient, headers: dict[str, str], *, product_kind: str, group_code: str) -> int:
-    r = await client.get(f"/pms/sku-coding/term-groups?product_kind={product_kind}", headers=headers)
+
+
+async def _attribute_def_id(client: httpx.AsyncClient, headers: dict[str, str], *, product_kind: str, code: str) -> int:
+    r = await client.get(
+        f"/pms/item-attribute-defs?product_kind={product_kind}&active_only=true",
+        headers=headers,
+    )
     assert r.status_code == 200, r.text
     rows = r.json()["data"]
     for row in rows:
-        if row["group_code"] == group_code:
+        if row["code"] == code:
             return int(row["id"])
-    raise AssertionError(f"group not found: {product_kind}/{group_code}")
+    raise AssertionError(f"attribute def not found: {product_kind}/{code}")
 
 
-async def _create_term(
+async def _create_attribute_option(
     client: httpx.AsyncClient,
     headers: dict[str, str],
     *,
-    group_id: int,
-    name_cn: str,
-    code: str,
+    attribute_def_id: int,
+    option_name: str,
+    option_code: str,
     sort_order: int,
 ) -> dict:
     r = await client.post(
-        "/pms/sku-coding/terms",
-        json={"group_id": group_id, "name_cn": name_cn, "code": code, "sort_order": sort_order},
+        f"/pms/item-attribute-defs/{attribute_def_id}/options",
+        json={"option_code": option_code, "option_name": option_name, "sort_order": sort_order},
         headers=headers,
     )
     assert r.status_code == 201, r.text
@@ -119,40 +124,40 @@ async def test_sku_coding_food_generate_contract(client: httpx.AsyncClient) -> N
         is_leaf=True,
     )
 
-    life_stage_gid = await _group_id(client, headers, product_kind="FOOD", group_code="LIFE_STAGE")
-    process_gid = await _group_id(client, headers, product_kind="FOOD", group_code="PROCESS")
-    flavor_gid = await _group_id(client, headers, product_kind="FOOD", group_code="FLAVOR")
+    life_stage_def_id = await _attribute_def_id(client, headers, product_kind="FOOD", code="LIFE_STAGE")
+    process_def_id = await _attribute_def_id(client, headers, product_kind="FOOD", code="PROCESS")
+    flavor_def_id = await _attribute_def_id(client, headers, product_kind="FOOD", code="FLAVOR")
 
-    als = await _create_term(
+    als = await _create_attribute_option(
         client,
         headers,
-        group_id=life_stage_gid,
-        name_cn=f"全期-UT-{sfx}",
-        code=life_stage_code,
+        attribute_def_id=life_stage_def_id,
+        option_name=f"全期-UT-{sfx}",
+        option_code=life_stage_code,
         sort_order=10,
     )
-    fm = await _create_term(
+    fm = await _create_attribute_option(
         client,
         headers,
-        group_id=process_gid,
-        name_cn=f"鲜肉-UT-{sfx}",
-        code=process_code,
+        attribute_def_id=process_def_id,
+        option_name=f"鲜肉-UT-{sfx}",
+        option_code=process_code,
         sort_order=10,
     )
-    chkn = await _create_term(
+    chkn = await _create_attribute_option(
         client,
         headers,
-        group_id=flavor_gid,
-        name_cn=f"鸡肉-UT-{sfx}",
-        code=chicken_code,
+        attribute_def_id=flavor_def_id,
+        option_name=f"鸡肉-UT-{sfx}",
+        option_code=chicken_code,
         sort_order=10,
     )
-    slmn = await _create_term(
+    slmn = await _create_attribute_option(
         client,
         headers,
-        group_id=flavor_gid,
-        name_cn=f"三文鱼-UT-{sfx}",
-        code=salmon_code,
+        attribute_def_id=flavor_def_id,
+        option_name=f"三文鱼-UT-{sfx}",
+        option_code=salmon_code,
         sort_order=20,
     )
 
@@ -162,7 +167,7 @@ async def test_sku_coding_food_generate_contract(client: httpx.AsyncClient) -> N
             "product_kind": "FOOD",
             "brand_id": int(brand["id"]),
             "category_id": int(leaf["id"]),
-            "term_ids": {
+            "attribute_option_ids": {
                 "LIFE_STAGE": [int(als["id"])],
                 "PROCESS": [int(fm["id"])],
                 "FLAVOR": [int(slmn["id"]), int(chkn["id"])],
@@ -223,22 +228,22 @@ async def test_sku_coding_supply_generate_contract(client: httpx.AsyncClient) ->
         is_leaf=True,
     )
 
-    model_gid = await _group_id(client, headers, product_kind="SUPPLY", group_code="MODEL")
-    color_gid = await _group_id(client, headers, product_kind="SUPPLY", group_code="COLOR")
-    pro = await _create_term(
+    model_def_id = await _attribute_def_id(client, headers, product_kind="SUPPLY", code="MODEL")
+    color_def_id = await _attribute_def_id(client, headers, product_kind="SUPPLY", code="COLOR")
+    pro = await _create_attribute_option(
         client,
         headers,
-        group_id=model_gid,
-        name_cn=f"PRO-UT-{sfx}",
-        code=model_code,
+        attribute_def_id=model_def_id,
+        option_name=f"PRO-UT-{sfx}",
+        option_code=model_code,
         sort_order=10,
     )
-    wht = await _create_term(
+    wht = await _create_attribute_option(
         client,
         headers,
-        group_id=color_gid,
-        name_cn=f"白色-UT-{sfx}",
-        code=color_code,
+        attribute_def_id=color_def_id,
+        option_name=f"白色-UT-{sfx}",
+        option_code=color_code,
         sort_order=10,
     )
 
@@ -248,7 +253,7 @@ async def test_sku_coding_supply_generate_contract(client: httpx.AsyncClient) ->
             "product_kind": "SUPPLY",
             "brand_id": int(brand["id"]),
             "category_id": int(leaf["id"]),
-            "term_ids": {
+            "attribute_option_ids": {
                 "MODEL": [int(pro["id"])],
                 "COLOR": [int(wht["id"])],
             },
@@ -261,42 +266,21 @@ async def test_sku_coding_supply_generate_contract(client: httpx.AsyncClient) ->
     assert data["sku"] == f"SKU-{brand_code}-{category_code}-{model_code}-2L-{color_code}"
 
 
+
+
 @pytest.mark.asyncio
-async def test_sku_coding_dictionary_update_and_toggle_contract(client: httpx.AsyncClient) -> None:
+async def test_sku_coding_legacy_dictionary_routes_are_retired(client: httpx.AsyncClient) -> None:
     headers = await _headers(client)
-    sfx = _suffix()
 
-    flavor_gid = await _group_id(client, headers, product_kind="FOOD", group_code="FLAVOR")
-    term = await _create_term(
-        client,
-        headers,
-        group_id=flavor_gid,
-        name_cn=f"口味编辑-UT-{sfx}",
-        code=f"FLV{sfx}",
-        sort_order=10,
-    )
+    r_groups = await client.get("/pms/sku-coding/term-groups", headers=headers)
+    assert r_groups.status_code == 404, r_groups.text
 
-    r_term_patch = await client.patch(
-        f"/pms/sku-coding/terms/{term['id']}",
-        json={
-            "name_cn": f"口味编辑后-UT-{sfx}",
-            "code": f"FLVX{sfx}",
-            "sort_order": 99,
-            "remark": "updated term",
-        },
+    r_terms = await client.get("/pms/sku-coding/terms", headers=headers)
+    assert r_terms.status_code == 404, r_terms.text
+
+    r_create = await client.post(
+        "/pms/sku-coding/terms",
+        json={"group_id": 1, "name_cn": "旧字典", "code": "OLD"},
         headers=headers,
     )
-    assert r_term_patch.status_code == 200, r_term_patch.text
-    term_updated = r_term_patch.json()
-    assert term_updated["name_cn"] == f"口味编辑后-UT-{sfx}"
-    assert term_updated["code"] == f"FLVX{sfx}"
-    assert term_updated["sort_order"] == 99
-    assert term_updated["remark"] == "updated term"
-
-    r_term_disable = await client.post(f"/pms/sku-coding/terms/{term['id']}/disable", headers=headers)
-    assert r_term_disable.status_code == 200, r_term_disable.text
-    assert r_term_disable.json()["is_active"] is False
-
-    r_term_enable = await client.post(f"/pms/sku-coding/terms/{term['id']}/enable", headers=headers)
-    assert r_term_enable.status_code == 200, r_term_enable.text
-    assert r_term_enable.json()["is_active"] is True
+    assert r_create.status_code == 404, r_create.text

--- a/tests/api/test_pms_sku_coding_navigation_api.py
+++ b/tests/api/test_pms_sku_coding_navigation_api.py
@@ -1,4 +1,3 @@
-# tests/api/test_pms_sku_coding_navigation_api.py
 from __future__ import annotations
 
 import httpx
@@ -8,22 +7,21 @@ import pytest
 def _walk_pages(pages: list[dict]) -> dict[str, dict]:
     out: dict[str, dict] = {}
 
-    def walk(node: dict) -> None:
-        out[str(node["code"])] = node
-        for child in node.get("children") or []:
-            walk(child)
+    def visit(rows: list[dict]) -> None:
+        for row in rows:
+            out[row["code"]] = row
+            visit(row.get("children") or [])
 
-    for page in pages:
-        walk(page)
+    visit(pages)
     return out
 
 
-def _route_map(route_prefixes: list[dict]) -> dict[str, dict]:
-    return {str(row["route_prefix"]): row for row in route_prefixes}
+def _route_map(routes: list[dict]) -> dict[str, dict]:
+    return {row["route_prefix"]: row for row in routes}
 
 
 @pytest.mark.asyncio
-async def test_pms_sku_coding_pages_and_routes_exist(client: httpx.AsyncClient) -> None:
+async def test_pms_sku_coding_page_and_route_exist(client: httpx.AsyncClient) -> None:
     login = await client.post("/users/login", json={"username": "admin", "password": "admin123"})
     assert login.status_code == 200, login.text
     headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
@@ -35,16 +33,14 @@ async def test_pms_sku_coding_pages_and_routes_exist(client: httpx.AsyncClient) 
     nodes = _walk_pages(data["pages"])
     routes = _route_map(data["route_prefixes"])
 
+    assert nodes["pms.sku_coding"]["name"] == "SKU 编码"
     assert nodes["pms.sku_coding"]["parent_code"] == "pms"
     assert nodes["pms.sku_coding"]["domain_code"] == "pms"
+    assert nodes["pms.sku_coding"]["level"] == 2
+    assert nodes["pms.sku_coding"]["effective_read_permission"] == "page.pms.read"
+    assert nodes["pms.sku_coding"]["effective_write_permission"] == "page.pms.write"
+    assert [x["code"] for x in nodes["pms.sku_coding"].get("children", [])] == []
 
-    assert nodes["pms.sku_coding.generator"]["parent_code"] == "pms.sku_coding"
-    assert nodes["pms.sku_coding.generator"]["effective_read_permission"] == "page.pms.read"
-    assert nodes["pms.sku_coding.generator"]["effective_write_permission"] == "page.pms.write"
-
-    assert nodes["pms.sku_coding.dictionaries"]["parent_code"] == "pms.sku_coding"
-    assert nodes["pms.sku_coding.dictionaries"]["effective_read_permission"] == "page.pms.read"
-    assert nodes["pms.sku_coding.dictionaries"]["effective_write_permission"] == "page.pms.write"
-
-    assert routes["/items/sku-coding/generator"]["page_code"] == "pms.sku_coding.generator"
-    assert routes["/items/sku-coding/dictionaries"]["page_code"] == "pms.sku_coding.dictionaries"
+    assert routes["/items/sku-coding"]["page_code"] == "pms.sku_coding"
+    assert "/items/sku-coding/generator" not in routes
+    assert "/items/sku-coding/dictionaries" not in routes


### PR DESCRIPTION
## Summary
- Cut SKU coding generation over from sku_code_terms to item_attribute_options.
- Use item_attribute_defs / item_attribute_options as the single truth source for SKU attribute segments.
- Retire legacy SKU dictionary tables: sku_code_term_groups, sku_code_terms and sku_code_term_aliases.
- Remove legacy SKU dictionary API routes.
- Promote SKU coding from third-level generator page to second-level PMS page.
- Register /items/sku-coding directly to pms.sku_coding.

## Validation
- python3 -m compileall app/pms/sku_coding tests/api/test_pms_sku_coding_api.py tests/api/test_pms_sku_coding_navigation_api.py tests/api/test_pms_master_data_navigation_api.py alembic/versions/20260430113408_sku_coding_segments_use_attribute_options.py
- make test TESTS=tests/api/test_pms_sku_coding_api.py
- make test TESTS=tests/api/test_pms_sku_coding_navigation_api.py
- make test TESTS=tests/api/test_pms_master_data_navigation_api.py
- make test TESTS=tests/api/test_pms_master_data_api.py

Result:
- SKU coding API: 3 passed
- SKU coding navigation: 1 passed
- PMS master data navigation: 1 passed
- PMS master data API: 2 passed