### PR TITLE
refactor(outbound): rename fulfillment outbound timestamps

### DIFF
--- a/alembic/versions/07c12e35bf8e_rename_order_fulfillment_outbound_.py
+++ b/alembic/versions/07c12e35bf8e_rename_order_fulfillment_outbound_.py
@@ -1,0 +1,198 @@
+"""rename order fulfillment outbound timestamps
+
+Revision ID: 07c12e35bf8e
+Revises: 'f24a651ec4a9'
+Create Date: 2026-05-07
+
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+
+revision: str = "07c12e35bf8e"
+down_revision: str | Sequence[str] | None = 'f24a651ec4a9'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Rename WMS outbound timestamp columns away from shipment wording."""
+
+    op.execute(
+        """
+        ALTER TABLE order_fulfillment
+        DROP CONSTRAINT IF EXISTS ck_order_fulfillment_ship_time_order
+        """
+    )
+
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF EXISTS (
+            SELECT 1
+              FROM information_schema.columns
+             WHERE table_schema = 'public'
+               AND table_name = 'order_fulfillment'
+               AND column_name = 'ship_committed_at'
+          )
+          AND NOT EXISTS (
+            SELECT 1
+              FROM information_schema.columns
+             WHERE table_schema = 'public'
+               AND table_name = 'order_fulfillment'
+               AND column_name = 'outbound_committed_at'
+          )
+          THEN
+            ALTER TABLE order_fulfillment
+            RENAME COLUMN ship_committed_at TO outbound_committed_at;
+          END IF;
+
+          IF EXISTS (
+            SELECT 1
+              FROM information_schema.columns
+             WHERE table_schema = 'public'
+               AND table_name = 'order_fulfillment'
+               AND column_name = 'shipped_at'
+          )
+          AND NOT EXISTS (
+            SELECT 1
+              FROM information_schema.columns
+             WHERE table_schema = 'public'
+               AND table_name = 'order_fulfillment'
+               AND column_name = 'outbound_completed_at'
+          )
+          THEN
+            ALTER TABLE order_fulfillment
+            RENAME COLUMN shipped_at TO outbound_completed_at;
+          END IF;
+        END $$;
+        """
+    )
+
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF NOT EXISTS (
+            SELECT 1
+              FROM pg_constraint
+             WHERE conname = 'ck_order_fulfillment_outbound_time_order'
+          )
+          THEN
+            ALTER TABLE order_fulfillment
+            ADD CONSTRAINT ck_order_fulfillment_outbound_time_order
+            CHECK (
+              outbound_completed_at IS NULL
+              OR outbound_committed_at IS NOT NULL
+            );
+          END IF;
+        END $$;
+        """
+    )
+
+    op.execute(
+        """
+        COMMENT ON COLUMN order_fulfillment.outbound_committed_at
+        IS 'WMS 出库提交/裁决链路进入时间；非物流发货时间'
+        """
+    )
+    op.execute(
+        """
+        COMMENT ON COLUMN order_fulfillment.outbound_completed_at
+        IS 'WMS 库存出库完成时间；非物流单号/面单完成时间'
+        """
+    )
+
+
+def downgrade() -> None:
+    """Restore legacy shipment-worded timestamp column names."""
+
+    op.execute(
+        """
+        ALTER TABLE order_fulfillment
+        DROP CONSTRAINT IF EXISTS ck_order_fulfillment_outbound_time_order
+        """
+    )
+
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF EXISTS (
+            SELECT 1
+              FROM information_schema.columns
+             WHERE table_schema = 'public'
+               AND table_name = 'order_fulfillment'
+               AND column_name = 'outbound_committed_at'
+          )
+          AND NOT EXISTS (
+            SELECT 1
+              FROM information_schema.columns
+             WHERE table_schema = 'public'
+               AND table_name = 'order_fulfillment'
+               AND column_name = 'ship_committed_at'
+          )
+          THEN
+            ALTER TABLE order_fulfillment
+            RENAME COLUMN outbound_committed_at TO ship_committed_at;
+          END IF;
+
+          IF EXISTS (
+            SELECT 1
+              FROM information_schema.columns
+             WHERE table_schema = 'public'
+               AND table_name = 'order_fulfillment'
+               AND column_name = 'outbound_completed_at'
+          )
+          AND NOT EXISTS (
+            SELECT 1
+              FROM information_schema.columns
+             WHERE table_schema = 'public'
+               AND table_name = 'order_fulfillment'
+               AND column_name = 'shipped_at'
+          )
+          THEN
+            ALTER TABLE order_fulfillment
+            RENAME COLUMN outbound_completed_at TO shipped_at;
+          END IF;
+        END $$;
+        """
+    )
+
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF NOT EXISTS (
+            SELECT 1
+              FROM pg_constraint
+             WHERE conname = 'ck_order_fulfillment_ship_time_order'
+          )
+          THEN
+            ALTER TABLE order_fulfillment
+            ADD CONSTRAINT ck_order_fulfillment_ship_time_order
+            CHECK (
+              shipped_at IS NULL
+              OR ship_committed_at IS NOT NULL
+            );
+          END IF;
+        END $$;
+        """
+    )
+
+    op.execute(
+        """
+        COMMENT ON COLUMN order_fulfillment.ship_committed_at
+        IS '进入出库裁决链路锚点（事实字段）'
+        """
+    )
+    op.execute(
+        """
+        COMMENT ON COLUMN order_fulfillment.shipped_at
+        IS '出库完成时间（事实字段）'
+        """
+    )

--- a/app/analytics/contracts/orders_sla_stats.py
+++ b/app/analytics/contracts/orders_sla_stats.py
@@ -6,25 +6,28 @@ from pydantic import BaseModel, Field
 
 class OrdersSlaStatsModel(BaseModel):
     """
-    发货 SLA 统计：
+    WMS 出库 SLA 统计：
 
-    - total_orders    : 时间窗口内有发货记录的订单数
-    - avg_ship_hours  : 平均发货耗时（小时）
-    - p95_ship_hours  : 95 分位发货耗时（小时）
-    - on_time_orders  : 在 SLA 小时内发货的订单数
+    - total_orders    : 时间窗口内 WMS 出库完成的订单数
+    - avg_ship_hours  : 平均 WMS 出库耗时（小时）
+    - p95_ship_hours  : 95 分位 WMS 出库耗时（小时）
+    - on_time_orders  : 在 SLA 小时内完成 WMS 出库的订单数
     - on_time_rate    : 准时率 = on_time_orders / total_orders
+
+    字段名暂保持 avg_ship_hours / p95_ship_hours，以维持当前统计 API 的输出合同；
+    其计算口径已切换为 order_fulfillment.outbound_completed_at。
     """
 
-    total_orders: int = Field(..., description="时间窗口内有发货记录的订单数量")
+    total_orders: int = Field(..., description="时间窗口内 WMS 出库完成的订单数量")
     avg_ship_hours: float | None = Field(
         None,
-        description="平均发货耗时（小时），无订单时为 null",
+        description="平均 WMS 出库耗时（小时），无订单时为 null",
     )
     p95_ship_hours: float | None = Field(
         None,
-        description="95 分位发货耗时（小时），无订单时为 null",
+        description="95 分位 WMS 出库耗时（小时），无订单时为 null",
     )
-    on_time_orders: int = Field(..., description="在 SLA 小时内发货的订单数")
+    on_time_orders: int = Field(..., description="在 SLA 小时内完成 WMS 出库的订单数")
     on_time_rate: float = Field(
         ...,
         description="准时率 = on_time_orders / total_orders（无订单时为 0.0）",

--- a/app/analytics/helpers/orders_sla_stats.py
+++ b/app/analytics/helpers/orders_sla_stats.py
@@ -11,7 +11,7 @@ def normalize_window(
 ) -> tuple[datetime, datetime]:
     """
     规范化时间窗口：
-    - 默认：最近 7 天（基于 shipped_at）
+    - 默认：最近 7 天（基于 order_fulfillment.outbound_completed_at）
     - 若只给一端，自动补另一端
     """
     now = datetime.now(timezone.utc)

--- a/app/analytics/routers/orders_sla_stats_routes.py
+++ b/app/analytics/routers/orders_sla_stats_routes.py
@@ -8,9 +8,9 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.db.deps import get_async_session as get_session
-from app.analytics.helpers.orders_sla_stats import normalize_window
 from app.analytics.contracts.orders_sla_stats import OrdersSlaStatsModel
+from app.analytics.helpers.orders_sla_stats import normalize_window
+from app.db.deps import get_async_session as get_session
 
 
 router = APIRouter(prefix="/orders/stats", tags=["orders-sla"])
@@ -24,11 +24,11 @@ def register(router: APIRouter) -> None:
     async def get_orders_sla_stats(
         time_from: Optional[datetime] = Query(
             None,
-            description="起始时间（含），用于过滤发货完成时间 order_fulfillment.shipped_at",
+            description="起始时间（含），用于过滤 WMS 出库完成时间 order_fulfillment.outbound_completed_at",
         ),
         time_to: Optional[datetime] = Query(
             None,
-            description="结束时间（含），用于过滤发货完成时间 order_fulfillment.shipped_at",
+            description="结束时间（含），用于过滤 WMS 出库完成时间 order_fulfillment.outbound_completed_at",
         ),
         platform: Optional[str] = Query(
             None,
@@ -41,18 +41,19 @@ def register(router: APIRouter) -> None:
         sla_hours: float = Query(
             24.0,
             ge=0.0,
-            description="SLA 阈值（小时），用于判断是否准时发货，默认 24 小时",
+            description="SLA 阈值（小时），用于判断是否准时完成 WMS 出库，默认 24 小时",
         ),
         session: AsyncSession = Depends(get_session),
     ) -> OrdersSlaStatsModel:
         """
-        订单发货 SLA 统计：
+        订单 WMS 出库 SLA 统计：
 
         - 以 orders.created_at 为下单时间；
-        - 以 order_fulfillment.shipped_at 为发货完成时间；
+        - 以 order_fulfillment.outbound_completed_at 为 WMS 出库完成时间；
         - 通过 order_fulfillment.order_id 关联 orders.id。
 
-        只统计在给定时间窗口内发货的订单（按 order_fulfillment.shipped_at 过滤）。
+        只统计在给定时间窗口内完成 WMS 出库的订单
+        （按 order_fulfillment.outbound_completed_at 过滤）。
 
         ✅ PROD-only（简化口径）：
         - 排除测试店铺（platform_test_stores.code='DEFAULT'，以 store_id 为事实锚点）
@@ -62,21 +63,21 @@ def register(router: APIRouter) -> None:
         plat = platform.upper().strip() if platform else None
 
         base_sql = """
-        WITH shipped AS (
+        WITH outbound_completed AS (
           SELECT
-            o.id                    AS order_id,
-            o.platform              AS platform,
-            o.store_code               AS store_code,
-            o.created_at            AS created_at,
-            f.shipped_at            AS shipped_at,
-            EXTRACT(EPOCH FROM (f.shipped_at - o.created_at)) / 3600.0
-                                    AS latency_hours
+            o.id                              AS order_id,
+            o.platform                        AS platform,
+            o.store_code                      AS store_code,
+            o.created_at                      AS created_at,
+            f.outbound_completed_at           AS outbound_completed_at,
+            EXTRACT(EPOCH FROM (f.outbound_completed_at - o.created_at)) / 3600.0
+                                              AS latency_hours
           FROM orders AS o
           JOIN order_fulfillment AS f
             ON f.order_id = o.id
-          WHERE f.shipped_at IS NOT NULL
-            AND f.shipped_at >= :start
-            AND f.shipped_at <= :end
+          WHERE f.outbound_completed_at IS NOT NULL
+            AND f.outbound_completed_at >= :start
+            AND f.outbound_completed_at <= :end
 
             -- ----------------- PROD-only：测试店铺门禁（store_id 级别） -----------------
             AND NOT EXISTS (
@@ -90,12 +91,12 @@ def register(router: APIRouter) -> None:
         )
         SELECT
           COUNT(*)                         AS total_orders,
-          AVG(latency_hours)              AS avg_hours,
+          AVG(latency_hours)               AS avg_hours,
           percentile_disc(0.95)
             WITHIN GROUP (ORDER BY latency_hours) AS p95_hours,
           COUNT(*) FILTER (WHERE latency_hours <= :sla_hours)
-                                          AS on_time_orders
-        FROM shipped
+                                           AS on_time_orders
+        FROM outbound_completed
         """
 
         params: dict[str, object] = {
@@ -145,6 +146,7 @@ def register(router: APIRouter) -> None:
             on_time_orders=on_time_orders,
             on_time_rate=on_time_rate,
         )
+
 
 register(router)
 

--- a/app/oms/orders/models/order_fulfillment.py
+++ b/app/oms/orders/models/order_fulfillment.py
@@ -19,8 +19,8 @@ class OrderFulfillment(Base):
     - planned_warehouse_id：服务归属快照（planned）
     - actual_warehouse_id：执行仓事实（actual）
     - execution_stage：显式执行阶段真相（PICK / SHIP；NULL = 未进入执行链路）
-    - ship_committed_at：进入出库裁决链路锚点（事实字段）
-    - shipped_at：出库完成时间（事实字段）
+    - outbound_committed_at：进入 WMS 出库提交 / 出库裁决链路的事实时间
+    - outbound_completed_at：WMS 库存出库完成时间；不是物流单号/面单完成时间
     - fulfillment_status：路由态/阻断态/人工干预语义（禁止再存 SHIP_COMMITTED/SHIPPED）
     - blocked_reasons：阻断原因（jsonb）
 
@@ -62,14 +62,16 @@ class OrderFulfillment(Base):
         nullable=True,
     )
 
-    ship_committed_at: Mapped[Optional[datetime]] = mapped_column(
+    outbound_committed_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True),
         nullable=True,
+        comment="WMS 出库提交/裁决链路进入时间；非物流发货时间",
     )
 
-    shipped_at: Mapped[Optional[datetime]] = mapped_column(
+    outbound_completed_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True),
         nullable=True,
+        comment="WMS 库存出库完成时间；非物流单号/面单完成时间",
     )
 
     updated_at: Mapped[datetime] = mapped_column(

--- a/app/wms/outbound/services/order_fulfillment_service.py
+++ b/app/wms/outbound/services/order_fulfillment_service.py
@@ -19,8 +19,8 @@ class FulfillmentRow:
     fulfillment_status: Optional[str]
     blocked_reasons: Optional[dict]
     execution_stage: Optional[str]
-    ship_committed_at: Optional[datetime]
-    shipped_at: Optional[datetime]
+    outbound_committed_at: Optional[datetime]
+    outbound_completed_at: Optional[datetime]
 
 
 class OrderFulfillmentService:
@@ -28,8 +28,8 @@ class OrderFulfillmentService:
     Phase 5（路 A）：执行阶段真相只看 execution_stage；SHIP 子状态机从 fulfillment_status 彻底移除。
 
     - execution_stage：NULL/PICK/SHIP（单向，不回退）
-    - ship_committed_at：进入出库裁决链路锚点（事实）
-    - shipped_at：出库完成（事实）
+    - outbound_committed_at：进入 WMS 出库提交 / 出库裁决链路的事实时间
+    - outbound_completed_at：WMS 库存出库完成时间；不是物流单号/面单完成时间
     - fulfillment_status：仅保留路由/阻断/人工干预语义（DB 已禁止 SHIP_COMMITTED/SHIPPED）
     """
 
@@ -37,7 +37,11 @@ class OrderFulfillmentService:
     STAGE_SHIP = "SHIP"
 
     @staticmethod
-    async def _load_for_update(session: AsyncSession, *, order_id: int) -> Optional[FulfillmentRow]:
+    async def _load_for_update(
+        session: AsyncSession,
+        *,
+        order_id: int,
+    ) -> Optional[FulfillmentRow]:
         row = (
             await session.execute(
                 text(
@@ -49,8 +53,8 @@ class OrderFulfillmentService:
                       fulfillment_status,
                       blocked_reasons,
                       execution_stage,
-                      ship_committed_at,
-                      shipped_at
+                      outbound_committed_at,
+                      outbound_completed_at
                     FROM order_fulfillment
                     WHERE order_id = :oid
                     FOR UPDATE
@@ -70,11 +74,11 @@ class OrderFulfillmentService:
             fulfillment_status=(str(row[3]) if row[3] is not None else None),
             blocked_reasons=(row[4] if row[4] is not None else None),
             execution_stage=(str(row[5]) if row[5] is not None else None),
-            ship_committed_at=(row[6] if row[6] is not None else None),
-            shipped_at=(row[7] if row[7] is not None else None),
+            outbound_committed_at=(row[6] if row[6] is not None else None),
+            outbound_completed_at=(row[7] if row[7] is not None else None),
         )
 
-    async def ensure_ship_committed(
+    async def ensure_outbound_committed(
         self,
         session: AsyncSession,
         *,
@@ -83,16 +87,16 @@ class OrderFulfillmentService:
         at: datetime,
     ) -> dict:
         """
-        进入出库裁决链路锚点（事实）：
+        进入 WMS 出库提交 / 出库裁决链路锚点（事实）：
 
         - 确保 order_fulfillment 行存在
         - 硬约束执行仓不可漂移
-        - ship_committed_at：NULL -> at；非 NULL 幂等
+        - outbound_committed_at：NULL -> at；非 NULL 幂等
         - execution_stage：单向推进到 SHIP（不回退）
 
         返回：
-        - idempotent: bool（ship_committed_at 是否已存在）
-        - ship_committed_at: str（ISO）
+        - idempotent: bool（outbound_committed_at 是否已存在）
+        - outbound_committed_at: str（ISO）
         """
         existing = await self._load_for_update(session, order_id=int(order_id))
 
@@ -103,24 +107,29 @@ class OrderFulfillmentService:
                     INSERT INTO order_fulfillment(
                       order_id,
                       actual_warehouse_id,
-                      ship_committed_at,
+                      outbound_committed_at,
                       execution_stage,
                       updated_at
                     )
-                    VALUES (:oid, :wid, :sca, :stg, :at)
+                    VALUES (:oid, :wid, :oca, :stg, :at)
                     """
                 ),
                 {
                     "oid": int(order_id),
                     "wid": int(warehouse_id),
-                    "sca": at,
+                    "oca": at,
                     "stg": self.STAGE_SHIP,
                     "at": at,
                 },
             )
-            return {"idempotent": False, "ship_committed_at": at.isoformat()}
+            return {
+                "idempotent": False,
+                "outbound_committed_at": at.isoformat(),
+            }
 
-        if existing.actual_warehouse_id is not None and int(existing.actual_warehouse_id) != int(warehouse_id):
+        if existing.actual_warehouse_id is not None and int(
+            existing.actual_warehouse_id
+        ) != int(warehouse_id):
             raise_problem(
                 status_code=409,
                 error_code="fulfillment_warehouse_conflict",
@@ -131,17 +140,22 @@ class OrderFulfillmentService:
                     "incoming_warehouse_id": int(warehouse_id),
                 },
                 details=[],
-                next_actions=[{"action": "inspect_fulfillment", "label": "检查订单履约记录"}],
+                next_actions=[
+                    {
+                        "action": "inspect_fulfillment",
+                        "label": "检查订单履约记录",
+                    }
+                ],
             )
 
-        idempotent = existing.ship_committed_at is not None
+        idempotent = existing.outbound_committed_at is not None
 
         await session.execute(
             text(
                 """
                 UPDATE order_fulfillment
                    SET actual_warehouse_id = COALESCE(actual_warehouse_id, :wid),
-                       ship_committed_at = COALESCE(ship_committed_at, :sca),
+                       outbound_committed_at = COALESCE(outbound_committed_at, :oca),
                        execution_stage = CASE
                            WHEN execution_stage IS NULL THEN 'SHIP'
                            WHEN execution_stage = 'PICK' THEN 'SHIP'
@@ -152,12 +166,17 @@ class OrderFulfillmentService:
                  WHERE order_id = :oid
                 """
             ),
-            {"oid": int(order_id), "wid": int(warehouse_id), "sca": at, "at": at},
+            {"oid": int(order_id), "wid": int(warehouse_id), "oca": at, "at": at},
         )
 
-        return {"idempotent": bool(idempotent), "ship_committed_at": (existing.ship_committed_at or at).isoformat()}
+        return {
+            "idempotent": bool(idempotent),
+            "outbound_committed_at": (
+                existing.outbound_committed_at or at
+            ).isoformat(),
+        }
 
-    async def mark_shipped(
+    async def mark_outbound_completed(
         self,
         session: AsyncSession,
         *,
@@ -165,31 +184,35 @@ class OrderFulfillmentService:
         at: datetime,
     ) -> dict:
         """
-        出库完成（事实）：
+        WMS 库存出库完成（事实）：
 
         规则（硬）：
-        - 必须先存在 ship_committed_at（否则 409）
-        - shipped_at 幂等：已存在则不重复写
+        - 必须先存在 outbound_committed_at（否则 409）
+        - outbound_completed_at 幂等：已存在则不重复写
         - execution_stage 强制为 SHIP（单向不回退）
 
         返回：
-        - idempotent: bool（shipped_at 是否已存在）
-        - shipped_at: str（ISO）
+        - idempotent: bool（outbound_completed_at 是否已存在）
+        - outbound_completed_at: str（ISO）
         """
         existing = await self._load_for_update(session, order_id=int(order_id))
         if existing is None:
             raise_problem(
                 status_code=409,
                 error_code="fulfillment_missing",
-                message="订单履约记录不存在：禁止直接标记已出库，请先进入出库裁决链路（ship_committed）。",
+                message="订单履约记录不存在：禁止直接标记已出库，请先进入 WMS 出库提交链路。",
                 context={"order_id": int(order_id)},
                 details=[],
-                next_actions=[{"action": "ensure_ship_committed", "label": "先进入出库裁决链路（ship_committed）"}],
+                next_actions=[
+                    {
+                        "action": "ensure_outbound_committed",
+                        "label": "先进入 WMS 出库提交链路",
+                    }
+                ],
             )
-            return {"idempotent": False, "shipped_at": ""}
+            return {"idempotent": False, "outbound_completed_at": ""}
 
-        if existing.shipped_at is not None:
-            # 幂等：已出库
+        if existing.outbound_completed_at is not None:
             await session.execute(
                 text(
                     """
@@ -206,24 +229,32 @@ class OrderFulfillmentService:
                 ),
                 {"oid": int(order_id), "at": at},
             )
-            return {"idempotent": True, "shipped_at": existing.shipped_at.isoformat()}
+            return {
+                "idempotent": True,
+                "outbound_completed_at": existing.outbound_completed_at.isoformat(),
+            }
 
-        if existing.ship_committed_at is None:
+        if existing.outbound_committed_at is None:
             raise_problem(
                 status_code=409,
                 error_code="fulfillment_invalid_transition",
-                message="履约状态不允许直接标记已出库：必须先进入出库裁决链路（ship_committed）。",
+                message="履约状态不允许直接标记已出库：必须先进入 WMS 出库提交链路。",
                 context={"order_id": int(order_id)},
                 details=[],
-                next_actions=[{"action": "ensure_ship_committed", "label": "先进入出库裁决链路（ship_committed）"}],
+                next_actions=[
+                    {
+                        "action": "ensure_outbound_committed",
+                        "label": "先进入 WMS 出库提交链路",
+                    }
+                ],
             )
-            return {"idempotent": False, "shipped_at": ""}
+            return {"idempotent": False, "outbound_completed_at": ""}
 
         await session.execute(
             text(
                 """
                 UPDATE order_fulfillment
-                   SET shipped_at = COALESCE(shipped_at, :sa),
+                   SET outbound_completed_at = COALESCE(outbound_completed_at, :oca),
                        execution_stage = CASE
                            WHEN execution_stage IS NULL THEN 'SHIP'
                            WHEN execution_stage = 'PICK' THEN 'SHIP'
@@ -234,7 +265,7 @@ class OrderFulfillmentService:
                  WHERE order_id = :oid
                 """
             ),
-            {"oid": int(order_id), "sa": at, "at": at},
+            {"oid": int(order_id), "oca": at, "at": at},
         )
 
-        return {"idempotent": False, "shipped_at": at.isoformat()}
+        return {"idempotent": False, "outbound_completed_at": at.isoformat()}

--- a/scripts/make/lint.mk
+++ b/scripts/make/lint.mk
@@ -2,7 +2,10 @@
 # lint.mk - backend lint
 # =================================
 
-.PHONY: lint-backend
-lint-backend:
-	@echo "[lint] Running ruff via pre-commit ..."
+.PHONY: lint lint-backend
+
+lint: lint-backend
+
+lint-backend: venv
+	@echo "[lint] Running pre-commit hooks ..."
 	pre-commit run --all-files

--- a/tests/api/test_orders_sla_stats_api.py
+++ b/tests/api/test_orders_sla_stats_api.py
@@ -14,13 +14,13 @@ from tests.services._helpers import ensure_store
 pytestmark = pytest.mark.asyncio
 
 
-async def _seed_shipped_order(
+async def _seed_outbound_completed_order(
     session: AsyncSession,
     *,
     platform: str = "PDD",
     store_code: str = "UT-SLA-STORE",
     created_at: datetime,
-    shipped_at: datetime,
+    outbound_completed_at: datetime,
 ) -> int:
     store_id = await ensure_store(
         session,
@@ -70,54 +70,54 @@ async def _seed_shipped_order(
               order_id,
               actual_warehouse_id,
               execution_stage,
-              ship_committed_at,
-              shipped_at,
+              outbound_committed_at,
+              outbound_completed_at,
               updated_at
             )
             VALUES (
               :order_id,
               1,
               'SHIP',
-              :shipped_at,
-              :shipped_at,
-              :shipped_at
+              :outbound_completed_at,
+              :outbound_completed_at,
+              :outbound_completed_at
             )
             ON CONFLICT (order_id) DO UPDATE
                SET actual_warehouse_id = EXCLUDED.actual_warehouse_id,
                    execution_stage = EXCLUDED.execution_stage,
-                   ship_committed_at = EXCLUDED.ship_committed_at,
-                   shipped_at = EXCLUDED.shipped_at,
+                   outbound_committed_at = EXCLUDED.outbound_committed_at,
+                   outbound_completed_at = EXCLUDED.outbound_completed_at,
                    updated_at = EXCLUDED.updated_at
             """
         ),
         {
             "order_id": order_id,
-            "shipped_at": shipped_at,
+            "outbound_completed_at": outbound_completed_at,
         },
     )
     await session.commit()
     return order_id
 
 
-async def test_orders_sla_stats_uses_order_fulfillment_shipped_at(
+async def test_orders_sla_stats_uses_order_fulfillment_outbound_completed_at(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
     now = datetime.now(timezone.utc).replace(microsecond=0)
     created_at = now - timedelta(hours=2)
-    shipped_at = now - timedelta(hours=1)
+    outbound_completed_at = now - timedelta(hours=1)
 
-    await _seed_shipped_order(
+    await _seed_outbound_completed_order(
         session,
         created_at=created_at,
-        shipped_at=shipped_at,
+        outbound_completed_at=outbound_completed_at,
     )
 
     resp = await client.get(
         "/orders/stats/sla",
         params={
-            "time_from": (shipped_at - timedelta(minutes=1)).isoformat(),
-            "time_to": (shipped_at + timedelta(minutes=1)).isoformat(),
+            "time_from": (outbound_completed_at - timedelta(minutes=1)).isoformat(),
+            "time_to": (outbound_completed_at + timedelta(minutes=1)).isoformat(),
             "platform": "PDD",
             "store_code": "UT-SLA-STORE",
             "sla_hours": 2,
@@ -133,18 +133,18 @@ async def test_orders_sla_stats_uses_order_fulfillment_shipped_at(
     assert 0.9 <= float(data["avg_ship_hours"]) <= 1.1
 
 
-async def test_orders_sla_stats_filters_by_shipped_at_window(
+async def test_orders_sla_stats_filters_by_outbound_completed_at_window(
     client: AsyncClient,
     session: AsyncSession,
 ) -> None:
     now = datetime.now(timezone.utc).replace(microsecond=0)
 
-    await _seed_shipped_order(
+    await _seed_outbound_completed_order(
         session,
         platform="PDD",
         store_code="UT-SLA-WINDOW",
         created_at=now - timedelta(hours=5),
-        shipped_at=now - timedelta(hours=4),
+        outbound_completed_at=now - timedelta(hours=4),
     )
 
     resp = await client.get(


### PR DESCRIPTION
## Summary
- rename order_fulfillment.ship_committed_at to outbound_committed_at
- rename order_fulfillment.shipped_at to outbound_completed_at
- update WMS fulfillment service naming away from shipment wording
- update order SLA stats to read outbound_completed_at
- add make lint alias for the existing backend lint entry
- update related model and tests

## Scope
- WMS outbound timestamp naming only
- no Logistics import/export table changes
- no Logistics API changes
- no frontend changes
- no OpenAPI snapshot changes in this PR

## Tests
- make upgrade-dev
- make alembic-check
- TESTS="tests/api/test_orders_sla_stats_api.py tests/api/test_order_outbound_submit_api.py tests/api/test_manual_outbound_submit_api.py" make test
- make lint
- make test