### PR TITLE
style(pms): rename sku coding nav as tool

### DIFF
--- a/alembic/versions/00352ddf8c0c_pms_sku_coding_tool_nav_name.py
+++ b/alembic/versions/00352ddf8c0c_pms_sku_coding_tool_nav_name.py
@@ -1,0 +1,43 @@
+"""pms sku coding tool nav name
+
+Revision ID: 00352ddf8c0c
+Revises: efbbba76f264
+Create Date: 2026-05-04 16:57:01.604285
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "00352ddf8c0c"
+down_revision: Union[str, Sequence[str], None] = "efbbba76f264"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Rename PMS SKU coding navigation node to tool semantics."""
+
+    op.execute(
+        """
+        UPDATE page_registry
+           SET name = 'SKU 编码工具'
+         WHERE code = 'pms.sku_coding'
+        """
+    )
+
+
+def downgrade() -> None:
+    """Restore previous PMS SKU coding navigation node name."""
+
+    op.execute(
+        """
+        UPDATE page_registry
+           SET name = 'SKU 编码'
+         WHERE code = 'pms.sku_coding'
+        """
+    )

--- a/tests/api/test_pms_master_data_navigation_api.py
+++ b/tests/api/test_pms_master_data_navigation_api.py
@@ -64,7 +64,7 @@ async def test_pms_master_data_page_tree_and_routes(client: httpx.AsyncClient) -
     assert nodes["pms.item_uoms"]["name"] == "包装单位"
     assert nodes["pms.suppliers"]["name"] == "供应商管理"
 
-    assert nodes["pms.sku_coding"]["name"] == "SKU 编码"
+    assert nodes["pms.sku_coding"]["name"] == "SKU 编码工具"
     assert [x["code"] for x in nodes["pms.sku_coding"].get("children", [])] == []
 
     expected_routes = {

--- a/tests/api/test_pms_sku_coding_navigation_api.py
+++ b/tests/api/test_pms_sku_coding_navigation_api.py
@@ -33,7 +33,7 @@ async def test_pms_sku_coding_page_and_route_exist(client: httpx.AsyncClient) ->
     nodes = _walk_pages(data["pages"])
     routes = _route_map(data["route_prefixes"])
 
-    assert nodes["pms.sku_coding"]["name"] == "SKU 编码"
+    assert nodes["pms.sku_coding"]["name"] == "SKU 编码工具"
     assert nodes["pms.sku_coding"]["parent_code"] == "pms"
     assert nodes["pms.sku_coding"]["domain_code"] == "pms"
     assert nodes["pms.sku_coding"]["level"] == 2


### PR DESCRIPTION
## Summary
- rename PMS SKU coding navigation node to SKU 编码工具
- keep /items/sku-coding route and pms.sku_coding page code unchanged
- update navigation contract tests

## Scope
- no business API changes
- no route changes
- no SKU coding logic changes

## Tests
- make upgrade-dev
- make alembic-check
- make test TESTS=tests/api/test_pms_sku_coding_navigation_api.py
- make test TESTS=tests/api/test_pms_master_data_navigation_api.py