### PR TITLE
refactor(pms): reuse uom row contract for barcode rows

### DIFF
--- a/app/pms/items/routers/item_barcodes.py
+++ b/app/pms/items/routers/item_barcodes.py
@@ -1,7 +1,6 @@
 # app/pms/items/routers/item_barcodes.py
 from __future__ import annotations
 
-from datetime import datetime
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -9,6 +8,7 @@ from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session
 
 from app.db.deps import get_db
+from app.pms.items.contracts.item_uom import ItemUomBarcodeRowOut
 from app.pms.items.repos.item_barcode_repo import (
     clear_primary_flags_for_item,
     create_item_barcode,
@@ -85,34 +85,18 @@ class ItemBarcodeOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
-class ItemBarcodeCompositeRow(BaseModel):
+class ItemBarcodeCompositeRow(ItemUomBarcodeRowOut):
     """
     商品条码页 owner 复合只读行：
-    - 一行 = 一个商品 + 一个单位 + 一条码
-    - 页面用它直接渲染，不再让前端分别请求 /item-barcodes 与 /item-uoms 后自行 join
+    - 继承 item_uoms owner 复合读模型，包装字段以 item_uoms 合同为唯一来源
+    - 当前接口只返回已绑定条码的行，因此条码字段在这里收紧为必填
     """
 
     barcode_id: int
-    item_id: int
-    item_uom_id: int
-
-    sku: str
-    item_name: str
-
-    uom: str
-    display_name: Optional[str]
-    ratio_to_base: int
-    net_weight_kg: Optional[float]
-    is_base: bool
-    is_purchase_default: bool
-    is_inbound_default: bool
-    is_outbound_default: bool
-
     barcode: str
     symbology: str
     is_primary: bool
     active: bool
-    updated_at: datetime
 
 
 @router.post("", response_model=ItemBarcodeOut, status_code=status.HTTP_201_CREATED)

--- a/openapi/_current.json
+++ b/openapi/_current.json
@@ -28817,9 +28817,13 @@
       },
       "ItemBarcodeCompositeRow": {
         "properties": {
-          "barcode_id": {
-            "type": "integer",
-            "title": "Barcode Id"
+          "sku": {
+            "type": "string",
+            "title": "Sku"
+          },
+          "item_name": {
+            "type": "string",
+            "title": "Item Name"
           },
           "item_id": {
             "type": "integer",
@@ -28828,14 +28832,6 @@
           "item_uom_id": {
             "type": "integer",
             "title": "Item Uom Id"
-          },
-          "sku": {
-            "type": "string",
-            "title": "Sku"
-          },
-          "item_name": {
-            "type": "string",
-            "title": "Item Name"
           },
           "uom": {
             "type": "string",
@@ -28883,6 +28879,10 @@
             "type": "boolean",
             "title": "Is Outbound Default"
           },
+          "barcode_id": {
+            "type": "integer",
+            "title": "Barcode Id"
+          },
           "barcode": {
             "type": "string",
             "title": "Barcode"
@@ -28907,11 +28907,10 @@
         },
         "type": "object",
         "required": [
-          "barcode_id",
-          "item_id",
-          "item_uom_id",
           "sku",
           "item_name",
+          "item_id",
+          "item_uom_id",
           "uom",
           "display_name",
           "ratio_to_base",
@@ -28920,6 +28919,7 @@
           "is_purchase_default",
           "is_inbound_default",
           "is_outbound_default",
+          "barcode_id",
           "barcode",
           "symbology",
           "is_primary",
@@ -28927,7 +28927,7 @@
           "updated_at"
         ],
         "title": "ItemBarcodeCompositeRow",
-        "description": "商品条码页 owner 复合只读行：\n- 一行 = 一个商品 + 一个单位 + 一条码\n- 页面用它直接渲染，不再让前端分别请求 /item-barcodes 与 /item-uoms 后自行 join"
+        "description": "商品条码页 owner 复合只读行：\n- 继承 item_uoms owner 复合读模型，包装字段以 item_uoms 合同为唯一来源\n- 当前接口只返回已绑定条码的行，因此条码字段在这里收紧为必填"
       },
       "ItemBarcodeCreate": {
         "properties": {

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -28817,9 +28817,13 @@
       },
       "ItemBarcodeCompositeRow": {
         "properties": {
-          "barcode_id": {
-            "type": "integer",
-            "title": "Barcode Id"
+          "sku": {
+            "type": "string",
+            "title": "Sku"
+          },
+          "item_name": {
+            "type": "string",
+            "title": "Item Name"
           },
           "item_id": {
             "type": "integer",
@@ -28828,14 +28832,6 @@
           "item_uom_id": {
             "type": "integer",
             "title": "Item Uom Id"
-          },
-          "sku": {
-            "type": "string",
-            "title": "Sku"
-          },
-          "item_name": {
-            "type": "string",
-            "title": "Item Name"
           },
           "uom": {
             "type": "string",
@@ -28883,6 +28879,10 @@
             "type": "boolean",
             "title": "Is Outbound Default"
           },
+          "barcode_id": {
+            "type": "integer",
+            "title": "Barcode Id"
+          },
           "barcode": {
             "type": "string",
             "title": "Barcode"
@@ -28907,11 +28907,10 @@
         },
         "type": "object",
         "required": [
-          "barcode_id",
-          "item_id",
-          "item_uom_id",
           "sku",
           "item_name",
+          "item_id",
+          "item_uom_id",
           "uom",
           "display_name",
           "ratio_to_base",
@@ -28920,6 +28919,7 @@
           "is_purchase_default",
           "is_inbound_default",
           "is_outbound_default",
+          "barcode_id",
           "barcode",
           "symbology",
           "is_primary",
@@ -28927,7 +28927,7 @@
           "updated_at"
         ],
         "title": "ItemBarcodeCompositeRow",
-        "description": "商品条码页 owner 复合只读行：\n- 一行 = 一个商品 + 一个单位 + 一条码\n- 页面用它直接渲染，不再让前端分别请求 /item-barcodes 与 /item-uoms 后自行 join"
+        "description": "商品条码页 owner 复合只读行：\n- 继承 item_uoms owner 复合读模型，包装字段以 item_uoms 合同为唯一来源\n- 当前接口只返回已绑定条码的行，因此条码字段在这里收紧为必填"
       },
       "ItemBarcodeCreate": {
         "properties": {


### PR DESCRIPTION
## Summary
- 让 ItemBarcodeCompositeRow 继承 ItemUomBarcodeRowOut
- 包装字段统一以 item_uoms owner 复合读模型为来源
- 对 /item-barcodes/item/{item_id}/rows 的已绑定条码字段保持必填：barcode_id、barcode、symbology、is_primary、active
- 重新生成 OpenAPI

## Tests
- python3 -m compileall app/pms/items/routers/item_barcodes.py
- make openapi
- ItemBarcodeCompositeRow schema check
- make test TESTS="tests/api/test_pms_master_data_navigation_api.py tests/api/test_user_navigation_api.py tests/ci/test_pms_item_openapi_contract.py"