### PR TITLE
refactor(pms): move supplier contact contracts

### DIFF
--- a/app/pms/suppliers/contracts/suppliers.py
+++ b/app/pms/suppliers/contracts/suppliers.py
@@ -39,3 +39,23 @@ class SupplierUpdateIn(BaseModel):
     code: Optional[str] = None
     website: Optional[str] = None
     active: Optional[bool] = None
+
+
+class SupplierContactCreateIn(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+    phone: Optional[str] = Field(None, max_length=50)
+    email: Optional[EmailStr] = Field(None, max_length=255)
+    wechat: Optional[str] = Field(None, max_length=64)
+    role: str = Field(default="other", max_length=32)
+    is_primary: bool = False
+    active: bool = True
+
+
+class SupplierContactUpdateIn(BaseModel):
+    name: Optional[str] = Field(None, min_length=1, max_length=100)
+    phone: Optional[str] = Field(None, max_length=50)
+    email: Optional[EmailStr] = Field(None, max_length=255)
+    wechat: Optional[str] = Field(None, max_length=64)
+    role: Optional[str] = Field(None, max_length=32)
+    is_primary: Optional[bool] = None
+    active: Optional[bool] = None

--- a/app/pms/suppliers/routers/supplier_contacts.py
+++ b/app/pms/suppliers/routers/supplier_contacts.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Path, status
-from pydantic import BaseModel, EmailStr, Field
 from sqlalchemy.orm import Session
 
 from app.user.deps.auth import get_current_user
 from app.db.deps import get_db
-from app.pms.suppliers.contracts.suppliers import SupplierContactOut
+from app.pms.suppliers.contracts.suppliers import (
+    SupplierContactCreateIn,
+    SupplierContactOut,
+    SupplierContactUpdateIn,
+)
 from app.pms.suppliers.repos.supplier_contact_repo import (
     clear_primary_contacts as repo_clear_primary_contacts,
 )
@@ -31,26 +34,6 @@ from app.pms.suppliers.repos.supplier_contact_repo import (
 from app.pms.suppliers.helpers.suppliers import check_perm
 
 router = APIRouter(tags=["supplier-contacts"])
-
-
-class SupplierContactCreateIn(BaseModel):
-    name: str = Field(..., min_length=1, max_length=100)
-    phone: Optional[str] = Field(None, max_length=50)
-    email: Optional[EmailStr] = Field(None, max_length=255)
-    wechat: Optional[str] = Field(None, max_length=64)
-    role: str = Field(default="other", max_length=32)
-    is_primary: bool = False
-    active: bool = True
-
-
-class SupplierContactUpdateIn(BaseModel):
-    name: Optional[str] = Field(None, min_length=1, max_length=100)
-    phone: Optional[str] = Field(None, max_length=50)
-    email: Optional[EmailStr] = Field(None, max_length=255)
-    wechat: Optional[str] = Field(None, max_length=64)
-    role: Optional[str] = Field(None, max_length=32)
-    is_primary: Optional[bool] = None
-    active: Optional[bool] = None
 
 
 def _to_out(c) -> SupplierContactOut:


### PR DESCRIPTION
## Summary
- 将 SupplierContactCreateIn / SupplierContactUpdateIn 从 supplier_contacts router 迁到 suppliers contracts
- router 只保留路由、权限、字段清洗和 repo 调用
- 不改变接口路径、字段语义和数据库结构

## Tests
- python3 -m compileall app/pms/suppliers/contracts/suppliers.py app/pms/suppliers/routers/supplier_contacts.py
- make test TESTS="tests/api/test_pms_public_suppliers_api.py tests/api/test_pms_master_data_navigation_api.py tests/api/test_user_navigation_api.py tests/api/test_purchase_orders_supplier_item_contract.py"