### PR TITLE
feat(outbound): add WMS logistics export records

### DIFF
--- a/alembic/versions/ec6037fb0e66_add_wms_logistics_export_records.py
+++ b/alembic/versions/ec6037fb0e66_add_wms_logistics_export_records.py
@@ -1,0 +1,102 @@
+"""add wms logistics export records
+
+Revision ID: ec6037fb0e66
+Revises: '07c12e35bf8e'
+Create Date: 2026-05-07
+
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "ec6037fb0e66"
+down_revision: str | Sequence[str] | None = '07c12e35bf8e'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+TABLE_NAME = "wms_logistics_export_records"
+
+
+def upgrade() -> None:
+    op.create_table(
+        TABLE_NAME,
+        sa.Column("id", sa.BigInteger(), sa.Identity(), nullable=False),
+        sa.Column("source_doc_type", sa.String(length=32), nullable=False, comment="WMS 来源单据类型：ORDER_OUTBOUND / MANUAL_OUTBOUND"),
+        sa.Column("source_doc_id", sa.BigInteger(), nullable=False, comment="WMS 来源单据主键：orders.id 或 manual_outbound_docs.id"),
+        sa.Column("source_doc_no", sa.String(length=128), nullable=False, comment="WMS 来源单据展示号：平台订单号或手工出库单号"),
+        sa.Column("source_ref", sa.String(length=192), nullable=False, comment="WMS 到 Logistics 的稳定幂等键"),
+        sa.Column("export_status", sa.String(length=16), nullable=False, server_default="PENDING", comment="交接导出状态：PENDING / EXPORTED / FAILED / CANCELLED"),
+        sa.Column("logistics_status", sa.String(length=16), nullable=False, server_default="NOT_IMPORTED", comment="Logistics 处理状态：NOT_IMPORTED / IMPORTED / IN_PROGRESS / COMPLETED / FAILED"),
+        sa.Column("logistics_request_id", sa.BigInteger(), nullable=True, comment="Logistics 发货请求 ID"),
+        sa.Column("logistics_request_no", sa.String(length=64), nullable=True, comment="Logistics 发货请求号"),
+        sa.Column("exported_at", sa.DateTime(timezone=True), nullable=True, comment="Logistics 成功导入时间"),
+        sa.Column("logistics_completed_at", sa.DateTime(timezone=True), nullable=True, comment="Logistics 物流处理完成时间"),
+        sa.Column("last_attempt_at", sa.DateTime(timezone=True), nullable=True, comment="最近一次导入/回写尝试时间"),
+        sa.Column("last_error", sa.Text(), nullable=True, comment="最近一次失败原因"),
+        sa.Column(
+            "source_snapshot",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+            comment="创建交接记录时的 WMS 来源快照",
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.PrimaryKeyConstraint("id", name="pk_wms_logistics_export_records"),
+        sa.UniqueConstraint("source_doc_type", "source_doc_id", name="uq_wms_logistics_export_records_doc"),
+        sa.UniqueConstraint("source_ref", name="uq_wms_logistics_export_records_source_ref"),
+        sa.CheckConstraint("source_doc_type IN ('ORDER_OUTBOUND', 'MANUAL_OUTBOUND')", name="ck_wms_logistics_export_records_doc_type"),
+        sa.CheckConstraint("export_status IN ('PENDING', 'EXPORTED', 'FAILED', 'CANCELLED')", name="ck_wms_logistics_export_records_export_status"),
+        sa.CheckConstraint("logistics_status IN ('NOT_IMPORTED', 'IMPORTED', 'IN_PROGRESS', 'COMPLETED', 'FAILED')", name="ck_wms_logistics_export_records_logistics_status"),
+    )
+
+    op.create_index(
+        "ix_wms_logistics_export_records_export_status",
+        TABLE_NAME,
+        ["export_status", "logistics_status"],
+    )
+    op.create_index(
+        "ix_wms_logistics_export_records_doc_type",
+        TABLE_NAME,
+        ["source_doc_type", "source_doc_id"],
+    )
+    op.create_index(
+        "ix_wms_logistics_export_records_request_no",
+        TABLE_NAME,
+        ["logistics_request_no"],
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION trg_wms_logistics_export_records_touch_updated_at()
+        RETURNS trigger AS $$
+        BEGIN
+          NEW.updated_at = now();
+          RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER trg_wms_logistics_export_records_updated_at
+        BEFORE UPDATE ON wms_logistics_export_records
+        FOR EACH ROW
+        EXECUTE FUNCTION trg_wms_logistics_export_records_touch_updated_at()
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS trg_wms_logistics_export_records_updated_at ON wms_logistics_export_records")
+    op.execute("DROP FUNCTION IF EXISTS trg_wms_logistics_export_records_touch_updated_at")
+    op.drop_index("ix_wms_logistics_export_records_request_no", table_name=TABLE_NAME)
+    op.drop_index("ix_wms_logistics_export_records_doc_type", table_name=TABLE_NAME)
+    op.drop_index("ix_wms_logistics_export_records_export_status", table_name=TABLE_NAME)
+    op.drop_table(TABLE_NAME)

--- a/app/wms/outbound/models/__init__.py
+++ b/app/wms/outbound/models/__init__.py
@@ -4,3 +4,4 @@ from .outbound_event import OutboundEventLine
 __all__ = ["OutboundEventLine", "PrintJob"]
 
 from app.wms.outbound.models.print_job import PrintJob
+from app.wms.outbound.models.logistics_export_record import WmsLogisticsExportRecord  # noqa: F401

--- a/app/wms/outbound/models/logistics_export_record.py
+++ b/app/wms/outbound/models/logistics_export_record.py
@@ -1,0 +1,132 @@
+# app/wms/outbound/models/logistics_export_record.py
+# WMS -> Logistics 交接状态表模型。
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+import sqlalchemy as sa
+from sqlalchemy import BigInteger, DateTime, String, Text, func, text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class WmsLogisticsExportRecord(Base):
+    """
+    wms_logistics_export_records：WMS 出库事实交接给 Logistics 的状态表。
+
+    - WMS 订单出库完成：source_doc_type = ORDER_OUTBOUND
+    - WMS 手工出库完成：source_doc_type = MANUAL_OUTBOUND
+    - export_status：WMS 交接导出状态
+    - logistics_status：Logistics 处理状态
+    """
+
+    __tablename__ = "wms_logistics_export_records"
+
+    __table_args__ = (
+        sa.UniqueConstraint("source_doc_type", "source_doc_id", name="uq_wms_logistics_export_records_doc"),
+        sa.UniqueConstraint("source_ref", name="uq_wms_logistics_export_records_source_ref"),
+        sa.CheckConstraint(
+            "source_doc_type IN ('ORDER_OUTBOUND', 'MANUAL_OUTBOUND')",
+            name="ck_wms_logistics_export_records_doc_type",
+        ),
+        sa.CheckConstraint(
+            "export_status IN ('PENDING', 'EXPORTED', 'FAILED', 'CANCELLED')",
+            name="ck_wms_logistics_export_records_export_status",
+        ),
+        sa.CheckConstraint(
+            "logistics_status IN ('NOT_IMPORTED', 'IMPORTED', 'IN_PROGRESS', 'COMPLETED', 'FAILED')",
+            name="ck_wms_logistics_export_records_logistics_status",
+        ),
+        sa.Index("ix_wms_logistics_export_records_export_status", "export_status", "logistics_status"),
+        sa.Index("ix_wms_logistics_export_records_doc_type", "source_doc_type", "source_doc_id"),
+        sa.Index("ix_wms_logistics_export_records_request_no", "logistics_request_no"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+
+    source_doc_type: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        comment="WMS 来源单据类型：ORDER_OUTBOUND / MANUAL_OUTBOUND",
+    )
+    source_doc_id: Mapped[int] = mapped_column(
+        BigInteger,
+        nullable=False,
+        comment="WMS 来源单据主键：orders.id 或 manual_outbound_docs.id",
+    )
+    source_doc_no: Mapped[str] = mapped_column(
+        String(128),
+        nullable=False,
+        comment="WMS 来源单据展示号：平台订单号或手工出库单号",
+    )
+    source_ref: Mapped[str] = mapped_column(
+        String(192),
+        nullable=False,
+        comment="WMS 到 Logistics 的稳定幂等键",
+    )
+
+    export_status: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        server_default="PENDING",
+        comment="交接导出状态：PENDING / EXPORTED / FAILED / CANCELLED",
+    )
+    logistics_status: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        server_default="NOT_IMPORTED",
+        comment="Logistics 处理状态：NOT_IMPORTED / IMPORTED / IN_PROGRESS / COMPLETED / FAILED",
+    )
+
+    logistics_request_id: Mapped[Optional[int]] = mapped_column(
+        BigInteger,
+        nullable=True,
+        comment="Logistics 发货请求 ID",
+    )
+    logistics_request_no: Mapped[Optional[str]] = mapped_column(
+        String(64),
+        nullable=True,
+        comment="Logistics 发货请求号",
+    )
+
+    exported_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Logistics 成功导入时间",
+    )
+    logistics_completed_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Logistics 物流处理完成时间",
+    )
+    last_attempt_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="最近一次导入/回写尝试时间",
+    )
+    last_error: Mapped[Optional[str]] = mapped_column(
+        Text,
+        nullable=True,
+        comment="最近一次失败原因",
+    )
+
+    source_snapshot: Mapped[dict] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'{}'::jsonb"),
+        comment="创建交接记录时的 WMS 来源快照",
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )

--- a/app/wms/outbound/repos/logistics_export_record_repo.py
+++ b/app/wms/outbound/repos/logistics_export_record_repo.py
@@ -1,0 +1,89 @@
+# app/wms/outbound/repos/logistics_export_record_repo.py
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def _json_snapshot(value: Mapping[str, Any] | None) -> str:
+    if not value:
+        return "{}"
+    return json.dumps(value, ensure_ascii=False, default=str)
+
+
+async def upsert_pending_logistics_export_record(
+    session: AsyncSession,
+    *,
+    source_doc_type: str,
+    source_doc_id: int,
+    source_doc_no: str,
+    source_ref: str,
+    source_snapshot: Mapping[str, Any] | None = None,
+) -> None:
+    """
+    幂等写入 WMS -> Logistics 待交接记录。
+
+    已进入 EXPORTED / IMPORTED / IN_PROGRESS / COMPLETED 的记录不被回退；
+    FAILED / CANCELLED 以外的未完成状态可回到 PENDING，供后续导入接口读取。
+    """
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_logistics_export_records (
+              source_doc_type,
+              source_doc_id,
+              source_doc_no,
+              source_ref,
+              export_status,
+              logistics_status,
+              source_snapshot,
+              last_error,
+              created_at,
+              updated_at
+            )
+            VALUES (
+              :source_doc_type,
+              :source_doc_id,
+              :source_doc_no,
+              :source_ref,
+              'PENDING',
+              'NOT_IMPORTED',
+              CAST(:source_snapshot AS jsonb),
+              NULL,
+              now(),
+              now()
+            )
+            ON CONFLICT (source_doc_type, source_doc_id) DO UPDATE
+               SET source_doc_no = EXCLUDED.source_doc_no,
+                   source_ref = EXCLUDED.source_ref,
+                   source_snapshot = EXCLUDED.source_snapshot,
+                   export_status = CASE
+                       WHEN wms_logistics_export_records.export_status = 'EXPORTED'
+                         THEN wms_logistics_export_records.export_status
+                       ELSE 'PENDING'
+                   END,
+                   logistics_status = CASE
+                       WHEN wms_logistics_export_records.logistics_status IN ('IMPORTED', 'IN_PROGRESS', 'COMPLETED')
+                         THEN wms_logistics_export_records.logistics_status
+                       ELSE 'NOT_IMPORTED'
+                   END,
+                   last_error = CASE
+                       WHEN wms_logistics_export_records.export_status = 'EXPORTED'
+                         THEN wms_logistics_export_records.last_error
+                       ELSE NULL
+                   END,
+                   updated_at = now()
+            """
+        ),
+        {
+            "source_doc_type": str(source_doc_type),
+            "source_doc_id": int(source_doc_id),
+            "source_doc_no": str(source_doc_no).strip(),
+            "source_ref": str(source_ref).strip(),
+            "source_snapshot": _json_snapshot(source_snapshot),
+        },
+    )

--- a/app/wms/outbound/services/outbound_event_submit_service.py
+++ b/app/wms/outbound/services/outbound_event_submit_service.py
@@ -31,6 +31,9 @@ from app.wms.outbound.repos.outbound_event_repo import (
     load_stocks_lot_for_update,
     update_stocks_lot_qty,
 )
+from app.wms.outbound.repos.logistics_export_record_repo import (
+    upsert_pending_logistics_export_record,
+)
 from app.wms.inventory_adjustment.count.services.count_freeze_guard_service import (
     ensure_warehouse_not_frozen,
 )
@@ -90,6 +93,48 @@ class ManualSubmitContext:
     doc_lines_by_id: Dict[int, Mapping[str, Any]]
     source_ref: str
     warehouse_id: int
+
+
+
+def _order_outbound_completed_after_submit(
+    *,
+    ctx: OrderSubmitContext,
+    progress_by_line: Dict[int, Dict[str, int]],
+    normalized_lines: List[Dict[str, Any]],
+) -> bool:
+    submitted_delta_by_line: Dict[int, int] = {}
+
+    for ln in normalized_lines:
+        order_line_id = int(ln["order_line_id"])
+        submitted_delta_by_line[order_line_id] = (
+            int(submitted_delta_by_line.get(order_line_id, 0))
+            + int(ln["qty_outbound"])
+        )
+
+    if not ctx.order_lines_by_id:
+        return False
+
+    for order_line_id, src in ctx.order_lines_by_id.items():
+        req_qty = int(src.get("req_qty") or 0)
+        already_submitted = int(
+            progress_by_line.get(int(order_line_id), {}).get("submitted_qty", 0)
+        )
+        newly_submitted = int(submitted_delta_by_line.get(int(order_line_id), 0))
+
+        if req_qty <= 0:
+            return False
+        if already_submitted + newly_submitted < req_qty:
+            return False
+
+    return True
+
+
+def _order_source_doc_no(order: Mapping[str, Any], *, order_id: int) -> str:
+    for key in ("ext_order_no", "order_no"):
+        value = order.get(key)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return str(order_id)
 
 
 async def load_order_submit_context(
@@ -514,6 +559,27 @@ async def submit_order_outbound_event(
         normalized_lines=normalized,
     )
 
+    if _order_outbound_completed_after_submit(
+        ctx=ctx,
+        progress_by_line=progress_by_line,
+        normalized_lines=normalized,
+    ):
+        await upsert_pending_logistics_export_record(
+            session,
+            source_doc_type="ORDER_OUTBOUND",
+            source_doc_id=int(order_id),
+            source_doc_no=_order_source_doc_no(ctx.order, order_id=int(order_id)),
+            source_ref=f"WMS:ORDER_OUTBOUND:{int(order_id)}",
+            source_snapshot={
+                "order": dict(ctx.order),
+                "wms_event_id": int(event["id"]),
+                "wms_source_ref": str(event["source_ref"]),
+                "warehouse_id": int(event["warehouse_id"]),
+                "occurred_at": event["occurred_at"],
+                "lines": normalized,
+            },
+        )
+
     return OrderOutboundSubmitOut(
         status="OK",
         event_id=int(event["id"]),
@@ -560,6 +626,21 @@ async def submit_manual_outbound_event(
         for row in progress_rows
     ):
         await complete_manual_doc(session, doc_id=int(doc_id))
+        await upsert_pending_logistics_export_record(
+            session,
+            source_doc_type="MANUAL_OUTBOUND",
+            source_doc_id=int(doc_id),
+            source_doc_no=str(ctx.doc["doc_no"]),
+            source_ref=f"WMS:MANUAL_OUTBOUND:{int(doc_id)}",
+            source_snapshot={
+                "doc": dict(ctx.doc),
+                "wms_event_id": int(event["id"]),
+                "wms_source_ref": str(event["source_ref"]),
+                "warehouse_id": int(event["warehouse_id"]),
+                "occurred_at": event["occurred_at"],
+                "lines": normalized,
+            },
+        )
 
     return ManualOutboundSubmitOut(
         status="OK",

--- a/tests/api/test_manual_outbound_submit_api.py
+++ b/tests/api/test_manual_outbound_submit_api.py
@@ -330,6 +330,40 @@ async def test_manual_outbound_submit_writes_event_and_ledger(
     ).scalar_one()
     assert str(doc_status) == "COMPLETED"
 
+    export_record = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  source_doc_type,
+                  source_doc_id,
+                  source_doc_no,
+                  source_ref,
+                  export_status,
+                  logistics_status,
+                  source_snapshot ->> 'wms_event_id' AS wms_event_id,
+                  source_snapshot ->> 'wms_source_ref' AS wms_source_ref,
+                  source_snapshot ->> 'warehouse_id' AS snapshot_warehouse_id
+                FROM wms_logistics_export_records
+                WHERE source_ref = :source_ref
+                LIMIT 1
+                """
+            ),
+            {"source_ref": f"WMS:MANUAL_OUTBOUND:{doc_id}"},
+        )
+    ).mappings().first()
+
+    assert export_record is not None
+    assert export_record["source_doc_type"] == "MANUAL_OUTBOUND"
+    assert int(export_record["source_doc_id"]) == int(doc_id)
+    assert str(export_record["source_doc_no"]).startswith("MOB-UT-")
+    assert export_record["source_ref"] == f"WMS:MANUAL_OUTBOUND:{doc_id}"
+    assert export_record["export_status"] == "PENDING"
+    assert export_record["logistics_status"] == "NOT_IMPORTED"
+    assert int(export_record["wms_event_id"]) == event_id
+    assert export_record["wms_source_ref"] == data["source_ref"]
+    assert int(export_record["snapshot_warehouse_id"]) == warehouse_id
+
 
 async def test_manual_outbound_submit_keeps_doc_released_when_partially_submitted(
     client: AsyncClient,
@@ -379,6 +413,20 @@ async def test_manual_outbound_submit_keeps_doc_released_when_partially_submitte
         )
     ).scalar_one()
     assert str(doc_status) == "RELEASED"
+
+    export_count = (
+        await session.execute(
+            text(
+                """
+                SELECT COUNT(*)
+                FROM wms_logistics_export_records
+                WHERE source_ref = :source_ref
+                """
+            ),
+            {"source_ref": f"WMS:MANUAL_OUTBOUND:{doc_id}"},
+        )
+    ).scalar_one()
+    assert int(export_count) == 0
 
 
 async def test_manual_outbound_submit_rejects_lot_code_and_batch_code_extras(

--- a/tests/api/test_order_outbound_submit_api.py
+++ b/tests/api/test_order_outbound_submit_api.py
@@ -311,6 +311,40 @@ async def test_order_outbound_submit_writes_event_and_ledger(
     opts_data = opts.json()
     assert opts_data["items"] == []
 
+    export_record = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  source_doc_type,
+                  source_doc_id,
+                  source_doc_no,
+                  source_ref,
+                  export_status,
+                  logistics_status,
+                  source_snapshot ->> 'wms_event_id' AS wms_event_id,
+                  source_snapshot ->> 'wms_source_ref' AS wms_source_ref,
+                  source_snapshot ->> 'warehouse_id' AS snapshot_warehouse_id
+                FROM wms_logistics_export_records
+                WHERE source_ref = :source_ref
+                LIMIT 1
+                """
+            ),
+            {"source_ref": f"WMS:ORDER_OUTBOUND:{order_id}"},
+        )
+    ).mappings().first()
+
+    assert export_record is not None
+    assert export_record["source_doc_type"] == "ORDER_OUTBOUND"
+    assert int(export_record["source_doc_id"]) == int(order_id)
+    assert str(export_record["source_doc_no"]).startswith("OUT-API-")
+    assert export_record["source_ref"] == f"WMS:ORDER_OUTBOUND:{order_id}"
+    assert export_record["export_status"] == "PENDING"
+    assert export_record["logistics_status"] == "NOT_IMPORTED"
+    assert int(export_record["wms_event_id"]) == event_id
+    assert export_record["wms_source_ref"] == data["source_ref"]
+    assert int(export_record["snapshot_warehouse_id"]) == warehouse_id
+
 
 async def test_order_outbound_submit_rejects_duplicate_submit_with_409(
     client: AsyncClient,

--- a/tests/fixtures/truncate.sql
+++ b/tests/fixtures/truncate.sql
@@ -41,6 +41,7 @@ TRUNCATE TABLE
   event_error_log,
 
   -- ===== shipping domain（避免每用例累积脏数据）=====
+  wms_logistics_export_records,
   shipping_records,
   shipping_providers,
 


### PR DESCRIPTION
## Summary
- add wms_logistics_export_records as WMS -> Logistics handoff state table
- add ORM model and repo for idempotent PENDING handoff records
- write ORDER_OUTBOUND handoff records after order outbound completion
- write MANUAL_OUTBOUND handoff records after manual outbound completion
- add tests for order/manual outbound export records
- include the new table in test truncation

## Scope
- WMS handoff state table only
- no WMS logistics-ready read API yet
- no import-results callback API yet
- no logistics-shipping-results callback API yet
- no Logistics-side import changes
- no frontend changes

## Tests
- make upgrade-dev
- make alembic-check
- TESTS="tests/api/test_order_outbound_submit_api.py tests/api/test_manual_outbound_submit_api.py" make test
- make lint
- make test