### PR TITLE
feat(records): expose shipping record options

### DIFF
--- a/app/shipping_assist/records/router.py
+++ b/app/shipping_assist/records/router.py
@@ -3,12 +3,13 @@
 # 分拆说明：
 # - 本文件是 TMS / Records 的路由装配入口。
 # - logistics ledger（shipping_records）相关接口已物理收口到 app/shipping_assist/records/；
-# - 当前 WMS 只保留物流台账读取、成本分析与从 Logistics 同步事实入口。
+# - 当前 WMS 只保留物流台账读取、成本分析、筛选项与从 Logistics 同步事实入口。
 from __future__ import annotations
 
 from fastapi import APIRouter
 
 from app.shipping_assist.records import routes_cost_analysis
+from app.shipping_assist.records import routes_options
 from app.shipping_assist.records import routes_read
 from app.shipping_assist.records import routes_sync
 
@@ -17,6 +18,7 @@ router = APIRouter(prefix="/shipping-assist/records", tags=["shipping-assist-rec
 
 def _register_all_routes() -> None:
     routes_read.register(router)
+    routes_options.register(router)
     routes_cost_analysis.register(router)
     routes_sync.register(router)
 

--- a/app/shipping_assist/records/routes_options.py
+++ b/app/shipping_assist/records/routes_options.py
@@ -1,0 +1,97 @@
+# app/shipping_assist/records/routes_options.py
+#
+# 分拆说明：
+# - 本文件承载 WMS 发货记录页筛选项；
+# - 当前 WMS 只保留 shipping_records 本地台帐与从 Logistics 同步事实；
+# - 本接口替代前端对 /shipping-assist/pricing/providers 的依赖，避免 records 页面继续耦合旧运价/网点管理路由。
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.deps import get_async_session as get_session
+from app.user.deps.auth import get_current_user
+
+
+class ShippingRecordsProviderOption(BaseModel):
+    id: int
+    name: str
+    shipping_provider_code: str
+
+
+class ShippingRecordsWarehouseOption(BaseModel):
+    id: int
+    name: str
+
+
+class ShippingRecordsOptionsOut(BaseModel):
+    ok: bool = True
+    providers: list[ShippingRecordsProviderOption]
+    warehouses: list[ShippingRecordsWarehouseOption]
+
+
+def register(router: APIRouter) -> None:
+    @router.get(
+        "/options",
+        response_model=ShippingRecordsOptionsOut,
+        summary="发货记录筛选项",
+    )
+    async def get_shipping_records_options(
+        session: AsyncSession = Depends(get_session),
+        current_user: Any = Depends(get_current_user),
+    ) -> ShippingRecordsOptionsOut:
+        del current_user
+
+        provider_rows = (
+            await session.execute(
+                text(
+                    """
+                    SELECT
+                      id,
+                      name,
+                      shipping_provider_code
+                    FROM shipping_providers
+                    WHERE active IS TRUE
+                    ORDER BY priority ASC, name ASC, id ASC
+                    """
+                )
+            )
+        ).mappings().all()
+
+        warehouse_rows = (
+            await session.execute(
+                text(
+                    """
+                    SELECT
+                      id,
+                      name
+                    FROM warehouses
+                    WHERE active IS TRUE
+                    ORDER BY name ASC, id ASC
+                    """
+                )
+            )
+        ).mappings().all()
+
+        return ShippingRecordsOptionsOut(
+            ok=True,
+            providers=[
+                ShippingRecordsProviderOption(
+                    id=int(row["id"]),
+                    name=str(row["name"]),
+                    shipping_provider_code=str(row["shipping_provider_code"]),
+                )
+                for row in provider_rows
+            ],
+            warehouses=[
+                ShippingRecordsWarehouseOption(
+                    id=int(row["id"]),
+                    name=str(row["name"]),
+                )
+                for row in warehouse_rows
+            ],
+        )

--- a/tests/api/test_shipping_records_options_api.py
+++ b/tests/api/test_shipping_records_options_api.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _login_headers(client: AsyncClient) -> dict[str, str]:
+    resp = await client.post("/users/login", json={"username": "admin", "password": "admin123"})
+    assert resp.status_code == 200, resp.text
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+async def test_shipping_records_options_returns_active_provider_and_warehouse(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    suffix = uuid4().hex[:8].upper()
+    warehouse_name = f"RECORDS-OPT-WH-{suffix}"
+    warehouse_code = f"ROWH{suffix}"
+    provider_name = f"RECORDS-OPT-PROVIDER-{suffix}"
+    provider_code = f"ROSP{suffix}"
+
+    warehouse_id = int(
+        (
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO warehouses (name, code, active, address)
+                    VALUES (:name, :code, true, 'records options test warehouse')
+                    RETURNING id
+                    """
+                ),
+                {"name": warehouse_name, "code": warehouse_code},
+            )
+        ).scalar_one()
+    )
+
+    provider_id = int(
+        (
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO shipping_providers (
+                      name,
+                      shipping_provider_code,
+                      active,
+                      priority,
+                      address
+                    )
+                    VALUES (
+                      :name,
+                      :code,
+                      true,
+                      10,
+                      'records options test provider'
+                    )
+                    RETURNING id
+                    """
+                ),
+                {"name": provider_name, "code": provider_code},
+            )
+        ).scalar_one()
+    )
+
+    await session.commit()
+
+    headers = await _login_headers(client)
+    resp = await client.get("/shipping-assist/records/options", headers=headers)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["ok"] is True
+
+    providers = body["providers"]
+    warehouses = body["warehouses"]
+
+    assert any(
+        int(item["id"]) == provider_id
+        and item["name"] == provider_name
+        and item["shipping_provider_code"] == provider_code
+        for item in providers
+    )
+
+    assert any(
+        int(item["id"]) == warehouse_id
+        and item["name"] == warehouse_name
+        for item in warehouses
+    )


### PR DESCRIPTION
## Summary
- add GET /shipping-assist/records/options for shipping records filter options
- return active WMS shipping provider and warehouse options
- prepare frontend to stop calling retired /shipping-assist/pricing/providers from the records page

## Validation
- make test TESTS=tests/api/test_shipping_records_options_api.py
- make test TESTS=tests/api/test_shipping_records_sync_from_logistics_api.py
- make test TESTS=tests/api/test_user_navigation_api.py
- make alembic-check