### PR TITLE
refactor(shipping-assist): retire WMS quote public routes

### DIFF
--- a/app/router_mount.py
+++ b/app/router_mount.py
@@ -73,7 +73,6 @@ def mount_routers(app: FastAPI) -> None:
     from app.shipping_assist.billing.router import router as tms_billing_router
     from app.shipping_assist.pricing.router import router as tms_pricing_router
     from app.shipping_assist.providers.router import router as tms_providers_router
-    from app.shipping_assist.quote.router import router as tms_quote_router
     from app.shipping_assist.records.router import router as tms_records_router
     from app.shipping_assist.reports.router import router as tms_reports_router
     from app.shipping_assist.shipment.orders_v2_router import router as tms_orders_shipment_v2_router
@@ -157,7 +156,6 @@ def mount_routers(app: FastAPI) -> None:
     app.include_router(tms_providers_router)
     app.include_router(geo_router)
 
-    app.include_router(tms_quote_router)
     app.include_router(tms_pricing_router)
 
     app.include_router(tms_reports_router)

--- a/tests/api/test_shipping_assist_quote_public_routes_retired.py
+++ b/tests/api/test_shipping_assist_quote_public_routes_retired.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from app.main import app
+
+
+def test_shipping_assist_quote_public_routes_are_retired_from_wms() -> None:
+    paths = {getattr(route, "path", "") for route in app.routes}
+
+    assert "/shipping-assist/shipping/quote/calc" not in paths
+    assert "/shipping-assist/shipping/quote/recommend" not in paths
+    assert "/metrics/shipping-assist/shipping/quote/failures" not in paths


### PR DESCRIPTION
## Summary
- retire WMS public quote API routes after quote calc/recommend/metrics moved to logistics-api
- keep WMS internal quote code temporarily because shipment prepare and waybill still consume quote snapshots
- add route regression coverage to ensure WMS no longer exposes quote calc/recommend/failure metrics routes
- keep shipment prepare, waybill, pricing, provider, records, reports, and navigation routes unchanged

## Verification
- make lint-backend
- make test TESTS=tests/api/test_shipping_assist_quote_public_routes_retired.py
- WMS_ENV=test WMS_DATABASE_URL=postgresql+psycopg://wms:wms@127.0.0.1:5433/wms_test WMS_TEST_DATABASE_URL=postgresql+psycopg://wms:wms@127.0.0.1:5433/wms_test .venv/bin/pytest --collect-only -q
- make alembic-check
