### PR TITLE
refactor(procurement): use pms uom export for receive po lines

### DIFF
--- a/app/procurement/repos/receive_po_line_repo.py
+++ b/app/procurement/repos/receive_po_line_repo.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from typing import Optional, Tuple
 
 from fastapi import HTTPException
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.pms.export.items.services.item_read_service import ItemReadService
+from app.pms.export.uoms.contracts.uom import PmsExportUom
+from app.pms.export.uoms.services.uom_read_service import PmsExportUomReadService
 
 
 async def load_item_expiry_policy(session: AsyncSession, *, item_id: int) -> str:
@@ -25,6 +26,11 @@ async def load_item_lot_source_policy(session: AsyncSession, *, item_id: int) ->
     return str(policy.lot_source_policy or "INTERNAL_ONLY").upper()
 
 
+def _uom_name_snapshot(row: PmsExportUom) -> Optional[str]:
+    name = str(row.uom_name or row.display_name or row.uom or "").strip()
+    return name or None
+
+
 async def require_item_uom_ratio_to_base(
     session: AsyncSession,
     *,
@@ -34,35 +40,18 @@ async def require_item_uom_ratio_to_base(
     if uom_id <= 0:
         raise HTTPException(status_code=400, detail="uom_id 必须为正整数")
 
-    row = await session.execute(
-        text(
-            """
-            SELECT
-              ratio_to_base,
-              COALESCE(NULLIF(TRIM(display_name), ''), NULLIF(TRIM(uom), '')) AS disp
-            FROM item_uoms
-            WHERE id = :uom_id AND item_id = :item_id
-            """
-        ),
-        {"uom_id": int(uom_id), "item_id": int(item_id)},
-    )
-    r = row.mappings().first()
-    if r is None:
+    row = await PmsExportUomReadService(session).aget_by_id(item_uom_id=int(uom_id))
+    if row is None or int(row.item_id) != int(item_id):
         raise HTTPException(
             status_code=400,
             detail=f"uom_id 不存在或不属于该商品：item_id={int(item_id)} uom_id={int(uom_id)}",
         )
 
-    try:
-        ratio = int(r.get("ratio_to_base") or 0)
-    except Exception:
-        ratio = 0
+    ratio = int(row.ratio_to_base or 0)
     if ratio <= 0:
-        raise HTTPException(status_code=400, detail="item_uoms.ratio_to_base 非法（必须 >= 1）")
+        raise HTTPException(status_code=400, detail="PMS export uom.ratio_to_base 非法（必须 >= 1）")
 
-    disp = r.get("disp")
-    disp = str(disp).strip() if disp is not None and str(disp).strip() else None
-    return ratio, disp
+    return ratio, _uom_name_snapshot(row)
 
 
 __all__ = [


### PR DESCRIPTION
Switches purchase receiving PO-line UOM validation from direct item_uoms SQL to the PMS export UOM read service. Keeps WMS inbound commit and inventory fact chains unchanged.