### PR TITLE
feat(pms): add item list row read model

### DIFF
--- a/app/pms/items/contracts/item_list.py
+++ b/app/pms/items/contracts/item_list.py
@@ -1,0 +1,49 @@
+# app/pms/items/contracts/item_list.py
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class ItemListRowOut(BaseModel):
+    """
+    PMS 商品列表页专用 owner 读模型。
+
+    定位：
+    - 一行 = 一个商品的完整列表摘要
+    - 只服务商品主数据总览页
+    - 不承载写入语义
+    - 不让前端再自行拼 item_uoms / item_barcodes / item_sku_codes / item_attribute_values
+    """
+
+    item_id: int
+    sku: str
+    name: str
+    spec: Optional[str] = None
+    enabled: bool
+
+    brand: Optional[str] = None
+    category: Optional[str] = None
+    supplier_name: Optional[str] = None
+
+    primary_barcode: Optional[str] = None
+
+    base_uom: Optional[str] = None
+    base_net_weight_kg: Optional[float] = Field(default=None, ge=0)
+
+    purchase_uom: Optional[str] = None
+    purchase_ratio_to_base: Optional[int] = Field(default=None, ge=1)
+
+    lot_source_policy: str
+    expiry_policy: str
+    shelf_life_value: Optional[int] = Field(default=None, ge=0)
+    shelf_life_unit: Optional[str] = None
+
+    uom_count: int = Field(default=0, ge=0)
+    barcode_count: int = Field(default=0, ge=0)
+    sku_code_count: int = Field(default=0, ge=0)
+    attribute_count: int = Field(default=0, ge=0)
+
+    updated_at: Optional[datetime] = None

--- a/app/pms/items/repos/item_list_repo.py
+++ b/app/pms/items/repos/item_list_repo.py
@@ -1,0 +1,172 @@
+# app/pms/items/repos/item_list_repo.py
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+
+def list_item_list_row_mappings(
+    db: Session,
+    *,
+    enabled: Optional[bool] = None,
+    supplier_id: Optional[int] = None,
+    q: Optional[str] = None,
+    limit: int = 200,
+) -> list[Mapping[str, Any]]:
+    """
+    商品列表页 owner 聚合读。
+
+    真相来源：
+    - items：商品身份、策略、启停
+    - pms_brands / pms_business_categories：品牌分类展示投影
+    - suppliers：供应商展示投影
+    - item_barcodes：主条码与条码数量
+    - item_uoms：基础包装、采购默认包装、净重、包装数量
+    - item_sku_codes：SKU 编码数量
+    - item_attribute_values：属性值数量
+    """
+
+    conditions: list[str] = []
+    params: dict[str, Any] = {
+        "limit": max(1, min(int(limit or 200), 500)),
+    }
+
+    if enabled is not None:
+        conditions.append("i.enabled = :enabled")
+        params["enabled"] = bool(enabled)
+
+    if supplier_id is not None:
+        conditions.append("i.supplier_id = :supplier_id")
+        params["supplier_id"] = int(supplier_id)
+
+    qv = (q or "").strip()
+    if qv:
+        conditions.append(
+            """
+            (
+              lower(i.sku) LIKE :q_like
+              OR lower(i.name) LIKE :q_like
+              OR lower(COALESCE(i.spec, '')) LIKE :q_like
+              OR lower(COALESCE(s.name, '')) LIKE :q_like
+              OR lower(COALESCE(br.name_cn, '')) LIKE :q_like
+              OR lower(COALESCE(cat.category_name, '')) LIKE :q_like
+              OR lower(COALESCE(pb.barcode, '')) LIKE :q_like
+            )
+            """
+        )
+        params["q_like"] = f"%{qv.lower()}%"
+
+    where_sql = ""
+    if conditions:
+        where_sql = "WHERE " + " AND ".join(conditions)
+
+    sql = f"""
+    WITH base_uom AS (
+      SELECT DISTINCT ON (u.item_id)
+        u.item_id,
+        u.uom,
+        u.net_weight_kg
+      FROM item_uoms u
+      WHERE u.is_base IS TRUE
+      ORDER BY u.item_id, u.id ASC
+    ),
+    purchase_uom AS (
+      SELECT DISTINCT ON (u.item_id)
+        u.item_id,
+        u.uom,
+        u.ratio_to_base
+      FROM item_uoms u
+      WHERE u.is_purchase_default IS TRUE
+      ORDER BY u.item_id, u.id ASC
+    ),
+    primary_barcode AS (
+      SELECT DISTINCT ON (b.item_id)
+        b.item_id,
+        b.barcode
+      FROM item_barcodes b
+      WHERE b.active IS TRUE
+        AND b.is_primary IS TRUE
+      ORDER BY b.item_id, b.id ASC
+    ),
+    uom_counts AS (
+      SELECT item_id, COUNT(*)::int AS cnt
+      FROM item_uoms
+      GROUP BY item_id
+    ),
+    barcode_counts AS (
+      SELECT item_id, COUNT(*)::int AS cnt
+      FROM item_barcodes
+      WHERE active IS TRUE
+      GROUP BY item_id
+    ),
+    sku_code_counts AS (
+      SELECT item_id, COUNT(*)::int AS cnt
+      FROM item_sku_codes
+      WHERE is_active IS TRUE
+      GROUP BY item_id
+    ),
+    attribute_counts AS (
+      SELECT item_id, COUNT(*)::int AS cnt
+      FROM item_attribute_values
+      GROUP BY item_id
+    )
+    SELECT
+      i.id::int AS item_id,
+      i.sku,
+      i.name,
+      i.spec,
+      i.enabled,
+
+      br.name_cn AS brand,
+      cat.category_name AS category,
+      s.name AS supplier_name,
+
+      pb.barcode AS primary_barcode,
+
+      bu.uom AS base_uom,
+      bu.net_weight_kg AS base_net_weight_kg,
+
+      pu.uom AS purchase_uom,
+      pu.ratio_to_base::int AS purchase_ratio_to_base,
+
+      i.lot_source_policy::text AS lot_source_policy,
+      i.expiry_policy::text AS expiry_policy,
+      i.shelf_life_value,
+      i.shelf_life_unit::text AS shelf_life_unit,
+
+      COALESCE(uc.cnt, 0)::int AS uom_count,
+      COALESCE(bc.cnt, 0)::int AS barcode_count,
+      COALESCE(sc.cnt, 0)::int AS sku_code_count,
+      COALESCE(ac.cnt, 0)::int AS attribute_count,
+
+      i.updated_at
+    FROM items i
+    LEFT JOIN pms_brands br
+      ON br.id = i.brand_id
+    LEFT JOIN pms_business_categories cat
+      ON cat.id = i.category_id
+    LEFT JOIN suppliers s
+      ON s.id = i.supplier_id
+    LEFT JOIN base_uom bu
+      ON bu.item_id = i.id
+    LEFT JOIN purchase_uom pu
+      ON pu.item_id = i.id
+    LEFT JOIN primary_barcode pb
+      ON pb.item_id = i.id
+    LEFT JOIN uom_counts uc
+      ON uc.item_id = i.id
+    LEFT JOIN barcode_counts bc
+      ON bc.item_id = i.id
+    LEFT JOIN sku_code_counts sc
+      ON sc.item_id = i.id
+    LEFT JOIN attribute_counts ac
+      ON ac.item_id = i.id
+    {where_sql}
+    ORDER BY i.updated_at DESC NULLS LAST, i.id DESC
+    LIMIT :limit
+    """
+
+    rows = db.execute(text(sql), params).mappings().all()
+    return list(rows)

--- a/app/pms/items/routers/item_list.py
+++ b/app/pms/items/routers/item_list.py
@@ -1,0 +1,33 @@
+# app/pms/items/routers/item_list.py
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.db.deps import get_db
+from app.pms.items.contracts.item_list import ItemListRowOut
+from app.pms.items.services.item_list_service import ItemListReadService
+
+router = APIRouter(prefix="/items", tags=["items-list"])
+
+
+def get_item_list_read_service(db: Session = Depends(get_db)) -> ItemListReadService:
+    return ItemListReadService(db)
+
+
+@router.get("/list-rows", response_model=list[ItemListRowOut])
+def list_item_rows(
+    enabled: Optional[bool] = Query(None, description="true=有效商品；false=无效商品；不传=全部"),
+    supplier_id: Optional[int] = Query(None, ge=1, description="按供应商过滤"),
+    q: Optional[str] = Query(None, description="关键词搜索 SKU / 名称 / 规格 / 品牌 / 分类 / 供应商 / 主条码"),
+    limit: int = Query(200, ge=1, le=500),
+    service: ItemListReadService = Depends(get_item_list_read_service),
+) -> list[ItemListRowOut]:
+    return service.list_rows(
+        enabled=enabled,
+        supplier_id=supplier_id,
+        q=q,
+        limit=limit,
+    )

--- a/app/pms/items/services/item_list_service.py
+++ b/app/pms/items/services/item_list_service.py
@@ -1,0 +1,37 @@
+# app/pms/items/services/item_list_service.py
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.pms.items.contracts.item_list import ItemListRowOut
+from app.pms.items.repos.item_list_repo import list_item_list_row_mappings
+
+
+class ItemListReadService:
+    """
+    PMS 商品列表页 owner 读服务。
+
+    只负责商品列表页的完整摘要行，不承载写入语义。
+    """
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def list_rows(
+        self,
+        *,
+        enabled: Optional[bool] = None,
+        supplier_id: Optional[int] = None,
+        q: Optional[str] = None,
+        limit: int = 200,
+    ) -> list[ItemListRowOut]:
+        rows = list_item_list_row_mappings(
+            self.db,
+            enabled=enabled,
+            supplier_id=supplier_id,
+            q=q,
+            limit=limit,
+        )
+        return [ItemListRowOut.model_validate(dict(row)) for row in rows]

--- a/app/router_mount.py
+++ b/app/router_mount.py
@@ -19,6 +19,7 @@ def mount_routers(app: FastAPI) -> None:
     from app.shipping_assist.routers.geo_cn import router as geo_router
     from app.pms.items.routers.item_aggregate import router as item_aggregate_router
     from app.pms.items.routers.item_barcodes import router as item_barcodes_router
+    from app.pms.items.routers.item_list import router as item_list_router
     from app.pms.items.routers.item_master import router as item_master_router
     from app.pms.items.routers.item_sku_codes import router as item_sku_codes_router
     from app.pms.items.routers.item_uoms import router as item_uoms_router
@@ -142,6 +143,7 @@ def mount_routers(app: FastAPI) -> None:
     app.include_router(pms_public_barcode_probe_router)
     app.include_router(pms_public_suppliers_read_router)
     app.include_router(item_aggregate_router)
+    app.include_router(item_list_router)
     app.include_router(items_router)
     app.include_router(item_master_router)
     app.include_router(item_sku_codes_router)

--- a/openapi/_current.json
+++ b/openapi/_current.json
@@ -9793,6 +9793,110 @@
         }
       }
     },
+    "/items/list-rows": {
+      "get": {
+        "tags": [
+          "items-list"
+        ],
+        "summary": "List Item Rows",
+        "operationId": "list_item_rows_items_list_rows_get",
+        "parameters": [
+          {
+            "name": "enabled",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "true=有效商品；false=无效商品；不传=全部",
+              "title": "Enabled"
+            },
+            "description": "true=有效商品；false=无效商品；不传=全部"
+          },
+          {
+            "name": "supplier_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "按供应商过滤",
+              "title": "Supplier Id"
+            },
+            "description": "按供应商过滤"
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "关键词搜索 SKU / 名称 / 规格 / 品牌 / 分类 / 供应商 / 主条码",
+              "title": "Q"
+            },
+            "description": "关键词搜索 SKU / 名称 / 规格 / 品牌 / 分类 / 供应商 / 主条码"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "default": 200,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ItemListRowOut"
+                  },
+                  "title": "Response List Item Rows Items List Rows Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/items": {
       "post": {
         "tags": [
@@ -29297,6 +29401,205 @@
         ],
         "title": "ItemCreate",
         "description": "Create Item（SKU 由调用方显式输入）：\n- 必须传 sku；SKU 编码页只负责生成候选 SKU，最终由商品创建合同写入 items.sku\n- brand/category 不再接受自由文本；请传 brand_id/category_id\n- 不接受 barcode 输入；主条码请走 /item-barcodes\n- 不接受 weight_kg 输入；基础包装净重请走 item_uoms（base uom）\n\nPhase M-3：\n- items.case_ratio/case_uom 已删除；包装单位请走 item_uoms"
+      },
+      "ItemListRowOut": {
+        "properties": {
+          "item_id": {
+            "type": "integer",
+            "title": "Item Id"
+          },
+          "sku": {
+            "type": "string",
+            "title": "Sku"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "spec": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spec"
+          },
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled"
+          },
+          "brand": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Brand"
+          },
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category"
+          },
+          "supplier_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Supplier Name"
+          },
+          "primary_barcode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Primary Barcode"
+          },
+          "base_uom": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Uom"
+          },
+          "base_net_weight_kg": {
+            "anyOf": [
+              {
+                "type": "number",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Net Weight Kg"
+          },
+          "purchase_uom": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Purchase Uom"
+          },
+          "purchase_ratio_to_base": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Purchase Ratio To Base"
+          },
+          "lot_source_policy": {
+            "type": "string",
+            "title": "Lot Source Policy"
+          },
+          "expiry_policy": {
+            "type": "string",
+            "title": "Expiry Policy"
+          },
+          "shelf_life_value": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shelf Life Value"
+          },
+          "shelf_life_unit": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shelf Life Unit"
+          },
+          "uom_count": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Uom Count",
+            "default": 0
+          },
+          "barcode_count": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Barcode Count",
+            "default": 0
+          },
+          "sku_code_count": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Sku Code Count",
+            "default": 0
+          },
+          "attribute_count": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Attribute Count",
+            "default": 0
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "item_id",
+          "sku",
+          "name",
+          "enabled",
+          "lot_source_policy",
+          "expiry_policy"
+        ],
+        "title": "ItemListRowOut",
+        "description": "PMS 商品列表页专用 owner 读模型。\n\n定位：\n- 一行 = 一个商品的完整列表摘要\n- 只服务商品主数据总览页\n- 不承载写入语义\n- 不让前端再自行拼 item_uoms / item_barcodes / item_sku_codes / item_attribute_values"
       },
       "ItemOut": {
         "properties": {

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -9793,6 +9793,110 @@
         }
       }
     },
+    "/items/list-rows": {
+      "get": {
+        "tags": [
+          "items-list"
+        ],
+        "summary": "List Item Rows",
+        "operationId": "list_item_rows_items_list_rows_get",
+        "parameters": [
+          {
+            "name": "enabled",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "true=有效商品；false=无效商品；不传=全部",
+              "title": "Enabled"
+            },
+            "description": "true=有效商品；false=无效商品；不传=全部"
+          },
+          {
+            "name": "supplier_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "按供应商过滤",
+              "title": "Supplier Id"
+            },
+            "description": "按供应商过滤"
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "关键词搜索 SKU / 名称 / 规格 / 品牌 / 分类 / 供应商 / 主条码",
+              "title": "Q"
+            },
+            "description": "关键词搜索 SKU / 名称 / 规格 / 品牌 / 分类 / 供应商 / 主条码"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "default": 200,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ItemListRowOut"
+                  },
+                  "title": "Response List Item Rows Items List Rows Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/items": {
       "post": {
         "tags": [
@@ -29297,6 +29401,205 @@
         ],
         "title": "ItemCreate",
         "description": "Create Item（SKU 由调用方显式输入）：\n- 必须传 sku；SKU 编码页只负责生成候选 SKU，最终由商品创建合同写入 items.sku\n- brand/category 不再接受自由文本；请传 brand_id/category_id\n- 不接受 barcode 输入；主条码请走 /item-barcodes\n- 不接受 weight_kg 输入；基础包装净重请走 item_uoms（base uom）\n\nPhase M-3：\n- items.case_ratio/case_uom 已删除；包装单位请走 item_uoms"
+      },
+      "ItemListRowOut": {
+        "properties": {
+          "item_id": {
+            "type": "integer",
+            "title": "Item Id"
+          },
+          "sku": {
+            "type": "string",
+            "title": "Sku"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "spec": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spec"
+          },
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled"
+          },
+          "brand": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Brand"
+          },
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category"
+          },
+          "supplier_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Supplier Name"
+          },
+          "primary_barcode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Primary Barcode"
+          },
+          "base_uom": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Uom"
+          },
+          "base_net_weight_kg": {
+            "anyOf": [
+              {
+                "type": "number",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Net Weight Kg"
+          },
+          "purchase_uom": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Purchase Uom"
+          },
+          "purchase_ratio_to_base": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Purchase Ratio To Base"
+          },
+          "lot_source_policy": {
+            "type": "string",
+            "title": "Lot Source Policy"
+          },
+          "expiry_policy": {
+            "type": "string",
+            "title": "Expiry Policy"
+          },
+          "shelf_life_value": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shelf Life Value"
+          },
+          "shelf_life_unit": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shelf Life Unit"
+          },
+          "uom_count": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Uom Count",
+            "default": 0
+          },
+          "barcode_count": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Barcode Count",
+            "default": 0
+          },
+          "sku_code_count": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Sku Code Count",
+            "default": 0
+          },
+          "attribute_count": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Attribute Count",
+            "default": 0
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "item_id",
+          "sku",
+          "name",
+          "enabled",
+          "lot_source_policy",
+          "expiry_policy"
+        ],
+        "title": "ItemListRowOut",
+        "description": "PMS 商品列表页专用 owner 读模型。\n\n定位：\n- 一行 = 一个商品的完整列表摘要\n- 只服务商品主数据总览页\n- 不承载写入语义\n- 不让前端再自行拼 item_uoms / item_barcodes / item_sku_codes / item_attribute_values"
       },
       "ItemOut": {
         "properties": {

--- a/tests/api/test_pms_items_list_rows_api.py
+++ b/tests/api/test_pms_items_list_rows_api.py
@@ -1,0 +1,101 @@
+# tests/api/test_pms_items_list_rows_api.py
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+
+async def _login_admin_headers(client: httpx.AsyncClient) -> dict[str, str]:
+    r = await client.post("/users/login", json={"username": "admin", "password": "admin123"})
+    assert r.status_code == 200, r.text
+    token = r.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _assert_item_list_row_contract(row: dict[str, Any]) -> None:
+    required = {
+        "item_id",
+        "sku",
+        "name",
+        "spec",
+        "enabled",
+        "brand",
+        "category",
+        "supplier_name",
+        "primary_barcode",
+        "base_uom",
+        "base_net_weight_kg",
+        "purchase_uom",
+        "purchase_ratio_to_base",
+        "lot_source_policy",
+        "expiry_policy",
+        "shelf_life_value",
+        "shelf_life_unit",
+        "uom_count",
+        "barcode_count",
+        "sku_code_count",
+        "attribute_count",
+        "updated_at",
+    }
+    assert required <= set(row.keys()), row
+
+    assert isinstance(row["item_id"], int), row
+    assert isinstance(row["sku"], str) and row["sku"].strip(), row
+    assert isinstance(row["name"], str) and row["name"].strip(), row
+    assert isinstance(row["enabled"], bool), row
+
+    for key in ("uom_count", "barcode_count", "sku_code_count", "attribute_count"):
+        assert isinstance(row[key], int), row
+        assert row[key] >= 0, row
+
+    assert "brand_id" not in row, row
+    assert "category_id" not in row, row
+    assert "supplier_id" not in row, row
+    assert "base_uom_id" not in row, row
+    assert "purchase_uom_id" not in row, row
+
+
+@pytest.mark.asyncio
+async def test_item_list_rows_returns_owner_summary_contract(client: httpx.AsyncClient) -> None:
+    headers = await _login_admin_headers(client)
+
+    r = await client.get("/items/list-rows?limit=20", headers=headers)
+    assert r.status_code == 200, r.text
+
+    rows = r.json()
+    assert isinstance(rows, list), rows
+    assert rows, "base seed should expose at least one item list row"
+
+    _assert_item_list_row_contract(rows[0])
+
+
+@pytest.mark.asyncio
+async def test_item_list_rows_supports_enabled_filter(client: httpx.AsyncClient) -> None:
+    headers = await _login_admin_headers(client)
+
+    r = await client.get("/items/list-rows?enabled=true&limit=50", headers=headers)
+    assert r.status_code == 200, r.text
+
+    rows = r.json()
+    assert isinstance(rows, list), rows
+    assert rows, "base seed should expose enabled item rows"
+    assert all(row["enabled"] is True for row in rows), rows
+
+
+@pytest.mark.asyncio
+async def test_item_list_rows_supports_q_filter(client: httpx.AsyncClient) -> None:
+    headers = await _login_admin_headers(client)
+
+    r = await client.get("/items/list-rows?limit=1", headers=headers)
+    assert r.status_code == 200, r.text
+    rows = r.json()
+    assert rows, rows
+
+    sku = str(rows[0]["sku"])
+    rq = await client.get(f"/items/list-rows?q={sku}&limit=20", headers=headers)
+    assert rq.status_code == 200, rq.text
+
+    q_rows = rq.json()
+    assert any(int(row["item_id"]) == int(rows[0]["item_id"]) for row in q_rows), q_rows


### PR DESCRIPTION
## Summary
- 新增 GET /items/list-rows 商品列表页 owner 读模型
- 后端一次返回商品主数据总览所需单列字段：品牌、分类、供应商、主条码、包装、策略、治理计数
- 不改变 /items 创建、编辑和主合同
- 为前端退役 buildBarcodeMaps 自拼做准备

## Tests
- python3 -m compileall app/pms/items/contracts/item_list.py app/pms/items/repos/item_list_repo.py app/pms/items/services/item_list_service.py app/pms/items/routers/item_list.py app/router_mount.py tests/api/test_pms_items_list_rows_api.py
- make openapi
- make test TESTS="tests/api/test_pms_items_list_rows_api.py tests/api/test_pms_master_data_navigation_api.py tests/api/test_user_navigation_api.py tests/ci/test_pms_item_openapi_contract.py"