### PR TITLE
feat(pms): generate sku from item attributes

### DIFF
--- a/app/pms/sku_coding/routers/sku_coding.py
+++ b/app/pms/sku_coding/routers/sku_coding.py
@@ -28,3 +28,12 @@ def generate_sku(payload: SkuGenerateIn, db: Session = Depends(get_db)):
         return {"ok": True, "data": data}
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e)) from e
+
+
+@router.post("/items/{item_id}/generate", response_model=SkuGenerateOut)
+def generate_sku_from_item(item_id: int, db: Session = Depends(get_db)):
+    try:
+        data = SkuCodingService(db).generate_from_item(item_id=int(item_id))
+        return {"ok": True, "data": data}
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e

--- a/app/pms/sku_coding/services/sku_coding_service.py
+++ b/app/pms/sku_coding/services/sku_coding_service.py
@@ -9,7 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
 
 from app.pms.items.models.item import Item
-from app.pms.items.models.item_master import ItemAttributeDef, ItemAttributeOption, PmsBrand, PmsBusinessCategory
+from app.pms.items.models.item_master import ItemAttributeDef, ItemAttributeOption, ItemAttributeValue, PmsBrand, PmsBusinessCategory
 from app.pms.items.models.item_sku_code import ItemSkuCode
 from app.pms.sku_coding.models.sku_coding import SkuCodeTemplate
 
@@ -135,6 +135,80 @@ class SkuCodingService:
         if len(rows) != len(normalized_ids):
             raise ValueError(f"属性选项不存在、已停用或属性不匹配：{attribute_def.code}")
         return list(rows)
+
+    def _build_attribute_option_ids_from_item(
+        self,
+        *,
+        item_id: int,
+        product_kind: str,
+    ) -> dict[str, list[int]]:
+        rows = (
+            self.db.execute(
+                select(ItemAttributeDef.code, ItemAttributeValue.value_option_id)
+                .join(
+                    ItemAttributeValue,
+                    ItemAttributeValue.attribute_def_id == ItemAttributeDef.id,
+                )
+                .where(
+                    ItemAttributeValue.item_id == int(item_id),
+                    ItemAttributeValue.value_option_id.is_not(None),
+                    ItemAttributeDef.product_kind == product_kind,
+                    ItemAttributeDef.is_active.is_(True),
+                    ItemAttributeDef.value_type == "OPTION",
+                    ItemAttributeDef.is_sku_segment.is_(True),
+                )
+                .order_by(
+                    ItemAttributeDef.sort_order.asc(),
+                    ItemAttributeDef.code.asc(),
+                    ItemAttributeValue.value_option_id.asc(),
+                )
+            )
+            .all()
+        )
+
+        out: dict[str, list[int]] = {}
+        for code, option_id in rows:
+            if option_id is None:
+                continue
+            key = str(code)
+            out.setdefault(key, []).append(int(option_id))
+        return out
+
+    def generate_from_item(self, *, item_id: int) -> dict:
+        item = self.db.get(Item, int(item_id))
+        if item is None:
+            raise ValueError("商品不存在")
+
+        if item.brand_id is None:
+            raise ValueError("商品未绑定品牌，不能生成 SKU")
+        if item.category_id is None:
+            raise ValueError("商品未绑定分类，不能生成 SKU")
+
+        spec_text = (item.spec or "").strip()
+        if not spec_text:
+            raise ValueError("商品规格为空，不能生成 SKU")
+
+        category = self.db.get(PmsBusinessCategory, int(item.category_id))
+        if category is None:
+            raise ValueError("商品分类不存在")
+
+        kind = _norm_code(str(category.product_kind))
+        if kind not in {"FOOD", "SUPPLY"}:
+            raise ValueError("当前商品类型暂不支持 SKU 编码生成")
+
+        attribute_option_ids = self._build_attribute_option_ids_from_item(
+            item_id=int(item.id),
+            product_kind=kind,
+        )
+
+        return self.generate(
+            product_kind=kind,
+            brand_id=int(item.brand_id),
+            category_id=int(item.category_id),
+            attribute_option_ids=attribute_option_ids,
+            text_segments={},
+            spec_text=spec_text,
+        )
 
     def generate(
         self,

--- a/tests/api/test_pms_sku_coding_api.py
+++ b/tests/api/test_pms_sku_coding_api.py
@@ -284,3 +284,129 @@ async def test_sku_coding_legacy_dictionary_routes_are_retired(client: httpx.Asy
         headers=headers,
     )
     assert r_create.status_code == 404, r_create.text
+
+
+@pytest.mark.asyncio
+async def test_sku_coding_generate_from_item_uses_item_category_and_attributes(client: httpx.AsyncClient) -> None:
+    headers = await _headers(client)
+    sfx = _suffix()
+
+    brand_code = f"ITB{sfx}"
+    category_code = f"ICF{sfx}"
+    life_stage_code = f"IALS{sfx}"
+    process_code = f"IDP{sfx}"
+    chicken_code = f"ICHK{sfx}"
+    salmon_code = f"ISLM{sfx}"
+
+    brand = await _create_brand(client, headers, name_cn=f"商品生成品牌-UT-{sfx}", code=brand_code)
+
+    root = await _create_category(
+        client,
+        headers,
+        parent_id=None,
+        level=1,
+        product_kind="FOOD",
+        category_name=f"商品生成食品-UT-{sfx}",
+        category_code=f"IPF{sfx}",
+        is_leaf=False,
+    )
+    mid = await _create_category(
+        client,
+        headers,
+        parent_id=int(root["id"]),
+        level=2,
+        product_kind="FOOD",
+        category_name=f"商品生成猫主食-UT-{sfx}",
+        category_code=f"ICATF{sfx}",
+        is_leaf=False,
+    )
+    leaf = await _create_category(
+        client,
+        headers,
+        parent_id=int(mid["id"]),
+        level=3,
+        product_kind="FOOD",
+        category_name=f"商品生成干粮-UT-{sfx}",
+        category_code=category_code,
+        is_leaf=True,
+    )
+
+    life_stage_def_id = await _attribute_def_id(client, headers, product_kind="FOOD", code="LIFE_STAGE")
+    process_def_id = await _attribute_def_id(client, headers, product_kind="FOOD", code="PROCESS")
+    flavor_def_id = await _attribute_def_id(client, headers, product_kind="FOOD", code="FLAVOR")
+
+    life_stage = await _create_attribute_option(
+        client,
+        headers,
+        attribute_def_id=life_stage_def_id,
+        option_name=f"全期-商品生成-UT-{sfx}",
+        option_code=life_stage_code,
+        sort_order=10,
+    )
+    process = await _create_attribute_option(
+        client,
+        headers,
+        attribute_def_id=process_def_id,
+        option_name=f"双拼-商品生成-UT-{sfx}",
+        option_code=process_code,
+        sort_order=10,
+    )
+    chicken = await _create_attribute_option(
+        client,
+        headers,
+        attribute_def_id=flavor_def_id,
+        option_name=f"鸡肉-商品生成-UT-{sfx}",
+        option_code=chicken_code,
+        sort_order=10,
+    )
+    salmon = await _create_attribute_option(
+        client,
+        headers,
+        attribute_def_id=flavor_def_id,
+        option_name=f"三文鱼-商品生成-UT-{sfx}",
+        option_code=salmon_code,
+        sort_order=20,
+    )
+
+    r_item = await client.post(
+        "/items",
+        json={
+            "sku": f"ITEM-SKU-SRC-{sfx}",
+            "name": f"从商品生成SKU-UT-{sfx}",
+            "spec": "500g",
+            "brand_id": int(brand["id"]),
+            "category_id": int(leaf["id"]),
+            "supplier_id": 1,
+            "lot_source_policy": "SUPPLIER_ONLY",
+            "expiry_policy": "NONE",
+            "derivation_allowed": True,
+            "uom_governance_enabled": False,
+        },
+        headers=headers,
+    )
+    assert r_item.status_code == 201, r_item.text
+    item_id = int(r_item.json()["id"])
+
+    r_values = await client.put(
+        f"/items/{item_id}/attributes",
+        json={
+            "values": [
+                {"attribute_def_id": int(life_stage_def_id), "value_option_ids": [int(life_stage["id"])]},
+                {"attribute_def_id": int(process_def_id), "value_option_ids": [int(process["id"])]},
+                {
+                    "attribute_def_id": int(flavor_def_id),
+                    "value_option_ids": [int(salmon["id"]), int(chicken["id"])],
+                },
+            ]
+        },
+        headers=headers,
+    )
+    assert r_values.status_code == 200, r_values.text
+
+    r = await client.post(f"/pms/sku-coding/items/{item_id}/generate", headers=headers)
+    assert r.status_code == 200, r.text
+    data = r.json()["data"]
+
+    assert data["sku"] == f"SKU-{brand_code}-{category_code}-{life_stage_code}-{process_code}-{chicken_code}-{salmon_code}-500G"
+    assert data["exists"] is False
+    assert data["segments"][-1] == {"segment_key": "SPEC", "name_cn": "500g", "code": "500G"}


### PR DESCRIPTION
## Summary
- add POST /pms/sku-coding/items/{item_id}/generate
- generate SKU from the item's real brand, category, spec, and SKU-segment attribute values
- keep the existing manual /pms/sku-coding/generate endpoint unchanged
- add API coverage proving item category + item attributes drive SKU generation

## Tests
- python3 -m compileall app/pms/sku_coding/services/sku_coding_service.py app/pms/sku_coding/routers/sku_coding.py tests/api/test_pms_sku_coding_api.py
- WMS_ENV=test WMS_TEST_DATABASE_URL=postgresql+psycopg://wms:wms@127.0.0.1:5433/wms_test WMS_DATABASE_URL=postgresql+psycopg://wms:wms@127.0.0.1:5433/wms_test python3 -m pytest tests/api/test_pms_sku_coding_api.py -q