### PR TITLE
refactor(pms): move item reads to export boundary

### DIFF
--- a/app/oms/services/platform_order_resolve_loaders.py
+++ b/app/oms/services/platform_order_resolve_loaders.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.public.items.services.item_read_service import ItemReadService
+from app.pms.export.items.services.item_read_service import ItemReadService
 
 
 async def load_fsku_components(

--- a/app/pms/export/items/__init__.py
+++ b/app/pms/export/items/__init__.py
@@ -1,15 +1,16 @@
-# app/pms/public/items/contracts/__init__.py
+# app/pms/export/items/__init__.py
 from __future__ import annotations
 
-from .barcode_probe import (
+from .contracts import (
     BarcodeProbeError,
     BarcodeProbeIn,
     BarcodeProbeOut,
     BarcodeProbeStatus,
+    ItemBasic,
+    ItemPolicy,
+    ItemReadQuery,
 )
-from .item_basic import ItemBasic
-from .item_policy import ItemPolicy
-from .item_query import ItemReadQuery
+from .services import BarcodeProbeService, ItemReadService
 
 __all__ = [
     "BarcodeProbeError",
@@ -19,4 +20,6 @@ __all__ = [
     "ItemBasic",
     "ItemPolicy",
     "ItemReadQuery",
+    "BarcodeProbeService",
+    "ItemReadService",
 ]

--- a/app/pms/export/items/contracts/__init__.py
+++ b/app/pms/export/items/contracts/__init__.py
@@ -1,16 +1,15 @@
-# app/pms/public/items/__init__.py
+# app/pms/export/items/contracts/__init__.py
 from __future__ import annotations
 
-from .contracts import (
+from .barcode_probe import (
     BarcodeProbeError,
     BarcodeProbeIn,
     BarcodeProbeOut,
     BarcodeProbeStatus,
-    ItemBasic,
-    ItemPolicy,
-    ItemReadQuery,
 )
-from .services import BarcodeProbeService, ItemReadService
+from .item_basic import ItemBasic
+from .item_policy import ItemPolicy
+from .item_query import ItemReadQuery
 
 __all__ = [
     "BarcodeProbeError",
@@ -20,6 +19,4 @@ __all__ = [
     "ItemBasic",
     "ItemPolicy",
     "ItemReadQuery",
-    "BarcodeProbeService",
-    "ItemReadService",
 ]

--- a/app/pms/export/items/contracts/barcode_probe.py
+++ b/app/pms/export/items/contracts/barcode_probe.py
@@ -1,11 +1,11 @@
-# app/pms/public/items/contracts/barcode_probe.py
+# app/pms/export/items/contracts/barcode_probe.py
 from __future__ import annotations
 
 from enum import Enum
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from app.pms.public.items.contracts.item_basic import ItemBasic
+from app.pms.export.items.contracts.item_basic import ItemBasic
 
 
 class _Base(BaseModel):

--- a/app/pms/export/items/contracts/item_aggregate.py
+++ b/app/pms/export/items/contracts/item_aggregate.py
@@ -1,4 +1,4 @@
-# app/pms/public/items/contracts/item_aggregate.py
+# app/pms/export/items/contracts/item_aggregate.py
 from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field

--- a/app/pms/export/items/contracts/item_basic.py
+++ b/app/pms/export/items/contracts/item_basic.py
@@ -1,4 +1,4 @@
-# app/pms/public/items/contracts/item_basic.py
+# app/pms/export/items/contracts/item_basic.py
 from __future__ import annotations
 
 from typing import Annotated

--- a/app/pms/export/items/contracts/item_policy.py
+++ b/app/pms/export/items/contracts/item_policy.py
@@ -1,4 +1,4 @@
-# app/pms/public/items/contracts/item_policy.py
+# app/pms/export/items/contracts/item_policy.py
 from __future__ import annotations
 
 from typing import Annotated, Literal

--- a/app/pms/export/items/contracts/item_query.py
+++ b/app/pms/export/items/contracts/item_query.py
@@ -1,4 +1,4 @@
-# app/pms/public/items/contracts/item_query.py
+# app/pms/export/items/contracts/item_query.py
 from __future__ import annotations
 
 from typing import Annotated
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 class ItemReadQuery(BaseModel):
     """
-    PMS public read 查询参数。
+    PMS export read 查询参数。
 
     说明：
     - 这是后端域间读取入参，不是 HTTP router 的直接替身

--- a/app/pms/export/items/routers/barcode_probe.py
+++ b/app/pms/export/items/routers/barcode_probe.py
@@ -1,21 +1,21 @@
-# app/pms/public/items/routers/barcode_probe.py
+# app/pms/export/items/routers/barcode_probe.py
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from app.db.deps import get_db
-from app.pms.public.items.contracts.barcode_probe import BarcodeProbeIn, BarcodeProbeOut
-from app.pms.public.items.services.barcode_probe_service import BarcodeProbeService
+from app.pms.export.items.contracts.barcode_probe import BarcodeProbeIn, BarcodeProbeOut
+from app.pms.export.items.services.barcode_probe_service import BarcodeProbeService
 
-router = APIRouter(tags=["pms-public-items"])
+router = APIRouter(tags=["pms-export-items"])
 
 
 def get_barcode_probe_service(db: Session = Depends(get_db)) -> BarcodeProbeService:
     return BarcodeProbeService(db)
 
 
-@router.post("/items/barcode-probe", response_model=BarcodeProbeOut)
+@router.post("/pms/export/items/barcode-probe", response_model=BarcodeProbeOut)
 def probe_barcode(
     body: BarcodeProbeIn,
     service: BarcodeProbeService = Depends(get_barcode_probe_service),

--- a/app/pms/export/items/routers/item_aggregate_read.py
+++ b/app/pms/export/items/routers/item_aggregate_read.py
@@ -1,14 +1,14 @@
-# app/pms/public/items/routers/item_aggregate_read.py
+# app/pms/export/items/routers/item_aggregate_read.py
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.db.deps import get_db
-from app.pms.public.items.contracts.item_aggregate import PublicItemAggregateOut
-from app.pms.public.items.services.item_aggregate_read_service import ItemAggregateReadService
+from app.pms.export.items.contracts.item_aggregate import PublicItemAggregateOut
+from app.pms.export.items.services.item_aggregate_read_service import ItemAggregateReadService
 
-router = APIRouter(prefix="/public/items", tags=["pms-public-items"])
+router = APIRouter(prefix="/pms/export/items", tags=["pms-export-items"])
 
 
 def get_item_aggregate_read_service(db: Session = Depends(get_db)) -> ItemAggregateReadService:
@@ -16,7 +16,7 @@ def get_item_aggregate_read_service(db: Session = Depends(get_db)) -> ItemAggreg
 
 
 @router.get("/{item_id}/aggregate", response_model=PublicItemAggregateOut, status_code=status.HTTP_200_OK)
-def get_public_item_aggregate_by_id(
+def get_export_item_aggregate_by_id(
     item_id: int,
     service: ItemAggregateReadService = Depends(get_item_aggregate_read_service),
 ) -> PublicItemAggregateOut:

--- a/app/pms/export/items/routers/items_read.py
+++ b/app/pms/export/items/routers/items_read.py
@@ -1,4 +1,4 @@
-# app/pms/public/items/routers/items_read.py
+# app/pms/export/items/routers/items_read.py
 from __future__ import annotations
 
 from typing import Optional
@@ -7,11 +7,11 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 from app.db.deps import get_db
-from app.pms.public.items.contracts.item_basic import ItemBasic
-from app.pms.public.items.contracts.item_query import ItemReadQuery
-from app.pms.public.items.services.item_read_service import ItemReadService
+from app.pms.export.items.contracts.item_basic import ItemBasic
+from app.pms.export.items.contracts.item_query import ItemReadQuery
+from app.pms.export.items.services.item_read_service import ItemReadService
 
-router = APIRouter(prefix="/public/items", tags=["pms-public-items"])
+router = APIRouter(prefix="/pms/export/items", tags=["pms-export-items"])
 
 
 def get_item_read_service(db: Session = Depends(get_db)) -> ItemReadService:
@@ -19,7 +19,7 @@ def get_item_read_service(db: Session = Depends(get_db)) -> ItemReadService:
 
 
 @router.get("", response_model=list[ItemBasic], status_code=status.HTTP_200_OK)
-def list_public_items(
+def list_export_items(
     supplier_id: Optional[int] = Query(None, ge=1, description="按供应商过滤"),
     enabled: Optional[bool] = Query(None, description="按启用状态过滤"),
     q: Optional[str] = Query(None, description="关键词搜索（sku/name）"),
@@ -36,7 +36,7 @@ def list_public_items(
 
 
 @router.get("/{item_id}", response_model=ItemBasic, status_code=status.HTTP_200_OK)
-def get_public_item_by_id(
+def get_export_item_by_id(
     item_id: int,
     service: ItemReadService = Depends(get_item_read_service),
 ) -> ItemBasic:

--- a/app/pms/export/items/services/__init__.py
+++ b/app/pms/export/items/services/__init__.py
@@ -1,4 +1,4 @@
-# app/pms/public/items/services/__init__.py
+# app/pms/export/items/services/__init__.py
 from __future__ import annotations
 
 from .barcode_probe_service import BarcodeProbeService

--- a/app/pms/export/items/services/barcode_probe_service.py
+++ b/app/pms/export/items/services/barcode_probe_service.py
@@ -1,4 +1,4 @@
-# app/pms/public/items/services/barcode_probe_service.py
+# app/pms/export/items/services/barcode_probe_service.py
 from __future__ import annotations
 
 from sqlalchemy import select
@@ -7,17 +7,17 @@ from sqlalchemy.orm import Session
 
 from app.pms.items.models.item_barcode import ItemBarcode
 from app.pms.items.models.item_uom import ItemUOM
-from app.pms.public.items.contracts.barcode_probe import (
+from app.pms.export.items.contracts.barcode_probe import (
     BarcodeProbeError,
     BarcodeProbeOut,
     BarcodeProbeStatus,
 )
-from app.pms.public.items.services.item_read_service import ItemReadService
+from app.pms.export.items.services.item_read_service import ItemReadService
 
 
 class BarcodeProbeService:
     """
-    PMS public barcode probe service。
+    PMS export barcode probe service。
 
     职责：
     - 解析 barcode 是否绑定

--- a/app/pms/export/items/services/item_aggregate_read_service.py
+++ b/app/pms/export/items/services/item_aggregate_read_service.py
@@ -1,10 +1,10 @@
-# app/pms/public/items/services/item_aggregate_read_service.py
+# app/pms/export/items/services/item_aggregate_read_service.py
 from __future__ import annotations
 
 from sqlalchemy.orm import Session
 
 from app.pms.items.repos.item_aggregate_read_repo import get_item_aggregate_record
-from app.pms.public.items.contracts.item_aggregate import (
+from app.pms.export.items.contracts.item_aggregate import (
     PublicAggregateBarcode,
     PublicAggregateItem,
     PublicAggregateUom,
@@ -21,7 +21,7 @@ def _enum_value(v: object) -> str | None:
 
 class ItemAggregateReadService:
     """
-    PMS public aggregate read service。
+    PMS export aggregate read service。
 
     定位：
     - 对外提供商品完整读面（item + uoms + barcodes）

--- a/app/pms/export/items/services/item_read_service.py
+++ b/app/pms/export/items/services/item_read_service.py
@@ -1,4 +1,4 @@
-# app/pms/public/items/services/item_read_service.py
+# app/pms/export/items/services/item_read_service.py
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -14,9 +14,9 @@ from app.pms.items.models.item_sku_code import ItemSkuCode
 from app.pms.items.repos.item_repo import get_item_by_id as repo_get_item_by_id
 from app.pms.items.repos.item_repo import get_item_by_sku as repo_get_item_by_sku
 from app.pms.items.repos.item_repo import get_items as repo_get_items
-from app.pms.public.items.contracts.item_basic import ItemBasic
-from app.pms.public.items.contracts.item_policy import ItemPolicy
-from app.pms.public.items.contracts.item_query import ItemReadQuery
+from app.pms.export.items.contracts.item_basic import ItemBasic
+from app.pms.export.items.contracts.item_policy import ItemPolicy
+from app.pms.export.items.contracts.item_query import ItemReadQuery
 
 
 def _enum_value(v: object) -> str | None:
@@ -45,7 +45,7 @@ class ItemReportMeta:
 
 class ItemReadService:
     """
-    PMS public read service。
+    PMS export read service。
 
     定位：
     - 供其他模块读取 PMS 商品最小事实

--- a/app/procurement/helpers/purchase_reports.py
+++ b/app/procurement/helpers/purchase_reports.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.public.items.services.item_read_service import ItemReadService
+from app.pms.export.items.services.item_read_service import ItemReadService
 
 
 async def resolve_report_item_ids(
@@ -17,7 +17,7 @@ async def resolve_report_item_ids(
     """
     返回：
     - [item_id]：显式 item_id 过滤
-    - [ids...]：按 PMS public item 搜索出的 item_id 集合
+    - [ids...]：按 PMS export item 搜索出的 item_id 集合
     - None：不加 item 过滤
     """
     if item_id is not None:

--- a/app/procurement/repos/receive_po_line_repo.py
+++ b/app/procurement/repos/receive_po_line_repo.py
@@ -6,7 +6,7 @@ from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.public.items.services.item_read_service import ItemReadService
+from app.pms.export.items.services.item_read_service import ItemReadService
 
 
 async def load_item_expiry_policy(session: AsyncSession, *, item_id: int) -> str:

--- a/app/procurement/routers/purchase_reports_routes_items.py
+++ b/app/procurement/routers/purchase_reports_routes_items.py
@@ -10,7 +10,7 @@ from sqlalchemy import distinct, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_session
-from app.pms.public.items.services.item_read_service import ItemReadService
+from app.pms.export.items.services.item_read_service import ItemReadService
 from app.procurement.contracts.purchase_report import ItemPurchaseReportItem
 from app.procurement.helpers.purchase_reports import resolve_report_item_ids
 from app.procurement.models.purchase_order import PurchaseOrder

--- a/app/procurement/services/purchase_order_create.py
+++ b/app/procurement/services/purchase_order_create.py
@@ -8,8 +8,8 @@ from typing import Any, Dict, List, Optional, Tuple
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.procurement.models.purchase_order import PurchaseOrder
-from app.pms.public.items.contracts.item_basic import ItemBasic
-from app.pms.public.items.services.item_read_service import ItemReadService
+from app.pms.export.items.contracts.item_basic import ItemBasic
+from app.pms.export.items.services.item_read_service import ItemReadService
 from app.partners.export.suppliers.services.supplier_read_service import SupplierReadService
 from app.procurement.repos.purchase_order_create_repo import (
     insert_purchase_order_head,

--- a/app/procurement/services/purchase_order_update.py
+++ b/app/procurement/services/purchase_order_update.py
@@ -9,7 +9,7 @@ from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.procurement.models.purchase_order import PurchaseOrder
-from app.pms.public.items.contracts.item_basic import ItemBasic
+from app.pms.export.items.contracts.item_basic import ItemBasic
 from app.procurement.repos.purchase_order_create_repo import (
     pick_default_purchase_uom,
     require_item_uom_ratio_to_base,

--- a/app/router_mount.py
+++ b/app/router_mount.py
@@ -24,11 +24,11 @@ def mount_routers(app: FastAPI) -> None:
     from app.pms.items.routers.item_uoms import router as item_uoms_router
     from app.pms.items.routers.items import router as items_router
     from app.pms.sku_coding.routers.sku_coding import router as sku_coding_router
-    from app.pms.public.items.routers.barcode_probe import router as pms_public_barcode_probe_router
-    from app.pms.public.items.routers.item_aggregate_read import (
-        router as pms_public_item_aggregate_read_router,
+    from app.pms.export.items.routers.barcode_probe import router as pms_export_barcode_probe_router
+    from app.pms.export.items.routers.item_aggregate_read import (
+        router as pms_export_item_aggregate_read_router,
     )
-    from app.pms.public.items.routers.items_read import router as pms_public_items_read_router
+    from app.pms.export.items.routers.items_read import router as pms_export_items_read_router
     from app.partners.export.suppliers.routers.suppliers_read import (
         router as partners_export_suppliers_read_router,
     )
@@ -126,12 +126,12 @@ def mount_routers(app: FastAPI) -> None:
 
     # PMS 相关：
     # - public 读面先挂
-    # - /items/barcode-probe 先于 /items/{id}
+    # - /pms/export/items/barcode-probe 先于 /items/{id}
     # - /items/aggregate 先于 /items/{id}
-    # - /public/items、/partners/export/suppliers 独立前缀，不与 owner 冲突
-    app.include_router(pms_public_item_aggregate_read_router)
-    app.include_router(pms_public_items_read_router)
-    app.include_router(pms_public_barcode_probe_router)
+    # - /pms/export/items、/partners/export/suppliers 独立前缀，不与 owner 冲突
+    app.include_router(pms_export_item_aggregate_read_router)
+    app.include_router(pms_export_items_read_router)
+    app.include_router(pms_export_barcode_probe_router)
     app.include_router(partners_export_suppliers_read_router)
     app.include_router(item_aggregate_router)
     app.include_router(item_list_router)

--- a/app/wms/inbound/repos/barcode_resolve_repo.py
+++ b/app/wms/inbound/repos/barcode_resolve_repo.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.public.items.services.barcode_probe_service import BarcodeProbeService
+from app.pms.export.items.services.barcode_probe_service import BarcodeProbeService
 
 
 @dataclass(frozen=True)
@@ -14,7 +14,7 @@ class InboundBarcodeResolved:
     入库条码解析结果。
 
     说明：
-    - 这是 WMS inbound 对 PMS public barcode probe 的轻包装
+    - 这是 WMS inbound 对 PMS export barcode probe 的轻包装
     - 只承载入库提交链真正需要的最小字段
     - 不承载 qty / event_id / lot 等仓内执行语义
     """
@@ -32,7 +32,7 @@ async def resolve_inbound_barcode(
     barcode: str,
 ) -> InboundBarcodeResolved | None:
     """
-    通过 PMS public barcode probe 解析入库条码。
+    通过 PMS export barcode probe 解析入库条码。
 
     规则：
     - 空条码 => None

--- a/app/wms/inbound/repos/item_lookup_repo.py
+++ b/app/wms/inbound/repos/item_lookup_repo.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.public.items.contracts.item_policy import ItemPolicy
-from app.pms.public.items.services.item_read_service import ItemReadService
+from app.pms.export.items.contracts.item_policy import ItemPolicy
+from app.pms.export.items.services.item_read_service import ItemReadService
 
 
 async def get_item_policy_by_id(

--- a/app/wms/inbound/repos/lot_resolve_repo.py
+++ b/app/wms/inbound/repos/lot_resolve_repo.py
@@ -4,7 +4,7 @@ from datetime import date
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.public.items.contracts.item_policy import ItemPolicy
+from app.pms.export.items.contracts.item_policy import ItemPolicy
 from app.wms.stock.services.lot_service import resolve_or_create_lot
 
 

--- a/app/wms/inventory_adjustment/return_inbound/contracts/inbound_task_read.py
+++ b/app/wms/inventory_adjustment/return_inbound/contracts/inbound_task_read.py
@@ -10,7 +10,7 @@ from app.wms.inventory_adjustment.return_inbound.contracts.enums import (
     InboundReceiptSourceType,
     InboundReceiptStatus,
 )
-from app.pms.public.items.contracts.item_policy import (
+from app.pms.export.items.contracts.item_policy import (
     ExpiryPolicy,
     LotSourcePolicy,
     ShelfLifeUnit,

--- a/app/wms/inventory_adjustment/return_inbound/services/inbound_task_probe_service.py
+++ b/app/wms/inventory_adjustment/return_inbound/services/inbound_task_probe_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.public.items.services.barcode_probe_service import BarcodeProbeService
+from app.pms.export.items.services.barcode_probe_service import BarcodeProbeService
 from app.wms.inventory_adjustment.return_inbound.contracts.probe import (
     InboundTaskProbeOut,
     InboundTaskProbeStatus,

--- a/app/wms/scan/services/scan_orchestrator_item_resolver.py
+++ b/app/wms/scan/services/scan_orchestrator_item_resolver.py
@@ -7,7 +7,7 @@ from typing import Optional
 from sqlalchemy import text as SA
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.public.items.services.barcode_probe_service import BarcodeProbeService
+from app.pms.export.items.services.barcode_probe_service import BarcodeProbeService
 
 
 @dataclass(frozen=True)
@@ -24,7 +24,7 @@ async def probe_item_from_barcode(
     barcode: str,
 ) -> Optional[ScanBarcodeResolved]:
     """
-    WMS scan 读取链复用 PMS public barcode probe：
+    WMS scan 读取链复用 PMS export barcode probe：
 
     - 不再直接查询 item_barcodes
     - 从 PMS BarcodeProbeService 获取主数据解析结果

--- a/app/wms/scan/services/scan_orchestrator_parse.py
+++ b/app/wms/scan/services/scan_orchestrator_parse.py
@@ -20,7 +20,7 @@ _BARCODE_RESOLVER = BarcodeResolver()
 
 def _apply_barcode_probe(parsed: Dict[str, Any], resolved: object) -> None:
     """
-    把 PMS public barcode probe 的 richer 结果并入 parsed。
+    把 PMS export barcode probe 的 richer 结果并入 parsed。
     当前阶段只做“写入 parsed”，不改变 parse_scan 的返回 tuple 形状。
     """
     item_id = getattr(resolved, "item_id", None)

--- a/app/wms/shared/services/expiry_resolver.py
+++ b/app/wms/shared/services/expiry_resolver.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.public.items.services.item_read_service import ItemReadService
+from app.pms.export.items.services.item_read_service import ItemReadService
 from app.wms.shared.services.expiry_rules import (
     ShelfLife,
     ShelfLifeUnit,

--- a/app/wms/stock/services/lot_service.py
+++ b/app/wms/stock/services/lot_service.py
@@ -9,7 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.wms.stock.models.lot import Lot
-from app.pms.public.items.contracts.item_policy import ItemPolicy
+from app.pms.export.items.contracts.item_policy import ItemPolicy
 from app.wms.stock.services.lots import ensure_internal_lot_singleton, ensure_lot_full
 
 

--- a/openapi/_current.json
+++ b/openapi/_current.json
@@ -8179,13 +8179,13 @@
         }
       }
     },
-    "/public/items/{item_id}/aggregate": {
+    "/pms/export/items/{item_id}/aggregate": {
       "get": {
         "tags": [
-          "pms-public-items"
+          "pms-export-items"
         ],
-        "summary": "Get Public Item Aggregate By Id",
-        "operationId": "get_public_item_aggregate_by_id_public_items__item_id__aggregate_get",
+        "summary": "Get Export Item Aggregate By Id",
+        "operationId": "get_export_item_aggregate_by_id_pms_export_items__item_id__aggregate_get",
         "parameters": [
           {
             "name": "item_id",
@@ -8221,13 +8221,13 @@
         }
       }
     },
-    "/public/items": {
+    "/pms/export/items": {
       "get": {
         "tags": [
-          "pms-public-items"
+          "pms-export-items"
         ],
-        "summary": "List Public Items",
-        "operationId": "list_public_items_public_items_get",
+        "summary": "List Export Items",
+        "operationId": "list_export_items_pms_export_items_get",
         "parameters": [
           {
             "name": "supplier_id",
@@ -8315,7 +8315,7 @@
                   "items": {
                     "$ref": "#/components/schemas/ItemBasic"
                   },
-                  "title": "Response List Public Items Public Items Get"
+                  "title": "Response List Export Items Pms Export Items Get"
                 }
               }
             }
@@ -8333,13 +8333,13 @@
         }
       }
     },
-    "/public/items/{item_id}": {
+    "/pms/export/items/{item_id}": {
       "get": {
         "tags": [
-          "pms-public-items"
+          "pms-export-items"
         ],
-        "summary": "Get Public Item By Id",
-        "operationId": "get_public_item_by_id_public_items__item_id__get",
+        "summary": "Get Export Item By Id",
+        "operationId": "get_export_item_by_id_pms_export_items__item_id__get",
         "parameters": [
           {
             "name": "item_id",
@@ -8375,13 +8375,13 @@
         }
       }
     },
-    "/items/barcode-probe": {
+    "/pms/export/items/barcode-probe": {
       "post": {
         "tags": [
-          "pms-public-items"
+          "pms-export-items"
         ],
         "summary": "Probe Barcode",
-        "operationId": "probe_barcode_items_barcode_probe_post",
+        "operationId": "probe_barcode_pms_export_items_barcode_probe_post",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8416,13 +8416,13 @@
         }
       }
     },
-    "/public/suppliers": {
+    "/partners/export/suppliers": {
       "get": {
         "tags": [
-          "pms-public-suppliers"
+          "partners-export-suppliers"
         ],
         "summary": "List Public Suppliers",
-        "operationId": "list_public_suppliers_public_suppliers_get",
+        "operationId": "list_public_suppliers_partners_export_suppliers_get",
         "parameters": [
           {
             "name": "active",
@@ -8472,7 +8472,7 @@
                   "items": {
                     "$ref": "#/components/schemas/SupplierBasic"
                   },
-                  "title": "Response List Public Suppliers Public Suppliers Get"
+                  "title": "Response List Public Suppliers Partners Export Suppliers Get"
                 }
               }
             }
@@ -11422,13 +11422,13 @@
         }
       }
     },
-    "/suppliers": {
+    "/partners/suppliers": {
       "get": {
         "tags": [
           "suppliers"
         ],
         "summary": "List Suppliers",
-        "operationId": "list_suppliers_suppliers_get",
+        "operationId": "list_suppliers_partners_suppliers_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -11482,7 +11482,7 @@
                   "items": {
                     "$ref": "#/components/schemas/SupplierOut"
                   },
-                  "title": "Response List Suppliers Suppliers Get"
+                  "title": "Response List Suppliers Partners Suppliers Get"
                 }
               }
             }
@@ -11504,7 +11504,7 @@
           "suppliers"
         ],
         "summary": "Create Supplier",
-        "operationId": "create_supplier_suppliers_post",
+        "operationId": "create_supplier_partners_suppliers_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -11544,13 +11544,13 @@
         }
       }
     },
-    "/suppliers/{supplier_id}": {
+    "/partners/suppliers/{supplier_id}": {
       "patch": {
         "tags": [
           "suppliers"
         ],
         "summary": "Update Supplier",
-        "operationId": "update_supplier_suppliers__supplier_id__patch",
+        "operationId": "update_supplier_partners_suppliers__supplier_id__patch",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -11602,13 +11602,13 @@
         }
       }
     },
-    "/suppliers/{supplier_id}/contacts": {
+    "/partners/suppliers/{supplier_id}/contacts": {
       "post": {
         "tags": [
           "supplier-contacts"
         ],
         "summary": "Supplier Create Contact",
-        "operationId": "supplier_create_contact_suppliers__supplier_id__contacts_post",
+        "operationId": "supplier_create_contact_partners_suppliers__supplier_id__contacts_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -11660,13 +11660,13 @@
         }
       }
     },
-    "/supplier-contacts/{contact_id}": {
+    "/partners/supplier-contacts/{contact_id}": {
       "patch": {
         "tags": [
           "supplier-contacts"
         ],
         "summary": "Supplier Update Contact",
-        "operationId": "supplier_update_contact_supplier_contacts__contact_id__patch",
+        "operationId": "supplier_update_contact_partners_supplier_contacts__contact_id__patch",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -11722,7 +11722,7 @@
           "supplier-contacts"
         ],
         "summary": "Supplier Delete Contact",
-        "operationId": "supplier_delete_contact_supplier_contacts__contact_id__delete",
+        "operationId": "supplier_delete_contact_partners_supplier_contacts__contact_id__delete",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -39811,7 +39811,7 @@
           "active"
         ],
         "title": "SupplierBasic",
-        "description": "PMS 对外最小供应商读模型。\n\n说明：\n- 这是跨域 public read surface\n- 只暴露其他模块稳定需要的最小读取字段\n- 不承载 owner contacts / 写入语义"
+        "description": "Partners 对外最小供应商读模型。\n\n说明：\n- 这是跨域 export read surface\n- 只暴露其他模块稳定需要的最小读取字段\n- 不承载 owner contacts / 写入语义"
       },
       "SupplierContactCreateIn": {
         "properties": {

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -8179,13 +8179,13 @@
         }
       }
     },
-    "/public/items/{item_id}/aggregate": {
+    "/pms/export/items/{item_id}/aggregate": {
       "get": {
         "tags": [
-          "pms-public-items"
+          "pms-export-items"
         ],
-        "summary": "Get Public Item Aggregate By Id",
-        "operationId": "get_public_item_aggregate_by_id_public_items__item_id__aggregate_get",
+        "summary": "Get Export Item Aggregate By Id",
+        "operationId": "get_export_item_aggregate_by_id_pms_export_items__item_id__aggregate_get",
         "parameters": [
           {
             "name": "item_id",
@@ -8221,13 +8221,13 @@
         }
       }
     },
-    "/public/items": {
+    "/pms/export/items": {
       "get": {
         "tags": [
-          "pms-public-items"
+          "pms-export-items"
         ],
-        "summary": "List Public Items",
-        "operationId": "list_public_items_public_items_get",
+        "summary": "List Export Items",
+        "operationId": "list_export_items_pms_export_items_get",
         "parameters": [
           {
             "name": "supplier_id",
@@ -8315,7 +8315,7 @@
                   "items": {
                     "$ref": "#/components/schemas/ItemBasic"
                   },
-                  "title": "Response List Public Items Public Items Get"
+                  "title": "Response List Export Items Pms Export Items Get"
                 }
               }
             }
@@ -8333,13 +8333,13 @@
         }
       }
     },
-    "/public/items/{item_id}": {
+    "/pms/export/items/{item_id}": {
       "get": {
         "tags": [
-          "pms-public-items"
+          "pms-export-items"
         ],
-        "summary": "Get Public Item By Id",
-        "operationId": "get_public_item_by_id_public_items__item_id__get",
+        "summary": "Get Export Item By Id",
+        "operationId": "get_export_item_by_id_pms_export_items__item_id__get",
         "parameters": [
           {
             "name": "item_id",
@@ -8375,13 +8375,13 @@
         }
       }
     },
-    "/items/barcode-probe": {
+    "/pms/export/items/barcode-probe": {
       "post": {
         "tags": [
-          "pms-public-items"
+          "pms-export-items"
         ],
         "summary": "Probe Barcode",
-        "operationId": "probe_barcode_items_barcode_probe_post",
+        "operationId": "probe_barcode_pms_export_items_barcode_probe_post",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8416,13 +8416,13 @@
         }
       }
     },
-    "/public/suppliers": {
+    "/partners/export/suppliers": {
       "get": {
         "tags": [
-          "pms-public-suppliers"
+          "partners-export-suppliers"
         ],
         "summary": "List Public Suppliers",
-        "operationId": "list_public_suppliers_public_suppliers_get",
+        "operationId": "list_public_suppliers_partners_export_suppliers_get",
         "parameters": [
           {
             "name": "active",
@@ -8472,7 +8472,7 @@
                   "items": {
                     "$ref": "#/components/schemas/SupplierBasic"
                   },
-                  "title": "Response List Public Suppliers Public Suppliers Get"
+                  "title": "Response List Public Suppliers Partners Export Suppliers Get"
                 }
               }
             }
@@ -11422,13 +11422,13 @@
         }
       }
     },
-    "/suppliers": {
+    "/partners/suppliers": {
       "get": {
         "tags": [
           "suppliers"
         ],
         "summary": "List Suppliers",
-        "operationId": "list_suppliers_suppliers_get",
+        "operationId": "list_suppliers_partners_suppliers_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -11482,7 +11482,7 @@
                   "items": {
                     "$ref": "#/components/schemas/SupplierOut"
                   },
-                  "title": "Response List Suppliers Suppliers Get"
+                  "title": "Response List Suppliers Partners Suppliers Get"
                 }
               }
             }
@@ -11504,7 +11504,7 @@
           "suppliers"
         ],
         "summary": "Create Supplier",
-        "operationId": "create_supplier_suppliers_post",
+        "operationId": "create_supplier_partners_suppliers_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -11544,13 +11544,13 @@
         }
       }
     },
-    "/suppliers/{supplier_id}": {
+    "/partners/suppliers/{supplier_id}": {
       "patch": {
         "tags": [
           "suppliers"
         ],
         "summary": "Update Supplier",
-        "operationId": "update_supplier_suppliers__supplier_id__patch",
+        "operationId": "update_supplier_partners_suppliers__supplier_id__patch",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -11602,13 +11602,13 @@
         }
       }
     },
-    "/suppliers/{supplier_id}/contacts": {
+    "/partners/suppliers/{supplier_id}/contacts": {
       "post": {
         "tags": [
           "supplier-contacts"
         ],
         "summary": "Supplier Create Contact",
-        "operationId": "supplier_create_contact_suppliers__supplier_id__contacts_post",
+        "operationId": "supplier_create_contact_partners_suppliers__supplier_id__contacts_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -11660,13 +11660,13 @@
         }
       }
     },
-    "/supplier-contacts/{contact_id}": {
+    "/partners/supplier-contacts/{contact_id}": {
       "patch": {
         "tags": [
           "supplier-contacts"
         ],
         "summary": "Supplier Update Contact",
-        "operationId": "supplier_update_contact_supplier_contacts__contact_id__patch",
+        "operationId": "supplier_update_contact_partners_supplier_contacts__contact_id__patch",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -11722,7 +11722,7 @@
           "supplier-contacts"
         ],
         "summary": "Supplier Delete Contact",
-        "operationId": "supplier_delete_contact_supplier_contacts__contact_id__delete",
+        "operationId": "supplier_delete_contact_partners_supplier_contacts__contact_id__delete",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -39811,7 +39811,7 @@
           "active"
         ],
         "title": "SupplierBasic",
-        "description": "PMS 对外最小供应商读模型。\n\n说明：\n- 这是跨域 public read surface\n- 只暴露其他模块稳定需要的最小读取字段\n- 不承载 owner contacts / 写入语义"
+        "description": "Partners 对外最小供应商读模型。\n\n说明：\n- 这是跨域 export read surface\n- 只暴露其他模块稳定需要的最小读取字段\n- 不承载 owner contacts / 写入语义"
       },
       "SupplierContactCreateIn": {
         "properties": {

--- a/tests/ci/test_pms_item_compat_contract.py
+++ b/tests/ci/test_pms_item_compat_contract.py
@@ -6,7 +6,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.pms.items.contracts.item import ItemCreate, ItemOut, ItemUpdate
-from app.pms.public.items.contracts.item_basic import ItemBasic
+from app.pms.export.items.contracts.item_basic import ItemBasic
 
 
 def test_pms_owner_item_contract_keeps_compat_output_but_forbids_write_inputs() -> None:
@@ -28,9 +28,9 @@ def test_pms_owner_item_contract_keeps_compat_output_but_forbids_write_inputs() 
     assert forbidden_write_inputs.isdisjoint(update_input_fields)
 
 
-def test_pms_public_item_basic_excludes_owner_compat_and_subtable_fields() -> None:
+def test_pms_export_item_basic_excludes_owner_compat_and_subtable_fields() -> None:
     """
-    PMS public ItemBasic 是跨域最小读模型：
+    PMS export ItemBasic 是跨域最小读模型：
 
     - 不暴露 owner 兼容输出；
     - 不混入 item_barcodes / item_uoms 子表事实；

--- a/tests/services/test_pms_export_item_read_service.py
+++ b/tests/services/test_pms_export_item_read_service.py
@@ -1,11 +1,11 @@
-# tests/services/test_pms_public_item_read_service.py
+# tests/services/test_pms_export_item_read_service.py
 from __future__ import annotations
 
 import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.public.items.services.item_read_service import ItemReadService
+from app.pms.export.items.services.item_read_service import ItemReadService
 
 pytestmark = pytest.mark.asyncio
 


### PR DESCRIPTION
Moves PMS item read APIs from public to export boundary. Retires /public/items and /items/barcode-probe in favor of /pms/export/items and /pms/export/items/barcode-probe. Updates backend consumers to import app.pms.export.items.