### PR TITLE
feat(outbound): add WMS logistics shipping results API

### DIFF
--- a/app/router_mount.py
+++ b/app/router_mount.py
@@ -54,6 +54,7 @@ def mount_routers(app: FastAPI) -> None:
     from app.wms.outbound.routers.lot_candidates import router as outbound_lot_candidates_router
     from app.wms.outbound.routers.logistics_ready import router as logistics_ready_router
     from app.wms.outbound.routers.logistics_import_results import router as logistics_import_results_router
+    from app.wms.outbound.routers.logistics_shipping_results import router as logistics_shipping_results_router
     from app.wms.outbound.routers.print_jobs import router as print_jobs_router
     from app.procurement.routers.purchase_orders import router as purchase_orders_router
     from app.procurement.routers.purchase_reports import router as purchase_reports_router
@@ -109,6 +110,7 @@ def mount_routers(app: FastAPI) -> None:
     app.include_router(outbound_lot_candidates_router)
     app.include_router(logistics_ready_router)
     app.include_router(logistics_import_results_router)
+    app.include_router(logistics_shipping_results_router)
     app.include_router(outbound_summary_router)
     app.include_router(outbound_reversal_router)
 

--- a/app/wms/outbound/contracts/logistics_shipping_results.py
+++ b/app/wms/outbound/contracts/logistics_shipping_results.py
@@ -1,0 +1,61 @@
+# app/wms/outbound/contracts/logistics_shipping_results.py
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+
+class LogisticsShippingResultPackageIn(_Base):
+    package_no: int = Field(..., ge=1)
+
+    tracking_no: str = Field(..., min_length=1, max_length=128)
+
+    shipping_provider_code: str = Field(..., min_length=1, max_length=64)
+    shipping_provider_name: str | None = Field(default=None, max_length=128)
+
+    gross_weight_kg: Decimal | None = Field(default=None, ge=0)
+    freight_estimated: Decimal | None = Field(default=None, ge=0)
+    surcharge_estimated: Decimal | None = Field(default=None, ge=0)
+    cost_estimated: Decimal | None = Field(default=None, ge=0)
+
+    length_cm: Decimal | None = Field(default=None, ge=0)
+    width_cm: Decimal | None = Field(default=None, ge=0)
+    height_cm: Decimal | None = Field(default=None, ge=0)
+
+    sender: str | None = Field(default=None, max_length=128)
+    dest_province: str | None = Field(default=None, max_length=64)
+    dest_city: str | None = Field(default=None, max_length=64)
+
+
+class LogisticsShippingResultIn(_Base):
+    source_ref: str = Field(..., min_length=1, max_length=192)
+
+    logistics_request_id: int | None = Field(default=None, ge=1)
+    logistics_request_no: str | None = Field(default=None, min_length=1, max_length=64)
+
+    completed_at: datetime | None = None
+    packages: list[LogisticsShippingResultPackageIn] = Field(..., min_length=1)
+
+    @model_validator(mode="after")
+    def validate_unique_packages(self) -> "LogisticsShippingResultIn":
+        package_numbers = [pkg.package_no for pkg in self.packages]
+        if len(package_numbers) != len(set(package_numbers)):
+            raise ValueError("package_no must be unique in one shipping result")
+        return self
+
+
+class LogisticsShippingResultOut(_Base):
+    ok: bool = True
+    source_ref: str
+    logistics_status: str
+    logistics_completed_at: datetime
+    shipping_record_ids: list[int] = Field(default_factory=list)
+    packages_count: int
+    source_snapshot: dict[str, Any] = Field(default_factory=dict)

--- a/app/wms/outbound/repos/logistics_shipping_result_repo.py
+++ b/app/wms/outbound/repos/logistics_shipping_result_repo.py
@@ -1,0 +1,412 @@
+# app/wms/outbound/repos/logistics_shipping_result_repo.py
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Mapping
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def _clean(value: object | None) -> str | None:
+    if value is None:
+        return None
+    s = str(value).strip()
+    return s or None
+
+
+def _clean_required(value: object | None, *, field: str) -> str:
+    s = _clean(value)
+    if s is None:
+        raise ValueError(f"{field}_required")
+    return s
+
+
+def _decimal_or_none(value: Decimal | int | float | str | None) -> Decimal | None:
+    if value is None:
+        return None
+    return Decimal(str(value))
+
+
+def _snapshot_dict(value: object | None) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if value is None:
+        return {}
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+async def _load_shipping_result_context(
+    session: AsyncSession,
+    *,
+    source_ref: str,
+) -> dict[str, Any] | None:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  r.source_doc_type,
+                  r.source_doc_id,
+                  r.source_doc_no,
+                  r.source_ref,
+                  r.export_status,
+                  r.logistics_status,
+                  r.logistics_request_id,
+                  r.logistics_request_no,
+                  r.source_snapshot,
+
+                  o.platform AS order_platform,
+                  o.store_code AS order_store_code,
+                  o.ext_order_no AS order_ext_order_no,
+                  f.actual_warehouse_id AS order_actual_warehouse_id,
+                  f.planned_warehouse_id AS order_planned_warehouse_id,
+                  a.province AS order_dest_province,
+                  a.city AS order_dest_city,
+
+                  md.warehouse_id AS manual_warehouse_id,
+                  md.doc_no AS manual_doc_no
+                FROM wms_logistics_export_records r
+                LEFT JOIN orders o
+                  ON r.source_doc_type = 'ORDER_OUTBOUND'
+                 AND o.id = r.source_doc_id
+                LEFT JOIN order_fulfillment f
+                  ON f.order_id = o.id
+                LEFT JOIN order_address a
+                  ON a.order_id = o.id
+                LEFT JOIN manual_outbound_docs md
+                  ON r.source_doc_type = 'MANUAL_OUTBOUND'
+                 AND md.id = r.source_doc_id
+                WHERE r.source_ref = :source_ref
+                FOR UPDATE OF r
+                """
+            ),
+            {"source_ref": str(source_ref).strip()},
+        )
+    ).mappings().first()
+
+    return dict(row) if row else None
+
+
+def _snapshot_warehouse_id(snapshot: Mapping[str, Any]) -> int | None:
+    value = snapshot.get("warehouse_id")
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _base_shipping_record_values(
+    ctx: Mapping[str, Any],
+) -> dict[str, object]:
+    source_doc_type = str(ctx["source_doc_type"])
+    snapshot = _snapshot_dict(ctx.get("source_snapshot"))
+
+    if source_doc_type == "ORDER_OUTBOUND":
+        platform = _clean_required(ctx.get("order_platform"), field="platform").upper()
+        store_code = _clean_required(ctx.get("order_store_code"), field="store_code")
+        ext_order_no = _clean_required(ctx.get("order_ext_order_no"), field="ext_order_no")
+        warehouse_id = (
+            ctx.get("order_actual_warehouse_id")
+            or ctx.get("order_planned_warehouse_id")
+            or _snapshot_warehouse_id(snapshot)
+        )
+        if warehouse_id is None:
+            raise ValueError("warehouse_id_required")
+
+        return {
+            "platform": platform,
+            "store_code": store_code,
+            "order_ref": f"ORD:{platform}:{store_code}:{ext_order_no}",
+            "warehouse_id": int(warehouse_id),
+            "dest_province": _clean(ctx.get("order_dest_province")),
+            "dest_city": _clean(ctx.get("order_dest_city")),
+            "source_snapshot": snapshot,
+        }
+
+    if source_doc_type == "MANUAL_OUTBOUND":
+        doc_no = _clean_required(
+            ctx.get("manual_doc_no") or ctx.get("source_doc_no"),
+            field="manual_doc_no",
+        )
+        warehouse_id = ctx.get("manual_warehouse_id") or _snapshot_warehouse_id(snapshot)
+        if warehouse_id is None:
+            raise ValueError("warehouse_id_required")
+
+        return {
+            "platform": "MANUAL",
+            "store_code": "MANUAL",
+            "order_ref": f"MANUAL:{doc_no}",
+            "warehouse_id": int(warehouse_id),
+            "dest_province": None,
+            "dest_city": None,
+            "source_snapshot": snapshot,
+        }
+
+    raise ValueError("unsupported_source_doc_type")
+
+
+async def _resolve_shipping_provider(
+    session: AsyncSession,
+    *,
+    shipping_provider_code: str,
+) -> dict[str, object]:
+    code = shipping_provider_code.strip().upper()
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  id,
+                  name,
+                  shipping_provider_code
+                FROM shipping_providers
+                WHERE shipping_provider_code = :shipping_provider_code
+                  AND active IS TRUE
+                LIMIT 1
+                """
+            ),
+            {"shipping_provider_code": code},
+        )
+    ).mappings().first()
+
+    if row is None:
+        raise ValueError(f"shipping_provider_mapping_not_found:{code}")
+
+    return {
+        "shipping_provider_id": int(row["id"]),
+        "shipping_provider_code": str(row["shipping_provider_code"]),
+        "shipping_provider_name": str(row["name"]),
+    }
+
+
+async def _upsert_shipping_record(
+    session: AsyncSession,
+    *,
+    base: Mapping[str, object],
+    package: Mapping[str, object],
+    completed_at: datetime | None,
+) -> int:
+    provider = await _resolve_shipping_provider(
+        session,
+        shipping_provider_code=_clean_required(
+            package.get("shipping_provider_code"),
+            field="shipping_provider_code",
+        ),
+    )
+
+    package_no = int(package["package_no"])
+    provider_name = _clean(package.get("shipping_provider_name")) or str(
+        provider["shipping_provider_name"]
+    )
+
+    dest_province = _clean(package.get("dest_province")) or _clean(base.get("dest_province"))
+    dest_city = _clean(package.get("dest_city")) or _clean(base.get("dest_city"))
+
+    row = (
+        await session.execute(
+            text(
+                """
+                INSERT INTO shipping_records (
+                  order_ref,
+                  platform,
+                  store_code,
+                  package_no,
+                  warehouse_id,
+                  shipping_provider_id,
+                  shipping_provider_code,
+                  shipping_provider_name,
+                  tracking_no,
+                  gross_weight_kg,
+                  freight_estimated,
+                  surcharge_estimated,
+                  cost_estimated,
+                  length_cm,
+                  width_cm,
+                  height_cm,
+                  sender,
+                  dest_province,
+                  dest_city,
+                  created_at
+                )
+                VALUES (
+                  :order_ref,
+                  :platform,
+                  :store_code,
+                  :package_no,
+                  :warehouse_id,
+                  :shipping_provider_id,
+                  :shipping_provider_code,
+                  :shipping_provider_name,
+                  :tracking_no,
+                  :gross_weight_kg,
+                  :freight_estimated,
+                  :surcharge_estimated,
+                  :cost_estimated,
+                  :length_cm,
+                  :width_cm,
+                  :height_cm,
+                  :sender,
+                  :dest_province,
+                  :dest_city,
+                  COALESCE(:completed_at, now())
+                )
+                ON CONFLICT (platform, store_code, order_ref, package_no) DO UPDATE SET
+                  warehouse_id = EXCLUDED.warehouse_id,
+                  shipping_provider_id = EXCLUDED.shipping_provider_id,
+                  shipping_provider_code = EXCLUDED.shipping_provider_code,
+                  shipping_provider_name = EXCLUDED.shipping_provider_name,
+                  tracking_no = EXCLUDED.tracking_no,
+                  gross_weight_kg = EXCLUDED.gross_weight_kg,
+                  freight_estimated = EXCLUDED.freight_estimated,
+                  surcharge_estimated = EXCLUDED.surcharge_estimated,
+                  cost_estimated = EXCLUDED.cost_estimated,
+                  length_cm = EXCLUDED.length_cm,
+                  width_cm = EXCLUDED.width_cm,
+                  height_cm = EXCLUDED.height_cm,
+                  sender = EXCLUDED.sender,
+                  dest_province = EXCLUDED.dest_province,
+                  dest_city = EXCLUDED.dest_city,
+                  created_at = EXCLUDED.created_at
+                RETURNING id
+                """
+            ),
+            {
+                "order_ref": str(base["order_ref"]),
+                "platform": str(base["platform"]),
+                "store_code": str(base["store_code"]),
+                "package_no": package_no,
+                "warehouse_id": int(base["warehouse_id"]),
+                "shipping_provider_id": int(provider["shipping_provider_id"]),
+                "shipping_provider_code": str(provider["shipping_provider_code"]),
+                "shipping_provider_name": provider_name,
+                "tracking_no": _clean_required(package.get("tracking_no"), field="tracking_no"),
+                "gross_weight_kg": _decimal_or_none(package.get("gross_weight_kg")),  # type: ignore[arg-type]
+                "freight_estimated": _decimal_or_none(package.get("freight_estimated")),  # type: ignore[arg-type]
+                "surcharge_estimated": _decimal_or_none(package.get("surcharge_estimated")),  # type: ignore[arg-type]
+                "cost_estimated": _decimal_or_none(package.get("cost_estimated")),  # type: ignore[arg-type]
+                "length_cm": _decimal_or_none(package.get("length_cm")),  # type: ignore[arg-type]
+                "width_cm": _decimal_or_none(package.get("width_cm")),  # type: ignore[arg-type]
+                "height_cm": _decimal_or_none(package.get("height_cm")),  # type: ignore[arg-type]
+                "sender": _clean(package.get("sender")),
+                "dest_province": dest_province,
+                "dest_city": dest_city,
+                "completed_at": completed_at,
+            },
+        )
+    ).scalar_one()
+
+    return int(row)
+
+
+def _assert_request_identity(
+    ctx: Mapping[str, Any],
+    *,
+    logistics_request_id: int | None,
+    logistics_request_no: str | None,
+) -> None:
+    existing_id = ctx.get("logistics_request_id")
+    existing_no = _clean(ctx.get("logistics_request_no"))
+
+    if existing_id is not None and logistics_request_id is not None:
+        if int(existing_id) != int(logistics_request_id):
+            raise ValueError("logistics_request_id_mismatch")
+
+    if existing_no is not None and logistics_request_no is not None:
+        if existing_no != logistics_request_no.strip():
+            raise ValueError("logistics_request_no_mismatch")
+
+
+async def apply_logistics_shipping_results(
+    session: AsyncSession,
+    *,
+    source_ref: str,
+    logistics_request_id: int | None,
+    logistics_request_no: str | None,
+    completed_at: datetime | None,
+    packages: list[Mapping[str, object]],
+) -> dict[str, object] | None:
+    ctx = await _load_shipping_result_context(session, source_ref=source_ref)
+    if ctx is None:
+        return None
+
+    export_status = str(ctx["export_status"])
+    logistics_status = str(ctx["logistics_status"])
+
+    if export_status != "EXPORTED":
+        raise ValueError("logistics_export_record_not_exported")
+
+    if logistics_status not in ("IMPORTED", "IN_PROGRESS", "COMPLETED"):
+        raise ValueError("logistics_export_record_not_imported")
+
+    _assert_request_identity(
+        ctx,
+        logistics_request_id=logistics_request_id,
+        logistics_request_no=logistics_request_no,
+    )
+
+    base = _base_shipping_record_values(ctx)
+
+    shipping_record_ids: list[int] = []
+    for package in packages:
+        shipping_record_ids.append(
+            await _upsert_shipping_record(
+                session,
+                base=base,
+                package=package,
+                completed_at=completed_at,
+            )
+        )
+
+    row = (
+        await session.execute(
+            text(
+                """
+                UPDATE wms_logistics_export_records
+                   SET logistics_status = 'COMPLETED',
+                       logistics_request_id = COALESCE(:logistics_request_id, logistics_request_id),
+                       logistics_request_no = COALESCE(:logistics_request_no, logistics_request_no),
+                       logistics_completed_at = COALESCE(:completed_at, now()),
+                       last_attempt_at = now(),
+                       last_error = NULL,
+                       updated_at = now()
+                 WHERE source_ref = :source_ref
+                 RETURNING
+                   source_ref,
+                   logistics_status,
+                   logistics_completed_at,
+                   source_snapshot
+                """
+            ),
+            {
+                "source_ref": str(source_ref).strip(),
+                "logistics_request_id": logistics_request_id,
+                "logistics_request_no": logistics_request_no.strip()
+                if logistics_request_no is not None
+                else None,
+                "completed_at": completed_at,
+            },
+        )
+    ).mappings().first()
+
+    if row is None:
+        return None
+
+    return {
+        "source_ref": str(row["source_ref"]),
+        "logistics_status": str(row["logistics_status"]),
+        "logistics_completed_at": row["logistics_completed_at"],
+        "shipping_record_ids": shipping_record_ids,
+        "packages_count": len(shipping_record_ids),
+        "source_snapshot": _snapshot_dict(row["source_snapshot"]),
+    }

--- a/app/wms/outbound/routers/logistics_shipping_results.py
+++ b/app/wms/outbound/routers/logistics_shipping_results.py
@@ -1,0 +1,50 @@
+# app/wms/outbound/routers/logistics_shipping_results.py
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.deps import get_async_session as get_session
+from app.user.deps.auth import get_current_user
+from app.wms.outbound.contracts.logistics_shipping_results import (
+    LogisticsShippingResultIn,
+    LogisticsShippingResultOut,
+)
+from app.wms.outbound.repos.logistics_shipping_result_repo import (
+    apply_logistics_shipping_results,
+)
+
+router = APIRouter(prefix="/wms/outbound", tags=["wms-outbound-logistics-shipping-results"])
+
+
+@router.post("/logistics-shipping-results", response_model=LogisticsShippingResultOut)
+async def record_wms_outbound_logistics_shipping_result(
+    payload: LogisticsShippingResultIn,
+    session: AsyncSession = Depends(get_session),
+    user=Depends(get_current_user),
+) -> LogisticsShippingResultOut:
+    try:
+        row = await apply_logistics_shipping_results(
+            session,
+            source_ref=payload.source_ref,
+            logistics_request_id=payload.logistics_request_id,
+            logistics_request_no=payload.logistics_request_no,
+            completed_at=payload.completed_at,
+            packages=[pkg.model_dump() for pkg in payload.packages],
+        )
+
+        if row is None:
+            await session.rollback()
+            raise HTTPException(status_code=404, detail="logistics export record not found")
+
+        await session.commit()
+        return LogisticsShippingResultOut(ok=True, **row)
+
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        await session.rollback()
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except Exception:
+        await session.rollback()
+        raise

--- a/tests/api/test_wms_logistics_shipping_results_api.py
+++ b/tests/api/test_wms_logistics_shipping_results_api.py
@@ -1,0 +1,576 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests.services._helpers import ensure_store
+
+pytestmark = pytest.mark.asyncio
+UTC = timezone.utc
+
+
+async def _login_admin_headers(client: AsyncClient) -> dict[str, str]:
+    r = await client.post("/users/login", json={"username": "admin", "password": "admin123"})
+    assert r.status_code == 200, r.text
+    return {"Authorization": f"Bearer {r.json()['access_token']}"}
+
+
+async def _ensure_warehouse(session: AsyncSession, warehouse_id: int = 1) -> int:
+    await session.execute(
+        text(
+            """
+            INSERT INTO warehouses (id, name, active)
+            VALUES (:id, :name, TRUE)
+            ON CONFLICT (id) DO UPDATE SET
+              name = EXCLUDED.name,
+              active = TRUE
+            """
+        ),
+        {"id": int(warehouse_id), "name": f"WH-{warehouse_id}"},
+    )
+    return int(warehouse_id)
+
+
+async def _ensure_provider(session: AsyncSession, *, code: str) -> int:
+    row = (
+        await session.execute(
+            text(
+                """
+                INSERT INTO shipping_providers (
+                  name,
+                  shipping_provider_code,
+                  active,
+                  priority,
+                  created_at,
+                  updated_at
+                )
+                VALUES (
+                  :name,
+                  :code,
+                  TRUE,
+                  10,
+                  now(),
+                  now()
+                )
+                ON CONFLICT (shipping_provider_code) DO UPDATE SET
+                  name = EXCLUDED.name,
+                  active = TRUE,
+                  updated_at = now()
+                RETURNING id
+                """
+            ),
+            {"name": f"UT Provider {code}", "code": code},
+        )
+    ).scalar_one()
+    return int(row)
+
+
+async def _seed_order_exported_record(
+    session: AsyncSession,
+    *,
+    source_ref_suffix: str | None = None,
+    export_status: str = "EXPORTED",
+    logistics_status: str = "IMPORTED",
+    logistics_request_id: int = 701,
+    logistics_request_no: str = "LSR-UT-0001",
+) -> tuple[str, str, str, str]:
+    now = datetime.now(UTC)
+    uniq = source_ref_suffix or uuid4().hex[:10]
+    platform = "PDD"
+    store_code = f"SHIPREADY{uniq[:6].upper()}"
+    ext_order_no = f"SHIP-ORD-{uniq}"
+    warehouse_id = await _ensure_warehouse(session, 1)
+
+    store_id = await ensure_store(
+        session,
+        platform=platform,
+        store_code=store_code,
+        name=f"UT-{platform}-{store_code}",
+    )
+
+    order_id = int(
+        (
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO orders (
+                      platform,
+                      store_code,
+                      store_id,
+                      ext_order_no,
+                      status,
+                      created_at,
+                      updated_at
+                    )
+                    VALUES (
+                      :platform,
+                      :store_code,
+                      :store_id,
+                      :ext_order_no,
+                      'CREATED',
+                      :now,
+                      :now
+                    )
+                    RETURNING id
+                    """
+                ),
+                {
+                    "platform": platform,
+                    "store_code": store_code,
+                    "store_id": int(store_id),
+                    "ext_order_no": ext_order_no,
+                    "now": now,
+                },
+            )
+        ).scalar_one()
+    )
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO order_address (
+              order_id,
+              receiver_name,
+              receiver_phone,
+              province,
+              city,
+              district,
+              detail,
+              created_at
+            )
+            VALUES (
+              :order_id,
+              '张三',
+              '13800000000',
+              '浙江省',
+              '杭州市',
+              '余杭区',
+              '测试路 1 号',
+              :now
+            )
+            """
+        ),
+        {"order_id": int(order_id), "now": now},
+    )
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO order_fulfillment (
+              order_id,
+              actual_warehouse_id,
+              execution_stage,
+              outbound_committed_at,
+              outbound_completed_at,
+              updated_at
+            )
+            VALUES (
+              :order_id,
+              :warehouse_id,
+              'SHIP',
+              :now,
+              :now,
+              :now
+            )
+            """
+        ),
+        {"order_id": int(order_id), "warehouse_id": int(warehouse_id), "now": now},
+    )
+
+    source_ref = f"WMS:ORDER_OUTBOUND:{order_id}"
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_logistics_export_records (
+              source_doc_type,
+              source_doc_id,
+              source_doc_no,
+              source_ref,
+              export_status,
+              logistics_status,
+              logistics_request_id,
+              logistics_request_no,
+              source_snapshot,
+              created_at,
+              updated_at
+            )
+            VALUES (
+              'ORDER_OUTBOUND',
+              :source_doc_id,
+              :source_doc_no,
+              :source_ref,
+              :export_status,
+              :logistics_status,
+              :logistics_request_id,
+              :logistics_request_no,
+              CAST(:source_snapshot AS jsonb),
+              :now,
+              :now
+            )
+            """
+        ),
+        {
+            "source_doc_id": int(order_id),
+            "source_doc_no": ext_order_no,
+            "source_ref": source_ref,
+            "export_status": export_status,
+            "logistics_status": logistics_status,
+            "logistics_request_id": int(logistics_request_id),
+            "logistics_request_no": logistics_request_no,
+            "source_snapshot": json.dumps({"warehouse_id": warehouse_id}, ensure_ascii=False),
+            "now": now,
+        },
+    )
+
+    await session.commit()
+    return source_ref, platform, store_code, ext_order_no
+
+
+async def _load_shipping_record(
+    session: AsyncSession,
+    *,
+    platform: str,
+    store_code: str,
+    order_ref: str,
+    package_no: int,
+) -> dict[str, object]:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT *
+                FROM shipping_records
+                WHERE platform = :platform
+                  AND store_code = :store_code
+                  AND order_ref = :order_ref
+                  AND package_no = :package_no
+                LIMIT 1
+                """
+            ),
+            {
+                "platform": platform,
+                "store_code": store_code,
+                "order_ref": order_ref,
+                "package_no": int(package_no),
+            },
+        )
+    ).mappings().first()
+    assert row is not None
+    return dict(row)
+
+
+async def test_logistics_shipping_results_upserts_shipping_record_and_refreshes_finance(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    suffix = uuid4().hex[:8].upper()
+    provider_code = f"WMSCB{suffix}"[:32]
+    provider_id = await _ensure_provider(session, code=provider_code)
+    source_ref, platform, store_code, ext_order_no = await _seed_order_exported_record(
+        session,
+        source_ref_suffix=suffix,
+        logistics_request_id=701,
+        logistics_request_no="LSR-UT-0001",
+    )
+
+    completed_at = datetime.now(UTC).isoformat()
+    resp = await client.post(
+        "/wms/outbound/logistics-shipping-results",
+        headers=headers,
+        json={
+            "source_ref": source_ref,
+            "logistics_request_id": 701,
+            "logistics_request_no": "LSR-UT-0001",
+            "completed_at": completed_at,
+            "packages": [
+                {
+                    "package_no": 1,
+                    "tracking_no": f"TRACK-{suffix}",
+                    "shipping_provider_code": provider_code,
+                    "shipping_provider_name": "REMOTE-PROVIDER-NAME",
+                    "gross_weight_kg": "1.250",
+                    "freight_estimated": "10.00",
+                    "surcharge_estimated": "2.50",
+                    "cost_estimated": "12.50",
+                    "length_cm": "10.00",
+                    "width_cm": "20.00",
+                    "height_cm": "30.00",
+                    "sender": "联调发件人",
+                    "dest_province": "浙江省",
+                    "dest_city": "杭州市",
+                }
+            ],
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["source_ref"] == source_ref
+    assert data["logistics_status"] == "COMPLETED"
+    assert data["packages_count"] == 1
+    assert len(data["shipping_record_ids"]) == 1
+
+    order_ref = f"ORD:{platform}:{store_code}:{ext_order_no}"
+    record = await _load_shipping_record(
+        session,
+        platform=platform,
+        store_code=store_code,
+        order_ref=order_ref,
+        package_no=1,
+    )
+    assert int(record["shipping_provider_id"]) == provider_id
+    assert record["shipping_provider_code"] == provider_code
+    assert record["tracking_no"] == f"TRACK-{suffix}"
+    assert float(record["cost_estimated"]) == pytest.approx(12.5)
+    assert record["dest_province"] == "浙江省"
+    assert record["dest_city"] == "杭州市"
+
+    export_row = (
+        await session.execute(
+            text(
+                """
+                SELECT logistics_status, logistics_completed_at, last_error
+                FROM wms_logistics_export_records
+                WHERE source_ref = :source_ref
+                LIMIT 1
+                """
+            ),
+            {"source_ref": source_ref},
+        )
+    ).mappings().first()
+    assert export_row is not None
+    assert export_row["logistics_status"] == "COMPLETED"
+    assert export_row["logistics_completed_at"] is not None
+    assert export_row["last_error"] is None
+
+    finance_line = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  shipping_record_id,
+                  shipping_provider_id,
+                  tracking_no,
+                  cost_estimated
+                FROM finance_shipping_cost_lines
+                WHERE shipping_record_id = :shipping_record_id
+                LIMIT 1
+                """
+            ),
+            {"shipping_record_id": int(record["id"])},
+        )
+    ).mappings().first()
+    assert finance_line is not None
+    assert int(finance_line["shipping_provider_id"]) == provider_id
+    assert finance_line["tracking_no"] == f"TRACK-{suffix}"
+    assert float(finance_line["cost_estimated"]) == pytest.approx(12.5)
+
+
+async def test_logistics_shipping_results_is_idempotent_by_package_key(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    suffix = uuid4().hex[:8].upper()
+    provider_code = f"WMSID{suffix}"[:32]
+    await _ensure_provider(session, code=provider_code)
+    source_ref, platform, store_code, ext_order_no = await _seed_order_exported_record(
+        session,
+        source_ref_suffix=suffix,
+    )
+
+    payload = {
+        "source_ref": source_ref,
+        "packages": [
+            {
+                "package_no": 1,
+                "tracking_no": f"TRACK-{suffix}",
+                "shipping_provider_code": provider_code,
+                "cost_estimated": "12.50",
+            }
+        ],
+    }
+
+    first = await client.post(
+        "/wms/outbound/logistics-shipping-results",
+        headers=headers,
+        json=payload,
+    )
+    assert first.status_code == 200, first.text
+    first_id = int(first.json()["shipping_record_ids"][0])
+
+    second_payload = {
+        **payload,
+        "packages": [
+            {
+                "package_no": 1,
+                "tracking_no": f"TRACK-{suffix}",
+                "shipping_provider_code": provider_code,
+                "cost_estimated": "18.75",
+            }
+        ],
+    }
+    second = await client.post(
+        "/wms/outbound/logistics-shipping-results",
+        headers=headers,
+        json=second_payload,
+    )
+    assert second.status_code == 200, second.text
+    assert int(second.json()["shipping_record_ids"][0]) == first_id
+
+    record = await _load_shipping_record(
+        session,
+        platform=platform,
+        store_code=store_code,
+        order_ref=f"ORD:{platform}:{store_code}:{ext_order_no}",
+        package_no=1,
+    )
+    assert int(record["id"]) == first_id
+    assert float(record["cost_estimated"]) == pytest.approx(18.75)
+
+
+async def test_logistics_shipping_results_rejects_before_imported(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    suffix = uuid4().hex[:8].upper()
+    provider_code = f"WMSNI{suffix}"[:32]
+    await _ensure_provider(session, code=provider_code)
+    source_ref, _platform, _store_code, _ext_order_no = await _seed_order_exported_record(
+        session,
+        source_ref_suffix=suffix,
+        export_status="PENDING",
+        logistics_status="NOT_IMPORTED",
+    )
+
+    resp = await client.post(
+        "/wms/outbound/logistics-shipping-results",
+        headers=headers,
+        json={
+            "source_ref": source_ref,
+            "packages": [
+                {
+                    "package_no": 1,
+                    "tracking_no": f"TRACK-{suffix}",
+                    "shipping_provider_code": provider_code,
+                }
+            ],
+        },
+    )
+
+    assert resp.status_code == 409, resp.text
+    assert "not_exported" in resp.text
+
+
+async def test_logistics_shipping_results_rejects_missing_provider_mapping(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    suffix = uuid4().hex[:8].upper()
+    source_ref, _platform, _store_code, _ext_order_no = await _seed_order_exported_record(
+        session,
+        source_ref_suffix=suffix,
+    )
+
+    resp = await client.post(
+        "/wms/outbound/logistics-shipping-results",
+        headers=headers,
+        json={
+            "source_ref": source_ref,
+            "packages": [
+                {
+                    "package_no": 1,
+                    "tracking_no": f"TRACK-{suffix}",
+                    "shipping_provider_code": f"MISSING{suffix}"[:32],
+                }
+            ],
+        },
+    )
+
+    assert resp.status_code == 409, resp.text
+    assert "shipping_provider_mapping_not_found" in resp.text
+
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT logistics_status
+                FROM wms_logistics_export_records
+                WHERE source_ref = :source_ref
+                LIMIT 1
+                """
+            ),
+            {"source_ref": source_ref},
+        )
+    ).mappings().first()
+    assert row is not None
+    assert row["logistics_status"] == "IMPORTED"
+
+
+async def test_logistics_shipping_results_returns_404_for_missing_source_ref(
+    client: AsyncClient,
+) -> None:
+    headers = await _login_admin_headers(client)
+
+    resp = await client.post(
+        "/wms/outbound/logistics-shipping-results",
+        headers=headers,
+        json={
+            "source_ref": "WMS:ORDER_OUTBOUND:NOT_FOUND",
+            "packages": [
+                {
+                    "package_no": 1,
+                    "tracking_no": "TRACK-NOT-FOUND",
+                    "shipping_provider_code": "NOTFOUND",
+                }
+            ],
+        },
+    )
+
+    assert resp.status_code == 404, resp.text
+
+
+async def test_logistics_shipping_results_validates_unique_package_no(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    suffix = uuid4().hex[:8].upper()
+    provider_code = f"WMSPK{suffix}"[:32]
+    await _ensure_provider(session, code=provider_code)
+    source_ref, _platform, _store_code, _ext_order_no = await _seed_order_exported_record(
+        session,
+        source_ref_suffix=suffix,
+    )
+
+    resp = await client.post(
+        "/wms/outbound/logistics-shipping-results",
+        headers=headers,
+        json={
+            "source_ref": source_ref,
+            "packages": [
+                {
+                    "package_no": 1,
+                    "tracking_no": f"TRACK-A-{suffix}",
+                    "shipping_provider_code": provider_code,
+                },
+                {
+                    "package_no": 1,
+                    "tracking_no": f"TRACK-B-{suffix}",
+                    "shipping_provider_code": provider_code,
+                },
+            ],
+        },
+    )
+
+    assert resp.status_code == 422, resp.text


### PR DESCRIPTION
## Summary
- add POST /wms/outbound/logistics-shipping-results
- upsert shipping_records from Logistics shipping completion facts
- update WMS logistics handoff records to COMPLETED
- resolve local shipping_provider_id by shipping_provider_code
- rely on existing DB triggers to refresh finance_shipping_cost_lines
- add API tests for success, idempotency, invalid state, missing provider mapping, missing source_ref and payload validation

## Scope
- WMS shipping-results callback API only
- no Logistics-side changes
- no frontend changes
- no OpenAPI snapshot changes in this PR

## Tests
- TESTS="tests/api/test_wms_logistics_shipping_results_api.py tests/api/test_wms_logistics_import_results_api.py tests/api/test_shipping_records_sync_from_logistics_api.py tests/api/test_finance_shipping_cost_ledger_api.py" make test
- make lint
- make test