### PR TITLE
refactor(warehouses): retire shipping provider bindings

### DIFF
--- a/app/shipping_assist/providers/models/warehouse_shipping_provider.py
+++ b/app/shipping_assist/providers/models/warehouse_shipping_provider.py
@@ -108,9 +108,10 @@ class WarehouseShippingProvider(Base):
         onupdate=func.now(),
     )
 
+    # WMS 仓库模型已不再反向暴露 warehouse_shipping_providers。
+    # 这里保留单向关系仅用于旧表/旧模型在清理完成前通过 mapper 配置。
     warehouse = relationship(
         "Warehouse",
-        back_populates="warehouse_shipping_providers",
         lazy="selectin",
     )
     shipping_provider = relationship(

--- a/app/wms/warehouses/models/warehouse.py
+++ b/app/wms/warehouses/models/warehouse.py
@@ -2,16 +2,12 @@
 # Domain move: Warehouse ORM belongs to WMS warehouses.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Optional
+from typing import Optional
 
 from sqlalchemy import Boolean, Integer, String, text
-from sqlalchemy.orm import Mapped, mapped_column, relationship, validates
+from sqlalchemy.orm import Mapped, mapped_column, validates
 
 from app.db.base import Base
-from app.shipping_assist.providers.models.warehouse_shipping_provider import WarehouseShippingProvider  # noqa: F401
-
-if TYPE_CHECKING:
-    from app.shipping_assist.providers.models.warehouse_shipping_provider import WarehouseShippingProvider
 
 
 class WarehouseCode:
@@ -64,13 +60,6 @@ class Warehouse(Base):
     contact_phone: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
     area_sqm: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
 
-    # ✅ Phase 1：仓库 × 快递公司（能力集合 / 事实绑定）
-    warehouse_shipping_providers: Mapped[List["WarehouseShippingProvider"]] = relationship(
-        "WarehouseShippingProvider",
-        back_populates="warehouse",
-        lazy="selectin",
-        passive_deletes=True,
-    )
 
     @validates("name")
     def _validate_name(self, _key: str, value: str) -> str:

--- a/tests/api/test_warehouse_shipping_provider_routes_retired.py
+++ b/tests/api/test_warehouse_shipping_provider_routes_retired.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from app.main import app
+
+
+def _mounted_paths() -> set[str]:
+    return {getattr(route, "path", "") for route in app.routes}
+
+
+def test_warehouse_shipping_provider_routes_are_not_mounted() -> None:
+    paths = _mounted_paths()
+
+    retired_paths = {
+        "/shipping-providers",
+        "/warehouses/{warehouse_id}/shipping-providers",
+        "/warehouses/{warehouse_id}/shipping-providers/bind",
+        "/warehouses/{warehouse_id}/shipping-providers/{shipping_provider_id}",
+    }
+
+    for path in retired_paths:
+        assert path not in paths, f"{path} should not be mounted in WMS"


### PR DESCRIPTION
## Summary
- remove WMS warehouse ORM reverse relationship to warehouse_shipping_providers
- keep legacy WarehouseShippingProvider mapper one-way only while old tables/code are being cleaned
- assert retired warehouse shipping-provider routes are not mounted
- keep shipping_providers table for WMS shipping records sync/options mapping

## Validation
- make test TESTS=tests/api/test_warehouse_shipping_provider_routes_retired.py
- make test TESTS=tests/api/test_shipping_records_options_api.py
- make test TESTS=tests/api/test_shipping_records_sync_from_logistics_api.py
- make test TESTS=tests/api/test_finance_shipping_cost_ledger_api.py
- make alembic-check