### PR TITLE
feat(outbound): add WMS logistics ready API

### DIFF
--- a/app/router_mount.py
+++ b/app/router_mount.py
@@ -52,6 +52,7 @@ def mount_routers(app: FastAPI) -> None:
         router as outbound_reversal_router,
     )
     from app.wms.outbound.routers.lot_candidates import router as outbound_lot_candidates_router
+    from app.wms.outbound.routers.logistics_ready import router as logistics_ready_router
     from app.wms.outbound.routers.print_jobs import router as print_jobs_router
     from app.procurement.routers.purchase_orders import router as purchase_orders_router
     from app.procurement.routers.purchase_reports import router as purchase_reports_router
@@ -105,6 +106,7 @@ def mount_routers(app: FastAPI) -> None:
     app.include_router(manual_docs_router)
     app.include_router(manual_submit_router)
     app.include_router(outbound_lot_candidates_router)
+    app.include_router(logistics_ready_router)
     app.include_router(outbound_summary_router)
     app.include_router(outbound_reversal_router)
 

--- a/app/wms/outbound/contracts/logistics_ready.py
+++ b/app/wms/outbound/contracts/logistics_ready.py
@@ -1,0 +1,68 @@
+# app/wms/outbound/contracts/logistics_ready.py
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+
+class LogisticsReadyItemOut(_Base):
+    line_no: int
+    item_id: int | None = None
+    qty: int
+    lot_id: int | None = None
+    lot_code_snapshot: str | None = None
+    item_name_snapshot: str | None = None
+    item_sku_snapshot: str | None = None
+    item_spec_snapshot: str | None = None
+
+
+class LogisticsReadyPackageOut(_Base):
+    source_package_ref: str
+    package_no: int
+    warehouse_id: int | None = None
+    weight_kg: str | None = None
+    items: list[LogisticsReadyItemOut] = Field(default_factory=list)
+
+
+class LogisticsReadyRowOut(_Base):
+    source_system: str = "WMS"
+    source_doc_type: str
+    source_doc_id: int
+    source_doc_no: str
+    source_ref: str
+
+    export_status: str
+    logistics_status: str
+
+    platform: str | None = None
+    store_code: str | None = None
+    platform_order_no: str | None = None
+    warehouse_id: int | None = None
+
+    receiver_name: str | None = None
+    receiver_phone: str | None = None
+    province: str | None = None
+    city: str | None = None
+    district: str | None = None
+    address_detail: str | None = None
+
+    outbound_completed_at: datetime | None = None
+    handoff_created_at: datetime
+    handoff_updated_at: datetime
+
+    packages: list[LogisticsReadyPackageOut] = Field(default_factory=list)
+    source_snapshot: dict[str, Any] = Field(default_factory=dict)
+
+
+class LogisticsReadyListOut(_Base):
+    ok: bool = True
+    rows: list[LogisticsReadyRowOut] = Field(default_factory=list)
+    total: int
+    limit: int
+    offset: int

--- a/app/wms/outbound/repos/logistics_ready_repo.py
+++ b/app/wms/outbound/repos/logistics_ready_repo.py
@@ -1,0 +1,260 @@
+# app/wms/outbound/repos/logistics_ready_repo.py
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+READY_EXPORT_STATUSES = ("PENDING", "FAILED")
+READY_SOURCE_DOC_TYPES = ("ORDER_OUTBOUND", "MANUAL_OUTBOUND")
+
+
+def _snapshot_dict(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if value is None:
+        return {}
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _int_or_none(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _clean_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    s = str(value).strip()
+    return s or None
+
+
+def _build_items(snapshot: Mapping[str, Any]) -> list[dict[str, Any]]:
+    raw_lines = snapshot.get("lines")
+    if not isinstance(raw_lines, list):
+        return []
+
+    items: list[dict[str, Any]] = []
+    for idx, raw in enumerate(raw_lines, start=1):
+        if not isinstance(raw, Mapping):
+            continue
+
+        qty = raw.get("qty_outbound", raw.get("qty", 0))
+        items.append(
+            {
+                "line_no": int(raw.get("ref_line") or idx),
+                "item_id": _int_or_none(raw.get("item_id")),
+                "qty": int(qty or 0),
+                "lot_id": _int_or_none(raw.get("lot_id")),
+                "lot_code_snapshot": _clean_text(raw.get("lot_code_snapshot")),
+                "item_name_snapshot": _clean_text(raw.get("item_name_snapshot")),
+                "item_sku_snapshot": _clean_text(raw.get("item_sku_snapshot")),
+                "item_spec_snapshot": _clean_text(raw.get("item_spec_snapshot")),
+            }
+        )
+
+    return items
+
+
+def _warehouse_id_from_row(row: Mapping[str, Any], snapshot: Mapping[str, Any]) -> int | None:
+    if str(row["source_doc_type"]) == "ORDER_OUTBOUND":
+        value = row.get("order_actual_warehouse_id")
+        return _int_or_none(value) or _int_or_none(snapshot.get("warehouse_id"))
+    value = row.get("manual_warehouse_id")
+    return _int_or_none(value) or _int_or_none(snapshot.get("warehouse_id"))
+
+
+def _row_to_ready_record(row: Mapping[str, Any]) -> dict[str, Any]:
+    snapshot = _snapshot_dict(row.get("source_snapshot"))
+    warehouse_id = _warehouse_id_from_row(row, snapshot)
+
+    if str(row["source_doc_type"]) == "ORDER_OUTBOUND":
+        receiver_name = _clean_text(row.get("receiver_name"))
+        receiver_phone = _clean_text(row.get("receiver_phone"))
+        province = _clean_text(row.get("province"))
+        city = _clean_text(row.get("city"))
+        district = _clean_text(row.get("district"))
+        address_detail = _clean_text(row.get("address_detail"))
+        platform = _clean_text(row.get("platform"))
+        store_code = _clean_text(row.get("store_code"))
+        platform_order_no = _clean_text(row.get("platform_order_no"))
+        outbound_completed_at = row.get("outbound_completed_at")
+    else:
+        receiver_name = _clean_text(row.get("manual_recipient_name"))
+        receiver_phone = None
+        province = None
+        city = None
+        district = None
+        address_detail = None
+        platform = None
+        store_code = None
+        platform_order_no = None
+        outbound_completed_at = snapshot.get("occurred_at")
+
+    source_ref = str(row["source_ref"])
+    packages = [
+        {
+            "source_package_ref": f"{source_ref}:PACKAGE:1",
+            "package_no": 1,
+            "warehouse_id": warehouse_id,
+            "weight_kg": None,
+            "items": _build_items(snapshot),
+        }
+    ]
+
+    return {
+        "source_system": "WMS",
+        "source_doc_type": str(row["source_doc_type"]),
+        "source_doc_id": int(row["source_doc_id"]),
+        "source_doc_no": str(row["source_doc_no"]),
+        "source_ref": source_ref,
+        "export_status": str(row["export_status"]),
+        "logistics_status": str(row["logistics_status"]),
+        "platform": platform,
+        "store_code": store_code,
+        "platform_order_no": platform_order_no,
+        "warehouse_id": warehouse_id,
+        "receiver_name": receiver_name,
+        "receiver_phone": receiver_phone,
+        "province": province,
+        "city": city,
+        "district": district,
+        "address_detail": address_detail,
+        "outbound_completed_at": outbound_completed_at,
+        "handoff_created_at": row["handoff_created_at"],
+        "handoff_updated_at": row["handoff_updated_at"],
+        "packages": packages,
+        "source_snapshot": snapshot,
+    }
+
+
+def _build_ready_where(
+    *,
+    source_doc_type: str | None,
+    export_status: str | None,
+) -> tuple[str, dict[str, object]]:
+    params: dict[str, object] = {}
+    clauses = ["1 = 1"]
+
+    if source_doc_type is not None:
+        clauses.append("r.source_doc_type = :source_doc_type")
+        params["source_doc_type"] = source_doc_type
+
+    if export_status is not None:
+        clauses.append("r.export_status = :export_status")
+        params["export_status"] = export_status
+    else:
+        clauses.append("r.export_status = ANY(:ready_statuses)")
+        params["ready_statuses"] = list(READY_EXPORT_STATUSES)
+
+    return " AND ".join(clauses), params
+
+
+async def count_logistics_ready_records(
+    session: AsyncSession,
+    *,
+    source_doc_type: str | None = None,
+    export_status: str | None = None,
+) -> int:
+    where_sql, params = _build_ready_where(
+        source_doc_type=source_doc_type,
+        export_status=export_status,
+    )
+
+    row = (
+        await session.execute(
+            text(
+                f"""
+                SELECT COUNT(*)
+                FROM wms_logistics_export_records r
+                WHERE {where_sql}
+                """
+            ),
+            params,
+        )
+    ).scalar_one()
+
+    return int(row)
+
+
+async def list_logistics_ready_records(
+    session: AsyncSession,
+    *,
+    source_doc_type: str | None = None,
+    export_status: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[dict[str, Any]]:
+    where_sql, params = _build_ready_where(
+        source_doc_type=source_doc_type,
+        export_status=export_status,
+    )
+    params["limit"] = int(limit)
+    params["offset"] = int(offset)
+
+    rows = (
+        (
+            await session.execute(
+                text(
+                    f"""
+                    SELECT
+                      r.source_doc_type,
+                      r.source_doc_id,
+                      r.source_doc_no,
+                      r.source_ref,
+                      r.export_status,
+                      r.logistics_status,
+                      r.source_snapshot,
+                      r.created_at AS handoff_created_at,
+                      r.updated_at AS handoff_updated_at,
+
+                      o.platform,
+                      o.store_code,
+                      o.ext_order_no AS platform_order_no,
+                      f.actual_warehouse_id AS order_actual_warehouse_id,
+                      f.outbound_completed_at AS outbound_completed_at,
+                      a.receiver_name,
+                      a.receiver_phone,
+                      a.province,
+                      a.city,
+                      a.district,
+                      a.detail AS address_detail,
+
+                      md.warehouse_id AS manual_warehouse_id,
+                      md.recipient_name AS manual_recipient_name
+                    FROM wms_logistics_export_records r
+                    LEFT JOIN orders o
+                      ON r.source_doc_type = 'ORDER_OUTBOUND'
+                     AND o.id = r.source_doc_id
+                    LEFT JOIN order_fulfillment f
+                      ON f.order_id = o.id
+                    LEFT JOIN order_address a
+                      ON a.order_id = o.id
+                    LEFT JOIN manual_outbound_docs md
+                      ON r.source_doc_type = 'MANUAL_OUTBOUND'
+                     AND md.id = r.source_doc_id
+                    WHERE {where_sql}
+                    ORDER BY r.created_at ASC, r.id ASC
+                    LIMIT :limit OFFSET :offset
+                    """
+                ),
+                params,
+            )
+        )
+        .mappings()
+        .all()
+    )
+
+    return [_row_to_ready_record(row) for row in rows]

--- a/app/wms/outbound/routers/logistics_ready.py
+++ b/app/wms/outbound/routers/logistics_ready.py
@@ -1,0 +1,60 @@
+# app/wms/outbound/routers/logistics_ready.py
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.deps import get_async_session as get_session
+from app.user.deps.auth import get_current_user
+from app.wms.outbound.contracts.logistics_ready import LogisticsReadyListOut
+from app.wms.outbound.repos.logistics_ready_repo import (
+    READY_EXPORT_STATUSES,
+    READY_SOURCE_DOC_TYPES,
+    count_logistics_ready_records,
+    list_logistics_ready_records,
+)
+
+router = APIRouter(prefix="/wms/outbound", tags=["wms-outbound-logistics-ready"])
+
+
+@router.get("/logistics-ready", response_model=LogisticsReadyListOut)
+async def list_wms_outbound_logistics_ready(
+    source_doc_type: str | None = Query(
+        default=None,
+        description="来源单据类型：ORDER_OUTBOUND / MANUAL_OUTBOUND；为空返回全部",
+    ),
+    export_status: str | None = Query(
+        default=None,
+        description="导出状态：PENDING / FAILED；为空返回 PENDING + FAILED",
+    ),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    session: AsyncSession = Depends(get_session),
+    user=Depends(get_current_user),
+) -> LogisticsReadyListOut:
+    if source_doc_type is not None and source_doc_type not in READY_SOURCE_DOC_TYPES:
+        raise HTTPException(status_code=422, detail="invalid source_doc_type")
+
+    if export_status is not None and export_status not in READY_EXPORT_STATUSES:
+        raise HTTPException(status_code=422, detail="invalid export_status")
+
+    total = await count_logistics_ready_records(
+        session,
+        source_doc_type=source_doc_type,
+        export_status=export_status,
+    )
+    rows = await list_logistics_ready_records(
+        session,
+        source_doc_type=source_doc_type,
+        export_status=export_status,
+        limit=int(limit),
+        offset=int(offset),
+    )
+
+    return LogisticsReadyListOut(
+        ok=True,
+        rows=rows,
+        total=int(total),
+        limit=int(limit),
+        offset=int(offset),
+    )

--- a/tests/api/test_wms_logistics_ready_api.py
+++ b/tests/api/test_wms_logistics_ready_api.py
@@ -1,0 +1,448 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests.services._helpers import ensure_store
+
+pytestmark = pytest.mark.asyncio
+UTC = timezone.utc
+
+
+async def _login_admin_headers(client: AsyncClient) -> dict[str, str]:
+    r = await client.post("/users/login", json={"username": "admin", "password": "admin123"})
+    assert r.status_code == 200, r.text
+    return {"Authorization": f"Bearer {r.json()['access_token']}"}
+
+
+async def _pick_any_item_id(session: AsyncSession) -> int:
+    row = await session.execute(text("SELECT id FROM items ORDER BY id ASC LIMIT 1"))
+    item_id = row.scalar_one_or_none()
+    assert item_id is not None
+    return int(item_id)
+
+
+async def _ensure_warehouse(session: AsyncSession, warehouse_id: int = 1) -> int:
+    await session.execute(
+        text(
+            """
+            INSERT INTO warehouses (id, name)
+            VALUES (:id, :name)
+            ON CONFLICT (id) DO NOTHING
+            """
+        ),
+        {"id": int(warehouse_id), "name": f"WH-{warehouse_id}"},
+    )
+    return int(warehouse_id)
+
+
+async def _seed_order_ready_record(
+    session: AsyncSession,
+    *,
+    export_status: str = "PENDING",
+) -> tuple[int, str]:
+    now = datetime.now(UTC)
+    uniq = uuid4().hex[:10]
+    platform = "PDD"
+    store_code = "UT-READY"
+    ext_order_no = f"READY-ORD-{uniq}"
+    warehouse_id = await _ensure_warehouse(session, 1)
+    item_id = await _pick_any_item_id(session)
+
+    store_id = await ensure_store(
+        session,
+        platform=platform,
+        store_code=store_code,
+        name=f"UT-{platform}-{store_code}",
+    )
+
+    order_id = int(
+        (
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO orders (
+                      platform,
+                      store_code,
+                      store_id,
+                      ext_order_no,
+                      status,
+                      created_at,
+                      updated_at
+                    )
+                    VALUES (
+                      :platform,
+                      :store_code,
+                      :store_id,
+                      :ext_order_no,
+                      'CREATED',
+                      :now,
+                      :now
+                    )
+                    RETURNING id
+                    """
+                ),
+                {
+                    "platform": platform,
+                    "store_code": store_code,
+                    "store_id": int(store_id),
+                    "ext_order_no": ext_order_no,
+                    "now": now,
+                },
+            )
+        ).scalar_one()
+    )
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO order_address (
+              order_id,
+              receiver_name,
+              receiver_phone,
+              province,
+              city,
+              district,
+              detail,
+              created_at
+            )
+            VALUES (
+              :order_id,
+              '张三',
+              '13800000000',
+              '浙江省',
+              '杭州市',
+              '余杭区',
+              '测试路 1 号',
+              :now
+            )
+            """
+        ),
+        {"order_id": int(order_id), "now": now},
+    )
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO order_fulfillment (
+              order_id,
+              actual_warehouse_id,
+              execution_stage,
+              outbound_committed_at,
+              outbound_completed_at,
+              updated_at
+            )
+            VALUES (
+              :order_id,
+              :warehouse_id,
+              'SHIP',
+              :now,
+              :now,
+              :now
+            )
+            """
+        ),
+        {"order_id": int(order_id), "warehouse_id": int(warehouse_id), "now": now},
+    )
+
+    source_ref = f"WMS:ORDER_OUTBOUND:{order_id}"
+    source_snapshot = {
+        "warehouse_id": warehouse_id,
+        "occurred_at": now.isoformat(),
+        "wms_event_id": 9001,
+        "wms_source_ref": f"ORD:{platform}:{store_code}:{ext_order_no}",
+        "lines": [
+            {
+                "ref_line": 1,
+                "item_id": item_id,
+                "qty_outbound": 2,
+                "lot_id": 1,
+                "lot_code_snapshot": "UT-LOT",
+                "item_name_snapshot": "测试商品",
+                "item_sku_snapshot": "SKU-READY",
+                "item_spec_snapshot": "1kg",
+            }
+        ],
+    }
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_logistics_export_records (
+              source_doc_type,
+              source_doc_id,
+              source_doc_no,
+              source_ref,
+              export_status,
+              logistics_status,
+              source_snapshot,
+              created_at,
+              updated_at
+            )
+            VALUES (
+              'ORDER_OUTBOUND',
+              :source_doc_id,
+              :source_doc_no,
+              :source_ref,
+              :export_status,
+              'NOT_IMPORTED',
+              CAST(:source_snapshot AS jsonb),
+              :now,
+              :now
+            )
+            """
+        ),
+        {
+            "source_doc_id": int(order_id),
+            "source_doc_no": ext_order_no,
+            "source_ref": source_ref,
+            "export_status": export_status,
+            "source_snapshot": json.dumps(source_snapshot, ensure_ascii=False),
+            "now": now,
+        },
+    )
+
+    await session.commit()
+    return order_id, source_ref
+
+
+async def _seed_manual_ready_record(
+    session: AsyncSession,
+    *,
+    export_status: str = "FAILED",
+) -> tuple[int, str]:
+    now = datetime.now(UTC)
+    uniq = uuid4().hex[:10]
+    warehouse_id = await _ensure_warehouse(session, 1)
+    item_id = await _pick_any_item_id(session)
+    doc_no = f"MOB-READY-{uniq}"
+
+    doc_id = int(
+        (
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO manual_outbound_docs (
+                      warehouse_id,
+                      doc_no,
+                      doc_type,
+                      status,
+                      recipient_name,
+                      remark,
+                      created_at
+                    )
+                    VALUES (
+                      :warehouse_id,
+                      :doc_no,
+                      'MANUAL_OUTBOUND',
+                      'COMPLETED',
+                      '李四',
+                      'ready api test',
+                      :now
+                    )
+                    RETURNING id
+                    """
+                ),
+                {"warehouse_id": int(warehouse_id), "doc_no": doc_no, "now": now},
+            )
+        ).scalar_one()
+    )
+
+    source_ref = f"WMS:MANUAL_OUTBOUND:{doc_id}"
+    source_snapshot = {
+        "warehouse_id": warehouse_id,
+        "occurred_at": now.isoformat(),
+        "wms_event_id": 9002,
+        "wms_source_ref": doc_no,
+        "lines": [
+            {
+                "ref_line": 1,
+                "item_id": item_id,
+                "qty_outbound": 1,
+                "lot_id": 1,
+                "lot_code_snapshot": "UT-MAN-LOT",
+                "item_name_snapshot": "手工商品",
+                "item_sku_snapshot": "SKU-MAN",
+                "item_spec_snapshot": "500g",
+            }
+        ],
+    }
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_logistics_export_records (
+              source_doc_type,
+              source_doc_id,
+              source_doc_no,
+              source_ref,
+              export_status,
+              logistics_status,
+              source_snapshot,
+              created_at,
+              updated_at
+            )
+            VALUES (
+              'MANUAL_OUTBOUND',
+              :source_doc_id,
+              :source_doc_no,
+              :source_ref,
+              :export_status,
+              'NOT_IMPORTED',
+              CAST(:source_snapshot AS jsonb),
+              :now,
+              :now
+            )
+            """
+        ),
+        {
+            "source_doc_id": int(doc_id),
+            "source_doc_no": doc_no,
+            "source_ref": source_ref,
+            "export_status": export_status,
+            "source_snapshot": json.dumps(source_snapshot, ensure_ascii=False),
+            "now": now,
+        },
+    )
+
+    await session.commit()
+    return doc_id, source_ref
+
+
+async def _seed_exported_record(session: AsyncSession) -> str:
+    now = datetime.now(UTC)
+    uniq = uuid4().hex[:10]
+    source_ref = f"WMS:ORDER_OUTBOUND:EXPORTED:{uniq}"
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_logistics_export_records (
+              source_doc_type,
+              source_doc_id,
+              source_doc_no,
+              source_ref,
+              export_status,
+              logistics_status,
+              source_snapshot,
+              created_at,
+              updated_at
+            )
+            VALUES (
+              'ORDER_OUTBOUND',
+              :source_doc_id,
+              :source_doc_no,
+              :source_ref,
+              'EXPORTED',
+              'IMPORTED',
+              CAST(:source_snapshot AS jsonb),
+              :now,
+              :now
+            )
+            """
+        ),
+        {
+            "source_doc_id": 900000000,
+            "source_doc_no": f"EXPORTED-{uniq}",
+            "source_ref": source_ref,
+            "source_snapshot": "{}",
+            "now": now,
+        },
+    )
+    await session.commit()
+    return source_ref
+
+
+async def test_logistics_ready_returns_pending_and_failed_records(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    _order_id, order_ref = await _seed_order_ready_record(session, export_status="PENDING")
+    _doc_id, manual_ref = await _seed_manual_ready_record(session, export_status="FAILED")
+    exported_ref = await _seed_exported_record(session)
+
+    resp = await client.get("/wms/outbound/logistics-ready", headers=headers)
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["total"] == 2
+
+    refs = {row["source_ref"] for row in data["rows"]}
+    assert order_ref in refs
+    assert manual_ref in refs
+    assert exported_ref not in refs
+
+    order_row = next(row for row in data["rows"] if row["source_ref"] == order_ref)
+    assert order_row["source_system"] == "WMS"
+    assert order_row["source_doc_type"] == "ORDER_OUTBOUND"
+    assert order_row["platform"] == "PDD"
+    assert order_row["store_code"] == "UT-READY"
+    assert order_row["receiver_name"] == "张三"
+    assert order_row["receiver_phone"] == "13800000000"
+    assert order_row["province"] == "浙江省"
+    assert order_row["city"] == "杭州市"
+    assert order_row["district"] == "余杭区"
+    assert order_row["address_detail"] == "测试路 1 号"
+    assert order_row["packages"][0]["source_package_ref"] == f"{order_ref}:PACKAGE:1"
+    assert order_row["packages"][0]["items"][0]["qty"] == 2
+
+    manual_row = next(row for row in data["rows"] if row["source_ref"] == manual_ref)
+    assert manual_row["source_doc_type"] == "MANUAL_OUTBOUND"
+    assert manual_row["export_status"] == "FAILED"
+    assert manual_row["receiver_name"] == "李四"
+    assert manual_row["platform"] is None
+    assert manual_row["packages"][0]["items"][0]["qty"] == 1
+
+
+async def test_logistics_ready_filters_source_doc_type_and_export_status(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    await _seed_order_ready_record(session, export_status="PENDING")
+    _doc_id, manual_ref = await _seed_manual_ready_record(session, export_status="FAILED")
+
+    resp = await client.get(
+        "/wms/outbound/logistics-ready",
+        headers=headers,
+        params={
+            "source_doc_type": "MANUAL_OUTBOUND",
+            "export_status": "FAILED",
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["total"] == 1
+    assert len(data["rows"]) == 1
+    assert data["rows"][0]["source_ref"] == manual_ref
+    assert data["rows"][0]["source_doc_type"] == "MANUAL_OUTBOUND"
+    assert data["rows"][0]["export_status"] == "FAILED"
+
+
+async def test_logistics_ready_rejects_invalid_filters(
+    client: AsyncClient,
+) -> None:
+    headers = await _login_admin_headers(client)
+
+    bad_type = await client.get(
+        "/wms/outbound/logistics-ready",
+        headers=headers,
+        params={"source_doc_type": "ERP_OUTBOUND"},
+    )
+    assert bad_type.status_code == 422
+
+    bad_status = await client.get(
+        "/wms/outbound/logistics-ready",
+        headers=headers,
+        params={"export_status": "EXPORTED"},
+    )
+    assert bad_status.status_code == 422


### PR DESCRIPTION
## Summary
- add GET /wms/outbound/logistics-ready
- return PENDING / FAILED WMS -> Logistics handoff records
- support source_doc_type and export_status filters
- assemble ORDER_OUTBOUND rows with order, fulfillment and address facts
- assemble MANUAL_OUTBOUND rows with manual outbound document facts
- include package and item snapshots for Logistics import
- add API tests for ready rows, filters and invalid filter rejection

## Scope
- WMS ready-for-logistics read API only
- no import-results callback API yet
- no logistics-shipping-results callback API yet
- no Logistics-side import changes
- no frontend changes
- no OpenAPI snapshot changes in this PR

## Tests
- TESTS="tests/api/test_wms_logistics_ready_api.py" make test
- make lint
- make test