### PR TITLE
feat(pms): support multi option item attributes

### DIFF
--- a/alembic/versions/efbbba76f264_support_multi_option_item_attributes.py
+++ b/alembic/versions/efbbba76f264_support_multi_option_item_attributes.py
@@ -1,0 +1,63 @@
+"""support multi option item attributes
+
+Revision ID: efbbba76f264
+Revises: 13fcf267f60e
+Create Date: 2026-04-30
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "efbbba76f264"
+down_revision: Union[str, Sequence[str], None] = "13fcf267f60e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Allow OPTION item attributes to store multiple selected options."""
+
+    op.drop_constraint(
+        "uq_item_attribute_values_item_def",
+        "item_attribute_values",
+        type_="unique",
+    )
+
+    op.create_index(
+        "uq_item_attribute_values_item_def_scalar",
+        "item_attribute_values",
+        ["item_id", "attribute_def_id"],
+        unique=True,
+        postgresql_where="value_option_id IS NULL",
+    )
+
+    op.create_index(
+        "uq_item_attribute_values_item_def_option",
+        "item_attribute_values",
+        ["item_id", "attribute_def_id", "value_option_id"],
+        unique=True,
+        postgresql_where="value_option_id IS NOT NULL",
+    )
+
+
+def downgrade() -> None:
+    """Restore one row per item + attribute definition."""
+
+    op.drop_index(
+        "uq_item_attribute_values_item_def_option",
+        table_name="item_attribute_values",
+    )
+    op.drop_index(
+        "uq_item_attribute_values_item_def_scalar",
+        table_name="item_attribute_values",
+    )
+
+    op.create_unique_constraint(
+        "uq_item_attribute_values_item_def",
+        "item_attribute_values",
+        ["item_id", "attribute_def_id"],
+    )

--- a/app/pms/items/contracts/item_list.py
+++ b/app/pms/items/contracts/item_list.py
@@ -104,9 +104,9 @@ class ItemListAttributeOut(BaseModel):
     value_text: Optional[str] = None
     value_number: Optional[float] = None
     value_bool: Optional[bool] = None
-    value_option_id: Optional[int] = None
-    value_option_code_snapshot: Optional[str] = None
-    value_option_name: Optional[str] = None
+    value_option_ids: list[int] = Field(default_factory=list)
+    value_option_code_snapshots: list[str] = Field(default_factory=list)
+    value_option_names: list[str] = Field(default_factory=list)
     value_unit_snapshot: Optional[str] = None
     updated_at: Optional[datetime] = None
 

--- a/app/pms/items/contracts/item_master.py
+++ b/app/pms/items/contracts/item_master.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from datetime import datetime
-from decimal import Decimal
 from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -242,35 +241,38 @@ class ItemAttributeOptionOut(_Base):
 class ItemAttributeValueIn(_Base):
     attribute_def_id: Annotated[int, Field(ge=1)]
     value_text: str | None = None
-    value_number: Decimal | None = None
+    value_number: float | None = None
     value_bool: bool | None = None
-    value_option_id: int | None = None
+    value_option_ids: list[Annotated[int, Field(ge=1)]] | None = None
 
     @model_validator(mode="after")
     def _one_value(self) -> "ItemAttributeValueIn":
-        filled = [
-            self.value_text is not None and str(self.value_text).strip() != "",
+        option_ids = self.value_option_ids or []
+        flags = [
+            self.value_text is not None,
             self.value_number is not None,
             self.value_bool is not None,
-            self.value_option_id is not None,
+            len(option_ids) > 0,
         ]
-        if sum(1 for x in filled if x) > 1:
-            raise ValueError("每个属性值只能提交一种 value_*")
+        if sum(1 for x in flags if x) != 1:
+            raise ValueError("必须且只能提交一种属性值")
+        if len(option_ids) != len(set(option_ids)):
+            raise ValueError("value_option_ids 不能重复")
         return self
 
 
 class ItemAttributeValueOut(_Base):
-    id: int
+    id: int | None = None
     item_id: int
     attribute_def_id: int
     value_text: str | None = None
-    value_number: Decimal | None = None
+    value_number: float | None = None
     value_bool: bool | None = None
-    value_option_id: int | None = None
-    value_option_code_snapshot: str | None = None
+    value_option_ids: list[int] = Field(default_factory=list)
+    value_option_code_snapshots: list[str] = Field(default_factory=list)
     value_unit_snapshot: str | None = None
-    created_at: datetime | None = None
-    updated_at: datetime | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
 
 
 class ItemAttributeValuesReplaceIn(_Base):

--- a/app/pms/items/models/item_master.py
+++ b/app/pms/items/models/item_master.py
@@ -206,7 +206,21 @@ class ItemAttributeValue(Base):
     option: Mapped[ItemAttributeOption | None] = relationship("ItemAttributeOption", lazy="joined")
 
     __table_args__ = (
-        sa.UniqueConstraint("item_id", "attribute_def_id", name="uq_item_attribute_values_item_def"),
+        sa.Index(
+            "uq_item_attribute_values_item_def_scalar",
+            "item_id",
+            "attribute_def_id",
+            unique=True,
+            postgresql_where=sa.text("value_option_id IS NULL"),
+        ),
+        sa.Index(
+            "uq_item_attribute_values_item_def_option",
+            "item_id",
+            "attribute_def_id",
+            "value_option_id",
+            unique=True,
+            postgresql_where=sa.text("value_option_id IS NOT NULL"),
+        ),
         sa.Index("ix_item_attribute_values_item_id", "item_id"),
         sa.Index("ix_item_attribute_values_def_id", "attribute_def_id"),
     )

--- a/app/pms/items/repos/item_list_repo.py
+++ b/app/pms/items/repos/item_list_repo.py
@@ -331,20 +331,42 @@ def list_item_list_attribute_mappings(
                   d.is_sku_segment,
                   d.sort_order::int AS sort_order,
 
-                  v.value_text,
-                  v.value_number::float8 AS value_number,
-                  v.value_bool,
-                  v.value_option_id::int AS value_option_id,
-                  v.value_option_code_snapshot,
-                  o.option_name AS value_option_name,
-                  v.value_unit_snapshot,
-                  v.updated_at
+                  MAX(v.value_text) AS value_text,
+                  MAX(v.value_number)::float8 AS value_number,
+                  BOOL_OR(v.value_bool) FILTER (WHERE v.value_bool IS NOT NULL) AS value_bool,
+
+                  COALESCE(
+                    ARRAY_REMOVE(ARRAY_AGG(v.value_option_id::int ORDER BY o.sort_order, o.id), NULL),
+                    ARRAY[]::int[]
+                  ) AS value_option_ids,
+                  COALESCE(
+                    ARRAY_REMOVE(ARRAY_AGG(v.value_option_code_snapshot ORDER BY o.sort_order, o.id), NULL),
+                    ARRAY[]::varchar[]
+                  ) AS value_option_code_snapshots,
+                  COALESCE(
+                    ARRAY_REMOVE(ARRAY_AGG(o.option_name ORDER BY o.sort_order, o.id), NULL),
+                    ARRAY[]::varchar[]
+                  ) AS value_option_names,
+
+                  MAX(v.value_unit_snapshot) AS value_unit_snapshot,
+                  MAX(v.updated_at) AS updated_at
                 FROM item_attribute_values v
                 JOIN item_attribute_defs d
                   ON d.id = v.attribute_def_id
                 LEFT JOIN item_attribute_options o
                   ON o.id = v.value_option_id
                 WHERE v.item_id = :item_id
+                GROUP BY
+                  d.id,
+                  d.code,
+                  d.name_cn,
+                  d.value_type,
+                  d.selection_mode,
+                  d.unit,
+                  d.is_item_required,
+                  d.is_sku_required,
+                  d.is_sku_segment,
+                  d.sort_order
                 ORDER BY
                   d.sort_order ASC,
                   d.id ASC

--- a/app/pms/items/routers/item_master.py
+++ b/app/pms/items/routers/item_master.py
@@ -459,17 +459,53 @@ def disable_item_attribute_option(option_id: int, db: Session = Depends(get_db))
     return obj
 
 
+def _list_item_attribute_value_out(db: Session, item_id: int) -> list[ItemAttributeValueOut]:
+    rows = (
+        db.execute(
+            select(ItemAttributeValue)
+            .where(ItemAttributeValue.item_id == int(item_id))
+            .order_by(
+                ItemAttributeValue.attribute_def_id.asc(),
+                ItemAttributeValue.value_option_id.asc().nullsfirst(),
+                ItemAttributeValue.id.asc(),
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    grouped: dict[int, dict] = {}
+
+    for row in rows:
+        key = int(row.attribute_def_id)
+        current = grouped.get(key)
+        if current is None:
+            current = {
+                "id": int(row.id),
+                "item_id": int(row.item_id),
+                "attribute_def_id": key,
+                "value_text": row.value_text,
+                "value_number": float(row.value_number) if row.value_number is not None else None,
+                "value_bool": row.value_bool,
+                "value_option_ids": [],
+                "value_option_code_snapshots": [],
+                "value_unit_snapshot": row.value_unit_snapshot,
+                "created_at": row.created_at.isoformat() if row.created_at else None,
+                "updated_at": row.updated_at.isoformat() if row.updated_at else None,
+            }
+            grouped[key] = current
+
+        if row.value_option_id is not None:
+            current["value_option_ids"].append(int(row.value_option_id))
+            if row.value_option_code_snapshot:
+                current["value_option_code_snapshots"].append(str(row.value_option_code_snapshot))
+
+    return [ItemAttributeValueOut.model_validate(x) for x in grouped.values()]
+
+
 @router.get("/items/{item_id}/attributes", response_model=ListOut[ItemAttributeValueOut])
 def list_item_attribute_values(item_id: int, db: Session = Depends(get_db)):
-    item = db.get(Item, int(item_id))
-    if item is None:
-        raise _not_found("商品不存在")
-    stmt = (
-        select(ItemAttributeValue)
-        .where(ItemAttributeValue.item_id == int(item_id))
-        .order_by(ItemAttributeValue.attribute_def_id.asc())
-    )
-    return {"ok": True, "data": list(db.execute(stmt).scalars().all())}
+    return {"ok": True, "data": _list_item_attribute_value_out(db, int(item_id))}
 
 
 @router.put("/items/{item_id}/attributes", response_model=ListOut[ItemAttributeValueOut])
@@ -480,59 +516,91 @@ def replace_item_attribute_values(
 ):
     item = db.get(Item, int(item_id))
     if item is None:
-        raise _not_found("商品不存在")
+        raise HTTPException(status_code=404, detail="Item not found")
+
+    seen_defs: set[int] = set()
 
     db.query(ItemAttributeValue).filter(ItemAttributeValue.item_id == int(item_id)).delete()
 
-    rows: list[ItemAttributeValue] = []
     for incoming in payload.values:
         attr = db.get(ItemAttributeDef, int(incoming.attribute_def_id))
         if attr is None or not bool(attr.is_active):
             raise _bad_request(f"属性模板不存在或已停用：{incoming.attribute_def_id}")
 
-        option_code_snapshot = None
-        unit_snapshot = attr.unit
+        attr_id = int(attr.id)
+        if attr_id in seen_defs:
+            raise _bad_request(f"同一属性不能重复提交：{attr.code}")
+        seen_defs.add(attr_id)
 
-        option_id = incoming.value_option_id
+        option_ids = incoming.value_option_ids or []
+
         if attr.value_type == "OPTION":
-            if option_id is None:
-                raise _bad_request(f"OPTION 属性必须提交 value_option_id：{attr.code}")
-            opt = db.get(ItemAttributeOption, int(option_id))
-            if opt is None or int(opt.attribute_def_id) != int(attr.id) or not bool(opt.is_active):
-                raise _bad_request(f"属性选项不存在、已停用或不属于当前模板：{attr.code}")
-            option_code_snapshot = opt.option_code
-        elif option_id is not None:
-            raise _bad_request(f"非 OPTION 属性不能提交 value_option_id：{attr.code}")
+            if incoming.value_text is not None or incoming.value_number is not None or incoming.value_bool is not None:
+                raise _bad_request(f"OPTION 属性只能提交 value_option_ids：{attr.code}")
+
+            if not option_ids:
+                raise _bad_request(f"OPTION 属性必须提交 value_option_ids：{attr.code}")
+
+            if attr.selection_mode == "SINGLE" and len(option_ids) > 1:
+                raise _bad_request(f"SINGLE 属性最多只能选择一个选项：{attr.code}")
+
+            for option_id in option_ids:
+                opt = db.get(ItemAttributeOption, int(option_id))
+                if opt is None or int(opt.attribute_def_id) != attr_id or not bool(opt.is_active):
+                    raise _bad_request(f"属性选项不存在、已停用或不属于当前属性：{attr.code}")
+
+                db.add(
+                    ItemAttributeValue(
+                        item_id=int(item_id),
+                        attribute_def_id=attr_id,
+                        value_text=None,
+                        value_number=None,
+                        value_bool=None,
+                        value_option_id=int(opt.id),
+                        value_option_code_snapshot=str(opt.option_code),
+                        value_unit_snapshot=attr.unit,
+                    )
+                )
+
+            continue
+
+        if option_ids:
+            raise _bad_request(f"非 OPTION 属性不能提交 value_option_ids：{attr.code}")
+
+        value_text = incoming.value_text
+        value_number = incoming.value_number
+        value_bool = incoming.value_bool
 
         if attr.value_type == "TEXT":
-            if incoming.value_text is None or not str(incoming.value_text).strip():
-                if attr.is_item_required:
-                    raise _bad_request(f"必填文本属性不能为空：{attr.code}")
+            if value_text is None:
+                raise _bad_request(f"TEXT 属性必须提交 value_text：{attr.code}")
+            value_number = None
+            value_bool = None
         elif attr.value_type == "NUMBER":
-            if incoming.value_number is None and attr.is_item_required:
-                raise _bad_request(f"必填数值属性不能为空：{attr.code}")
+            if value_number is None:
+                raise _bad_request(f"NUMBER 属性必须提交 value_number：{attr.code}")
+            value_text = None
+            value_bool = None
         elif attr.value_type == "BOOL":
-            if incoming.value_bool is None and attr.is_item_required:
-                raise _bad_request(f"必填布尔属性不能为空：{attr.code}")
+            if value_bool is None:
+                raise _bad_request(f"BOOL 属性必须提交 value_bool：{attr.code}")
+            value_text = None
+            value_number = None
+        else:
+            raise _bad_request(f"不支持的属性类型：{attr.value_type}")
 
-        row = ItemAttributeValue(
-            item_id=int(item_id),
-            attribute_def_id=int(attr.id),
-            value_text=(str(incoming.value_text).strip() if incoming.value_text is not None else None),
-            value_number=incoming.value_number,
-            value_bool=incoming.value_bool,
-            value_option_id=option_id,
-            value_option_code_snapshot=option_code_snapshot,
-            value_unit_snapshot=unit_snapshot,
+        db.add(
+            ItemAttributeValue(
+                item_id=int(item_id),
+                attribute_def_id=attr_id,
+                value_text=value_text,
+                value_number=value_number,
+                value_bool=value_bool,
+                value_option_id=None,
+                value_option_code_snapshot=None,
+                value_unit_snapshot=attr.unit,
+            )
         )
-        db.add(row)
-        rows.append(row)
 
     db.commit()
-
-    stmt = (
-        select(ItemAttributeValue)
-        .where(ItemAttributeValue.item_id == int(item_id))
-        .order_by(ItemAttributeValue.attribute_def_id.asc())
-    )
-    return {"ok": True, "data": list(db.execute(stmt).scalars().all())}
+    return {"ok": True, "data": _list_item_attribute_value_out(db, int(item_id))}

--- a/openapi/_current.json
+++ b/openapi/_current.json
@@ -28796,10 +28796,6 @@
                 "type": "number"
               },
               {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
                 "type": "null"
               }
             ],
@@ -28816,16 +28812,20 @@
             ],
             "title": "Value Bool"
           },
-          "value_option_id": {
+          "value_option_ids": {
             "anyOf": [
               {
-                "type": "integer"
+                "items": {
+                  "type": "integer",
+                  "minimum": 1.0
+                },
+                "type": "array"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Value Option Id"
+            "title": "Value Option Ids"
           }
         },
         "type": "object",
@@ -28837,7 +28837,14 @@
       "ItemAttributeValueOut": {
         "properties": {
           "id": {
-            "type": "integer",
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Id"
           },
           "item_id": {
@@ -28862,8 +28869,7 @@
           "value_number": {
             "anyOf": [
               {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                "type": "number"
               },
               {
                 "type": "null"
@@ -28882,27 +28888,19 @@
             ],
             "title": "Value Bool"
           },
-          "value_option_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Option Id"
+          "value_option_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Value Option Ids"
           },
-          "value_option_code_snapshot": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Option Code Snapshot"
+          "value_option_code_snapshots": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Value Option Code Snapshots"
           },
           "value_unit_snapshot": {
             "anyOf": [
@@ -28918,8 +28916,7 @@
           "created_at": {
             "anyOf": [
               {
-                "type": "string",
-                "format": "date-time"
+                "type": "string"
               },
               {
                 "type": "null"
@@ -28930,8 +28927,7 @@
           "updated_at": {
             "anyOf": [
               {
-                "type": "string",
-                "format": "date-time"
+                "type": "string"
               },
               {
                 "type": "null"
@@ -28942,7 +28938,6 @@
         },
         "type": "object",
         "required": [
-          "id",
           "item_id",
           "attribute_def_id"
         ],
@@ -29526,38 +29521,26 @@
             ],
             "title": "Value Bool"
           },
-          "value_option_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Option Id"
+          "value_option_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Value Option Ids"
           },
-          "value_option_code_snapshot": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Option Code Snapshot"
+          "value_option_code_snapshots": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Value Option Code Snapshots"
           },
-          "value_option_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Option Name"
+          "value_option_names": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Value Option Names"
           },
           "value_unit_snapshot": {
             "anyOf": [

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -28796,10 +28796,6 @@
                 "type": "number"
               },
               {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
                 "type": "null"
               }
             ],
@@ -28816,16 +28812,20 @@
             ],
             "title": "Value Bool"
           },
-          "value_option_id": {
+          "value_option_ids": {
             "anyOf": [
               {
-                "type": "integer"
+                "items": {
+                  "type": "integer",
+                  "minimum": 1.0
+                },
+                "type": "array"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Value Option Id"
+            "title": "Value Option Ids"
           }
         },
         "type": "object",
@@ -28837,7 +28837,14 @@
       "ItemAttributeValueOut": {
         "properties": {
           "id": {
-            "type": "integer",
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Id"
           },
           "item_id": {
@@ -28862,8 +28869,7 @@
           "value_number": {
             "anyOf": [
               {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                "type": "number"
               },
               {
                 "type": "null"
@@ -28882,27 +28888,19 @@
             ],
             "title": "Value Bool"
           },
-          "value_option_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Option Id"
+          "value_option_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Value Option Ids"
           },
-          "value_option_code_snapshot": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Option Code Snapshot"
+          "value_option_code_snapshots": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Value Option Code Snapshots"
           },
           "value_unit_snapshot": {
             "anyOf": [
@@ -28918,8 +28916,7 @@
           "created_at": {
             "anyOf": [
               {
-                "type": "string",
-                "format": "date-time"
+                "type": "string"
               },
               {
                 "type": "null"
@@ -28930,8 +28927,7 @@
           "updated_at": {
             "anyOf": [
               {
-                "type": "string",
-                "format": "date-time"
+                "type": "string"
               },
               {
                 "type": "null"
@@ -28942,7 +28938,6 @@
         },
         "type": "object",
         "required": [
-          "id",
           "item_id",
           "attribute_def_id"
         ],
@@ -29526,38 +29521,26 @@
             ],
             "title": "Value Bool"
           },
-          "value_option_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Option Id"
+          "value_option_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Value Option Ids"
           },
-          "value_option_code_snapshot": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Option Code Snapshot"
+          "value_option_code_snapshots": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Value Option Code Snapshots"
           },
-          "value_option_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Option Name"
+          "value_option_names": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Value Option Names"
           },
           "value_unit_snapshot": {
             "anyOf": [

--- a/tests/api/test_pms_item_attribute_values_multiselect_api.py
+++ b/tests/api/test_pms_item_attribute_values_multiselect_api.py
@@ -1,0 +1,165 @@
+# tests/api/test_pms_item_attribute_values_multiselect_api.py
+from __future__ import annotations
+
+from uuid import uuid4
+
+import httpx
+import pytest
+
+
+async def _headers(client: httpx.AsyncClient) -> dict[str, str]:
+    r = await client.post("/users/login", json={"username": "admin", "password": "admin123"})
+    assert r.status_code == 200, r.text
+    return {"Authorization": f"Bearer {r.json()['access_token']}"}
+
+
+async def _first_item_id(client: httpx.AsyncClient, headers: dict[str, str]) -> int:
+    r = await client.get("/items", headers=headers)
+    assert r.status_code == 200, r.text
+    rows = r.json()
+    assert rows, rows
+    return int(rows[0]["id"])
+
+
+async def _attribute_def(client: httpx.AsyncClient, headers: dict[str, str], *, product_kind: str, code: str) -> dict:
+    r = await client.get(
+        f"/pms/item-attribute-defs?product_kind={product_kind}&active_only=true",
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+    for row in r.json()["data"]:
+        if row["code"] == code:
+            return row
+    raise AssertionError(f"attribute def not found: {product_kind}/{code}")
+
+
+async def _create_option(
+    client: httpx.AsyncClient,
+    headers: dict[str, str],
+    *,
+    attribute_def_id: int,
+    option_code: str,
+    option_name: str,
+) -> dict:
+    r = await client.post(
+        f"/pms/item-attribute-defs/{attribute_def_id}/options",
+        json={"option_code": option_code, "option_name": option_name, "sort_order": 999},
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+@pytest.mark.asyncio
+async def test_item_attribute_option_multi_values_are_saved_and_returned(client: httpx.AsyncClient) -> None:
+    headers = await _headers(client)
+    item_id = await _first_item_id(client, headers)
+
+    flavor = await _attribute_def(client, headers, product_kind="FOOD", code="FLAVOR")
+    suffix = uuid4().hex[:6].upper()
+
+    chicken = await _create_option(
+        client,
+        headers,
+        attribute_def_id=int(flavor["id"]),
+        option_code=f"CHK{suffix}",
+        option_name=f"鸡肉-{suffix}",
+    )
+    salmon = await _create_option(
+        client,
+        headers,
+        attribute_def_id=int(flavor["id"]),
+        option_code=f"SLM{suffix}",
+        option_name=f"三文鱼-{suffix}",
+    )
+
+    r = await client.put(
+        f"/items/{item_id}/attributes",
+        json={
+            "values": [
+                {
+                    "attribute_def_id": int(flavor["id"]),
+                    "value_option_ids": [int(chicken["id"]), int(salmon["id"])],
+                }
+            ]
+        },
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+
+    rows = r.json()["data"]
+    assert len(rows) == 1
+    assert rows[0]["attribute_def_id"] == int(flavor["id"])
+    assert set(rows[0]["value_option_ids"]) == {int(chicken["id"]), int(salmon["id"])}
+    assert {f"CHK{suffix}", f"SLM{suffix}"} <= set(rows[0]["value_option_code_snapshots"])
+
+    r_get = await client.get(f"/items/{item_id}/attributes", headers=headers)
+    assert r_get.status_code == 200, r_get.text
+    got = r_get.json()["data"][0]
+    assert set(got["value_option_ids"]) == {int(chicken["id"]), int(salmon["id"])}
+
+
+@pytest.mark.asyncio
+async def test_item_attribute_single_rejects_multiple_options(client: httpx.AsyncClient) -> None:
+    headers = await _headers(client)
+    item_id = await _first_item_id(client, headers)
+
+    life_stage = await _attribute_def(client, headers, product_kind="FOOD", code="LIFE_STAGE")
+    suffix = uuid4().hex[:6].upper()
+
+    a = await _create_option(
+        client,
+        headers,
+        attribute_def_id=int(life_stage["id"]),
+        option_code=f"A{suffix}",
+        option_name=f"阶段A-{suffix}",
+    )
+    b = await _create_option(
+        client,
+        headers,
+        attribute_def_id=int(life_stage["id"]),
+        option_code=f"B{suffix}",
+        option_name=f"阶段B-{suffix}",
+    )
+
+    r = await client.put(
+        f"/items/{item_id}/attributes",
+        json={
+            "values": [
+                {
+                    "attribute_def_id": int(life_stage["id"]),
+                    "value_option_ids": [int(a["id"]), int(b["id"])],
+                }
+            ]
+        },
+        headers=headers,
+    )
+    assert r.status_code == 400, r.text
+    assert "最多只能选择一个" in r.text
+
+
+@pytest.mark.asyncio
+async def test_item_attribute_scalar_values_still_work(client: httpx.AsyncClient) -> None:
+    headers = await _headers(client)
+    item_id = await _first_item_id(client, headers)
+
+    origin = await _attribute_def(client, headers, product_kind="COMMON", code="ORIGIN")
+
+    r = await client.put(
+        f"/items/{item_id}/attributes",
+        json={
+            "values": [
+                {
+                    "attribute_def_id": int(origin["id"]),
+                    "value_text": "山东",
+                }
+            ]
+        },
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+
+    rows = r.json()["data"]
+    assert rows[0]["attribute_def_id"] == int(origin["id"])
+    assert rows[0]["value_text"] == "山东"
+    assert rows[0]["value_option_ids"] == []

--- a/tests/api/test_pms_items_list_rows_api.py
+++ b/tests/api/test_pms_items_list_rows_api.py
@@ -132,9 +132,9 @@ def _assert_detail_contract(data: dict[str, Any]) -> None:
             "value_text",
             "value_number",
             "value_bool",
-            "value_option_id",
-            "value_option_code_snapshot",
-            "value_option_name",
+            "value_option_ids",
+            "value_option_code_snapshots",
+            "value_option_names",
             "value_unit_snapshot",
             "updated_at",
         } <= set(attr.keys()), attr

--- a/tests/api/test_pms_master_data_api.py
+++ b/tests/api/test_pms_master_data_api.py
@@ -270,7 +270,7 @@ async def test_pms_attribute_template_options_and_item_values_contract(client: h
 
     r_values = await client.put(
         f"/items/{item_id}/attributes",
-        json={"values": [{"attribute_def_id": int(attr["id"]), "value_option_id": int(option["id"])}]},
+        json={"values": [{"attribute_def_id": int(attr["id"]), "value_option_ids": [int(option["id"])]}]},
         headers=headers,
     )
     assert r_values.status_code == 200, r_values.text
@@ -278,9 +278,9 @@ async def test_pms_attribute_template_options_and_item_values_contract(client: h
     assert len(values) == 1
     assert values[0]["item_id"] == item_id
     assert values[0]["attribute_def_id"] == int(attr["id"])
-    assert values[0]["value_option_id"] == int(option["id"])
-    assert values[0]["value_option_code_snapshot"] == f"WHT{sfx}"
+    assert values[0]["value_option_ids"] == [int(option["id"])]
+    assert values[0]["value_option_code_snapshots"] == [f"WHT{sfx}"]
 
     r_get = await client.get(f"/items/{item_id}/attributes", headers=headers)
     assert r_get.status_code == 200, r_get.text
-    assert r_get.json()["data"][0]["value_option_code_snapshot"] == f"WHT{sfx}"
+    assert r_get.json()["data"][0]["value_option_code_snapshots"] == [f"WHT{sfx}"]


### PR DESCRIPTION
## Summary
- 调整 item_attribute_values 唯一约束，支持 OPTION 属性一属性多选项
- PUT /items/{item_id}/attributes 改为使用 value_option_ids
- SINGLE 属性校验最多一个选项，MULTI 属性允许多个选项
- GET /items/{item_id}/attributes 返回 value_option_ids / value_option_code_snapshots
- 商品列表详情属性输出同步改为多选数组合同
- 补充多选、单选校验和标量属性回归测试
- 重新生成 OpenAPI

## Tests
- python3 -m compileall alembic/versions/efbbba76f264_support_multi_option_item_attributes.py app/pms/items/contracts/item_master.py app/pms/items/contracts/item_list.py app/pms/items/routers/item_master.py app/pms/items/repos/item_list_repo.py app/pms/items/models/item_master.py tests/api/test_pms_item_attribute_values_multiselect_api.py
- make upgrade-dev
- make alembic-check
- make test TESTS="tests/api/test_pms_item_attribute_values_multiselect_api.py tests/api/test_pms_master_data_api.py tests/api/test_pms_items_list_rows_api.py tests/api/test_pms_sku_coding_api.py"
- make openapi