### PR TITLE
feat(outbound): add logistics handoff payloads

### DIFF
--- a/alembic/versions/bf9a287b97de_add_wms_logistics_handoff_payloads.py
+++ b/alembic/versions/bf9a287b97de_add_wms_logistics_handoff_payloads.py
@@ -1,0 +1,560 @@
+"""add wms logistics handoff payloads
+
+Revision ID: bf9a287b97de
+Revises: 7abe99f04b00
+Create Date: 2026-05-07 21:49:22.376521
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "bf9a287b97de"
+down_revision: Union[str, Sequence[str], None] = "7abe99f04b00"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+PAYLOAD_TABLE = "wms_logistics_handoff_payloads"
+EXPORT_TABLE = "wms_logistics_export_records"
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+
+    op.create_table(
+        PAYLOAD_TABLE,
+        sa.Column(
+            "id",
+            sa.BigInteger(),
+            sa.Identity(always=False),
+            nullable=False,
+        ),
+        sa.Column("export_record_id", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "source_system",
+            sa.String(length=32),
+            nullable=False,
+            server_default=sa.text("'WMS'"),
+            comment="来源系统，当前固定 WMS",
+        ),
+        sa.Column(
+            "request_source",
+            sa.String(length=32),
+            nullable=False,
+            server_default=sa.text("'API_IMPORT'"),
+            comment="Logistics 请求来源，当前固定 API_IMPORT",
+        ),
+        sa.Column(
+            "source_doc_type",
+            sa.String(length=32),
+            nullable=False,
+            comment="WMS 来源单据类型：ORDER_OUTBOUND / MANUAL_OUTBOUND",
+        ),
+        sa.Column(
+            "source_doc_id",
+            sa.BigInteger(),
+            nullable=False,
+            comment="WMS 来源单据主键：orders.id 或 manual_outbound_docs.id",
+        ),
+        sa.Column(
+            "source_doc_no",
+            sa.String(length=128),
+            nullable=False,
+            comment="WMS 来源单据展示号：平台订单号或手工出库单号",
+        ),
+        sa.Column(
+            "source_ref",
+            sa.String(length=192),
+            nullable=False,
+            comment="WMS 到 Logistics 的稳定幂等键",
+        ),
+        sa.Column(
+            "platform",
+            sa.String(length=32),
+            nullable=True,
+            comment="平台：PDD / TAOBAO / JD；手工出库为空",
+        ),
+        sa.Column(
+            "store_code",
+            sa.String(length=64),
+            nullable=True,
+            comment="店铺编码；手工出库为空",
+        ),
+        sa.Column(
+            "order_ref",
+            sa.String(length=128),
+            nullable=True,
+            comment="订单物流引用，如 ORD:PDD:STORE:EXT_ORDER_NO；手工出库可为空",
+        ),
+        sa.Column(
+            "ext_order_no",
+            sa.String(length=128),
+            nullable=True,
+            comment="平台外部订单号；手工出库为空",
+        ),
+        sa.Column(
+            "warehouse_id",
+            sa.Integer(),
+            nullable=True,
+            comment="WMS 出库仓库 ID 快照",
+        ),
+        sa.Column(
+            "warehouse_name_snapshot",
+            sa.String(length=100),
+            nullable=True,
+            comment="WMS 出库仓库名称快照",
+        ),
+        sa.Column(
+            "receiver_name",
+            sa.String(length=128),
+            nullable=True,
+            comment="收件人姓名快照",
+        ),
+        sa.Column(
+            "receiver_phone",
+            sa.String(length=64),
+            nullable=True,
+            comment="收件人电话快照",
+        ),
+        sa.Column(
+            "receiver_province",
+            sa.String(length=64),
+            nullable=True,
+            comment="收件省份快照",
+        ),
+        sa.Column(
+            "receiver_city",
+            sa.String(length=64),
+            nullable=True,
+            comment="收件城市快照",
+        ),
+        sa.Column(
+            "receiver_district",
+            sa.String(length=64),
+            nullable=True,
+            comment="收件区县快照",
+        ),
+        sa.Column(
+            "receiver_address",
+            sa.String(length=255),
+            nullable=True,
+            comment="收件详细地址快照",
+        ),
+        sa.Column(
+            "receiver_postcode",
+            sa.String(length=32),
+            nullable=True,
+            comment="收件邮编快照",
+        ),
+        sa.Column(
+            "outbound_event_id",
+            sa.Integer(),
+            nullable=True,
+            comment="触发本次交接的 WMS OUTBOUND COMMIT 事件 ID",
+        ),
+        sa.Column(
+            "outbound_source_ref",
+            sa.String(length=128),
+            nullable=True,
+            comment="WMS 出库事件 source_ref",
+        ),
+        sa.Column(
+            "outbound_completed_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            comment="WMS 库存出库完成时间，非物流发货完成时间",
+        ),
+        sa.Column(
+            "shipment_items",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+            comment="WMS 已出库商品行快照，供 Logistics 创建发货请求与人工规划包裹使用",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_wms_logistics_handoff_payloads"),
+        sa.ForeignKeyConstraint(
+            ["export_record_id"],
+            [f"{EXPORT_TABLE}.id"],
+            name="fk_wms_logistics_handoff_payloads_export_record",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint(
+            "export_record_id",
+            name="uq_wms_logistics_handoff_payloads_export_record_id",
+        ),
+        sa.UniqueConstraint(
+            "source_ref",
+            name="uq_wms_logistics_handoff_payloads_source_ref",
+        ),
+        sa.CheckConstraint(
+            "source_system = 'WMS'",
+            name="ck_wms_logistics_handoff_payloads_source_system",
+        ),
+        sa.CheckConstraint(
+            "request_source = 'API_IMPORT'",
+            name="ck_wms_logistics_handoff_payloads_request_source",
+        ),
+        sa.CheckConstraint(
+            "source_doc_type IN ('ORDER_OUTBOUND', 'MANUAL_OUTBOUND')",
+            name="ck_wms_logistics_handoff_payloads_doc_type",
+        ),
+        sa.CheckConstraint(
+            "jsonb_typeof(shipment_items) = 'array'",
+            name="ck_wms_logistics_handoff_payloads_shipment_items_array",
+        ),
+    )
+
+    op.create_index(
+        "ix_wms_logistics_handoff_payloads_doc",
+        PAYLOAD_TABLE,
+        ["source_doc_type", "source_doc_id"],
+    )
+    op.create_index(
+        "ix_wms_logistics_handoff_payloads_platform_store",
+        PAYLOAD_TABLE,
+        ["platform", "store_code"],
+    )
+    op.create_index(
+        "ix_wms_logistics_handoff_payloads_warehouse_id",
+        PAYLOAD_TABLE,
+        ["warehouse_id"],
+    )
+    op.create_index(
+        "ix_wms_logistics_handoff_payloads_outbound_event_id",
+        PAYLOAD_TABLE,
+        ["outbound_event_id"],
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION trg_wms_logistics_handoff_payloads_touch_updated_at()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+          NEW.updated_at := now();
+          RETURN NEW;
+        END;
+        $$;
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER trg_wms_logistics_handoff_payloads_updated_at
+        BEFORE UPDATE ON wms_logistics_handoff_payloads
+        FOR EACH ROW
+        EXECUTE FUNCTION trg_wms_logistics_handoff_payloads_touch_updated_at()
+        """
+    )
+
+    # 一次性历史迁移：
+    # - 旧 source_snapshot 只用于本 migration 的历史数据搬迁；
+    # - 正式运行合同从本迁移完成后改为 payload 表；
+    # - 搬迁完成后立即删除 source_snapshot，避免形成长期灰色合同。
+    op.execute(
+        """
+        WITH base AS (
+          SELECT
+            r.id AS export_record_id,
+            r.source_doc_type,
+            r.source_doc_id,
+            r.source_doc_no,
+            r.source_ref,
+            r.created_at,
+            r.updated_at,
+            r.source_snapshot,
+
+            o.platform,
+            o.store_code,
+            o.ext_order_no,
+            o.buyer_name,
+            o.buyer_phone,
+
+            oa.receiver_name AS order_receiver_name,
+            oa.receiver_phone AS order_receiver_phone,
+            oa.province AS order_receiver_province,
+            oa.city AS order_receiver_city,
+            oa.district AS order_receiver_district,
+            oa.detail AS order_receiver_address,
+            oa.zipcode AS order_receiver_postcode,
+
+            ofu.actual_warehouse_id AS order_actual_warehouse_id,
+            ofu.planned_warehouse_id AS order_planned_warehouse_id,
+            ofu.outbound_completed_at AS order_outbound_completed_at,
+
+            md.warehouse_id AS manual_warehouse_id,
+            md.doc_no AS manual_doc_no,
+            md.recipient_name AS manual_recipient_name,
+
+            COALESCE(
+              CASE
+                WHEN (r.source_snapshot ->> 'wms_event_id') ~ '^[0-9]+$'
+                  THEN (r.source_snapshot ->> 'wms_event_id')::integer
+                ELSE NULL
+              END,
+              latest_event.id
+            ) AS outbound_event_id
+          FROM wms_logistics_export_records r
+          LEFT JOIN orders o
+            ON r.source_doc_type = 'ORDER_OUTBOUND'
+           AND o.id = r.source_doc_id
+          LEFT JOIN order_address oa
+            ON oa.order_id = o.id
+          LEFT JOIN order_fulfillment ofu
+            ON ofu.order_id = o.id
+          LEFT JOIN manual_outbound_docs md
+            ON r.source_doc_type = 'MANUAL_OUTBOUND'
+           AND md.id = r.source_doc_id
+          LEFT JOIN LATERAL (
+            SELECT e.id
+            FROM wms_events e
+            WHERE e.event_type = 'OUTBOUND'
+              AND e.event_kind = 'COMMIT'
+              AND e.status = 'COMMITTED'
+              AND (
+                (
+                  r.source_doc_type = 'ORDER_OUTBOUND'
+                  AND o.id IS NOT NULL
+                  AND e.source_type = 'ORDER'
+                  AND e.source_ref = ('ORD:' || UPPER(o.platform) || ':' || o.store_code || ':' || o.ext_order_no)
+                )
+                OR
+                (
+                  r.source_doc_type = 'MANUAL_OUTBOUND'
+                  AND md.id IS NOT NULL
+                  AND e.source_type = 'MANUAL'
+                  AND e.source_ref = md.doc_no
+                )
+              )
+            ORDER BY e.occurred_at DESC, e.id DESC
+            LIMIT 1
+          ) latest_event ON TRUE
+        ),
+        enriched AS (
+          SELECT
+            b.*,
+            e.source_ref AS outbound_source_ref,
+            e.occurred_at AS event_occurred_at,
+            e.warehouse_id AS event_warehouse_id,
+
+            COALESCE(
+              e.warehouse_id,
+              b.order_actual_warehouse_id,
+              b.order_planned_warehouse_id,
+              b.manual_warehouse_id,
+              CASE
+                WHEN (b.source_snapshot ->> 'warehouse_id') ~ '^[0-9]+$'
+                  THEN (b.source_snapshot ->> 'warehouse_id')::integer
+                ELSE NULL
+              END
+            ) AS resolved_warehouse_id,
+
+            COALESCE(
+              e.occurred_at,
+              b.order_outbound_completed_at,
+              CASE
+                WHEN NULLIF(b.source_snapshot ->> 'occurred_at', '') IS NOT NULL
+                  THEN NULLIF(b.source_snapshot ->> 'occurred_at', '')::timestamptz
+                ELSE NULL
+              END
+            ) AS resolved_outbound_completed_at
+          FROM base b
+          LEFT JOIN wms_events e
+            ON e.id = b.outbound_event_id
+        ),
+        shipment_item_rows AS (
+          SELECT
+            e.export_record_id,
+            COALESCE(
+              jsonb_agg(
+                jsonb_build_object(
+                  'source_line_type',
+                    CASE
+                      WHEN l.order_line_id IS NOT NULL THEN 'ORDER_LINE'
+                      WHEN l.manual_doc_line_id IS NOT NULL THEN 'MANUAL_OUTBOUND_LINE'
+                      ELSE 'UNKNOWN'
+                    END,
+                  'source_line_id', COALESCE(l.order_line_id, l.manual_doc_line_id),
+                  'source_line_no', l.ref_line,
+                  'item_id', l.item_id,
+                  'item_sku_snapshot', l.item_sku_snapshot,
+                  'item_name_snapshot', l.item_name_snapshot,
+                  'item_spec_snapshot', l.item_spec_snapshot,
+                  'qty_outbound', l.qty_outbound
+                )
+                ORDER BY l.ref_line ASC, l.id ASC
+              ) FILTER (WHERE l.id IS NOT NULL),
+              '[]'::jsonb
+            ) AS shipment_items
+          FROM enriched e
+          LEFT JOIN outbound_event_lines l
+            ON l.event_id = e.outbound_event_id
+          GROUP BY e.export_record_id
+        )
+        INSERT INTO wms_logistics_handoff_payloads (
+          export_record_id,
+          source_system,
+          request_source,
+          source_doc_type,
+          source_doc_id,
+          source_doc_no,
+          source_ref,
+          platform,
+          store_code,
+          order_ref,
+          ext_order_no,
+          warehouse_id,
+          warehouse_name_snapshot,
+          receiver_name,
+          receiver_phone,
+          receiver_province,
+          receiver_city,
+          receiver_district,
+          receiver_address,
+          receiver_postcode,
+          outbound_event_id,
+          outbound_source_ref,
+          outbound_completed_at,
+          shipment_items,
+          created_at,
+          updated_at
+        )
+        SELECT
+          e.export_record_id,
+          'WMS',
+          'API_IMPORT',
+          e.source_doc_type,
+          e.source_doc_id,
+          e.source_doc_no,
+          e.source_ref,
+          CASE
+            WHEN e.source_doc_type = 'ORDER_OUTBOUND' THEN e.platform
+            ELSE NULL
+          END AS platform,
+          CASE
+            WHEN e.source_doc_type = 'ORDER_OUTBOUND' THEN e.store_code
+            ELSE NULL
+          END AS store_code,
+          CASE
+            WHEN e.source_doc_type = 'ORDER_OUTBOUND'
+             AND e.platform IS NOT NULL
+             AND e.store_code IS NOT NULL
+             AND e.ext_order_no IS NOT NULL
+            THEN 'ORD:' || UPPER(e.platform) || ':' || e.store_code || ':' || e.ext_order_no
+            ELSE NULL
+          END AS order_ref,
+          CASE
+            WHEN e.source_doc_type = 'ORDER_OUTBOUND' THEN e.ext_order_no
+            ELSE NULL
+          END AS ext_order_no,
+          e.resolved_warehouse_id,
+          w.name AS warehouse_name_snapshot,
+          CASE
+            WHEN e.source_doc_type = 'ORDER_OUTBOUND'
+              THEN COALESCE(e.order_receiver_name, e.buyer_name)
+            ELSE e.manual_recipient_name
+          END AS receiver_name,
+          CASE
+            WHEN e.source_doc_type = 'ORDER_OUTBOUND'
+              THEN COALESCE(e.order_receiver_phone, e.buyer_phone)
+            ELSE NULL
+          END AS receiver_phone,
+          CASE
+            WHEN e.source_doc_type = 'ORDER_OUTBOUND' THEN e.order_receiver_province
+            ELSE NULL
+          END AS receiver_province,
+          CASE
+            WHEN e.source_doc_type = 'ORDER_OUTBOUND' THEN e.order_receiver_city
+            ELSE NULL
+          END AS receiver_city,
+          CASE
+            WHEN e.source_doc_type = 'ORDER_OUTBOUND' THEN e.order_receiver_district
+            ELSE NULL
+          END AS receiver_district,
+          CASE
+            WHEN e.source_doc_type = 'ORDER_OUTBOUND' THEN e.order_receiver_address
+            ELSE NULL
+          END AS receiver_address,
+          CASE
+            WHEN e.source_doc_type = 'ORDER_OUTBOUND' THEN e.order_receiver_postcode
+            ELSE NULL
+          END AS receiver_postcode,
+          e.outbound_event_id,
+          e.outbound_source_ref,
+          e.resolved_outbound_completed_at,
+          COALESCE(sir.shipment_items, '[]'::jsonb),
+          e.created_at,
+          e.updated_at
+        FROM enriched e
+        LEFT JOIN warehouses w
+          ON w.id = e.resolved_warehouse_id
+        LEFT JOIN shipment_item_rows sir
+          ON sir.export_record_id = e.export_record_id
+        ON CONFLICT (export_record_id) DO NOTHING
+        """
+    )
+
+    op.drop_column(EXPORT_TABLE, "source_snapshot")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+
+    op.add_column(
+        EXPORT_TABLE,
+        sa.Column(
+            "source_snapshot",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+            comment="创建交接记录时的 WMS 来源快照",
+        ),
+    )
+
+    op.execute(
+        """
+        UPDATE wms_logistics_export_records r
+           SET source_snapshot = jsonb_build_object(
+                 'source_system', p.source_system,
+                 'request_source', p.request_source,
+                 'wms_event_id', p.outbound_event_id,
+                 'wms_source_ref', p.outbound_source_ref,
+                 'warehouse_id', p.warehouse_id,
+                 'occurred_at', p.outbound_completed_at,
+                 'lines', p.shipment_items
+               )
+          FROM wms_logistics_handoff_payloads p
+         WHERE p.export_record_id = r.id
+        """
+    )
+
+    op.execute(
+        "DROP TRIGGER IF EXISTS trg_wms_logistics_handoff_payloads_updated_at "
+        "ON wms_logistics_handoff_payloads"
+    )
+    op.execute("DROP FUNCTION IF EXISTS trg_wms_logistics_handoff_payloads_touch_updated_at")
+
+    op.drop_index("ix_wms_logistics_handoff_payloads_outbound_event_id", table_name=PAYLOAD_TABLE)
+    op.drop_index("ix_wms_logistics_handoff_payloads_warehouse_id", table_name=PAYLOAD_TABLE)
+    op.drop_index("ix_wms_logistics_handoff_payloads_platform_store", table_name=PAYLOAD_TABLE)
+    op.drop_index("ix_wms_logistics_handoff_payloads_doc", table_name=PAYLOAD_TABLE)
+    op.drop_table(PAYLOAD_TABLE)

--- a/app/shipping_assist/handoffs/contracts.py
+++ b/app/shipping_assist/handoffs/contracts.py
@@ -2,18 +2,29 @@
 #
 # 分拆说明：
 # - 本文件承载 Shipping Assist / Handoffs（发货交接）只读合同；
-# - 主数据源是 wms_logistics_export_records；
+# - 状态来自 wms_logistics_export_records；
+# - 交接数据来自 wms_logistics_handoff_payloads；
 # - 发货交接页只观察 WMS -> Logistics 交接状态，不写 shipping_records。
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
 
 class _Base(BaseModel):
     model_config = ConfigDict(extra="forbid")
+
+
+class ShippingHandoffShipmentItem(_Base):
+    source_line_type: str
+    source_line_id: int | None = None
+    source_line_no: int | None = None
+    item_id: int | None = None
+    item_sku_snapshot: str | None = None
+    item_name_snapshot: str | None = None
+    item_spec_snapshot: str | None = None
+    qty_outbound: int
 
 
 class ShippingHandoffRow(_Base):
@@ -35,7 +46,30 @@ class ShippingHandoffRow(_Base):
     last_attempt_at: datetime | None = None
     last_error: str | None = None
 
-    source_snapshot: dict[str, Any] = Field(default_factory=dict)
+    source_system: str = "WMS"
+    request_source: str = "API_IMPORT"
+
+    platform: str | None = None
+    store_code: str | None = None
+    order_ref: str | None = None
+    ext_order_no: str | None = None
+
+    warehouse_id: int | None = None
+    warehouse_name_snapshot: str | None = None
+
+    receiver_name: str | None = None
+    receiver_phone: str | None = None
+    receiver_province: str | None = None
+    receiver_city: str | None = None
+    receiver_district: str | None = None
+    receiver_address: str | None = None
+    receiver_postcode: str | None = None
+
+    outbound_event_id: int | None = None
+    outbound_source_ref: str | None = None
+    outbound_completed_at: datetime | None = None
+
+    shipment_items: list[ShippingHandoffShipmentItem] = Field(default_factory=list)
 
     created_at: datetime
     updated_at: datetime

--- a/app/shipping_assist/handoffs/repository.py
+++ b/app/shipping_assist/handoffs/repository.py
@@ -3,10 +3,11 @@
 # 分拆说明：
 # - 本文件承载 Shipping Assist / Handoffs（发货交接）只读查询；
 # - wms_logistics_export_records 是 WMS 与 Logistics 的交接状态主表；
+# - wms_logistics_handoff_payloads 是 WMS 给 Logistics 的交接数据表；
 # - 不读取 shipping_records，避免把交接状态与物流事实台账混在一起。
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Mapping
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -25,28 +26,56 @@ LOGISTICS_STATUSES = {
 
 _SELECT_HANDOFF_BASE = """
 SELECT
-  id,
-  source_doc_type,
-  source_doc_id,
-  source_doc_no,
-  source_ref,
-  export_status,
-  logistics_status,
-  logistics_request_id,
-  logistics_request_no,
-  exported_at,
-  logistics_completed_at,
-  last_attempt_at,
-  last_error,
-  source_snapshot,
-  created_at,
-  updated_at
-FROM wms_logistics_export_records
+  r.id,
+  r.source_doc_type,
+  r.source_doc_id,
+  r.source_doc_no,
+  r.source_ref,
+  r.export_status,
+  r.logistics_status,
+  r.logistics_request_id,
+  r.logistics_request_no,
+  r.exported_at,
+  r.logistics_completed_at,
+  r.last_attempt_at,
+  r.last_error,
+
+  p.source_system,
+  p.request_source,
+  p.platform,
+  p.store_code,
+  p.order_ref,
+  p.ext_order_no,
+  p.warehouse_id,
+  p.warehouse_name_snapshot,
+  p.receiver_name,
+  p.receiver_phone,
+  p.receiver_province,
+  p.receiver_city,
+  p.receiver_district,
+  p.receiver_address,
+  p.receiver_postcode,
+  p.outbound_event_id,
+  p.outbound_source_ref,
+  p.outbound_completed_at,
+  p.shipment_items,
+
+  r.created_at,
+  r.updated_at
+FROM wms_logistics_export_records r
+JOIN wms_logistics_handoff_payloads p
+  ON p.export_record_id = r.id
 """
 
 
 def _clean_opt_str(value: str | None) -> str | None:
     return (value or "").strip() or None
+
+
+def _json_array(value: Any) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [dict(x) for x in value if isinstance(x, Mapping)]
+    return []
 
 
 def _build_where_clause(
@@ -63,35 +92,41 @@ def _build_where_clause(
 
     source_doc_type_clean = _clean_opt_str(source_doc_type)
     if source_doc_type_clean:
-        conditions.append("source_doc_type = :source_doc_type")
+        conditions.append("r.source_doc_type = :source_doc_type")
         params["source_doc_type"] = source_doc_type_clean
 
     export_status_clean = _clean_opt_str(export_status)
     if export_status_clean:
-        conditions.append("export_status = :export_status")
+        conditions.append("r.export_status = :export_status")
         params["export_status"] = export_status_clean
 
     logistics_status_clean = _clean_opt_str(logistics_status)
     if logistics_status_clean:
-        conditions.append("logistics_status = :logistics_status")
+        conditions.append("r.logistics_status = :logistics_status")
         params["logistics_status"] = logistics_status_clean
 
     source_ref_clean = _clean_opt_str(source_ref)
     if source_ref_clean:
-        conditions.append("source_ref = :source_ref")
+        conditions.append("r.source_ref = :source_ref")
         params["source_ref"] = source_ref_clean
 
     source_doc_no_clean = _clean_opt_str(source_doc_no)
     if source_doc_no_clean:
-        conditions.append("source_doc_no ILIKE :source_doc_no_like")
+        conditions.append("r.source_doc_no ILIKE :source_doc_no_like")
         params["source_doc_no_like"] = f"%{source_doc_no_clean}%"
 
     logistics_request_no_clean = _clean_opt_str(logistics_request_no)
     if logistics_request_no_clean:
-        conditions.append("logistics_request_no = :logistics_request_no")
+        conditions.append("r.logistics_request_no = :logistics_request_no")
         params["logistics_request_no"] = logistics_request_no_clean
 
     return " AND ".join(conditions), params
+
+
+def _row_to_dict(row: Mapping[str, Any]) -> dict[str, object]:
+    out = dict(row)
+    out["shipment_items"] = _json_array(row.get("shipment_items"))
+    return out
 
 
 async def list_shipping_handoffs(
@@ -121,7 +156,9 @@ async def list_shipping_handoffs(
                 text(
                     f"""
                     SELECT COUNT(*)
-                    FROM wms_logistics_export_records
+                    FROM wms_logistics_export_records r
+                    JOIN wms_logistics_handoff_payloads p
+                      ON p.export_record_id = r.id
                     WHERE {where_sql}
                     """
                 ),
@@ -141,7 +178,7 @@ async def list_shipping_handoffs(
                 f"""
                 {_SELECT_HANDOFF_BASE}
                 WHERE {where_sql}
-                ORDER BY updated_at DESC, id DESC
+                ORDER BY r.updated_at DESC, r.id DESC
                 LIMIT :limit OFFSET :offset
                 """
             ),
@@ -149,4 +186,4 @@ async def list_shipping_handoffs(
         )
     ).mappings().all()
 
-    return total, [dict(row) for row in rows]
+    return total, [_row_to_dict(row) for row in rows]

--- a/app/wms/outbound/contracts/logistics_ready.py
+++ b/app/wms/outbound/contracts/logistics_ready.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -11,27 +10,21 @@ class _Base(BaseModel):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
 
-class LogisticsReadyItemOut(_Base):
-    line_no: int
+class LogisticsReadyShipmentItemOut(_Base):
+    source_line_type: str
+    source_line_id: int | None = None
+    source_line_no: int | None = None
     item_id: int | None = None
-    qty: int
-    lot_id: int | None = None
-    lot_code_snapshot: str | None = None
-    item_name_snapshot: str | None = None
     item_sku_snapshot: str | None = None
+    item_name_snapshot: str | None = None
     item_spec_snapshot: str | None = None
-
-
-class LogisticsReadyPackageOut(_Base):
-    source_package_ref: str
-    package_no: int
-    warehouse_id: int | None = None
-    weight_kg: str | None = None
-    items: list[LogisticsReadyItemOut] = Field(default_factory=list)
+    qty_outbound: int
 
 
 class LogisticsReadyRowOut(_Base):
     source_system: str = "WMS"
+    request_source: str = "API_IMPORT"
+
     source_doc_type: str
     source_doc_id: int
     source_doc_no: str
@@ -42,22 +35,28 @@ class LogisticsReadyRowOut(_Base):
 
     platform: str | None = None
     store_code: str | None = None
-    platform_order_no: str | None = None
+    order_ref: str | None = None
+    ext_order_no: str | None = None
+
     warehouse_id: int | None = None
+    warehouse_name_snapshot: str | None = None
 
     receiver_name: str | None = None
     receiver_phone: str | None = None
-    province: str | None = None
-    city: str | None = None
-    district: str | None = None
-    address_detail: str | None = None
+    receiver_province: str | None = None
+    receiver_city: str | None = None
+    receiver_district: str | None = None
+    receiver_address: str | None = None
+    receiver_postcode: str | None = None
 
+    outbound_event_id: int | None = None
+    outbound_source_ref: str | None = None
     outbound_completed_at: datetime | None = None
+
+    shipment_items: list[LogisticsReadyShipmentItemOut] = Field(default_factory=list)
+
     handoff_created_at: datetime
     handoff_updated_at: datetime
-
-    packages: list[LogisticsReadyPackageOut] = Field(default_factory=list)
-    source_snapshot: dict[str, Any] = Field(default_factory=dict)
 
 
 class LogisticsReadyListOut(_Base):

--- a/app/wms/outbound/contracts/logistics_shipping_results.py
+++ b/app/wms/outbound/contracts/logistics_shipping_results.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
-from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -58,4 +57,3 @@ class LogisticsShippingResultOut(_Base):
     logistics_completed_at: datetime
     shipping_record_ids: list[int] = Field(default_factory=list)
     packages_count: int
-    source_snapshot: dict[str, Any] = Field(default_factory=dict)

--- a/app/wms/outbound/models/logistics_export_record.py
+++ b/app/wms/outbound/models/logistics_export_record.py
@@ -1,12 +1,12 @@
 # app/wms/outbound/models/logistics_export_record.py
-# WMS -> Logistics 交接状态表模型。
+# WMS -> Logistics 交接状态表与交接数据表模型。
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
 import sqlalchemy as sa
-from sqlalchemy import BigInteger, DateTime, String, Text, func, text
+from sqlalchemy import BigInteger, DateTime, Integer, String, Text, func, text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -15,12 +15,16 @@ from app.db.base import Base
 
 class WmsLogisticsExportRecord(Base):
     """
-    wms_logistics_export_records：WMS 出库事实交接给 Logistics 的状态表。
+    wms_logistics_export_records：WMS 与 Logistics 之间的交接状态表。
 
+    只表达调用关系与状态：
     - WMS 订单出库完成：source_doc_type = ORDER_OUTBOUND
     - WMS 手工出库完成：source_doc_type = MANUAL_OUTBOUND
     - export_status：WMS 交接导出状态
     - logistics_status：Logistics 处理状态
+
+    发货请求所需的结构化数据不在本表，统一放在：
+    - wms_logistics_handoff_payloads
     """
 
     __tablename__ = "wms_logistics_export_records"
@@ -113,11 +117,205 @@ class WmsLogisticsExportRecord(Base):
         comment="最近一次失败原因",
     )
 
-    source_snapshot: Mapped[dict] = mapped_column(
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+
+class WmsLogisticsHandoffPayload(Base):
+    """
+    wms_logistics_handoff_payloads：WMS 给 Logistics 创建发货请求的数据合同表。
+
+    本表保存结构化交接数据：
+    - 平台 / 店铺 / 订单号
+    - 仓库快照
+    - 收件人地址快照
+    - WMS 出库完成事实
+    - WMS 已出库商品行 shipment_items
+
+    不保留旧快照字段。
+    """
+
+    __tablename__ = "wms_logistics_handoff_payloads"
+
+    __table_args__ = (
+        sa.ForeignKeyConstraint(
+            ["export_record_id"],
+            ["wms_logistics_export_records.id"],
+            name="fk_wms_logistics_handoff_payloads_export_record",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint(
+            "export_record_id",
+            name="uq_wms_logistics_handoff_payloads_export_record_id",
+        ),
+        sa.UniqueConstraint(
+            "source_ref",
+            name="uq_wms_logistics_handoff_payloads_source_ref",
+        ),
+        sa.CheckConstraint(
+            "source_system = 'WMS'",
+            name="ck_wms_logistics_handoff_payloads_source_system",
+        ),
+        sa.CheckConstraint(
+            "request_source = 'API_IMPORT'",
+            name="ck_wms_logistics_handoff_payloads_request_source",
+        ),
+        sa.CheckConstraint(
+            "source_doc_type IN ('ORDER_OUTBOUND', 'MANUAL_OUTBOUND')",
+            name="ck_wms_logistics_handoff_payloads_doc_type",
+        ),
+        sa.CheckConstraint(
+            "jsonb_typeof(shipment_items) = 'array'",
+            name="ck_wms_logistics_handoff_payloads_shipment_items_array",
+        ),
+        sa.Index("ix_wms_logistics_handoff_payloads_doc", "source_doc_type", "source_doc_id"),
+        sa.Index("ix_wms_logistics_handoff_payloads_platform_store", "platform", "store_code"),
+        sa.Index("ix_wms_logistics_handoff_payloads_warehouse_id", "warehouse_id"),
+        sa.Index("ix_wms_logistics_handoff_payloads_outbound_event_id", "outbound_event_id"),
+    )
+
+    id: Mapped[int] = mapped_column(
+        BigInteger,
+        sa.Identity(always=False),
+        primary_key=True,
+    )
+
+    export_record_id: Mapped[int] = mapped_column(
+        BigInteger,
+        nullable=False,
+    )
+
+    source_system: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        server_default=text("'WMS'"),
+        comment="来源系统，当前固定 WMS",
+    )
+    request_source: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        server_default=text("'API_IMPORT'"),
+        comment="Logistics 请求来源，当前固定 API_IMPORT",
+    )
+
+    source_doc_type: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        comment="WMS 来源单据类型：ORDER_OUTBOUND / MANUAL_OUTBOUND",
+    )
+    source_doc_id: Mapped[int] = mapped_column(
+        BigInteger,
+        nullable=False,
+        comment="WMS 来源单据主键：orders.id 或 manual_outbound_docs.id",
+    )
+    source_doc_no: Mapped[str] = mapped_column(
+        String(128),
+        nullable=False,
+        comment="WMS 来源单据展示号：平台订单号或手工出库单号",
+    )
+    source_ref: Mapped[str] = mapped_column(
+        String(192),
+        nullable=False,
+        comment="WMS 到 Logistics 的稳定幂等键",
+    )
+
+    platform: Mapped[Optional[str]] = mapped_column(
+        String(32),
+        nullable=True,
+        comment="平台：PDD / TAOBAO / JD；手工出库为空",
+    )
+    store_code: Mapped[Optional[str]] = mapped_column(
+        String(64),
+        nullable=True,
+        comment="店铺编码；手工出库为空",
+    )
+    order_ref: Mapped[Optional[str]] = mapped_column(
+        String(128),
+        nullable=True,
+        comment="订单物流引用，如 ORD:PDD:STORE:EXT_ORDER_NO；手工出库可为空",
+    )
+    ext_order_no: Mapped[Optional[str]] = mapped_column(
+        String(128),
+        nullable=True,
+        comment="平台外部订单号；手工出库为空",
+    )
+
+    warehouse_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        nullable=True,
+        comment="WMS 出库仓库 ID 快照",
+    )
+    warehouse_name_snapshot: Mapped[Optional[str]] = mapped_column(
+        String(100),
+        nullable=True,
+        comment="WMS 出库仓库名称快照",
+    )
+
+    receiver_name: Mapped[Optional[str]] = mapped_column(
+        String(128),
+        nullable=True,
+        comment="收件人姓名快照",
+    )
+    receiver_phone: Mapped[Optional[str]] = mapped_column(
+        String(64),
+        nullable=True,
+        comment="收件人电话快照",
+    )
+    receiver_province: Mapped[Optional[str]] = mapped_column(
+        String(64),
+        nullable=True,
+        comment="收件省份快照",
+    )
+    receiver_city: Mapped[Optional[str]] = mapped_column(
+        String(64),
+        nullable=True,
+        comment="收件城市快照",
+    )
+    receiver_district: Mapped[Optional[str]] = mapped_column(
+        String(64),
+        nullable=True,
+        comment="收件区县快照",
+    )
+    receiver_address: Mapped[Optional[str]] = mapped_column(
+        String(255),
+        nullable=True,
+        comment="收件详细地址快照",
+    )
+    receiver_postcode: Mapped[Optional[str]] = mapped_column(
+        String(32),
+        nullable=True,
+        comment="收件邮编快照",
+    )
+
+    outbound_event_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        nullable=True,
+        comment="触发本次交接的 WMS OUTBOUND COMMIT 事件 ID",
+    )
+    outbound_source_ref: Mapped[Optional[str]] = mapped_column(
+        String(128),
+        nullable=True,
+        comment="WMS 出库事件 source_ref",
+    )
+    outbound_completed_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="WMS 库存出库完成时间，非物流发货完成时间",
+    )
+
+    shipment_items: Mapped[list[dict[str, Any]]] = mapped_column(
         JSONB,
         nullable=False,
-        server_default=text("'{}'::jsonb"),
-        comment="创建交接记录时的 WMS 来源快照",
+        server_default=text("'[]'::jsonb"),
+        comment="WMS 已出库商品行快照，供 Logistics 创建发货请求与人工规划包裹使用",
     )
 
     created_at: Mapped[datetime] = mapped_column(

--- a/app/wms/outbound/repos/logistics_export_record_repo.py
+++ b/app/wms/outbound/repos/logistics_export_record_repo.py
@@ -2,16 +2,17 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Mapping
+from datetime import datetime
+from typing import Any, Mapping, Sequence
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
-def _json_snapshot(value: Mapping[str, Any] | None) -> str:
+def _json_array(value: Sequence[Mapping[str, Any]] | None) -> str:
     if not value:
-        return "{}"
-    return json.dumps(value, ensure_ascii=False, default=str)
+        return "[]"
+    return json.dumps(list(value), ensure_ascii=False, default=str)
 
 
 async def upsert_pending_logistics_export_record(
@@ -21,70 +22,217 @@ async def upsert_pending_logistics_export_record(
     source_doc_id: int,
     source_doc_no: str,
     source_ref: str,
-    source_snapshot: Mapping[str, Any] | None = None,
-) -> None:
+) -> int:
     """
-    幂等写入 WMS -> Logistics 待交接记录。
+    幂等写入 WMS -> Logistics 待交接状态记录。
+
+    本函数只写状态表 wms_logistics_export_records。
+    发货请求结构化数据必须写入 wms_logistics_handoff_payloads。
 
     已进入 EXPORTED / IMPORTED / IN_PROGRESS / COMPLETED 的记录不被回退；
     FAILED / CANCELLED 以外的未完成状态可回到 PENDING，供后续导入接口读取。
     """
 
+    row = (
+        await session.execute(
+            text(
+                """
+                INSERT INTO wms_logistics_export_records (
+                  source_doc_type,
+                  source_doc_id,
+                  source_doc_no,
+                  source_ref,
+                  export_status,
+                  logistics_status,
+                  last_error,
+                  created_at,
+                  updated_at
+                )
+                VALUES (
+                  :source_doc_type,
+                  :source_doc_id,
+                  :source_doc_no,
+                  :source_ref,
+                  'PENDING',
+                  'NOT_IMPORTED',
+                  NULL,
+                  now(),
+                  now()
+                )
+                ON CONFLICT (source_doc_type, source_doc_id) DO UPDATE
+                   SET source_doc_no = EXCLUDED.source_doc_no,
+                       source_ref = EXCLUDED.source_ref,
+                       export_status = CASE
+                           WHEN wms_logistics_export_records.export_status = 'EXPORTED'
+                             THEN wms_logistics_export_records.export_status
+                           ELSE 'PENDING'
+                       END,
+                       logistics_status = CASE
+                           WHEN wms_logistics_export_records.logistics_status IN ('IMPORTED', 'IN_PROGRESS', 'COMPLETED')
+                             THEN wms_logistics_export_records.logistics_status
+                           ELSE 'NOT_IMPORTED'
+                       END,
+                       last_error = CASE
+                           WHEN wms_logistics_export_records.export_status = 'EXPORTED'
+                             THEN wms_logistics_export_records.last_error
+                           ELSE NULL
+                       END,
+                       updated_at = now()
+                RETURNING id
+                """
+            ),
+            {
+                "source_doc_type": str(source_doc_type),
+                "source_doc_id": int(source_doc_id),
+                "source_doc_no": str(source_doc_no).strip(),
+                "source_ref": str(source_ref).strip(),
+            },
+        )
+    ).scalar_one()
+
+    return int(row)
+
+
+async def upsert_logistics_handoff_payload(
+    session: AsyncSession,
+    *,
+    export_record_id: int,
+    source_doc_type: str,
+    source_doc_id: int,
+    source_doc_no: str,
+    source_ref: str,
+    platform: str | None,
+    store_code: str | None,
+    order_ref: str | None,
+    ext_order_no: str | None,
+    warehouse_id: int | None,
+    warehouse_name_snapshot: str | None,
+    receiver_name: str | None,
+    receiver_phone: str | None,
+    receiver_province: str | None,
+    receiver_city: str | None,
+    receiver_district: str | None,
+    receiver_address: str | None,
+    receiver_postcode: str | None,
+    outbound_event_id: int | None,
+    outbound_source_ref: str | None,
+    outbound_completed_at: datetime | None,
+    shipment_items: Sequence[Mapping[str, Any]] | None,
+) -> None:
+    """
+    幂等写入 WMS -> Logistics 交接数据 payload。
+
+    本表是 Logistics 创建发货请求的数据源。
+    不使用旧快照字段，不做 JSON 内部私有字段兜底。
+    """
+
     await session.execute(
         text(
             """
-            INSERT INTO wms_logistics_export_records (
+            INSERT INTO wms_logistics_handoff_payloads (
+              export_record_id,
+              source_system,
+              request_source,
               source_doc_type,
               source_doc_id,
               source_doc_no,
               source_ref,
-              export_status,
-              logistics_status,
-              source_snapshot,
-              last_error,
+              platform,
+              store_code,
+              order_ref,
+              ext_order_no,
+              warehouse_id,
+              warehouse_name_snapshot,
+              receiver_name,
+              receiver_phone,
+              receiver_province,
+              receiver_city,
+              receiver_district,
+              receiver_address,
+              receiver_postcode,
+              outbound_event_id,
+              outbound_source_ref,
+              outbound_completed_at,
+              shipment_items,
               created_at,
               updated_at
             )
             VALUES (
+              :export_record_id,
+              'WMS',
+              'API_IMPORT',
               :source_doc_type,
               :source_doc_id,
               :source_doc_no,
               :source_ref,
-              'PENDING',
-              'NOT_IMPORTED',
-              CAST(:source_snapshot AS jsonb),
-              NULL,
+              :platform,
+              :store_code,
+              :order_ref,
+              :ext_order_no,
+              :warehouse_id,
+              :warehouse_name_snapshot,
+              :receiver_name,
+              :receiver_phone,
+              :receiver_province,
+              :receiver_city,
+              :receiver_district,
+              :receiver_address,
+              :receiver_postcode,
+              :outbound_event_id,
+              :outbound_source_ref,
+              :outbound_completed_at,
+              CAST(:shipment_items AS jsonb),
               now(),
               now()
             )
-            ON CONFLICT (source_doc_type, source_doc_id) DO UPDATE
-               SET source_doc_no = EXCLUDED.source_doc_no,
+            ON CONFLICT (export_record_id) DO UPDATE
+               SET source_doc_type = EXCLUDED.source_doc_type,
+                   source_doc_id = EXCLUDED.source_doc_id,
+                   source_doc_no = EXCLUDED.source_doc_no,
                    source_ref = EXCLUDED.source_ref,
-                   source_snapshot = EXCLUDED.source_snapshot,
-                   export_status = CASE
-                       WHEN wms_logistics_export_records.export_status = 'EXPORTED'
-                         THEN wms_logistics_export_records.export_status
-                       ELSE 'PENDING'
-                   END,
-                   logistics_status = CASE
-                       WHEN wms_logistics_export_records.logistics_status IN ('IMPORTED', 'IN_PROGRESS', 'COMPLETED')
-                         THEN wms_logistics_export_records.logistics_status
-                       ELSE 'NOT_IMPORTED'
-                   END,
-                   last_error = CASE
-                       WHEN wms_logistics_export_records.export_status = 'EXPORTED'
-                         THEN wms_logistics_export_records.last_error
-                       ELSE NULL
-                   END,
+                   platform = EXCLUDED.platform,
+                   store_code = EXCLUDED.store_code,
+                   order_ref = EXCLUDED.order_ref,
+                   ext_order_no = EXCLUDED.ext_order_no,
+                   warehouse_id = EXCLUDED.warehouse_id,
+                   warehouse_name_snapshot = EXCLUDED.warehouse_name_snapshot,
+                   receiver_name = EXCLUDED.receiver_name,
+                   receiver_phone = EXCLUDED.receiver_phone,
+                   receiver_province = EXCLUDED.receiver_province,
+                   receiver_city = EXCLUDED.receiver_city,
+                   receiver_district = EXCLUDED.receiver_district,
+                   receiver_address = EXCLUDED.receiver_address,
+                   receiver_postcode = EXCLUDED.receiver_postcode,
+                   outbound_event_id = EXCLUDED.outbound_event_id,
+                   outbound_source_ref = EXCLUDED.outbound_source_ref,
+                   outbound_completed_at = EXCLUDED.outbound_completed_at,
+                   shipment_items = EXCLUDED.shipment_items,
                    updated_at = now()
             """
         ),
         {
+            "export_record_id": int(export_record_id),
             "source_doc_type": str(source_doc_type),
             "source_doc_id": int(source_doc_id),
             "source_doc_no": str(source_doc_no).strip(),
             "source_ref": str(source_ref).strip(),
-            "source_snapshot": _json_snapshot(source_snapshot),
+            "platform": platform,
+            "store_code": store_code,
+            "order_ref": order_ref,
+            "ext_order_no": ext_order_no,
+            "warehouse_id": int(warehouse_id) if warehouse_id is not None else None,
+            "warehouse_name_snapshot": warehouse_name_snapshot,
+            "receiver_name": receiver_name,
+            "receiver_phone": receiver_phone,
+            "receiver_province": receiver_province,
+            "receiver_city": receiver_city,
+            "receiver_district": receiver_district,
+            "receiver_address": receiver_address,
+            "receiver_postcode": receiver_postcode,
+            "outbound_event_id": int(outbound_event_id) if outbound_event_id is not None else None,
+            "outbound_source_ref": outbound_source_ref,
+            "outbound_completed_at": outbound_completed_at,
+            "shipment_items": _json_array(shipment_items),
         },
     )
 

--- a/app/wms/outbound/repos/logistics_ready_repo.py
+++ b/app/wms/outbound/repos/logistics_ready_repo.py
@@ -1,7 +1,6 @@
 # app/wms/outbound/repos/logistics_ready_repo.py
 from __future__ import annotations
 
-import json
 from typing import Any, Mapping
 
 from sqlalchemy import text
@@ -11,132 +10,41 @@ READY_EXPORT_STATUSES = ("PENDING", "FAILED")
 READY_SOURCE_DOC_TYPES = ("ORDER_OUTBOUND", "MANUAL_OUTBOUND")
 
 
-def _snapshot_dict(value: Any) -> dict[str, Any]:
-    if isinstance(value, dict):
-        return value
-    if value is None:
-        return {}
-    if isinstance(value, str):
-        try:
-            parsed = json.loads(value)
-        except json.JSONDecodeError:
-            return {}
-        return parsed if isinstance(parsed, dict) else {}
-    return {}
-
-
-def _int_or_none(value: Any) -> int | None:
-    if value is None:
-        return None
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
-
-
-def _clean_text(value: Any) -> str | None:
-    if value is None:
-        return None
-    s = str(value).strip()
-    return s or None
-
-
-def _build_items(snapshot: Mapping[str, Any]) -> list[dict[str, Any]]:
-    raw_lines = snapshot.get("lines")
-    if not isinstance(raw_lines, list):
-        return []
-
-    items: list[dict[str, Any]] = []
-    for idx, raw in enumerate(raw_lines, start=1):
-        if not isinstance(raw, Mapping):
-            continue
-
-        qty = raw.get("qty_outbound", raw.get("qty", 0))
-        items.append(
-            {
-                "line_no": int(raw.get("ref_line") or idx),
-                "item_id": _int_or_none(raw.get("item_id")),
-                "qty": int(qty or 0),
-                "lot_id": _int_or_none(raw.get("lot_id")),
-                "lot_code_snapshot": _clean_text(raw.get("lot_code_snapshot")),
-                "item_name_snapshot": _clean_text(raw.get("item_name_snapshot")),
-                "item_sku_snapshot": _clean_text(raw.get("item_sku_snapshot")),
-                "item_spec_snapshot": _clean_text(raw.get("item_spec_snapshot")),
-            }
-        )
-
-    return items
-
-
-def _warehouse_id_from_row(row: Mapping[str, Any], snapshot: Mapping[str, Any]) -> int | None:
-    if str(row["source_doc_type"]) == "ORDER_OUTBOUND":
-        value = row.get("order_actual_warehouse_id")
-        return _int_or_none(value) or _int_or_none(snapshot.get("warehouse_id"))
-    value = row.get("manual_warehouse_id")
-    return _int_or_none(value) or _int_or_none(snapshot.get("warehouse_id"))
+def _json_array(value: Any) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [dict(x) for x in value if isinstance(x, Mapping)]
+    return []
 
 
 def _row_to_ready_record(row: Mapping[str, Any]) -> dict[str, Any]:
-    snapshot = _snapshot_dict(row.get("source_snapshot"))
-    warehouse_id = _warehouse_id_from_row(row, snapshot)
-
-    if str(row["source_doc_type"]) == "ORDER_OUTBOUND":
-        receiver_name = _clean_text(row.get("receiver_name"))
-        receiver_phone = _clean_text(row.get("receiver_phone"))
-        province = _clean_text(row.get("province"))
-        city = _clean_text(row.get("city"))
-        district = _clean_text(row.get("district"))
-        address_detail = _clean_text(row.get("address_detail"))
-        platform = _clean_text(row.get("platform"))
-        store_code = _clean_text(row.get("store_code"))
-        platform_order_no = _clean_text(row.get("platform_order_no"))
-        outbound_completed_at = row.get("outbound_completed_at")
-    else:
-        receiver_name = _clean_text(row.get("manual_recipient_name"))
-        receiver_phone = None
-        province = None
-        city = None
-        district = None
-        address_detail = None
-        platform = None
-        store_code = None
-        platform_order_no = None
-        outbound_completed_at = snapshot.get("occurred_at")
-
-    source_ref = str(row["source_ref"])
-    packages = [
-        {
-            "source_package_ref": f"{source_ref}:PACKAGE:1",
-            "package_no": 1,
-            "warehouse_id": warehouse_id,
-            "weight_kg": None,
-            "items": _build_items(snapshot),
-        }
-    ]
-
     return {
-        "source_system": "WMS",
+        "source_system": str(row["source_system"]),
+        "request_source": str(row["request_source"]),
         "source_doc_type": str(row["source_doc_type"]),
         "source_doc_id": int(row["source_doc_id"]),
         "source_doc_no": str(row["source_doc_no"]),
-        "source_ref": source_ref,
+        "source_ref": str(row["source_ref"]),
         "export_status": str(row["export_status"]),
         "logistics_status": str(row["logistics_status"]),
-        "platform": platform,
-        "store_code": store_code,
-        "platform_order_no": platform_order_no,
-        "warehouse_id": warehouse_id,
-        "receiver_name": receiver_name,
-        "receiver_phone": receiver_phone,
-        "province": province,
-        "city": city,
-        "district": district,
-        "address_detail": address_detail,
-        "outbound_completed_at": outbound_completed_at,
+        "platform": row.get("platform"),
+        "store_code": row.get("store_code"),
+        "order_ref": row.get("order_ref"),
+        "ext_order_no": row.get("ext_order_no"),
+        "warehouse_id": int(row["warehouse_id"]) if row.get("warehouse_id") is not None else None,
+        "warehouse_name_snapshot": row.get("warehouse_name_snapshot"),
+        "receiver_name": row.get("receiver_name"),
+        "receiver_phone": row.get("receiver_phone"),
+        "receiver_province": row.get("receiver_province"),
+        "receiver_city": row.get("receiver_city"),
+        "receiver_district": row.get("receiver_district"),
+        "receiver_address": row.get("receiver_address"),
+        "receiver_postcode": row.get("receiver_postcode"),
+        "outbound_event_id": int(row["outbound_event_id"]) if row.get("outbound_event_id") is not None else None,
+        "outbound_source_ref": row.get("outbound_source_ref"),
+        "outbound_completed_at": row.get("outbound_completed_at"),
+        "shipment_items": _json_array(row.get("shipment_items")),
         "handoff_created_at": row["handoff_created_at"],
         "handoff_updated_at": row["handoff_updated_at"],
-        "packages": packages,
-        "source_snapshot": snapshot,
     }
 
 
@@ -179,6 +87,8 @@ async def count_logistics_ready_records(
                 f"""
                 SELECT COUNT(*)
                 FROM wms_logistics_export_records r
+                JOIN wms_logistics_handoff_payloads p
+                  ON p.export_record_id = r.id
                 WHERE {where_sql}
                 """
             ),
@@ -210,41 +120,40 @@ async def list_logistics_ready_records(
                 text(
                     f"""
                     SELECT
+                      p.source_system,
+                      p.request_source,
                       r.source_doc_type,
                       r.source_doc_id,
                       r.source_doc_no,
                       r.source_ref,
                       r.export_status,
                       r.logistics_status,
-                      r.source_snapshot,
+
+                      p.platform,
+                      p.store_code,
+                      p.order_ref,
+                      p.ext_order_no,
+                      p.warehouse_id,
+                      p.warehouse_name_snapshot,
+
+                      p.receiver_name,
+                      p.receiver_phone,
+                      p.receiver_province,
+                      p.receiver_city,
+                      p.receiver_district,
+                      p.receiver_address,
+                      p.receiver_postcode,
+
+                      p.outbound_event_id,
+                      p.outbound_source_ref,
+                      p.outbound_completed_at,
+                      p.shipment_items,
+
                       r.created_at AS handoff_created_at,
-                      r.updated_at AS handoff_updated_at,
-
-                      o.platform,
-                      o.store_code,
-                      o.ext_order_no AS platform_order_no,
-                      f.actual_warehouse_id AS order_actual_warehouse_id,
-                      f.outbound_completed_at AS outbound_completed_at,
-                      a.receiver_name,
-                      a.receiver_phone,
-                      a.province,
-                      a.city,
-                      a.district,
-                      a.detail AS address_detail,
-
-                      md.warehouse_id AS manual_warehouse_id,
-                      md.recipient_name AS manual_recipient_name
+                      r.updated_at AS handoff_updated_at
                     FROM wms_logistics_export_records r
-                    LEFT JOIN orders o
-                      ON r.source_doc_type = 'ORDER_OUTBOUND'
-                     AND o.id = r.source_doc_id
-                    LEFT JOIN order_fulfillment f
-                      ON f.order_id = o.id
-                    LEFT JOIN order_address a
-                      ON a.order_id = o.id
-                    LEFT JOIN manual_outbound_docs md
-                      ON r.source_doc_type = 'MANUAL_OUTBOUND'
-                     AND md.id = r.source_doc_id
+                    JOIN wms_logistics_handoff_payloads p
+                      ON p.export_record_id = r.id
                     WHERE {where_sql}
                     ORDER BY r.created_at ASC, r.id ASC
                     LIMIT :limit OFFSET :offset

--- a/app/wms/outbound/repos/logistics_shipping_result_repo.py
+++ b/app/wms/outbound/repos/logistics_shipping_result_repo.py
@@ -1,7 +1,6 @@
 # app/wms/outbound/repos/logistics_shipping_result_repo.py
 from __future__ import annotations
 
-import json
 from datetime import datetime
 from decimal import Decimal
 from typing import Any, Mapping
@@ -30,20 +29,6 @@ def _decimal_or_none(value: Decimal | int | float | str | None) -> Decimal | Non
     return Decimal(str(value))
 
 
-def _snapshot_dict(value: object | None) -> dict[str, Any]:
-    if isinstance(value, dict):
-        return value
-    if value is None:
-        return {}
-    if isinstance(value, str):
-        try:
-            parsed = json.loads(value)
-        except json.JSONDecodeError:
-            return {}
-        return parsed if isinstance(parsed, dict) else {}
-    return {}
-
-
 async def _load_shipping_result_context(
     session: AsyncSession,
     *,
@@ -62,29 +47,17 @@ async def _load_shipping_result_context(
                   r.logistics_status,
                   r.logistics_request_id,
                   r.logistics_request_no,
-                  r.source_snapshot,
 
-                  o.platform AS order_platform,
-                  o.store_code AS order_store_code,
-                  o.ext_order_no AS order_ext_order_no,
-                  f.actual_warehouse_id AS order_actual_warehouse_id,
-                  f.planned_warehouse_id AS order_planned_warehouse_id,
-                  a.province AS order_dest_province,
-                  a.city AS order_dest_city,
-
-                  md.warehouse_id AS manual_warehouse_id,
-                  md.doc_no AS manual_doc_no
+                  p.platform,
+                  p.store_code,
+                  p.order_ref,
+                  p.ext_order_no,
+                  p.warehouse_id,
+                  p.receiver_province,
+                  p.receiver_city
                 FROM wms_logistics_export_records r
-                LEFT JOIN orders o
-                  ON r.source_doc_type = 'ORDER_OUTBOUND'
-                 AND o.id = r.source_doc_id
-                LEFT JOIN order_fulfillment f
-                  ON f.order_id = o.id
-                LEFT JOIN order_address a
-                  ON a.order_id = o.id
-                LEFT JOIN manual_outbound_docs md
-                  ON r.source_doc_type = 'MANUAL_OUTBOUND'
-                 AND md.id = r.source_doc_id
+                JOIN wms_logistics_handoff_payloads p
+                  ON p.export_record_id = r.id
                 WHERE r.source_ref = :source_ref
                 FOR UPDATE OF r
                 """
@@ -96,50 +69,35 @@ async def _load_shipping_result_context(
     return dict(row) if row else None
 
 
-def _snapshot_warehouse_id(snapshot: Mapping[str, Any]) -> int | None:
-    value = snapshot.get("warehouse_id")
-    if value is None:
-        return None
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
-
-
 def _base_shipping_record_values(
     ctx: Mapping[str, Any],
 ) -> dict[str, object]:
     source_doc_type = str(ctx["source_doc_type"])
-    snapshot = _snapshot_dict(ctx.get("source_snapshot"))
 
     if source_doc_type == "ORDER_OUTBOUND":
-        platform = _clean_required(ctx.get("order_platform"), field="platform").upper()
-        store_code = _clean_required(ctx.get("order_store_code"), field="store_code")
-        ext_order_no = _clean_required(ctx.get("order_ext_order_no"), field="ext_order_no")
-        warehouse_id = (
-            ctx.get("order_actual_warehouse_id")
-            or ctx.get("order_planned_warehouse_id")
-            or _snapshot_warehouse_id(snapshot)
-        )
+        platform = _clean_required(ctx.get("platform"), field="platform").upper()
+        store_code = _clean_required(ctx.get("store_code"), field="store_code")
+        order_ref = _clean(ctx.get("order_ref"))
+        if order_ref is None:
+            ext_order_no = _clean_required(ctx.get("ext_order_no"), field="ext_order_no")
+            order_ref = f"ORD:{platform}:{store_code}:{ext_order_no}"
+
+        warehouse_id = ctx.get("warehouse_id")
         if warehouse_id is None:
             raise ValueError("warehouse_id_required")
 
         return {
             "platform": platform,
             "store_code": store_code,
-            "order_ref": f"ORD:{platform}:{store_code}:{ext_order_no}",
+            "order_ref": order_ref,
             "warehouse_id": int(warehouse_id),
-            "dest_province": _clean(ctx.get("order_dest_province")),
-            "dest_city": _clean(ctx.get("order_dest_city")),
-            "source_snapshot": snapshot,
+            "dest_province": _clean(ctx.get("receiver_province")),
+            "dest_city": _clean(ctx.get("receiver_city")),
         }
 
     if source_doc_type == "MANUAL_OUTBOUND":
-        doc_no = _clean_required(
-            ctx.get("manual_doc_no") or ctx.get("source_doc_no"),
-            field="manual_doc_no",
-        )
-        warehouse_id = ctx.get("manual_warehouse_id") or _snapshot_warehouse_id(snapshot)
+        doc_no = _clean_required(ctx.get("source_doc_no"), field="manual_doc_no")
+        warehouse_id = ctx.get("warehouse_id")
         if warehouse_id is None:
             raise ValueError("warehouse_id_required")
 
@@ -150,7 +108,6 @@ def _base_shipping_record_values(
             "warehouse_id": int(warehouse_id),
             "dest_province": None,
             "dest_city": None,
-            "source_snapshot": snapshot,
         }
 
     raise ValueError("unsupported_source_doc_type")
@@ -384,8 +341,7 @@ async def apply_logistics_shipping_results(
                  RETURNING
                    source_ref,
                    logistics_status,
-                   logistics_completed_at,
-                   source_snapshot
+                   logistics_completed_at
                 """
             ),
             {
@@ -408,5 +364,4 @@ async def apply_logistics_shipping_results(
         "logistics_completed_at": row["logistics_completed_at"],
         "shipping_record_ids": shipping_record_ids,
         "packages_count": len(shipping_record_ids),
-        "source_snapshot": _snapshot_dict(row["source_snapshot"]),
     }

--- a/app/wms/outbound/services/outbound_event_submit_service.py
+++ b/app/wms/outbound/services/outbound_event_submit_service.py
@@ -32,6 +32,7 @@ from app.wms.outbound.repos.outbound_event_repo import (
     update_stocks_lot_qty,
 )
 from app.wms.outbound.repos.logistics_export_record_repo import (
+    upsert_logistics_handoff_payload,
     upsert_pending_logistics_export_record,
 )
 from app.wms.inventory_adjustment.count.services.count_freeze_guard_service import (
@@ -137,6 +138,99 @@ def _order_source_doc_no(order: Mapping[str, Any], *, order_id: int) -> str:
     return str(order_id)
 
 
+def _build_shipment_items(saved_lines: List[Mapping[str, Any]]) -> List[Dict[str, Any]]:
+    items: List[Dict[str, Any]] = []
+    for line in saved_lines:
+        order_line_id = line.get("order_line_id")
+        manual_doc_line_id = line.get("manual_doc_line_id")
+
+        if order_line_id is not None:
+            source_line_type = "ORDER_LINE"
+            source_line_id = int(order_line_id)
+        elif manual_doc_line_id is not None:
+            source_line_type = "MANUAL_OUTBOUND_LINE"
+            source_line_id = int(manual_doc_line_id)
+        else:
+            source_line_type = "UNKNOWN"
+            source_line_id = None
+
+        items.append(
+            {
+                "source_line_type": source_line_type,
+                "source_line_id": source_line_id,
+                "source_line_no": int(line["ref_line"]) if line.get("ref_line") is not None else None,
+                "item_id": int(line["item_id"]) if line.get("item_id") is not None else None,
+                "item_sku_snapshot": _clean_text(line.get("item_sku_snapshot")),
+                "item_name_snapshot": _clean_text(line.get("item_name_snapshot")),
+                "item_spec_snapshot": _clean_text(line.get("item_spec_snapshot")),
+                "qty_outbound": int(line["qty_outbound"]),
+            }
+        )
+
+    return items
+
+
+async def _load_warehouse_name_snapshot(
+    session: AsyncSession,
+    *,
+    warehouse_id: int,
+) -> str | None:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT name
+                FROM warehouses
+                WHERE id = :warehouse_id
+                LIMIT 1
+                """
+            ),
+            {"warehouse_id": int(warehouse_id)},
+        )
+    ).scalar_one_or_none()
+
+    return _clean_text(row)
+
+
+async def _load_order_handoff_payload_context(
+    session: AsyncSession,
+    *,
+    order_id: int,
+) -> Mapping[str, Any]:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  o.platform,
+                  o.store_code,
+                  o.ext_order_no,
+                  o.buyer_name,
+                  o.buyer_phone,
+                  a.receiver_name,
+                  a.receiver_phone,
+                  a.province,
+                  a.city,
+                  a.district,
+                  a.detail,
+                  a.zipcode
+                FROM orders o
+                LEFT JOIN order_address a
+                  ON a.order_id = o.id
+                WHERE o.id = :order_id
+                LIMIT 1
+                """
+            ),
+            {"order_id": int(order_id)},
+        )
+    ).mappings().first()
+
+    if row is None:
+        raise ValueError(f"order_not_found: id={order_id}")
+
+    return row
+
+
 async def load_order_submit_context(
     session: AsyncSession,
     *,
@@ -174,7 +268,8 @@ async def load_manual_submit_context(
                       id,
                       warehouse_id,
                       doc_no,
-                      status
+                      status,
+                      recipient_name
                     FROM manual_outbound_docs
                     WHERE id = :doc_id
                     LIMIT 1
@@ -564,20 +659,55 @@ async def submit_order_outbound_event(
         progress_by_line=progress_by_line,
         normalized_lines=normalized,
     ):
-        await upsert_pending_logistics_export_record(
+        source_doc_no = _order_source_doc_no(ctx.order, order_id=int(order_id))
+        export_record_id = await upsert_pending_logistics_export_record(
             session,
             source_doc_type="ORDER_OUTBOUND",
             source_doc_id=int(order_id),
-            source_doc_no=_order_source_doc_no(ctx.order, order_id=int(order_id)),
+            source_doc_no=source_doc_no,
             source_ref=f"WMS:ORDER_OUTBOUND:{int(order_id)}",
-            source_snapshot={
-                "order": dict(ctx.order),
-                "wms_event_id": int(event["id"]),
-                "wms_source_ref": str(event["source_ref"]),
-                "warehouse_id": int(event["warehouse_id"]),
-                "occurred_at": event["occurred_at"],
-                "lines": normalized,
-            },
+        )
+        order_payload = await _load_order_handoff_payload_context(
+            session,
+            order_id=int(order_id),
+        )
+        platform = _clean_text(order_payload.get("platform"))
+        store_code = _clean_text(order_payload.get("store_code"))
+        ext_order_no = _clean_text(order_payload.get("ext_order_no"))
+        order_ref = (
+            f"ORD:{str(platform).upper()}:{store_code}:{ext_order_no}"
+            if platform and store_code and ext_order_no
+            else None
+        )
+        await upsert_logistics_handoff_payload(
+            session,
+            export_record_id=export_record_id,
+            source_doc_type="ORDER_OUTBOUND",
+            source_doc_id=int(order_id),
+            source_doc_no=source_doc_no,
+            source_ref=f"WMS:ORDER_OUTBOUND:{int(order_id)}",
+            platform=platform,
+            store_code=store_code,
+            order_ref=order_ref,
+            ext_order_no=ext_order_no,
+            warehouse_id=int(event["warehouse_id"]),
+            warehouse_name_snapshot=await _load_warehouse_name_snapshot(
+                session,
+                warehouse_id=int(event["warehouse_id"]),
+            ),
+            receiver_name=_clean_text(order_payload.get("receiver_name"))
+            or _clean_text(order_payload.get("buyer_name")),
+            receiver_phone=_clean_text(order_payload.get("receiver_phone"))
+            or _clean_text(order_payload.get("buyer_phone")),
+            receiver_province=_clean_text(order_payload.get("province")),
+            receiver_city=_clean_text(order_payload.get("city")),
+            receiver_district=_clean_text(order_payload.get("district")),
+            receiver_address=_clean_text(order_payload.get("detail")),
+            receiver_postcode=_clean_text(order_payload.get("zipcode")),
+            outbound_event_id=int(event["id"]),
+            outbound_source_ref=str(event["source_ref"]),
+            outbound_completed_at=event["occurred_at"],
+            shipment_items=_build_shipment_items(saved_lines),
         )
 
     return OrderOutboundSubmitOut(
@@ -626,20 +756,41 @@ async def submit_manual_outbound_event(
         for row in progress_rows
     ):
         await complete_manual_doc(session, doc_id=int(doc_id))
-        await upsert_pending_logistics_export_record(
+        source_doc_no = str(ctx.doc["doc_no"])
+        export_record_id = await upsert_pending_logistics_export_record(
             session,
             source_doc_type="MANUAL_OUTBOUND",
             source_doc_id=int(doc_id),
-            source_doc_no=str(ctx.doc["doc_no"]),
+            source_doc_no=source_doc_no,
             source_ref=f"WMS:MANUAL_OUTBOUND:{int(doc_id)}",
-            source_snapshot={
-                "doc": dict(ctx.doc),
-                "wms_event_id": int(event["id"]),
-                "wms_source_ref": str(event["source_ref"]),
-                "warehouse_id": int(event["warehouse_id"]),
-                "occurred_at": event["occurred_at"],
-                "lines": normalized,
-            },
+        )
+        await upsert_logistics_handoff_payload(
+            session,
+            export_record_id=export_record_id,
+            source_doc_type="MANUAL_OUTBOUND",
+            source_doc_id=int(doc_id),
+            source_doc_no=source_doc_no,
+            source_ref=f"WMS:MANUAL_OUTBOUND:{int(doc_id)}",
+            platform=None,
+            store_code=None,
+            order_ref=None,
+            ext_order_no=None,
+            warehouse_id=int(event["warehouse_id"]),
+            warehouse_name_snapshot=await _load_warehouse_name_snapshot(
+                session,
+                warehouse_id=int(event["warehouse_id"]),
+            ),
+            receiver_name=_clean_text(ctx.doc.get("recipient_name")),
+            receiver_phone=None,
+            receiver_province=None,
+            receiver_city=None,
+            receiver_district=None,
+            receiver_address=None,
+            receiver_postcode=None,
+            outbound_event_id=int(event["id"]),
+            outbound_source_ref=str(event["source_ref"]),
+            outbound_completed_at=event["occurred_at"],
+            shipment_items=_build_shipment_items(saved_lines),
         )
 
     return ManualOutboundSubmitOut(

--- a/tests/api/test_manual_outbound_submit_api.py
+++ b/tests/api/test_manual_outbound_submit_api.py
@@ -335,17 +335,20 @@ async def test_manual_outbound_submit_writes_event_and_ledger(
             text(
                 """
                 SELECT
-                  source_doc_type,
-                  source_doc_id,
-                  source_doc_no,
-                  source_ref,
-                  export_status,
-                  logistics_status,
-                  source_snapshot ->> 'wms_event_id' AS wms_event_id,
-                  source_snapshot ->> 'wms_source_ref' AS wms_source_ref,
-                  source_snapshot ->> 'warehouse_id' AS snapshot_warehouse_id
-                FROM wms_logistics_export_records
-                WHERE source_ref = :source_ref
+                  r.source_doc_type,
+                  r.source_doc_id,
+                  r.source_doc_no,
+                  r.source_ref,
+                  r.export_status,
+                  r.logistics_status,
+                  p.outbound_event_id,
+                  p.outbound_source_ref,
+                  p.warehouse_id AS payload_warehouse_id,
+                  p.shipment_items
+                FROM wms_logistics_export_records r
+                JOIN wms_logistics_handoff_payloads p
+                  ON p.export_record_id = r.id
+                WHERE r.source_ref = :source_ref
                 LIMIT 1
                 """
             ),
@@ -360,9 +363,17 @@ async def test_manual_outbound_submit_writes_event_and_ledger(
     assert export_record["source_ref"] == f"WMS:MANUAL_OUTBOUND:{doc_id}"
     assert export_record["export_status"] == "PENDING"
     assert export_record["logistics_status"] == "NOT_IMPORTED"
-    assert int(export_record["wms_event_id"]) == event_id
-    assert export_record["wms_source_ref"] == data["source_ref"]
-    assert int(export_record["snapshot_warehouse_id"]) == warehouse_id
+    assert int(export_record["outbound_event_id"]) == event_id
+    assert export_record["outbound_source_ref"] == data["source_ref"]
+    assert int(export_record["payload_warehouse_id"]) == warehouse_id
+
+    shipment_items = export_record["shipment_items"]
+    assert isinstance(shipment_items, list)
+    assert len(shipment_items) == 1
+    assert shipment_items[0]["source_line_type"] == "MANUAL_OUTBOUND_LINE"
+    assert int(shipment_items[0]["source_line_id"]) == doc_line_id
+    assert int(shipment_items[0]["item_id"]) == item_id
+    assert int(shipment_items[0]["qty_outbound"]) == 2
 
 
 async def test_manual_outbound_submit_keeps_doc_released_when_partially_submitted(

--- a/tests/api/test_order_outbound_submit_api.py
+++ b/tests/api/test_order_outbound_submit_api.py
@@ -316,17 +316,20 @@ async def test_order_outbound_submit_writes_event_and_ledger(
             text(
                 """
                 SELECT
-                  source_doc_type,
-                  source_doc_id,
-                  source_doc_no,
-                  source_ref,
-                  export_status,
-                  logistics_status,
-                  source_snapshot ->> 'wms_event_id' AS wms_event_id,
-                  source_snapshot ->> 'wms_source_ref' AS wms_source_ref,
-                  source_snapshot ->> 'warehouse_id' AS snapshot_warehouse_id
-                FROM wms_logistics_export_records
-                WHERE source_ref = :source_ref
+                  r.source_doc_type,
+                  r.source_doc_id,
+                  r.source_doc_no,
+                  r.source_ref,
+                  r.export_status,
+                  r.logistics_status,
+                  p.outbound_event_id,
+                  p.outbound_source_ref,
+                  p.warehouse_id AS payload_warehouse_id,
+                  p.shipment_items
+                FROM wms_logistics_export_records r
+                JOIN wms_logistics_handoff_payloads p
+                  ON p.export_record_id = r.id
+                WHERE r.source_ref = :source_ref
                 LIMIT 1
                 """
             ),
@@ -341,9 +344,17 @@ async def test_order_outbound_submit_writes_event_and_ledger(
     assert export_record["source_ref"] == f"WMS:ORDER_OUTBOUND:{order_id}"
     assert export_record["export_status"] == "PENDING"
     assert export_record["logistics_status"] == "NOT_IMPORTED"
-    assert int(export_record["wms_event_id"]) == event_id
-    assert export_record["wms_source_ref"] == data["source_ref"]
-    assert int(export_record["snapshot_warehouse_id"]) == warehouse_id
+    assert int(export_record["outbound_event_id"]) == event_id
+    assert export_record["outbound_source_ref"] == data["source_ref"]
+    assert int(export_record["payload_warehouse_id"]) == warehouse_id
+
+    shipment_items = export_record["shipment_items"]
+    assert isinstance(shipment_items, list)
+    assert len(shipment_items) == 1
+    assert shipment_items[0]["source_line_type"] == "ORDER_LINE"
+    assert int(shipment_items[0]["source_line_id"]) == order_line_id
+    assert int(shipment_items[0]["item_id"]) == item_id
+    assert int(shipment_items[0]["qty_outbound"]) == 2
 
 
 async def test_order_outbound_submit_rejects_duplicate_submit_with_409(

--- a/tests/api/test_shipping_assist_handoffs_api.py
+++ b/tests/api/test_shipping_assist_handoffs_api.py
@@ -39,63 +39,142 @@ async def _seed_handoff(
     exported_at = now if export_status == "EXPORTED" else None
     logistics_completed_at = now if logistics_status == "COMPLETED" else None
 
+    export_record_id = int(
+        (
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO wms_logistics_export_records (
+                      source_doc_type,
+                      source_doc_id,
+                      source_doc_no,
+                      source_ref,
+                      export_status,
+                      logistics_status,
+                      logistics_request_id,
+                      logistics_request_no,
+                      exported_at,
+                      logistics_completed_at,
+                      last_attempt_at,
+                      last_error,
+                      created_at,
+                      updated_at
+                    )
+                    VALUES (
+                      :source_doc_type,
+                      :source_doc_id,
+                      :source_doc_no,
+                      :source_ref,
+                      :export_status,
+                      :logistics_status,
+                      :logistics_request_id,
+                      :logistics_request_no,
+                      :exported_at,
+                      :logistics_completed_at,
+                      :now,
+                      :last_error,
+                      :now,
+                      :now
+                    )
+                    RETURNING id
+                    """
+                ),
+                {
+                    "source_doc_type": source_doc_type,
+                    "source_doc_id": source_doc_id,
+                    "source_doc_no": doc_no,
+                    "source_ref": source_ref,
+                    "export_status": export_status,
+                    "logistics_status": logistics_status,
+                    "logistics_request_id": logistics_request_id,
+                    "logistics_request_no": logistics_request_no,
+                    "exported_at": exported_at,
+                    "logistics_completed_at": logistics_completed_at,
+                    "last_error": last_error,
+                    "now": now,
+                },
+            )
+        ).scalar_one()
+    )
+
     await session.execute(
         text(
             """
-            INSERT INTO wms_logistics_export_records (
+            INSERT INTO wms_logistics_handoff_payloads (
+              export_record_id,
               source_doc_type,
               source_doc_id,
               source_doc_no,
               source_ref,
-              export_status,
-              logistics_status,
-              logistics_request_id,
-              logistics_request_no,
-              exported_at,
-              logistics_completed_at,
-              last_attempt_at,
-              last_error,
-              source_snapshot,
+              platform,
+              store_code,
+              order_ref,
+              ext_order_no,
+              warehouse_id,
+              warehouse_name_snapshot,
+              receiver_name,
+              receiver_phone,
+              receiver_province,
+              receiver_city,
+              receiver_district,
+              receiver_address,
+              outbound_completed_at,
+              shipment_items,
               created_at,
               updated_at
             )
             VALUES (
+              :export_record_id,
               :source_doc_type,
               :source_doc_id,
               :source_doc_no,
               :source_ref,
-              :export_status,
-              :logistics_status,
-              :logistics_request_id,
-              :logistics_request_no,
-              :exported_at,
-              :logistics_completed_at,
+              :platform,
+              :store_code,
+              :order_ref,
+              :ext_order_no,
+              1,
+              'UT-HANDOFF-WH',
+              '张三',
+              '13800000000',
+              '浙江省',
+              '杭州市',
+              '余杭区',
+              '测试路 1 号',
               :now,
-              :last_error,
-              CAST(:source_snapshot AS jsonb),
+              CAST(:shipment_items AS jsonb),
               :now,
               :now
             )
             """
         ),
         {
+            "export_record_id": export_record_id,
             "source_doc_type": source_doc_type,
             "source_doc_id": source_doc_id,
             "source_doc_no": doc_no,
             "source_ref": source_ref,
-            "export_status": export_status,
-            "logistics_status": logistics_status,
-            "logistics_request_id": logistics_request_id,
-            "logistics_request_no": logistics_request_no,
-            "exported_at": exported_at,
-            "logistics_completed_at": logistics_completed_at,
-            "last_error": last_error,
-            "source_snapshot": json.dumps(
-                {
-                    "warehouse_id": 1,
-                    "receiver_province": "浙江省",
-                    "receiver_city": "杭州市",
-                },
+            "platform": "PDD" if source_doc_type == "ORDER_OUTBOUND" else None,
+            "store_code": "UT-HANDOFF" if source_doc_type == "ORDER_OUTBOUND" else None,
+            "order_ref": f"ORD:PDD:UT-HANDOFF:{doc_no}"
+            if source_doc_type == "ORDER_OUTBOUND"
+            else None,
+            "ext_order_no": doc_no if source_doc_type == "ORDER_OUTBOUND" else None,
+            "shipment_items": json.dumps(
+                [
+                    {
+                        "source_line_type": "ORDER_LINE"
+                        if source_doc_type == "ORDER_OUTBOUND"
+                        else "MANUAL_OUTBOUND_LINE",
+                        "source_line_id": 1,
+                        "source_line_no": 1,
+                        "item_id": 1,
+                        "item_sku_snapshot": "SKU-HANDOFF",
+                        "item_name_snapshot": "交接测试商品",
+                        "item_spec_snapshot": "1kg",
+                        "qty_outbound": 1,
+                    }
+                ],
                 ensure_ascii=False,
             ),
             "now": now,
@@ -134,7 +213,8 @@ async def test_shipping_assist_handoffs_lists_records(
     assert completed["export_status"] == "EXPORTED"
     assert completed["logistics_status"] == "COMPLETED"
     assert completed["logistics_request_no"] == "LSR-HANDOFF-0001"
-    assert completed["source_snapshot"]["receiver_city"] == "杭州市"
+    assert completed["receiver_city"] == "杭州市"
+    assert completed["shipment_items"][0]["item_name_snapshot"] == "交接测试商品"
 
 
 async def test_shipping_assist_handoffs_filters_by_status_and_source(

--- a/tests/api/test_wms_logistics_import_results_api.py
+++ b/tests/api/test_wms_logistics_import_results_api.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from datetime import datetime, timezone
 from uuid import uuid4
 
@@ -45,7 +44,6 @@ async def _seed_export_record(
               logistics_status,
               logistics_request_id,
               logistics_request_no,
-              source_snapshot,
               created_at,
               updated_at
             )
@@ -58,7 +56,6 @@ async def _seed_export_record(
               :logistics_status,
               :logistics_request_id,
               :logistics_request_no,
-              CAST(:source_snapshot AS jsonb),
               :now,
               :now
             )
@@ -73,7 +70,6 @@ async def _seed_export_record(
             "logistics_status": logistics_status,
             "logistics_request_id": logistics_request_id,
             "logistics_request_no": logistics_request_no,
-            "source_snapshot": json.dumps({"seed": uniq}, ensure_ascii=False),
             "now": now,
         },
     )

--- a/tests/api/test_wms_logistics_ready_api.py
+++ b/tests/api/test_wms_logistics_ready_api.py
@@ -152,58 +152,121 @@ async def _seed_order_ready_record(
     )
 
     source_ref = f"WMS:ORDER_OUTBOUND:{order_id}"
-    source_snapshot = {
-        "warehouse_id": warehouse_id,
-        "occurred_at": now.isoformat(),
-        "wms_event_id": 9001,
-        "wms_source_ref": f"ORD:{platform}:{store_code}:{ext_order_no}",
-        "lines": [
-            {
-                "ref_line": 1,
-                "item_id": item_id,
-                "qty_outbound": 2,
-                "lot_id": 1,
-                "lot_code_snapshot": "UT-LOT",
-                "item_name_snapshot": "测试商品",
-                "item_sku_snapshot": "SKU-READY",
-                "item_spec_snapshot": "1kg",
-            }
-        ],
-    }
+    export_record_id = int(
+        (
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO wms_logistics_export_records (
+                      source_doc_type,
+                      source_doc_id,
+                      source_doc_no,
+                      source_ref,
+                      export_status,
+                      logistics_status,
+                      created_at,
+                      updated_at
+                    )
+                    VALUES (
+                      'ORDER_OUTBOUND',
+                      :source_doc_id,
+                      :source_doc_no,
+                      :source_ref,
+                      :export_status,
+                      'NOT_IMPORTED',
+                      :now,
+                      :now
+                    )
+                    RETURNING id
+                    """
+                ),
+                {
+                    "source_doc_id": int(order_id),
+                    "source_doc_no": ext_order_no,
+                    "source_ref": source_ref,
+                    "export_status": export_status,
+                    "now": now,
+                },
+            )
+        ).scalar_one()
+    )
+
+    shipment_items = [
+        {
+            "source_line_type": "ORDER_LINE",
+            "source_line_id": 9001,
+            "source_line_no": 1,
+            "item_id": item_id,
+            "item_sku_snapshot": "SKU-READY",
+            "item_name_snapshot": "测试商品",
+            "item_spec_snapshot": "1kg",
+            "qty_outbound": 2,
+        }
+    ]
 
     await session.execute(
         text(
             """
-            INSERT INTO wms_logistics_export_records (
+            INSERT INTO wms_logistics_handoff_payloads (
+              export_record_id,
               source_doc_type,
               source_doc_id,
               source_doc_no,
               source_ref,
-              export_status,
-              logistics_status,
-              source_snapshot,
+              platform,
+              store_code,
+              order_ref,
+              ext_order_no,
+              warehouse_id,
+              warehouse_name_snapshot,
+              receiver_name,
+              receiver_phone,
+              receiver_province,
+              receiver_city,
+              receiver_district,
+              receiver_address,
+              outbound_completed_at,
+              shipment_items,
               created_at,
               updated_at
             )
             VALUES (
+              :export_record_id,
               'ORDER_OUTBOUND',
               :source_doc_id,
               :source_doc_no,
               :source_ref,
-              :export_status,
-              'NOT_IMPORTED',
-              CAST(:source_snapshot AS jsonb),
+              :platform,
+              :store_code,
+              :order_ref,
+              :ext_order_no,
+              :warehouse_id,
+              :warehouse_name_snapshot,
+              '张三',
+              '13800000000',
+              '浙江省',
+              '杭州市',
+              '余杭区',
+              '测试路 1 号',
+              :now,
+              CAST(:shipment_items AS jsonb),
               :now,
               :now
             )
             """
         ),
         {
+            "export_record_id": export_record_id,
             "source_doc_id": int(order_id),
             "source_doc_no": ext_order_no,
             "source_ref": source_ref,
-            "export_status": export_status,
-            "source_snapshot": json.dumps(source_snapshot, ensure_ascii=False),
+            "platform": platform,
+            "store_code": store_code,
+            "order_ref": f"ORD:{platform}:{store_code}:{ext_order_no}",
+            "ext_order_no": ext_order_no,
+            "warehouse_id": int(warehouse_id),
+            "warehouse_name_snapshot": f"WH-{warehouse_id}",
+            "shipment_items": json.dumps(shipment_items, ensure_ascii=False),
             "now": now,
         },
     )
@@ -255,58 +318,99 @@ async def _seed_manual_ready_record(
     )
 
     source_ref = f"WMS:MANUAL_OUTBOUND:{doc_id}"
-    source_snapshot = {
-        "warehouse_id": warehouse_id,
-        "occurred_at": now.isoformat(),
-        "wms_event_id": 9002,
-        "wms_source_ref": doc_no,
-        "lines": [
-            {
-                "ref_line": 1,
-                "item_id": item_id,
-                "qty_outbound": 1,
-                "lot_id": 1,
-                "lot_code_snapshot": "UT-MAN-LOT",
-                "item_name_snapshot": "手工商品",
-                "item_sku_snapshot": "SKU-MAN",
-                "item_spec_snapshot": "500g",
-            }
-        ],
-    }
+    export_record_id = int(
+        (
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO wms_logistics_export_records (
+                      source_doc_type,
+                      source_doc_id,
+                      source_doc_no,
+                      source_ref,
+                      export_status,
+                      logistics_status,
+                      created_at,
+                      updated_at
+                    )
+                    VALUES (
+                      'MANUAL_OUTBOUND',
+                      :source_doc_id,
+                      :source_doc_no,
+                      :source_ref,
+                      :export_status,
+                      'NOT_IMPORTED',
+                      :now,
+                      :now
+                    )
+                    RETURNING id
+                    """
+                ),
+                {
+                    "source_doc_id": int(doc_id),
+                    "source_doc_no": doc_no,
+                    "source_ref": source_ref,
+                    "export_status": export_status,
+                    "now": now,
+                },
+            )
+        ).scalar_one()
+    )
+
+    shipment_items = [
+        {
+            "source_line_type": "MANUAL_OUTBOUND_LINE",
+            "source_line_id": 9002,
+            "source_line_no": 1,
+            "item_id": item_id,
+            "item_sku_snapshot": "SKU-MAN",
+            "item_name_snapshot": "手工商品",
+            "item_spec_snapshot": "500g",
+            "qty_outbound": 1,
+        }
+    ]
 
     await session.execute(
         text(
             """
-            INSERT INTO wms_logistics_export_records (
+            INSERT INTO wms_logistics_handoff_payloads (
+              export_record_id,
               source_doc_type,
               source_doc_id,
               source_doc_no,
               source_ref,
-              export_status,
-              logistics_status,
-              source_snapshot,
+              warehouse_id,
+              warehouse_name_snapshot,
+              receiver_name,
+              outbound_completed_at,
+              shipment_items,
               created_at,
               updated_at
             )
             VALUES (
+              :export_record_id,
               'MANUAL_OUTBOUND',
               :source_doc_id,
               :source_doc_no,
               :source_ref,
-              :export_status,
-              'NOT_IMPORTED',
-              CAST(:source_snapshot AS jsonb),
+              :warehouse_id,
+              :warehouse_name_snapshot,
+              '李四',
+              :now,
+              CAST(:shipment_items AS jsonb),
               :now,
               :now
             )
             """
         ),
         {
+            "export_record_id": export_record_id,
             "source_doc_id": int(doc_id),
             "source_doc_no": doc_no,
             "source_ref": source_ref,
-            "export_status": export_status,
-            "source_snapshot": json.dumps(source_snapshot, ensure_ascii=False),
+            "warehouse_id": int(warehouse_id),
+            "warehouse_name_snapshot": f"WH-{warehouse_id}",
+            "shipment_items": json.dumps(shipment_items, ensure_ascii=False),
             "now": now,
         },
     )
@@ -320,41 +424,77 @@ async def _seed_exported_record(session: AsyncSession) -> str:
     uniq = uuid4().hex[:10]
     source_ref = f"WMS:ORDER_OUTBOUND:EXPORTED:{uniq}"
 
+    export_record_id = int(
+        (
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO wms_logistics_export_records (
+                      source_doc_type,
+                      source_doc_id,
+                      source_doc_no,
+                      source_ref,
+                      export_status,
+                      logistics_status,
+                      created_at,
+                      updated_at
+                    )
+                    VALUES (
+                      'ORDER_OUTBOUND',
+                      :source_doc_id,
+                      :source_doc_no,
+                      :source_ref,
+                      'EXPORTED',
+                      'IMPORTED',
+                      :now,
+                      :now
+                    )
+                    RETURNING id
+                    """
+                ),
+                {
+                    "source_doc_id": 900000000,
+                    "source_doc_no": f"EXPORTED-{uniq}",
+                    "source_ref": source_ref,
+                    "now": now,
+                },
+            )
+        ).scalar_one()
+    )
+
     await session.execute(
         text(
             """
-            INSERT INTO wms_logistics_export_records (
+            INSERT INTO wms_logistics_handoff_payloads (
+              export_record_id,
               source_doc_type,
               source_doc_id,
               source_doc_no,
               source_ref,
-              export_status,
-              logistics_status,
-              source_snapshot,
+              shipment_items,
               created_at,
               updated_at
             )
             VALUES (
+              :export_record_id,
               'ORDER_OUTBOUND',
-              :source_doc_id,
+              900000000,
               :source_doc_no,
               :source_ref,
-              'EXPORTED',
-              'IMPORTED',
-              CAST(:source_snapshot AS jsonb),
+              '[]'::jsonb,
               :now,
               :now
             )
             """
         ),
         {
-            "source_doc_id": 900000000,
+            "export_record_id": export_record_id,
             "source_doc_no": f"EXPORTED-{uniq}",
             "source_ref": source_ref,
-            "source_snapshot": "{}",
             "now": now,
         },
     )
+
     await session.commit()
     return source_ref
 
@@ -387,19 +527,18 @@ async def test_logistics_ready_returns_pending_and_failed_records(
     assert order_row["store_code"] == "UT-READY"
     assert order_row["receiver_name"] == "张三"
     assert order_row["receiver_phone"] == "13800000000"
-    assert order_row["province"] == "浙江省"
-    assert order_row["city"] == "杭州市"
-    assert order_row["district"] == "余杭区"
-    assert order_row["address_detail"] == "测试路 1 号"
-    assert order_row["packages"][0]["source_package_ref"] == f"{order_ref}:PACKAGE:1"
-    assert order_row["packages"][0]["items"][0]["qty"] == 2
+    assert order_row["receiver_province"] == "浙江省"
+    assert order_row["receiver_city"] == "杭州市"
+    assert order_row["receiver_district"] == "余杭区"
+    assert order_row["receiver_address"] == "测试路 1 号"
+    assert order_row["shipment_items"][0]["qty_outbound"] == 2
 
     manual_row = next(row for row in data["rows"] if row["source_ref"] == manual_ref)
     assert manual_row["source_doc_type"] == "MANUAL_OUTBOUND"
     assert manual_row["export_status"] == "FAILED"
     assert manual_row["receiver_name"] == "李四"
     assert manual_row["platform"] is None
-    assert manual_row["packages"][0]["items"][0]["qty"] == 1
+    assert manual_row["shipment_items"][0]["qty_outbound"] == 1
 
 
 async def test_logistics_ready_filters_source_doc_type_and_export_status(

--- a/tests/api/test_wms_logistics_shipping_results_api.py
+++ b/tests/api/test_wms_logistics_shipping_results_api.py
@@ -184,46 +184,115 @@ async def _seed_order_exported_record(
     )
 
     source_ref = f"WMS:ORDER_OUTBOUND:{order_id}"
+    export_record_id = int(
+        (
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO wms_logistics_export_records (
+                      source_doc_type,
+                      source_doc_id,
+                      source_doc_no,
+                      source_ref,
+                      export_status,
+                      logistics_status,
+                      logistics_request_id,
+                      logistics_request_no,
+                      created_at,
+                      updated_at
+                    )
+                    VALUES (
+                      'ORDER_OUTBOUND',
+                      :source_doc_id,
+                      :source_doc_no,
+                      :source_ref,
+                      :export_status,
+                      :logistics_status,
+                      :logistics_request_id,
+                      :logistics_request_no,
+                      :now,
+                      :now
+                    )
+                    RETURNING id
+                    """
+                ),
+                {
+                    "source_doc_id": int(order_id),
+                    "source_doc_no": ext_order_no,
+                    "source_ref": source_ref,
+                    "export_status": export_status,
+                    "logistics_status": logistics_status,
+                    "logistics_request_id": int(logistics_request_id),
+                    "logistics_request_no": logistics_request_no,
+                    "now": now,
+                },
+            )
+        ).scalar_one()
+    )
+
     await session.execute(
         text(
             """
-            INSERT INTO wms_logistics_export_records (
+            INSERT INTO wms_logistics_handoff_payloads (
+              export_record_id,
               source_doc_type,
               source_doc_id,
               source_doc_no,
               source_ref,
-              export_status,
-              logistics_status,
-              logistics_request_id,
-              logistics_request_no,
-              source_snapshot,
+              platform,
+              store_code,
+              order_ref,
+              ext_order_no,
+              warehouse_id,
+              warehouse_name_snapshot,
+              receiver_name,
+              receiver_phone,
+              receiver_province,
+              receiver_city,
+              receiver_district,
+              receiver_address,
+              outbound_completed_at,
+              shipment_items,
               created_at,
               updated_at
             )
             VALUES (
+              :export_record_id,
               'ORDER_OUTBOUND',
               :source_doc_id,
               :source_doc_no,
               :source_ref,
-              :export_status,
-              :logistics_status,
-              :logistics_request_id,
-              :logistics_request_no,
-              CAST(:source_snapshot AS jsonb),
+              :platform,
+              :store_code,
+              :order_ref,
+              :ext_order_no,
+              :warehouse_id,
+              :warehouse_name_snapshot,
+              '张三',
+              '13800000000',
+              '浙江省',
+              '杭州市',
+              '余杭区',
+              '测试路 1 号',
+              :now,
+              CAST(:shipment_items AS jsonb),
               :now,
               :now
             )
             """
         ),
         {
+            "export_record_id": export_record_id,
             "source_doc_id": int(order_id),
             "source_doc_no": ext_order_no,
             "source_ref": source_ref,
-            "export_status": export_status,
-            "logistics_status": logistics_status,
-            "logistics_request_id": int(logistics_request_id),
-            "logistics_request_no": logistics_request_no,
-            "source_snapshot": json.dumps({"warehouse_id": warehouse_id}, ensure_ascii=False),
+            "platform": platform,
+            "store_code": store_code,
+            "order_ref": f"ORD:{platform}:{store_code}:{ext_order_no}",
+            "ext_order_no": ext_order_no,
+            "warehouse_id": int(warehouse_id),
+            "warehouse_name_snapshot": f"WH-{warehouse_id}",
+            "shipment_items": "[]",
             "now": now,
         },
     )

--- a/tests/fixtures/truncate.sql
+++ b/tests/fixtures/truncate.sql
@@ -41,6 +41,7 @@ TRUNCATE TABLE
   event_error_log,
 
   -- ===== shipping domain（避免每用例累积脏数据）=====
+  wms_logistics_handoff_payloads,
   wms_logistics_export_records,
   shipping_records,
   shipping_providers,


### PR DESCRIPTION
## Summary
- add wms_logistics_handoff_payloads as the structured WMS -> Logistics handoff data contract
- keep wms_logistics_export_records focused on handoff status and Logistics callback state
- remove source_snapshot from runtime contracts and tests
- switch logistics-ready, logistics-shipping-results, and shipping-assist handoffs to payload data

## Tests
- make alembic-check
- make test TESTS="tests/api/test_order_outbound_submit_api.py tests/api/test_manual_outbound_submit_api.py tests/api/test_wms_logistics_ready_api.py tests/api/test_shipping_assist_handoffs_api.py tests/api/test_wms_logistics_shipping_results_api.py tests/api/test_wms_logistics_import_results_api.py"
- rg -n "source_snapshot|packages\\[0\\]|source_package_ref" app tests scripts --glob '!**/__pycache__/**' --glob '!*.pyc' || true