### PR TITLE
feat(pms): add item list detail read model

### DIFF
--- a/app/pms/items/contracts/item_list.py
+++ b/app/pms/items/contracts/item_list.py
@@ -47,3 +47,82 @@ class ItemListRowOut(BaseModel):
     attribute_count: int = Field(default=0, ge=0)
 
     updated_at: Optional[datetime] = None
+
+
+class ItemListUomOut(BaseModel):
+    id: int
+    item_id: int
+    uom: str
+    display_name: Optional[str] = None
+    ratio_to_base: int = Field(ge=1)
+    net_weight_kg: Optional[float] = Field(default=None, ge=0)
+    is_base: bool
+    is_purchase_default: bool
+    is_inbound_default: bool
+    is_outbound_default: bool
+    updated_at: Optional[datetime] = None
+
+
+class ItemListBarcodeOut(BaseModel):
+    id: int
+    item_id: int
+    item_uom_id: int
+    uom: Optional[str] = None
+    display_name: Optional[str] = None
+    barcode: str
+    symbology: str
+    active: bool
+    is_primary: bool
+    updated_at: Optional[datetime] = None
+
+
+class ItemListSkuCodeOut(BaseModel):
+    id: int
+    item_id: int
+    code: str
+    code_type: str
+    is_primary: bool
+    is_active: bool
+    effective_from: Optional[datetime] = None
+    effective_to: Optional[datetime] = None
+    remark: Optional[str] = None
+    updated_at: Optional[datetime] = None
+
+
+class ItemListAttributeOut(BaseModel):
+    attribute_def_id: int
+    code: str
+    name_cn: str
+    value_type: str
+    selection_mode: str
+    unit: Optional[str] = None
+    is_item_required: bool
+    is_sku_required: bool
+    is_sku_segment: bool
+    sort_order: int
+
+    value_text: Optional[str] = None
+    value_number: Optional[float] = None
+    value_bool: Optional[bool] = None
+    value_option_id: Optional[int] = None
+    value_option_code_snapshot: Optional[str] = None
+    value_option_name: Optional[str] = None
+    value_unit_snapshot: Optional[str] = None
+    updated_at: Optional[datetime] = None
+
+
+class ItemListDetailOut(BaseModel):
+    """
+    PMS 商品列表详情读模型。
+
+    定位：
+    - 只读展示合同
+    - 给商品列表页“详情展开”使用
+    - row 复用 ItemListRowOut，确保列表摘要与详情头部一致
+    """
+
+    row: ItemListRowOut
+    uoms: list[ItemListUomOut]
+    barcodes: list[ItemListBarcodeOut]
+    sku_codes: list[ItemListSkuCodeOut]
+    attributes: list[ItemListAttributeOut]

--- a/app/pms/items/repos/item_list_repo.py
+++ b/app/pms/items/repos/item_list_repo.py
@@ -7,62 +7,8 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 
-def list_item_list_row_mappings(
-    db: Session,
-    *,
-    enabled: Optional[bool] = None,
-    supplier_id: Optional[int] = None,
-    q: Optional[str] = None,
-    limit: int = 200,
-) -> list[Mapping[str, Any]]:
-    """
-    商品列表页 owner 聚合读。
-
-    真相来源：
-    - items：商品身份、策略、启停
-    - pms_brands / pms_business_categories：品牌分类展示投影
-    - suppliers：供应商展示投影
-    - item_barcodes：主条码与条码数量
-    - item_uoms：基础包装、采购默认包装、净重、包装数量
-    - item_sku_codes：SKU 编码数量
-    - item_attribute_values：属性值数量
-    """
-
-    conditions: list[str] = []
-    params: dict[str, Any] = {
-        "limit": max(1, min(int(limit or 200), 500)),
-    }
-
-    if enabled is not None:
-        conditions.append("i.enabled = :enabled")
-        params["enabled"] = bool(enabled)
-
-    if supplier_id is not None:
-        conditions.append("i.supplier_id = :supplier_id")
-        params["supplier_id"] = int(supplier_id)
-
-    qv = (q or "").strip()
-    if qv:
-        conditions.append(
-            """
-            (
-              lower(i.sku) LIKE :q_like
-              OR lower(i.name) LIKE :q_like
-              OR lower(COALESCE(i.spec, '')) LIKE :q_like
-              OR lower(COALESCE(s.name, '')) LIKE :q_like
-              OR lower(COALESCE(br.name_cn, '')) LIKE :q_like
-              OR lower(COALESCE(cat.category_name, '')) LIKE :q_like
-              OR lower(COALESCE(pb.barcode, '')) LIKE :q_like
-            )
-            """
-        )
-        params["q_like"] = f"%{qv.lower()}%"
-
-    where_sql = ""
-    if conditions:
-        where_sql = "WHERE " + " AND ".join(conditions)
-
-    sql = f"""
+def _item_list_rows_sql(where_sql: str) -> str:
+    return f"""
     WITH base_uom AS (
       SELECT DISTINCT ON (u.item_id)
         u.item_id,
@@ -168,5 +114,245 @@ def list_item_list_row_mappings(
     LIMIT :limit
     """
 
-    rows = db.execute(text(sql), params).mappings().all()
+
+def list_item_list_row_mappings(
+    db: Session,
+    *,
+    enabled: Optional[bool] = None,
+    supplier_id: Optional[int] = None,
+    q: Optional[str] = None,
+    limit: int = 200,
+) -> list[Mapping[str, Any]]:
+    """
+    商品列表页 owner 聚合读。
+
+    真相来源：
+    - items：商品身份、策略、启停
+    - pms_brands / pms_business_categories：品牌分类展示投影
+    - suppliers：供应商展示投影
+    - item_barcodes：主条码与条码数量
+    - item_uoms：基础包装、采购默认包装、净重、包装数量
+    - item_sku_codes：SKU 编码数量
+    - item_attribute_values：属性值数量
+    """
+
+    conditions: list[str] = []
+    params: dict[str, Any] = {
+        "limit": max(1, min(int(limit or 200), 500)),
+    }
+
+    if enabled is not None:
+        conditions.append("i.enabled = :enabled")
+        params["enabled"] = bool(enabled)
+
+    if supplier_id is not None:
+        conditions.append("i.supplier_id = :supplier_id")
+        params["supplier_id"] = int(supplier_id)
+
+    qv = (q or "").strip()
+    if qv:
+        conditions.append(
+            """
+            (
+              lower(i.sku) LIKE :q_like
+              OR lower(i.name) LIKE :q_like
+              OR lower(COALESCE(i.spec, '')) LIKE :q_like
+              OR lower(COALESCE(s.name, '')) LIKE :q_like
+              OR lower(COALESCE(br.name_cn, '')) LIKE :q_like
+              OR lower(COALESCE(cat.category_name, '')) LIKE :q_like
+              OR lower(COALESCE(pb.barcode, '')) LIKE :q_like
+            )
+            """
+        )
+        params["q_like"] = f"%{qv.lower()}%"
+
+    where_sql = ""
+    if conditions:
+        where_sql = "WHERE " + " AND ".join(conditions)
+
+    rows = db.execute(text(_item_list_rows_sql(where_sql)), params).mappings().all()
+    return list(rows)
+
+
+def get_item_list_row_mapping(
+    db: Session,
+    *,
+    item_id: int,
+) -> Mapping[str, Any] | None:
+    params: dict[str, Any] = {
+        "item_id": int(item_id),
+        "limit": 1,
+    }
+    rows = (
+        db.execute(
+            text(_item_list_rows_sql("WHERE i.id = :item_id")),
+            params,
+        )
+        .mappings()
+        .all()
+    )
+    return rows[0] if rows else None
+
+
+def list_item_list_uom_mappings(
+    db: Session,
+    *,
+    item_id: int,
+) -> list[Mapping[str, Any]]:
+    rows = (
+        db.execute(
+            text(
+                """
+                SELECT
+                  u.id::int AS id,
+                  u.item_id::int AS item_id,
+                  u.uom,
+                  u.display_name,
+                  u.ratio_to_base::int AS ratio_to_base,
+                  u.net_weight_kg,
+                  u.is_base,
+                  u.is_purchase_default,
+                  u.is_inbound_default,
+                  u.is_outbound_default,
+                  u.updated_at
+                FROM item_uoms u
+                WHERE u.item_id = :item_id
+                ORDER BY
+                  u.is_base DESC,
+                  u.is_purchase_default DESC,
+                  u.is_inbound_default DESC,
+                  u.is_outbound_default DESC,
+                  u.ratio_to_base ASC,
+                  u.id ASC
+                """
+            ),
+            {"item_id": int(item_id)},
+        )
+        .mappings()
+        .all()
+    )
+    return list(rows)
+
+
+def list_item_list_barcode_mappings(
+    db: Session,
+    *,
+    item_id: int,
+) -> list[Mapping[str, Any]]:
+    rows = (
+        db.execute(
+            text(
+                """
+                SELECT
+                  b.id::int AS id,
+                  b.item_id::int AS item_id,
+                  b.item_uom_id::int AS item_uom_id,
+                  u.uom,
+                  u.display_name,
+                  b.barcode,
+                  b.symbology,
+                  b.active,
+                  b.is_primary,
+                  b.updated_at
+                FROM item_barcodes b
+                LEFT JOIN item_uoms u
+                  ON u.id = b.item_uom_id
+                 AND u.item_id = b.item_id
+                WHERE b.item_id = :item_id
+                ORDER BY
+                  b.is_primary DESC,
+                  b.active DESC,
+                  u.ratio_to_base ASC NULLS LAST,
+                  b.id ASC
+                """
+            ),
+            {"item_id": int(item_id)},
+        )
+        .mappings()
+        .all()
+    )
+    return list(rows)
+
+
+def list_item_list_sku_code_mappings(
+    db: Session,
+    *,
+    item_id: int,
+) -> list[Mapping[str, Any]]:
+    rows = (
+        db.execute(
+            text(
+                """
+                SELECT
+                  c.id::int AS id,
+                  c.item_id::int AS item_id,
+                  c.code,
+                  c.code_type,
+                  c.is_primary,
+                  c.is_active,
+                  c.effective_from,
+                  c.effective_to,
+                  c.remark,
+                  c.updated_at
+                FROM item_sku_codes c
+                WHERE c.item_id = :item_id
+                ORDER BY
+                  c.is_primary DESC,
+                  c.is_active DESC,
+                  c.id ASC
+                """
+            ),
+            {"item_id": int(item_id)},
+        )
+        .mappings()
+        .all()
+    )
+    return list(rows)
+
+
+def list_item_list_attribute_mappings(
+    db: Session,
+    *,
+    item_id: int,
+) -> list[Mapping[str, Any]]:
+    rows = (
+        db.execute(
+            text(
+                """
+                SELECT
+                  d.id::int AS attribute_def_id,
+                  d.code,
+                  d.name_cn,
+                  d.value_type,
+                  d.selection_mode,
+                  d.unit,
+                  d.is_item_required,
+                  d.is_sku_required,
+                  d.is_sku_segment,
+                  d.sort_order::int AS sort_order,
+
+                  v.value_text,
+                  v.value_number::float8 AS value_number,
+                  v.value_bool,
+                  v.value_option_id::int AS value_option_id,
+                  v.value_option_code_snapshot,
+                  o.option_name AS value_option_name,
+                  v.value_unit_snapshot,
+                  v.updated_at
+                FROM item_attribute_values v
+                JOIN item_attribute_defs d
+                  ON d.id = v.attribute_def_id
+                LEFT JOIN item_attribute_options o
+                  ON o.id = v.value_option_id
+                WHERE v.item_id = :item_id
+                ORDER BY
+                  d.sort_order ASC,
+                  d.id ASC
+                """
+            ),
+            {"item_id": int(item_id)},
+        )
+        .mappings()
+        .all()
+    )
     return list(rows)

--- a/app/pms/items/routers/item_list.py
+++ b/app/pms/items/routers/item_list.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from app.db.deps import get_db
-from app.pms.items.contracts.item_list import ItemListRowOut
+from app.pms.items.contracts.item_list import ItemListDetailOut, ItemListRowOut
 from app.pms.items.services.item_list_service import ItemListReadService
 
 router = APIRouter(prefix="/items", tags=["items-list"])
@@ -31,3 +31,14 @@ def list_item_rows(
         q=q,
         limit=limit,
     )
+
+
+@router.get("/{item_id}/list-detail", response_model=ItemListDetailOut)
+def get_item_list_detail(
+    item_id: int,
+    service: ItemListReadService = Depends(get_item_list_read_service),
+) -> ItemListDetailOut:
+    detail = service.get_detail(item_id=int(item_id))
+    if detail is None:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return detail

--- a/app/pms/items/services/item_list_service.py
+++ b/app/pms/items/services/item_list_service.py
@@ -5,15 +5,29 @@ from typing import Optional
 
 from sqlalchemy.orm import Session
 
-from app.pms.items.contracts.item_list import ItemListRowOut
-from app.pms.items.repos.item_list_repo import list_item_list_row_mappings
+from app.pms.items.contracts.item_list import (
+    ItemListAttributeOut,
+    ItemListBarcodeOut,
+    ItemListDetailOut,
+    ItemListRowOut,
+    ItemListSkuCodeOut,
+    ItemListUomOut,
+)
+from app.pms.items.repos.item_list_repo import (
+    get_item_list_row_mapping,
+    list_item_list_attribute_mappings,
+    list_item_list_barcode_mappings,
+    list_item_list_row_mappings,
+    list_item_list_sku_code_mappings,
+    list_item_list_uom_mappings,
+)
 
 
 class ItemListReadService:
     """
     PMS 商品列表页 owner 读服务。
 
-    只负责商品列表页的完整摘要行，不承载写入语义。
+    只负责商品列表页的摘要行与详情展开，不承载写入语义。
     """
 
     def __init__(self, db: Session) -> None:
@@ -35,3 +49,21 @@ class ItemListReadService:
             limit=limit,
         )
         return [ItemListRowOut.model_validate(dict(row)) for row in rows]
+
+    def get_detail(self, *, item_id: int) -> ItemListDetailOut | None:
+        row = get_item_list_row_mapping(self.db, item_id=int(item_id))
+        if row is None:
+            return None
+
+        uoms = list_item_list_uom_mappings(self.db, item_id=int(item_id))
+        barcodes = list_item_list_barcode_mappings(self.db, item_id=int(item_id))
+        sku_codes = list_item_list_sku_code_mappings(self.db, item_id=int(item_id))
+        attributes = list_item_list_attribute_mappings(self.db, item_id=int(item_id))
+
+        return ItemListDetailOut(
+            row=ItemListRowOut.model_validate(dict(row)),
+            uoms=[ItemListUomOut.model_validate(dict(x)) for x in uoms],
+            barcodes=[ItemListBarcodeOut.model_validate(dict(x)) for x in barcodes],
+            sku_codes=[ItemListSkuCodeOut.model_validate(dict(x)) for x in sku_codes],
+            attributes=[ItemListAttributeOut.model_validate(dict(x)) for x in attributes],
+        )

--- a/openapi/_current.json
+++ b/openapi/_current.json
@@ -9897,6 +9897,48 @@
         }
       }
     },
+    "/items/{item_id}/list-detail": {
+      "get": {
+        "tags": [
+          "items-list"
+        ],
+        "summary": "Get Item List Detail",
+        "operationId": "get_item_list_detail_items__item_id__list_detail_get",
+        "parameters": [
+          {
+            "name": "item_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Item Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemListDetailOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/items": {
       "post": {
         "tags": [
@@ -29402,6 +29444,281 @@
         "title": "ItemCreate",
         "description": "Create Item（SKU 由调用方显式输入）：\n- 必须传 sku；SKU 编码页只负责生成候选 SKU，最终由商品创建合同写入 items.sku\n- brand/category 不再接受自由文本；请传 brand_id/category_id\n- 不接受 barcode 输入；主条码请走 /item-barcodes\n- 不接受 weight_kg 输入；基础包装净重请走 item_uoms（base uom）\n\nPhase M-3：\n- items.case_ratio/case_uom 已删除；包装单位请走 item_uoms"
       },
+      "ItemListAttributeOut": {
+        "properties": {
+          "attribute_def_id": {
+            "type": "integer",
+            "title": "Attribute Def Id"
+          },
+          "code": {
+            "type": "string",
+            "title": "Code"
+          },
+          "name_cn": {
+            "type": "string",
+            "title": "Name Cn"
+          },
+          "value_type": {
+            "type": "string",
+            "title": "Value Type"
+          },
+          "selection_mode": {
+            "type": "string",
+            "title": "Selection Mode"
+          },
+          "unit": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit"
+          },
+          "is_item_required": {
+            "type": "boolean",
+            "title": "Is Item Required"
+          },
+          "is_sku_required": {
+            "type": "boolean",
+            "title": "Is Sku Required"
+          },
+          "is_sku_segment": {
+            "type": "boolean",
+            "title": "Is Sku Segment"
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order"
+          },
+          "value_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value Text"
+          },
+          "value_number": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value Number"
+          },
+          "value_bool": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value Bool"
+          },
+          "value_option_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value Option Id"
+          },
+          "value_option_code_snapshot": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value Option Code Snapshot"
+          },
+          "value_option_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value Option Name"
+          },
+          "value_unit_snapshot": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value Unit Snapshot"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "attribute_def_id",
+          "code",
+          "name_cn",
+          "value_type",
+          "selection_mode",
+          "is_item_required",
+          "is_sku_required",
+          "is_sku_segment",
+          "sort_order"
+        ],
+        "title": "ItemListAttributeOut"
+      },
+      "ItemListBarcodeOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "item_id": {
+            "type": "integer",
+            "title": "Item Id"
+          },
+          "item_uom_id": {
+            "type": "integer",
+            "title": "Item Uom Id"
+          },
+          "uom": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uom"
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "barcode": {
+            "type": "string",
+            "title": "Barcode"
+          },
+          "symbology": {
+            "type": "string",
+            "title": "Symbology"
+          },
+          "active": {
+            "type": "boolean",
+            "title": "Active"
+          },
+          "is_primary": {
+            "type": "boolean",
+            "title": "Is Primary"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "item_id",
+          "item_uom_id",
+          "barcode",
+          "symbology",
+          "active",
+          "is_primary"
+        ],
+        "title": "ItemListBarcodeOut"
+      },
+      "ItemListDetailOut": {
+        "properties": {
+          "row": {
+            "$ref": "#/components/schemas/ItemListRowOut"
+          },
+          "uoms": {
+            "items": {
+              "$ref": "#/components/schemas/ItemListUomOut"
+            },
+            "type": "array",
+            "title": "Uoms"
+          },
+          "barcodes": {
+            "items": {
+              "$ref": "#/components/schemas/ItemListBarcodeOut"
+            },
+            "type": "array",
+            "title": "Barcodes"
+          },
+          "sku_codes": {
+            "items": {
+              "$ref": "#/components/schemas/ItemListSkuCodeOut"
+            },
+            "type": "array",
+            "title": "Sku Codes"
+          },
+          "attributes": {
+            "items": {
+              "$ref": "#/components/schemas/ItemListAttributeOut"
+            },
+            "type": "array",
+            "title": "Attributes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "row",
+          "uoms",
+          "barcodes",
+          "sku_codes",
+          "attributes"
+        ],
+        "title": "ItemListDetailOut",
+        "description": "PMS 商品列表详情读模型。\n\n定位：\n- 只读展示合同\n- 给商品列表页“详情展开”使用\n- row 复用 ItemListRowOut，确保列表摘要与详情头部一致"
+      },
       "ItemListRowOut": {
         "properties": {
           "item_id": {
@@ -29600,6 +29917,175 @@
         ],
         "title": "ItemListRowOut",
         "description": "PMS 商品列表页专用 owner 读模型。\n\n定位：\n- 一行 = 一个商品的完整列表摘要\n- 只服务商品主数据总览页\n- 不承载写入语义\n- 不让前端再自行拼 item_uoms / item_barcodes / item_sku_codes / item_attribute_values"
+      },
+      "ItemListSkuCodeOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "item_id": {
+            "type": "integer",
+            "title": "Item Id"
+          },
+          "code": {
+            "type": "string",
+            "title": "Code"
+          },
+          "code_type": {
+            "type": "string",
+            "title": "Code Type"
+          },
+          "is_primary": {
+            "type": "boolean",
+            "title": "Is Primary"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "effective_from": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Effective From"
+          },
+          "effective_to": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Effective To"
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "item_id",
+          "code",
+          "code_type",
+          "is_primary",
+          "is_active"
+        ],
+        "title": "ItemListSkuCodeOut"
+      },
+      "ItemListUomOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "item_id": {
+            "type": "integer",
+            "title": "Item Id"
+          },
+          "uom": {
+            "type": "string",
+            "title": "Uom"
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "ratio_to_base": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Ratio To Base"
+          },
+          "net_weight_kg": {
+            "anyOf": [
+              {
+                "type": "number",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Net Weight Kg"
+          },
+          "is_base": {
+            "type": "boolean",
+            "title": "Is Base"
+          },
+          "is_purchase_default": {
+            "type": "boolean",
+            "title": "Is Purchase Default"
+          },
+          "is_inbound_default": {
+            "type": "boolean",
+            "title": "Is Inbound Default"
+          },
+          "is_outbound_default": {
+            "type": "boolean",
+            "title": "Is Outbound Default"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "item_id",
+          "uom",
+          "ratio_to_base",
+          "is_base",
+          "is_purchase_default",
+          "is_inbound_default",
+          "is_outbound_default"
+        ],
+        "title": "ItemListUomOut"
       },
       "ItemOut": {
         "properties": {

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -9897,6 +9897,48 @@
         }
       }
     },
+    "/items/{item_id}/list-detail": {
+      "get": {
+        "tags": [
+          "items-list"
+        ],
+        "summary": "Get Item List Detail",
+        "operationId": "get_item_list_detail_items__item_id__list_detail_get",
+        "parameters": [
+          {
+            "name": "item_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Item Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemListDetailOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/items": {
       "post": {
         "tags": [
@@ -29402,6 +29444,281 @@
         "title": "ItemCreate",
         "description": "Create Item（SKU 由调用方显式输入）：\n- 必须传 sku；SKU 编码页只负责生成候选 SKU，最终由商品创建合同写入 items.sku\n- brand/category 不再接受自由文本；请传 brand_id/category_id\n- 不接受 barcode 输入；主条码请走 /item-barcodes\n- 不接受 weight_kg 输入；基础包装净重请走 item_uoms（base uom）\n\nPhase M-3：\n- items.case_ratio/case_uom 已删除；包装单位请走 item_uoms"
       },
+      "ItemListAttributeOut": {
+        "properties": {
+          "attribute_def_id": {
+            "type": "integer",
+            "title": "Attribute Def Id"
+          },
+          "code": {
+            "type": "string",
+            "title": "Code"
+          },
+          "name_cn": {
+            "type": "string",
+            "title": "Name Cn"
+          },
+          "value_type": {
+            "type": "string",
+            "title": "Value Type"
+          },
+          "selection_mode": {
+            "type": "string",
+            "title": "Selection Mode"
+          },
+          "unit": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit"
+          },
+          "is_item_required": {
+            "type": "boolean",
+            "title": "Is Item Required"
+          },
+          "is_sku_required": {
+            "type": "boolean",
+            "title": "Is Sku Required"
+          },
+          "is_sku_segment": {
+            "type": "boolean",
+            "title": "Is Sku Segment"
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order"
+          },
+          "value_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value Text"
+          },
+          "value_number": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value Number"
+          },
+          "value_bool": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value Bool"
+          },
+          "value_option_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value Option Id"
+          },
+          "value_option_code_snapshot": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value Option Code Snapshot"
+          },
+          "value_option_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value Option Name"
+          },
+          "value_unit_snapshot": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value Unit Snapshot"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "attribute_def_id",
+          "code",
+          "name_cn",
+          "value_type",
+          "selection_mode",
+          "is_item_required",
+          "is_sku_required",
+          "is_sku_segment",
+          "sort_order"
+        ],
+        "title": "ItemListAttributeOut"
+      },
+      "ItemListBarcodeOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "item_id": {
+            "type": "integer",
+            "title": "Item Id"
+          },
+          "item_uom_id": {
+            "type": "integer",
+            "title": "Item Uom Id"
+          },
+          "uom": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uom"
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "barcode": {
+            "type": "string",
+            "title": "Barcode"
+          },
+          "symbology": {
+            "type": "string",
+            "title": "Symbology"
+          },
+          "active": {
+            "type": "boolean",
+            "title": "Active"
+          },
+          "is_primary": {
+            "type": "boolean",
+            "title": "Is Primary"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "item_id",
+          "item_uom_id",
+          "barcode",
+          "symbology",
+          "active",
+          "is_primary"
+        ],
+        "title": "ItemListBarcodeOut"
+      },
+      "ItemListDetailOut": {
+        "properties": {
+          "row": {
+            "$ref": "#/components/schemas/ItemListRowOut"
+          },
+          "uoms": {
+            "items": {
+              "$ref": "#/components/schemas/ItemListUomOut"
+            },
+            "type": "array",
+            "title": "Uoms"
+          },
+          "barcodes": {
+            "items": {
+              "$ref": "#/components/schemas/ItemListBarcodeOut"
+            },
+            "type": "array",
+            "title": "Barcodes"
+          },
+          "sku_codes": {
+            "items": {
+              "$ref": "#/components/schemas/ItemListSkuCodeOut"
+            },
+            "type": "array",
+            "title": "Sku Codes"
+          },
+          "attributes": {
+            "items": {
+              "$ref": "#/components/schemas/ItemListAttributeOut"
+            },
+            "type": "array",
+            "title": "Attributes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "row",
+          "uoms",
+          "barcodes",
+          "sku_codes",
+          "attributes"
+        ],
+        "title": "ItemListDetailOut",
+        "description": "PMS 商品列表详情读模型。\n\n定位：\n- 只读展示合同\n- 给商品列表页“详情展开”使用\n- row 复用 ItemListRowOut，确保列表摘要与详情头部一致"
+      },
       "ItemListRowOut": {
         "properties": {
           "item_id": {
@@ -29600,6 +29917,175 @@
         ],
         "title": "ItemListRowOut",
         "description": "PMS 商品列表页专用 owner 读模型。\n\n定位：\n- 一行 = 一个商品的完整列表摘要\n- 只服务商品主数据总览页\n- 不承载写入语义\n- 不让前端再自行拼 item_uoms / item_barcodes / item_sku_codes / item_attribute_values"
+      },
+      "ItemListSkuCodeOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "item_id": {
+            "type": "integer",
+            "title": "Item Id"
+          },
+          "code": {
+            "type": "string",
+            "title": "Code"
+          },
+          "code_type": {
+            "type": "string",
+            "title": "Code Type"
+          },
+          "is_primary": {
+            "type": "boolean",
+            "title": "Is Primary"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "effective_from": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Effective From"
+          },
+          "effective_to": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Effective To"
+          },
+          "remark": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remark"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "item_id",
+          "code",
+          "code_type",
+          "is_primary",
+          "is_active"
+        ],
+        "title": "ItemListSkuCodeOut"
+      },
+      "ItemListUomOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "item_id": {
+            "type": "integer",
+            "title": "Item Id"
+          },
+          "uom": {
+            "type": "string",
+            "title": "Uom"
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "ratio_to_base": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Ratio To Base"
+          },
+          "net_weight_kg": {
+            "anyOf": [
+              {
+                "type": "number",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Net Weight Kg"
+          },
+          "is_base": {
+            "type": "boolean",
+            "title": "Is Base"
+          },
+          "is_purchase_default": {
+            "type": "boolean",
+            "title": "Is Purchase Default"
+          },
+          "is_inbound_default": {
+            "type": "boolean",
+            "title": "Is Inbound Default"
+          },
+          "is_outbound_default": {
+            "type": "boolean",
+            "title": "Is Outbound Default"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "item_id",
+          "uom",
+          "ratio_to_base",
+          "is_base",
+          "is_purchase_default",
+          "is_inbound_default",
+          "is_outbound_default"
+        ],
+        "title": "ItemListUomOut"
       },
       "ItemOut": {
         "properties": {

--- a/tests/api/test_pms_items_list_rows_api.py
+++ b/tests/api/test_pms_items_list_rows_api.py
@@ -57,6 +57,92 @@ def _assert_item_list_row_contract(row: dict[str, Any]) -> None:
     assert "purchase_uom_id" not in row, row
 
 
+def _assert_detail_contract(data: dict[str, Any]) -> None:
+    assert set(data.keys()) == {"row", "uoms", "barcodes", "sku_codes", "attributes"}, data
+
+    row = data["row"]
+    assert isinstance(row, dict), data
+    _assert_item_list_row_contract(row)
+
+    for key in ("uoms", "barcodes", "sku_codes", "attributes"):
+        assert isinstance(data[key], list), data
+
+    for uom in data["uoms"]:
+        assert {
+            "id",
+            "item_id",
+            "uom",
+            "display_name",
+            "ratio_to_base",
+            "net_weight_kg",
+            "is_base",
+            "is_purchase_default",
+            "is_inbound_default",
+            "is_outbound_default",
+            "updated_at",
+        } <= set(uom.keys()), uom
+        assert int(uom["item_id"]) == int(row["item_id"]), uom
+        assert isinstance(uom["uom"], str) and uom["uom"].strip(), uom
+        assert isinstance(uom["ratio_to_base"], int) and uom["ratio_to_base"] >= 1, uom
+
+    for barcode in data["barcodes"]:
+        assert {
+            "id",
+            "item_id",
+            "item_uom_id",
+            "uom",
+            "display_name",
+            "barcode",
+            "symbology",
+            "active",
+            "is_primary",
+            "updated_at",
+        } <= set(barcode.keys()), barcode
+        assert int(barcode["item_id"]) == int(row["item_id"]), barcode
+        assert isinstance(barcode["barcode"], str) and barcode["barcode"].strip(), barcode
+
+    for code in data["sku_codes"]:
+        assert {
+            "id",
+            "item_id",
+            "code",
+            "code_type",
+            "is_primary",
+            "is_active",
+            "effective_from",
+            "effective_to",
+            "remark",
+            "updated_at",
+        } <= set(code.keys()), code
+        assert int(code["item_id"]) == int(row["item_id"]), code
+        assert isinstance(code["code"], str) and code["code"].strip(), code
+
+    for attr in data["attributes"]:
+        assert {
+            "attribute_def_id",
+            "code",
+            "name_cn",
+            "value_type",
+            "selection_mode",
+            "unit",
+            "is_item_required",
+            "is_sku_required",
+            "is_sku_segment",
+            "sort_order",
+            "value_text",
+            "value_number",
+            "value_bool",
+            "value_option_id",
+            "value_option_code_snapshot",
+            "value_option_name",
+            "value_unit_snapshot",
+            "updated_at",
+        } <= set(attr.keys()), attr
+        assert isinstance(attr["attribute_def_id"], int), attr
+        assert isinstance(attr["code"], str) and attr["code"].strip(), attr
+        assert isinstance(attr["name_cn"], str) and attr["name_cn"].strip(), attr
+
+
 @pytest.mark.asyncio
 async def test_item_list_rows_returns_owner_summary_contract(client: httpx.AsyncClient) -> None:
     headers = await _login_admin_headers(client)
@@ -99,3 +185,33 @@ async def test_item_list_rows_supports_q_filter(client: httpx.AsyncClient) -> No
 
     q_rows = rq.json()
     assert any(int(row["item_id"]) == int(rows[0]["item_id"]) for row in q_rows), q_rows
+
+
+@pytest.mark.asyncio
+async def test_item_list_detail_returns_owner_detail_contract(client: httpx.AsyncClient) -> None:
+    headers = await _login_admin_headers(client)
+
+    r = await client.get("/items/list-rows?limit=50", headers=headers)
+    assert r.status_code == 200, r.text
+    rows = r.json()
+    assert rows, rows
+
+    picked = next((row for row in rows if int(row["uom_count"]) > 0), rows[0])
+    item_id = int(picked["item_id"])
+
+    detail_resp = await client.get(f"/items/{item_id}/list-detail", headers=headers)
+    assert detail_resp.status_code == 200, detail_resp.text
+
+    detail = detail_resp.json()
+    _assert_detail_contract(detail)
+
+    assert int(detail["row"]["item_id"]) == item_id
+    assert detail["row"]["sku"] == picked["sku"]
+
+
+@pytest.mark.asyncio
+async def test_item_list_detail_returns_404_for_missing_item(client: httpx.AsyncClient) -> None:
+    headers = await _login_admin_headers(client)
+
+    r = await client.get("/items/999999999/list-detail", headers=headers)
+    assert r.status_code == 404, r.text


### PR DESCRIPTION
## Summary
- 新增 GET /items/{item_id}/list-detail 商品列表详情读模型
- 详情一次返回 row、包装单位、条码、SKU 编码、属性值
- 复用 ItemListRowOut，确保列表摘要与详情头部一致
- 不改变 /items 创建、编辑和主合同

## Tests
- python3 -m compileall app/pms/items/contracts/item_list.py app/pms/items/repos/item_list_repo.py app/pms/items/services/item_list_service.py app/pms/items/routers/item_list.py tests/api/test_pms_items_list_rows_api.py
- make openapi
- make test TESTS="tests/api/test_pms_items_list_rows_api.py tests/api/test_pms_master_data_navigation_api.py tests/api/test_user_navigation_api.py tests/ci/test_pms_item_openapi_contract.py"