### PR TITLE
feat(pms): add item completeness read model

### DIFF
--- a/app/pms/items/contracts/item_list.py
+++ b/app/pms/items/contracts/item_list.py
@@ -2,9 +2,50 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
+
+
+ItemCompletenessStatus = Literal["COMPLETE", "WARNING", "BLOCKED"]
+ItemCompletenessProductKind = Literal["FOOD", "SUPPLY", "OTHER"]
+
+
+class ItemCompletenessOut(BaseModel):
+    """
+    PMS 商品完整度 owner read model。
+
+    定位：
+    - 后端统一计算商品完整度
+    - 前端列表、详情、编辑流程只消费这个合同
+    - 不让前端根据多个数组自行拼完整度判断
+    """
+
+    status: ItemCompletenessStatus
+    is_complete: bool
+
+    product_kind: Optional[ItemCompletenessProductKind] = None
+
+    has_brand: bool = False
+    has_active_leaf_category: bool = False
+    has_base_uom: bool = False
+    has_active_primary_barcode: bool = False
+    has_active_primary_sku: bool = False
+
+    item_required_attributes_complete: bool = True
+    sku_required_attributes_complete: bool = True
+    sku_segment_attributes_present: bool = True
+
+    sku_generation_applicable: bool = False
+    can_generate_sku: bool = False
+
+    missing_item_required_attribute_codes: list[str] = Field(default_factory=list)
+    missing_sku_required_attribute_codes: list[str] = Field(default_factory=list)
+    missing_sku_segment_attribute_codes: list[str] = Field(default_factory=list)
+
+    missing_items: list[str] = Field(default_factory=list)
+    blocking_items: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
 
 
 class ItemListRowOut(BaseModel):
@@ -45,6 +86,8 @@ class ItemListRowOut(BaseModel):
     barcode_count: int = Field(default=0, ge=0)
     sku_code_count: int = Field(default=0, ge=0)
     attribute_count: int = Field(default=0, ge=0)
+
+    completeness: ItemCompletenessOut
 
     updated_at: Optional[datetime] = None
 

--- a/app/pms/items/repos/item_list_repo.py
+++ b/app/pms/items/repos/item_list_repo.py
@@ -36,6 +36,15 @@ def _item_list_rows_sql(where_sql: str) -> str:
         AND b.is_primary IS TRUE
       ORDER BY b.item_id, b.id ASC
     ),
+    active_primary_sku AS (
+      SELECT DISTINCT ON (c.item_id)
+        c.item_id,
+        c.code
+      FROM item_sku_codes c
+      WHERE c.is_primary IS TRUE
+        AND c.is_active IS TRUE
+      ORDER BY c.item_id, c.id ASC
+    ),
     uom_counts AS (
       SELECT item_id, COUNT(*)::int AS cnt
       FROM item_uoms
@@ -57,6 +66,75 @@ def _item_list_rows_sql(where_sql: str) -> str:
       SELECT item_id, COUNT(*)::int AS cnt
       FROM item_attribute_values
       GROUP BY item_id
+    ),
+    attr_value_presence AS (
+      SELECT
+        v.item_id,
+        v.attribute_def_id,
+        BOOL_OR(
+          CASE
+            WHEN d.value_type = 'OPTION' THEN v.value_option_id IS NOT NULL
+            WHEN d.value_type = 'TEXT' THEN NULLIF(BTRIM(COALESCE(v.value_text, '')), '') IS NOT NULL
+            WHEN d.value_type = 'NUMBER' THEN v.value_number IS NOT NULL
+            WHEN d.value_type = 'BOOL' THEN v.value_bool IS NOT NULL
+            ELSE FALSE
+          END
+        ) AS has_value
+      FROM item_attribute_values v
+      JOIN item_attribute_defs d
+        ON d.id = v.attribute_def_id
+      GROUP BY v.item_id, v.attribute_def_id
+    ),
+    attr_requirement_stats AS (
+      SELECT
+        i.id AS item_id,
+        COALESCE(
+          ARRAY_AGG(DISTINCT d.code ORDER BY d.code)
+          FILTER (
+            WHERE d.is_item_required IS TRUE
+              AND COALESCE(avp.has_value, FALSE) IS FALSE
+          ),
+          ARRAY[]::varchar[]
+        ) AS missing_item_required_attribute_codes,
+        COALESCE(
+          ARRAY_AGG(DISTINCT d.code ORDER BY d.code)
+          FILTER (
+            WHERE d.is_sku_required IS TRUE
+              AND COALESCE(avp.has_value, FALSE) IS FALSE
+          ),
+          ARRAY[]::varchar[]
+        ) AS missing_sku_required_attribute_codes,
+        COALESCE(
+          ARRAY_AGG(DISTINCT d.code ORDER BY d.code)
+          FILTER (
+            WHERE d.is_sku_segment IS TRUE
+              AND COALESCE(avp.has_value, FALSE) IS FALSE
+          ),
+          ARRAY[]::varchar[]
+        ) AS missing_sku_segment_attribute_codes
+      FROM items i
+      LEFT JOIN pms_business_categories cat
+        ON cat.id = i.category_id
+      LEFT JOIN item_attribute_defs d
+        ON d.is_active IS TRUE
+       AND (
+         d.product_kind = 'COMMON'
+         OR (
+           cat.product_kind IS NOT NULL
+           AND d.product_kind = cat.product_kind
+         )
+       )
+      LEFT JOIN attr_value_presence avp
+        ON avp.item_id = i.id
+       AND avp.attribute_def_id = d.id
+      GROUP BY i.id
+    ),
+    sku_template_stats AS (
+      SELECT
+        product_kind,
+        BOOL_OR(is_active) AS has_active_template
+      FROM sku_code_templates
+      GROUP BY product_kind
     )
     SELECT
       i.id::int AS item_id,
@@ -87,6 +165,26 @@ def _item_list_rows_sql(where_sql: str) -> str:
       COALESCE(sc.cnt, 0)::int AS sku_code_count,
       COALESCE(ac.cnt, 0)::int AS attribute_count,
 
+      cat.product_kind::text AS product_kind,
+      (br.id IS NOT NULL AND br.is_active IS TRUE) AS has_brand,
+      (cat.id IS NOT NULL AND cat.is_active IS TRUE AND cat.is_leaf IS TRUE) AS has_active_leaf_category,
+      (bu.item_id IS NOT NULL) AS has_base_uom,
+      (pb.item_id IS NOT NULL) AS has_active_primary_barcode,
+      (aps.item_id IS NOT NULL) AS has_active_primary_sku,
+      COALESCE(st.has_active_template, FALSE) AS has_active_sku_template,
+      COALESCE(
+        ars.missing_item_required_attribute_codes,
+        ARRAY[]::varchar[]
+      ) AS missing_item_required_attribute_codes,
+      COALESCE(
+        ars.missing_sku_required_attribute_codes,
+        ARRAY[]::varchar[]
+      ) AS missing_sku_required_attribute_codes,
+      COALESCE(
+        ars.missing_sku_segment_attribute_codes,
+        ARRAY[]::varchar[]
+      ) AS missing_sku_segment_attribute_codes,
+
       i.updated_at
     FROM items i
     LEFT JOIN pms_brands br
@@ -101,6 +199,8 @@ def _item_list_rows_sql(where_sql: str) -> str:
       ON pu.item_id = i.id
     LEFT JOIN primary_barcode pb
       ON pb.item_id = i.id
+    LEFT JOIN active_primary_sku aps
+      ON aps.item_id = i.id
     LEFT JOIN uom_counts uc
       ON uc.item_id = i.id
     LEFT JOIN barcode_counts bc
@@ -109,6 +209,10 @@ def _item_list_rows_sql(where_sql: str) -> str:
       ON sc.item_id = i.id
     LEFT JOIN attribute_counts ac
       ON ac.item_id = i.id
+    LEFT JOIN attr_requirement_stats ars
+      ON ars.item_id = i.id
+    LEFT JOIN sku_template_stats st
+      ON st.product_kind = cat.product_kind
     {where_sql}
     ORDER BY i.updated_at DESC NULLS LAST, i.id DESC
     LIMIT :limit
@@ -133,7 +237,7 @@ def list_item_list_row_mappings(
     - item_barcodes：主条码与条码数量
     - item_uoms：基础包装、采购默认包装、净重、包装数量
     - item_sku_codes：SKU 编码数量
-    - item_attribute_values：属性值数量
+    - item_attribute_values / item_attribute_defs：属性值与完整度
     """
 
     conditions: list[str] = []

--- a/app/pms/items/services/item_list_service.py
+++ b/app/pms/items/services/item_list_service.py
@@ -1,7 +1,7 @@
 # app/pms/items/services/item_list_service.py
 from __future__ import annotations
 
-from typing import Optional
+from collections.abc import Mapping
 
 from sqlalchemy.orm import Session
 
@@ -23,22 +23,170 @@ from app.pms.items.repos.item_list_repo import (
 )
 
 
+SKU_GENERATION_PRODUCT_KINDS = {"FOOD", "SUPPLY"}
+VALID_PRODUCT_KINDS = {"FOOD", "SUPPLY", "OTHER"}
+
+
+def _as_bool(value: object) -> bool:
+    return bool(value is True)
+
+
+def _as_clean_text(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def _as_str_list(value: object) -> list[str]:
+    if not isinstance(value, (list, tuple, set)):
+        return []
+
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        text = str(item or "").strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        out.append(text)
+    return out
+
+
+def _unique(items: list[str]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        text = item.strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        out.append(text)
+    return out
+
+
+def _build_completeness(row: Mapping[str, object]) -> dict[str, object]:
+    raw_product_kind = _as_clean_text(row.get("product_kind"))
+    product_kind = raw_product_kind if raw_product_kind in VALID_PRODUCT_KINDS else None
+
+    has_brand = _as_bool(row.get("has_brand"))
+    has_active_leaf_category = _as_bool(row.get("has_active_leaf_category"))
+    has_base_uom = _as_bool(row.get("has_base_uom"))
+    has_active_primary_barcode = _as_bool(row.get("has_active_primary_barcode"))
+    has_active_primary_sku = _as_bool(row.get("has_active_primary_sku"))
+    has_active_sku_template = _as_bool(row.get("has_active_sku_template"))
+
+    spec = _as_clean_text(row.get("spec"))
+    has_spec = spec is not None
+
+    missing_item_required_attribute_codes = _as_str_list(
+        row.get("missing_item_required_attribute_codes")
+    )
+    missing_sku_required_attribute_codes = _as_str_list(
+        row.get("missing_sku_required_attribute_codes")
+    )
+    missing_sku_segment_attribute_codes = _as_str_list(
+        row.get("missing_sku_segment_attribute_codes")
+    )
+
+    item_required_attributes_complete = len(missing_item_required_attribute_codes) == 0
+    sku_required_attributes_complete = len(missing_sku_required_attribute_codes) == 0
+    sku_segment_attributes_present = len(missing_sku_segment_attribute_codes) == 0
+
+    sku_generation_applicable = bool(
+        has_active_leaf_category and product_kind in SKU_GENERATION_PRODUCT_KINDS
+    )
+    can_generate_sku = bool(
+        sku_generation_applicable
+        and has_brand
+        and has_spec
+        and has_active_sku_template
+        and sku_required_attributes_complete
+    )
+
+    blocking_items: list[str] = []
+    warnings: list[str] = []
+
+    if not has_brand:
+        blocking_items.append("未绑定启用品牌")
+    if not has_active_leaf_category:
+        blocking_items.append("未绑定启用叶子分类")
+    if not has_base_uom:
+        blocking_items.append("未维护基础包装")
+    if not has_active_primary_barcode:
+        blocking_items.append("未绑定启用主条码")
+    if not has_active_primary_sku:
+        blocking_items.append("未维护启用主 SKU")
+
+    for code in missing_item_required_attribute_codes:
+        blocking_items.append(f"缺少商品必填属性：{code}")
+
+    for code in missing_sku_required_attribute_codes:
+        blocking_items.append(f"缺少 SKU 必填属性：{code}")
+
+    if has_active_leaf_category and product_kind == "OTHER":
+        warnings.append("OTHER 商品类型暂不支持 SKU 编码生成")
+    elif has_active_leaf_category and product_kind not in SKU_GENERATION_PRODUCT_KINDS:
+        warnings.append("当前商品类型暂不支持 SKU 编码生成")
+
+    if sku_generation_applicable:
+        if not has_spec:
+            warnings.append("商品规格为空，不能生成候选 SKU")
+        if not has_active_sku_template:
+            warnings.append(f"缺少启用 SKU 编码模板：{product_kind}")
+        for code in missing_sku_segment_attribute_codes:
+            if code not in missing_sku_required_attribute_codes:
+                warnings.append(f"缺少 SKU 段属性：{code}")
+
+    if blocking_items:
+        status = "BLOCKED"
+    elif warnings:
+        status = "WARNING"
+    else:
+        status = "COMPLETE"
+
+    blocking_items = _unique(blocking_items)
+    warnings = _unique(warnings)
+
+    return {
+        "status": status,
+        "is_complete": status == "COMPLETE",
+        "product_kind": product_kind,
+        "has_brand": has_brand,
+        "has_active_leaf_category": has_active_leaf_category,
+        "has_base_uom": has_base_uom,
+        "has_active_primary_barcode": has_active_primary_barcode,
+        "has_active_primary_sku": has_active_primary_sku,
+        "item_required_attributes_complete": item_required_attributes_complete,
+        "sku_required_attributes_complete": sku_required_attributes_complete,
+        "sku_segment_attributes_present": sku_segment_attributes_present,
+        "sku_generation_applicable": sku_generation_applicable,
+        "can_generate_sku": can_generate_sku,
+        "missing_item_required_attribute_codes": missing_item_required_attribute_codes,
+        "missing_sku_required_attribute_codes": missing_sku_required_attribute_codes,
+        "missing_sku_segment_attribute_codes": missing_sku_segment_attribute_codes,
+        "missing_items": _unique(blocking_items + warnings),
+        "blocking_items": blocking_items,
+        "warnings": warnings,
+    }
+
+
+def _row_out_from_mapping(row: Mapping[str, object]) -> ItemListRowOut:
+    payload = dict(row)
+    payload["completeness"] = _build_completeness(row)
+    return ItemListRowOut.model_validate(payload)
+
+
 class ItemListReadService:
-    """
-    PMS 商品列表页 owner 读服务。
-
-    只负责商品列表页的摘要行与详情展开，不承载写入语义。
-    """
-
-    def __init__(self, db: Session) -> None:
+    def __init__(self, db: Session):
         self.db = db
 
     def list_rows(
         self,
         *,
-        enabled: Optional[bool] = None,
-        supplier_id: Optional[int] = None,
-        q: Optional[str] = None,
+        enabled: bool | None = None,
+        supplier_id: int | None = None,
+        q: str | None = None,
         limit: int = 200,
     ) -> list[ItemListRowOut]:
         rows = list_item_list_row_mappings(
@@ -48,7 +196,7 @@ class ItemListReadService:
             q=q,
             limit=limit,
         )
-        return [ItemListRowOut.model_validate(dict(row)) for row in rows]
+        return [_row_out_from_mapping(row) for row in rows]
 
     def get_detail(self, *, item_id: int) -> ItemListDetailOut | None:
         row = get_item_list_row_mapping(self.db, item_id=int(item_id))
@@ -61,7 +209,7 @@ class ItemListReadService:
         attributes = list_item_list_attribute_mappings(self.db, item_id=int(item_id))
 
         return ItemListDetailOut(
-            row=ItemListRowOut.model_validate(dict(row)),
+            row=_row_out_from_mapping(row),
             uoms=[ItemListUomOut.model_validate(dict(x)) for x in uoms],
             barcodes=[ItemListBarcodeOut.model_validate(dict(x)) for x in barcodes],
             sku_codes=[ItemListSkuCodeOut.model_validate(dict(x)) for x in sku_codes],

--- a/tests/api/test_pms_items_list_rows_api.py
+++ b/tests/api/test_pms_items_list_rows_api.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Any
+from uuid import uuid4
 
 import httpx
 import pytest
@@ -12,6 +13,63 @@ async def _login_admin_headers(client: httpx.AsyncClient) -> dict[str, str]:
     assert r.status_code == 200, r.text
     token = r.json()["access_token"]
     return {"Authorization": f"Bearer {token}"}
+
+
+def _suffix() -> str:
+    return uuid4().hex[:8].upper()
+
+
+def _assert_completeness_contract(value: dict[str, Any]) -> None:
+    required = {
+        "status",
+        "is_complete",
+        "product_kind",
+        "has_brand",
+        "has_active_leaf_category",
+        "has_base_uom",
+        "has_active_primary_barcode",
+        "has_active_primary_sku",
+        "item_required_attributes_complete",
+        "sku_required_attributes_complete",
+        "sku_segment_attributes_present",
+        "sku_generation_applicable",
+        "can_generate_sku",
+        "missing_item_required_attribute_codes",
+        "missing_sku_required_attribute_codes",
+        "missing_sku_segment_attribute_codes",
+        "missing_items",
+        "blocking_items",
+        "warnings",
+    }
+    assert required <= set(value.keys()), value
+    assert value["status"] in {"COMPLETE", "WARNING", "BLOCKED"}, value
+    assert isinstance(value["is_complete"], bool), value
+    assert value["product_kind"] is None or value["product_kind"] in {"FOOD", "SUPPLY", "OTHER"}, value
+
+    for key in (
+        "has_brand",
+        "has_active_leaf_category",
+        "has_base_uom",
+        "has_active_primary_barcode",
+        "has_active_primary_sku",
+        "item_required_attributes_complete",
+        "sku_required_attributes_complete",
+        "sku_segment_attributes_present",
+        "sku_generation_applicable",
+        "can_generate_sku",
+    ):
+        assert isinstance(value[key], bool), value
+
+    for key in (
+        "missing_item_required_attribute_codes",
+        "missing_sku_required_attribute_codes",
+        "missing_sku_segment_attribute_codes",
+        "missing_items",
+        "blocking_items",
+        "warnings",
+    ):
+        assert isinstance(value[key], list), value
+        assert all(isinstance(x, str) and x.strip() for x in value[key]), value
 
 
 def _assert_item_list_row_contract(row: dict[str, Any]) -> None:
@@ -37,6 +95,7 @@ def _assert_item_list_row_contract(row: dict[str, Any]) -> None:
         "barcode_count",
         "sku_code_count",
         "attribute_count",
+        "completeness",
         "updated_at",
     }
     assert required <= set(row.keys()), row
@@ -45,6 +104,8 @@ def _assert_item_list_row_contract(row: dict[str, Any]) -> None:
     assert isinstance(row["sku"], str) and row["sku"].strip(), row
     assert isinstance(row["name"], str) and row["name"].strip(), row
     assert isinstance(row["enabled"], bool), row
+    assert isinstance(row["completeness"], dict), row
+    _assert_completeness_contract(row["completeness"])
 
     for key in ("uom_count", "barcode_count", "sku_code_count", "attribute_count"):
         assert isinstance(row[key], int), row
@@ -155,6 +216,56 @@ async def test_item_list_rows_returns_owner_summary_contract(client: httpx.Async
     assert rows, "base seed should expose at least one item list row"
 
     _assert_item_list_row_contract(rows[0])
+
+
+@pytest.mark.asyncio
+async def test_item_list_rows_completeness_reports_missing_blocking_parts(client: httpx.AsyncClient) -> None:
+    headers = await _login_admin_headers(client)
+    sfx = _suffix()
+    sku = f"COMPLETE-MISSING-{sfx}"
+
+    r_create = await client.post(
+        "/items",
+        json={
+            "sku": sku,
+            "name": f"完整度缺失项测试-{sfx}",
+            "spec": "500g",
+            "lot_source_policy": "SUPPLIER_ONLY",
+            "expiry_policy": "NONE",
+            "derivation_allowed": True,
+            "uom_governance_enabled": False,
+        },
+        headers=headers,
+    )
+    assert r_create.status_code == 201, r_create.text
+    item_id = int(r_create.json()["id"])
+
+    r = await client.get(f"/items/list-rows?q={sku}&limit=20", headers=headers)
+    assert r.status_code == 200, r.text
+    rows = r.json()
+    row = next((x for x in rows if int(x["item_id"]) == item_id), None)
+    assert row is not None, rows
+
+    completeness = row["completeness"]
+    _assert_completeness_contract(completeness)
+
+    assert completeness["status"] == "BLOCKED", completeness
+    assert completeness["is_complete"] is False, completeness
+    assert completeness["has_brand"] is False, completeness
+    assert completeness["has_active_leaf_category"] is False, completeness
+    # POST /items 主合同会自动补最小基础包装；完整度不应把基础包装判缺。
+    assert completeness["has_base_uom"] is True, completeness
+    assert completeness["has_active_primary_barcode"] is False, completeness
+    assert "未绑定启用品牌" in completeness["blocking_items"], completeness
+    assert "未绑定启用叶子分类" in completeness["blocking_items"], completeness
+    assert "未维护基础包装" not in completeness["blocking_items"], completeness
+    assert "未绑定启用主条码" in completeness["blocking_items"], completeness
+
+    detail_resp = await client.get(f"/items/{item_id}/list-detail", headers=headers)
+    assert detail_resp.status_code == 200, detail_resp.text
+    detail = detail_resp.json()
+    _assert_detail_contract(detail)
+    assert detail["row"]["completeness"] == completeness
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add PMS item completeness owner read model to item list rows
- expose completeness through /items/list-rows and /items/{item_id}/list-detail row
- centralize completeness calculation on backend instead of frontend self-judging flow status

## Scope
- no database migration
- no SKU coding service change
- no frontend change in this PR

## Tests
- make test TESTS=tests/api/test_pms_items_list_rows_api.py
- make test TESTS=tests/api/test_pms_sku_coding_api.py