### PR TITLE
fix(shipping-assist): require complete ready handoff facts

### DIFF
--- a/app/shipping_assist/handoffs/repository_ready.py
+++ b/app/shipping_assist/handoffs/repository_ready.py
@@ -63,6 +63,8 @@ def _build_ready_where(
     clauses = [
         "1 = 1",
         "p.outbound_event_id IS NOT NULL",
+        "NULLIF(BTRIM(COALESCE(p.outbound_source_ref, '')), '') IS NOT NULL",
+        "p.outbound_completed_at IS NOT NULL",
         "jsonb_array_length(p.shipment_items) > 0",
         "NULLIF(BTRIM(COALESCE(p.receiver_name, '')), '') IS NOT NULL",
         "NULLIF(BTRIM(COALESCE(p.receiver_phone, '')), '') IS NOT NULL",

--- a/tests/api/test_shipping_assist_handoffs_ready_contract.py
+++ b/tests/api/test_shipping_assist_handoffs_ready_contract.py
@@ -1,0 +1,22 @@
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_shipping_assist_handoffs_ready_requires_complete_outbound_fact() -> None:
+    source = Path("app/shipping_assist/handoffs/repository_ready.py").read_text()
+
+    assert '"p.outbound_event_id IS NOT NULL"' in source
+    assert (
+        '"NULLIF(BTRIM(COALESCE(p.outbound_source_ref, \'\')), \'\') IS NOT NULL"'
+        in source
+    )
+    assert '"p.outbound_completed_at IS NOT NULL"' in source
+    assert '"jsonb_array_length(p.shipment_items) > 0"' in source
+
+    assert '"NULLIF(BTRIM(COALESCE(p.receiver_name, \'\')), \'\') IS NOT NULL"' in source
+    assert '"NULLIF(BTRIM(COALESCE(p.receiver_phone, \'\')), \'\') IS NOT NULL"' in source
+    assert '"NULLIF(BTRIM(COALESCE(p.receiver_province, \'\')), \'\') IS NOT NULL"' in source
+    assert '"NULLIF(BTRIM(COALESCE(p.receiver_city, \'\')), \'\') IS NOT NULL"' in source
+    assert '"NULLIF(BTRIM(COALESCE(p.receiver_address, \'\')), \'\') IS NOT NULL"' in source


### PR DESCRIPTION
## Summary
- tighten /shipping-assist/handoffs/ready filtering
- require outbound_source_ref and outbound_completed_at before exposing a handoff as ready
- keep WMS responsible for text address facts only
- leave province/city code mapping to Logistics

## Verification
- python3 -m compileall app tests
- make test TESTS="tests/api/test_shipping_assist_handoffs_ready_api.py tests/api/test_shipping_assist_handoffs_ready_contract.py tests/api/test_shipping_assist_handoffs_api.py tests/api/test_shipping_assist_handoffs_machine_routes_retired.py"
- make openapi
- OpenAPI route check: missing=[] leaked=[]