### PR TITLE
feat(outbound): add WMS logistics import results API

### DIFF
--- a/app/router_mount.py
+++ b/app/router_mount.py
@@ -53,6 +53,7 @@ def mount_routers(app: FastAPI) -> None:
     )
     from app.wms.outbound.routers.lot_candidates import router as outbound_lot_candidates_router
     from app.wms.outbound.routers.logistics_ready import router as logistics_ready_router
+    from app.wms.outbound.routers.logistics_import_results import router as logistics_import_results_router
     from app.wms.outbound.routers.print_jobs import router as print_jobs_router
     from app.procurement.routers.purchase_orders import router as purchase_orders_router
     from app.procurement.routers.purchase_reports import router as purchase_reports_router
@@ -107,6 +108,7 @@ def mount_routers(app: FastAPI) -> None:
     app.include_router(manual_submit_router)
     app.include_router(outbound_lot_candidates_router)
     app.include_router(logistics_ready_router)
+    app.include_router(logistics_import_results_router)
     app.include_router(outbound_summary_router)
     app.include_router(outbound_reversal_router)
 

--- a/app/wms/outbound/contracts/logistics_import_results.py
+++ b/app/wms/outbound/contracts/logistics_import_results.py
@@ -1,0 +1,56 @@
+# app/wms/outbound/contracts/logistics_import_results.py
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+
+class LogisticsImportResultIn(_Base):
+    source_ref: str = Field(..., min_length=1, max_length=192)
+    export_status: Literal["EXPORTED", "FAILED"]
+
+    logistics_request_id: int | None = Field(default=None, ge=1)
+    logistics_request_no: str | None = Field(default=None, min_length=1, max_length=64)
+
+    error_message: str | None = Field(default=None, min_length=1, max_length=2000)
+
+    @model_validator(mode="after")
+    def validate_result_contract(self) -> "LogisticsImportResultIn":
+        if self.export_status == "EXPORTED":
+            if self.logistics_request_id is None:
+                raise ValueError("logistics_request_id is required when export_status=EXPORTED")
+            if not self.logistics_request_no:
+                raise ValueError("logistics_request_no is required when export_status=EXPORTED")
+            if self.error_message:
+                raise ValueError("error_message must be empty when export_status=EXPORTED")
+            return self
+
+        if self.export_status == "FAILED":
+            if not self.error_message:
+                raise ValueError("error_message is required when export_status=FAILED")
+            if self.logistics_request_id is not None or self.logistics_request_no:
+                raise ValueError("logistics request fields must be empty when export_status=FAILED")
+            return self
+
+        return self
+
+
+class LogisticsImportResultOut(_Base):
+    ok: bool = True
+    source_ref: str
+    export_status: str
+    logistics_status: str
+
+    logistics_request_id: int | None = None
+    logistics_request_no: str | None = None
+
+    exported_at: datetime | None = None
+    last_attempt_at: datetime | None = None
+    last_error: str | None = None
+    updated_at: datetime

--- a/app/wms/outbound/repos/logistics_export_record_repo.py
+++ b/app/wms/outbound/repos/logistics_export_record_repo.py
@@ -87,3 +87,213 @@ async def upsert_pending_logistics_export_record(
             "source_snapshot": _json_snapshot(source_snapshot),
         },
     )
+
+
+async def _load_export_record_for_update(
+    session: AsyncSession,
+    *,
+    source_ref: str,
+) -> dict[str, Any] | None:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  id,
+                  source_ref,
+                  export_status,
+                  logistics_status,
+                  logistics_request_id,
+                  logistics_request_no,
+                  exported_at,
+                  last_attempt_at,
+                  last_error,
+                  updated_at
+                FROM wms_logistics_export_records
+                WHERE source_ref = :source_ref
+                FOR UPDATE
+                """
+            ),
+            {"source_ref": str(source_ref).strip()},
+        )
+    ).mappings().first()
+
+    return dict(row) if row else None
+
+
+def _same_logistics_request(
+    record: Mapping[str, Any],
+    *,
+    logistics_request_id: int,
+    logistics_request_no: str,
+) -> bool:
+    return (
+        record.get("logistics_request_id") is not None
+        and int(record["logistics_request_id"]) == int(logistics_request_id)
+        and str(record.get("logistics_request_no") or "") == str(logistics_request_no)
+    )
+
+
+async def apply_logistics_import_success(
+    session: AsyncSession,
+    *,
+    source_ref: str,
+    logistics_request_id: int,
+    logistics_request_no: str,
+) -> dict[str, Any] | None:
+    """
+    Logistics 成功导入后的 WMS 交接状态回写。
+
+    幂等规则：
+    - 未导入：PENDING / FAILED -> EXPORTED / IMPORTED
+    - 已导入且 request_id/request_no 相同：允许重复回写
+    - 已导入但 request_id/request_no 不同：拒绝，避免错绑
+    - CANCELLED：拒绝
+    """
+
+    current = await _load_export_record_for_update(session, source_ref=source_ref)
+    if current is None:
+        return None
+
+    export_status = str(current["export_status"])
+    logistics_status = str(current["logistics_status"])
+
+    if export_status == "CANCELLED":
+        raise ValueError("logistics_export_record_cancelled")
+
+    if export_status == "EXPORTED":
+        if _same_logistics_request(
+            current,
+            logistics_request_id=int(logistics_request_id),
+            logistics_request_no=str(logistics_request_no),
+        ):
+            row = (
+                await session.execute(
+                    text(
+                        """
+                        UPDATE wms_logistics_export_records
+                           SET last_attempt_at = now(),
+                               updated_at = now()
+                         WHERE source_ref = :source_ref
+                         RETURNING
+                           source_ref,
+                           export_status,
+                           logistics_status,
+                           logistics_request_id,
+                           logistics_request_no,
+                           exported_at,
+                           last_attempt_at,
+                           last_error,
+                           updated_at
+                        """
+                    ),
+                    {"source_ref": str(source_ref).strip()},
+                )
+            ).mappings().first()
+            return dict(row) if row else None
+
+        raise ValueError("logistics_export_record_already_exported")
+
+    if logistics_status in ("IMPORTED", "IN_PROGRESS", "COMPLETED"):
+        raise ValueError("logistics_export_record_invalid_import_transition")
+
+    row = (
+        await session.execute(
+            text(
+                """
+                UPDATE wms_logistics_export_records
+                   SET export_status = 'EXPORTED',
+                       logistics_status = 'IMPORTED',
+                       logistics_request_id = :logistics_request_id,
+                       logistics_request_no = :logistics_request_no,
+                       exported_at = COALESCE(exported_at, now()),
+                       last_attempt_at = now(),
+                       last_error = NULL,
+                       updated_at = now()
+                 WHERE source_ref = :source_ref
+                 RETURNING
+                   source_ref,
+                   export_status,
+                   logistics_status,
+                   logistics_request_id,
+                   logistics_request_no,
+                   exported_at,
+                   last_attempt_at,
+                   last_error,
+                   updated_at
+                """
+            ),
+            {
+                "source_ref": str(source_ref).strip(),
+                "logistics_request_id": int(logistics_request_id),
+                "logistics_request_no": str(logistics_request_no).strip(),
+            },
+        )
+    ).mappings().first()
+
+    return dict(row) if row else None
+
+
+async def apply_logistics_import_failure(
+    session: AsyncSession,
+    *,
+    source_ref: str,
+    error_message: str,
+) -> dict[str, Any] | None:
+    """
+    Logistics 导入失败后的 WMS 交接状态回写。
+
+    失败只允许发生在尚未成功导入前；
+    已 EXPORTED / IMPORTED / IN_PROGRESS / COMPLETED 的记录不允许被失败回写降级。
+    """
+
+    current = await _load_export_record_for_update(session, source_ref=source_ref)
+    if current is None:
+        return None
+
+    export_status = str(current["export_status"])
+    logistics_status = str(current["logistics_status"])
+
+    if export_status == "CANCELLED":
+        raise ValueError("logistics_export_record_cancelled")
+
+    if export_status == "EXPORTED" or logistics_status in (
+        "IMPORTED",
+        "IN_PROGRESS",
+        "COMPLETED",
+    ):
+        raise ValueError("logistics_export_record_already_imported")
+
+    row = (
+        await session.execute(
+            text(
+                """
+                UPDATE wms_logistics_export_records
+                   SET export_status = 'FAILED',
+                       logistics_status = 'FAILED',
+                       logistics_request_id = NULL,
+                       logistics_request_no = NULL,
+                       last_attempt_at = now(),
+                       last_error = :last_error,
+                       updated_at = now()
+                 WHERE source_ref = :source_ref
+                 RETURNING
+                   source_ref,
+                   export_status,
+                   logistics_status,
+                   logistics_request_id,
+                   logistics_request_no,
+                   exported_at,
+                   last_attempt_at,
+                   last_error,
+                   updated_at
+                """
+            ),
+            {
+                "source_ref": str(source_ref).strip(),
+                "last_error": str(error_message).strip(),
+            },
+        )
+    ).mappings().first()
+
+    return dict(row) if row else None

--- a/app/wms/outbound/routers/logistics_import_results.py
+++ b/app/wms/outbound/routers/logistics_import_results.py
@@ -1,0 +1,56 @@
+# app/wms/outbound/routers/logistics_import_results.py
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.deps import get_async_session as get_session
+from app.user.deps.auth import get_current_user
+from app.wms.outbound.contracts.logistics_import_results import (
+    LogisticsImportResultIn,
+    LogisticsImportResultOut,
+)
+from app.wms.outbound.repos.logistics_export_record_repo import (
+    apply_logistics_import_failure,
+    apply_logistics_import_success,
+)
+
+router = APIRouter(prefix="/wms/outbound", tags=["wms-outbound-logistics-import-results"])
+
+
+@router.post("/logistics-import-results", response_model=LogisticsImportResultOut)
+async def record_wms_outbound_logistics_import_result(
+    payload: LogisticsImportResultIn,
+    session: AsyncSession = Depends(get_session),
+    user=Depends(get_current_user),
+) -> LogisticsImportResultOut:
+    try:
+        if payload.export_status == "EXPORTED":
+            row = await apply_logistics_import_success(
+                session,
+                source_ref=payload.source_ref,
+                logistics_request_id=int(payload.logistics_request_id or 0),
+                logistics_request_no=str(payload.logistics_request_no or ""),
+            )
+        else:
+            row = await apply_logistics_import_failure(
+                session,
+                source_ref=payload.source_ref,
+                error_message=str(payload.error_message or ""),
+            )
+
+        if row is None:
+            await session.rollback()
+            raise HTTPException(status_code=404, detail="logistics export record not found")
+
+        await session.commit()
+        return LogisticsImportResultOut(ok=True, **row)
+
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        await session.rollback()
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except Exception:
+        await session.rollback()
+        raise

--- a/tests/api/test_wms_logistics_import_results_api.py
+++ b/tests/api/test_wms_logistics_import_results_api.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+pytestmark = pytest.mark.asyncio
+UTC = timezone.utc
+
+
+async def _login_admin_headers(client: AsyncClient) -> dict[str, str]:
+    r = await client.post("/users/login", json={"username": "admin", "password": "admin123"})
+    assert r.status_code == 200, r.text
+    return {"Authorization": f"Bearer {r.json()['access_token']}"}
+
+
+async def _seed_export_record(
+    session: AsyncSession,
+    *,
+    source_doc_type: str = "ORDER_OUTBOUND",
+    export_status: str = "PENDING",
+    logistics_status: str = "NOT_IMPORTED",
+    logistics_request_id: int | None = None,
+    logistics_request_no: str | None = None,
+) -> str:
+    now = datetime.now(UTC)
+    uniq = uuid4().hex[:10]
+    source_ref = f"WMS:{source_doc_type}:{uniq}"
+    source_doc_id = int(int(uuid4().int % 900000000) + 1000)
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_logistics_export_records (
+              source_doc_type,
+              source_doc_id,
+              source_doc_no,
+              source_ref,
+              export_status,
+              logistics_status,
+              logistics_request_id,
+              logistics_request_no,
+              source_snapshot,
+              created_at,
+              updated_at
+            )
+            VALUES (
+              :source_doc_type,
+              :source_doc_id,
+              :source_doc_no,
+              :source_ref,
+              :export_status,
+              :logistics_status,
+              :logistics_request_id,
+              :logistics_request_no,
+              CAST(:source_snapshot AS jsonb),
+              :now,
+              :now
+            )
+            """
+        ),
+        {
+            "source_doc_type": source_doc_type,
+            "source_doc_id": source_doc_id,
+            "source_doc_no": f"DOC-{uniq}",
+            "source_ref": source_ref,
+            "export_status": export_status,
+            "logistics_status": logistics_status,
+            "logistics_request_id": logistics_request_id,
+            "logistics_request_no": logistics_request_no,
+            "source_snapshot": json.dumps({"seed": uniq}, ensure_ascii=False),
+            "now": now,
+        },
+    )
+    await session.commit()
+    return source_ref
+
+
+async def _load_export_record(
+    session: AsyncSession,
+    *,
+    source_ref: str,
+) -> dict[str, object]:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  source_ref,
+                  export_status,
+                  logistics_status,
+                  logistics_request_id,
+                  logistics_request_no,
+                  exported_at,
+                  last_attempt_at,
+                  last_error
+                FROM wms_logistics_export_records
+                WHERE source_ref = :source_ref
+                LIMIT 1
+                """
+            ),
+            {"source_ref": source_ref},
+        )
+    ).mappings().first()
+    assert row is not None
+    return dict(row)
+
+
+async def test_logistics_import_results_marks_exported(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    source_ref = await _seed_export_record(session)
+
+    resp = await client.post(
+        "/wms/outbound/logistics-import-results",
+        headers=headers,
+        json={
+            "source_ref": source_ref,
+            "export_status": "EXPORTED",
+            "logistics_request_id": 88,
+            "logistics_request_no": "LSR202605070001",
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["source_ref"] == source_ref
+    assert data["export_status"] == "EXPORTED"
+    assert data["logistics_status"] == "IMPORTED"
+    assert data["logistics_request_id"] == 88
+    assert data["logistics_request_no"] == "LSR202605070001"
+    assert data["exported_at"] is not None
+    assert data["last_attempt_at"] is not None
+    assert data["last_error"] is None
+
+    row = await _load_export_record(session, source_ref=source_ref)
+    assert row["export_status"] == "EXPORTED"
+    assert row["logistics_status"] == "IMPORTED"
+    assert int(row["logistics_request_id"]) == 88
+    assert row["logistics_request_no"] == "LSR202605070001"
+    assert row["exported_at"] is not None
+    assert row["last_attempt_at"] is not None
+    assert row["last_error"] is None
+
+
+async def test_logistics_import_results_success_is_idempotent_for_same_request(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    source_ref = await _seed_export_record(
+        session,
+        export_status="EXPORTED",
+        logistics_status="IMPORTED",
+        logistics_request_id=88,
+        logistics_request_no="LSR202605070001",
+    )
+
+    resp = await client.post(
+        "/wms/outbound/logistics-import-results",
+        headers=headers,
+        json={
+            "source_ref": source_ref,
+            "export_status": "EXPORTED",
+            "logistics_request_id": 88,
+            "logistics_request_no": "LSR202605070001",
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["export_status"] == "EXPORTED"
+    assert data["logistics_status"] == "IMPORTED"
+    assert data["logistics_request_id"] == 88
+    assert data["logistics_request_no"] == "LSR202605070001"
+
+
+async def test_logistics_import_results_rejects_success_with_different_request(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    source_ref = await _seed_export_record(
+        session,
+        export_status="EXPORTED",
+        logistics_status="IMPORTED",
+        logistics_request_id=88,
+        logistics_request_no="LSR202605070001",
+    )
+
+    resp = await client.post(
+        "/wms/outbound/logistics-import-results",
+        headers=headers,
+        json={
+            "source_ref": source_ref,
+            "export_status": "EXPORTED",
+            "logistics_request_id": 99,
+            "logistics_request_no": "LSR-DIFFERENT",
+        },
+    )
+
+    assert resp.status_code == 409, resp.text
+    assert "already_exported" in resp.text
+
+
+async def test_logistics_import_results_marks_failed(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    source_ref = await _seed_export_record(session)
+
+    resp = await client.post(
+        "/wms/outbound/logistics-import-results",
+        headers=headers,
+        json={
+            "source_ref": source_ref,
+            "export_status": "FAILED",
+            "error_message": "receiver_phone is missing",
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["source_ref"] == source_ref
+    assert data["export_status"] == "FAILED"
+    assert data["logistics_status"] == "FAILED"
+    assert data["logistics_request_id"] is None
+    assert data["logistics_request_no"] is None
+    assert data["last_attempt_at"] is not None
+    assert data["last_error"] == "receiver_phone is missing"
+
+    row = await _load_export_record(session, source_ref=source_ref)
+    assert row["export_status"] == "FAILED"
+    assert row["logistics_status"] == "FAILED"
+    assert row["last_error"] == "receiver_phone is missing"
+
+
+async def test_logistics_import_results_rejects_failed_after_exported(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    source_ref = await _seed_export_record(
+        session,
+        export_status="EXPORTED",
+        logistics_status="IMPORTED",
+        logistics_request_id=88,
+        logistics_request_no="LSR202605070001",
+    )
+
+    resp = await client.post(
+        "/wms/outbound/logistics-import-results",
+        headers=headers,
+        json={
+            "source_ref": source_ref,
+            "export_status": "FAILED",
+            "error_message": "late failure callback",
+        },
+    )
+
+    assert resp.status_code == 409, resp.text
+    assert "already_imported" in resp.text
+
+
+async def test_logistics_import_results_returns_404_for_missing_source_ref(
+    client: AsyncClient,
+) -> None:
+    headers = await _login_admin_headers(client)
+
+    resp = await client.post(
+        "/wms/outbound/logistics-import-results",
+        headers=headers,
+        json={
+            "source_ref": "WMS:ORDER_OUTBOUND:NOT_FOUND",
+            "export_status": "EXPORTED",
+            "logistics_request_id": 88,
+            "logistics_request_no": "LSR202605070001",
+        },
+    )
+
+    assert resp.status_code == 404, resp.text
+
+
+async def test_logistics_import_results_validates_payload_contract(
+    client: AsyncClient,
+) -> None:
+    headers = await _login_admin_headers(client)
+
+    missing_request = await client.post(
+        "/wms/outbound/logistics-import-results",
+        headers=headers,
+        json={
+            "source_ref": "WMS:ORDER_OUTBOUND:1",
+            "export_status": "EXPORTED",
+        },
+    )
+    assert missing_request.status_code == 422
+
+    missing_error = await client.post(
+        "/wms/outbound/logistics-import-results",
+        headers=headers,
+        json={
+            "source_ref": "WMS:ORDER_OUTBOUND:1",
+            "export_status": "FAILED",
+        },
+    )
+    assert missing_error.status_code == 422


### PR DESCRIPTION
## Summary
- add POST /wms/outbound/logistics-import-results
- support EXPORTED callbacks with Logistics request id/no
- support FAILED callbacks with error message
- keep successful import callbacks idempotent for the same Logistics request
- reject conflicting callbacks after import/export
- add API tests for success, failure, idempotency, conflicts, missing source_ref and payload validation

## Scope
- WMS import-results callback API only
- no logistics-shipping-results callback API yet
- no Logistics-side import changes
- no frontend changes
- no OpenAPI snapshot changes in this PR

## Tests
- TESTS="tests/api/test_wms_logistics_import_results_api.py tests/api/test_wms_logistics_ready_api.py" make test
- make lint
- make test