### PR TITLE
feat(wms): add pms projection tables

### DIFF
--- a/alembic/versions/e7b9c2a4d6f8_add_wms_pms_projection_tables.py
+++ b/alembic/versions/e7b9c2a4d6f8_add_wms_pms_projection_tables.py
@@ -1,0 +1,417 @@
+"""add wms pms projection tables
+
+Revision ID: e7b9c2a4d6f8
+Revises: c91e7c4f2a31
+Create Date: 2026-05-09 05:00:00.000000
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "e7b9c2a4d6f8"
+down_revision: Union[str, Sequence[str], None] = "c91e7c4f2a31"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+LOT_SOURCE_POLICY = postgresql.ENUM(
+    "INTERNAL_ONLY",
+    "SUPPLIER_ONLY",
+    name="lot_source_policy",
+    create_type=False,
+)
+
+EXPIRY_POLICY = postgresql.ENUM(
+    "NONE",
+    "REQUIRED",
+    name="expiry_policy",
+    create_type=False,
+)
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+
+    op.create_table(
+        "wms_pms_item_projection",
+        sa.Column("item_id", sa.Integer(), nullable=False, autoincrement=False),
+        sa.Column("sku", sa.String(length=128), nullable=False),
+        sa.Column("name", sa.String(length=128), nullable=False),
+        sa.Column("spec", sa.String(length=128), nullable=True),
+        sa.Column("enabled", sa.Boolean(), nullable=False),
+        sa.Column("brand_id", sa.Integer(), nullable=True),
+        sa.Column("category_id", sa.Integer(), nullable=True),
+        sa.Column("source_updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("source_event_id", sa.String(length=64), nullable=True),
+        sa.Column("source_version", sa.BigInteger(), nullable=True),
+        sa.Column(
+            "synced_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("item_id", name="pk_wms_pms_item_projection"),
+        sa.UniqueConstraint("sku", name="uq_wms_pms_item_projection_sku"),
+    )
+    op.create_index(
+        "ix_wms_pms_item_projection_enabled",
+        "wms_pms_item_projection",
+        ["enabled"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_wms_pms_item_projection_brand_id",
+        "wms_pms_item_projection",
+        ["brand_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_wms_pms_item_projection_category_id",
+        "wms_pms_item_projection",
+        ["category_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "wms_pms_item_uom_projection",
+        sa.Column("item_uom_id", sa.Integer(), nullable=False, autoincrement=False),
+        sa.Column("item_id", sa.Integer(), nullable=False),
+        sa.Column("uom", sa.String(length=16), nullable=False),
+        sa.Column("display_name", sa.String(length=32), nullable=True),
+        sa.Column("ratio_to_base", sa.Integer(), nullable=False),
+        sa.Column("is_base", sa.Boolean(), nullable=False),
+        sa.Column("is_purchase_default", sa.Boolean(), nullable=False),
+        sa.Column("is_inbound_default", sa.Boolean(), nullable=False),
+        sa.Column("is_outbound_default", sa.Boolean(), nullable=False),
+        sa.Column("net_weight_kg", sa.Numeric(10, 3), nullable=True),
+        sa.Column("source_updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("source_event_id", sa.String(length=64), nullable=True),
+        sa.Column("source_version", sa.BigInteger(), nullable=True),
+        sa.Column(
+            "synced_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("item_uom_id", name="pk_wms_pms_item_uom_projection"),
+        sa.ForeignKeyConstraint(
+            ["item_id"],
+            ["wms_pms_item_projection.item_id"],
+            name="fk_wms_pms_item_uom_projection_item",
+            ondelete="RESTRICT",
+        ),
+        sa.UniqueConstraint(
+            "item_uom_id",
+            "item_id",
+            name="uq_wms_pms_item_uom_id_item_id",
+        ),
+        sa.UniqueConstraint(
+            "item_id",
+            "uom",
+            name="uq_wms_pms_item_uom_item_uom",
+        ),
+        sa.CheckConstraint(
+            "ratio_to_base >= 1",
+            name="ck_wms_pms_item_uom_ratio_ge_1",
+        ),
+    )
+    op.create_index(
+        "ix_wms_pms_item_uom_item_id",
+        "wms_pms_item_uom_projection",
+        ["item_id"],
+        unique=False,
+    )
+    op.create_index(
+        "uq_wms_pms_item_uom_one_base",
+        "wms_pms_item_uom_projection",
+        ["item_id"],
+        unique=True,
+        postgresql_where=sa.text("is_base = true"),
+    )
+    op.create_index(
+        "uq_wms_pms_item_uom_one_purchase_default",
+        "wms_pms_item_uom_projection",
+        ["item_id"],
+        unique=True,
+        postgresql_where=sa.text("is_purchase_default = true"),
+    )
+    op.create_index(
+        "uq_wms_pms_item_uom_one_inbound_default",
+        "wms_pms_item_uom_projection",
+        ["item_id"],
+        unique=True,
+        postgresql_where=sa.text("is_inbound_default = true"),
+    )
+    op.create_index(
+        "uq_wms_pms_item_uom_one_outbound_default",
+        "wms_pms_item_uom_projection",
+        ["item_id"],
+        unique=True,
+        postgresql_where=sa.text("is_outbound_default = true"),
+    )
+
+    op.create_table(
+        "wms_pms_item_policy_projection",
+        sa.Column("item_id", sa.Integer(), nullable=False),
+        sa.Column("lot_source_policy", LOT_SOURCE_POLICY, nullable=False),
+        sa.Column("expiry_policy", EXPIRY_POLICY, nullable=False),
+        sa.Column("shelf_life_value", sa.Integer(), nullable=True),
+        sa.Column("shelf_life_unit", sa.String(length=16), nullable=True),
+        sa.Column("derivation_allowed", sa.Boolean(), nullable=False),
+        sa.Column("uom_governance_enabled", sa.Boolean(), nullable=False),
+        sa.Column("source_updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("source_event_id", sa.String(length=64), nullable=True),
+        sa.Column("source_version", sa.BigInteger(), nullable=True),
+        sa.Column(
+            "synced_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("item_id", name="pk_wms_pms_item_policy_projection"),
+        sa.ForeignKeyConstraint(
+            ["item_id"],
+            ["wms_pms_item_projection.item_id"],
+            name="fk_wms_pms_item_policy_projection_item",
+            ondelete="RESTRICT",
+        ),
+        sa.CheckConstraint(
+            "expiry_policy = 'REQUIRED' OR "
+            "(shelf_life_value IS NULL AND shelf_life_unit IS NULL)",
+            name="ck_wms_pms_policy_shelf_life_by_expiry",
+        ),
+        sa.CheckConstraint(
+            "(shelf_life_value IS NULL) = (shelf_life_unit IS NULL)",
+            name="ck_wms_pms_policy_shelf_life_pair",
+        ),
+        sa.CheckConstraint(
+            "shelf_life_unit IS NULL OR shelf_life_unit IN ('DAY','WEEK','MONTH','YEAR')",
+            name="ck_wms_pms_policy_shelf_life_unit",
+        ),
+        sa.CheckConstraint(
+            "shelf_life_value IS NULL OR shelf_life_value > 0",
+            name="ck_wms_pms_policy_shelf_life_value_pos",
+        ),
+    )
+
+    op.create_table(
+        "wms_pms_item_sku_code_projection",
+        sa.Column("sku_code_id", sa.Integer(), nullable=False, autoincrement=False),
+        sa.Column("item_id", sa.Integer(), nullable=False),
+        sa.Column("code", sa.String(length=128), nullable=False),
+        sa.Column("code_type", sa.String(length=16), nullable=False),
+        sa.Column("is_primary", sa.Boolean(), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False),
+        sa.Column("effective_from", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("effective_to", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("remark", sa.String(length=255), nullable=True),
+        sa.Column("source_updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("source_event_id", sa.String(length=64), nullable=True),
+        sa.Column("source_version", sa.BigInteger(), nullable=True),
+        sa.Column(
+            "synced_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("sku_code_id", name="pk_wms_pms_item_sku_code_projection"),
+        sa.ForeignKeyConstraint(
+            ["item_id"],
+            ["wms_pms_item_projection.item_id"],
+            name="fk_wms_pms_item_sku_code_projection_item",
+            ondelete="RESTRICT",
+        ),
+        sa.UniqueConstraint("code", name="uq_wms_pms_item_sku_code_code"),
+        sa.UniqueConstraint(
+            "sku_code_id",
+            "item_id",
+            name="uq_wms_pms_item_sku_code_id_item_id",
+        ),
+        sa.CheckConstraint(
+            "length(trim(code)) > 0",
+            name="ck_wms_pms_sku_code_non_empty",
+        ),
+        sa.CheckConstraint(
+            "code_type IN ('PRIMARY','ALIAS','LEGACY','MANUAL')",
+            name="ck_wms_pms_sku_code_type",
+        ),
+        sa.CheckConstraint(
+            "is_primary = false OR is_active = true",
+            name="ck_wms_pms_sku_primary_active",
+        ),
+        sa.CheckConstraint(
+            "is_primary = false OR effective_to IS NULL",
+            name="ck_wms_pms_sku_primary_no_effective_to",
+        ),
+        sa.CheckConstraint(
+            "(code_type = 'PRIMARY') = (is_primary = true)",
+            name="ck_wms_pms_sku_primary_type",
+        ),
+    )
+    op.create_index(
+        "ix_wms_pms_item_sku_code_item_id",
+        "wms_pms_item_sku_code_projection",
+        ["item_id"],
+        unique=False,
+    )
+    op.create_index(
+        "uq_wms_pms_item_sku_code_one_primary",
+        "wms_pms_item_sku_code_projection",
+        ["item_id"],
+        unique=True,
+        postgresql_where=sa.text("is_primary = true"),
+    )
+
+    op.create_table(
+        "wms_pms_item_barcode_projection",
+        sa.Column("barcode_id", sa.BigInteger(), nullable=False, autoincrement=False),
+        sa.Column("item_id", sa.Integer(), nullable=False),
+        sa.Column("item_uom_id", sa.Integer(), nullable=False),
+        sa.Column("barcode", sa.Text(), nullable=False),
+        sa.Column("active", sa.Boolean(), nullable=False),
+        sa.Column("is_primary", sa.Boolean(), nullable=False),
+        sa.Column("symbology", sa.Text(), nullable=False),
+        sa.Column("source_updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("source_event_id", sa.String(length=64), nullable=True),
+        sa.Column("source_version", sa.BigInteger(), nullable=True),
+        sa.Column(
+            "synced_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("barcode_id", name="pk_wms_pms_item_barcode_projection"),
+        sa.ForeignKeyConstraint(
+            ["item_id"],
+            ["wms_pms_item_projection.item_id"],
+            name="fk_wms_pms_item_barcode_projection_item",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["item_uom_id", "item_id"],
+            [
+                "wms_pms_item_uom_projection.item_uom_id",
+                "wms_pms_item_uom_projection.item_id",
+            ],
+            name="fk_wms_pms_item_barcode_projection_uom_pair",
+            ondelete="RESTRICT",
+        ),
+        sa.UniqueConstraint("barcode", name="uq_wms_pms_item_barcode_barcode"),
+        sa.CheckConstraint(
+            "NOT is_primary OR active",
+            name="ck_wms_pms_barcode_primary_active",
+        ),
+    )
+    op.create_index(
+        "ix_wms_pms_item_barcode_item_id",
+        "wms_pms_item_barcode_projection",
+        ["item_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_wms_pms_item_barcode_item_uom_id",
+        "wms_pms_item_barcode_projection",
+        ["item_uom_id"],
+        unique=False,
+    )
+    op.create_index(
+        "uq_wms_pms_item_barcode_one_primary",
+        "wms_pms_item_barcode_projection",
+        ["item_id"],
+        unique=True,
+        postgresql_where=sa.text("is_primary = true"),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+
+    op.drop_index("uq_wms_pms_item_barcode_one_primary", table_name="wms_pms_item_barcode_projection")
+    op.drop_index("ix_wms_pms_item_barcode_item_uom_id", table_name="wms_pms_item_barcode_projection")
+    op.drop_index("ix_wms_pms_item_barcode_item_id", table_name="wms_pms_item_barcode_projection")
+    op.drop_table("wms_pms_item_barcode_projection")
+
+    op.drop_index("uq_wms_pms_item_sku_code_one_primary", table_name="wms_pms_item_sku_code_projection")
+    op.drop_index("ix_wms_pms_item_sku_code_item_id", table_name="wms_pms_item_sku_code_projection")
+    op.drop_table("wms_pms_item_sku_code_projection")
+
+    op.drop_table("wms_pms_item_policy_projection")
+
+    op.drop_index("uq_wms_pms_item_uom_one_outbound_default", table_name="wms_pms_item_uom_projection")
+    op.drop_index("uq_wms_pms_item_uom_one_inbound_default", table_name="wms_pms_item_uom_projection")
+    op.drop_index("uq_wms_pms_item_uom_one_purchase_default", table_name="wms_pms_item_uom_projection")
+    op.drop_index("uq_wms_pms_item_uom_one_base", table_name="wms_pms_item_uom_projection")
+    op.drop_index("ix_wms_pms_item_uom_item_id", table_name="wms_pms_item_uom_projection")
+    op.drop_table("wms_pms_item_uom_projection")
+
+    op.drop_index("ix_wms_pms_item_projection_category_id", table_name="wms_pms_item_projection")
+    op.drop_index("ix_wms_pms_item_projection_brand_id", table_name="wms_pms_item_projection")
+    op.drop_index("ix_wms_pms_item_projection_enabled", table_name="wms_pms_item_projection")
+    op.drop_table("wms_pms_item_projection")

--- a/app/wms/pms_projection/__init__.py
+++ b/app/wms/pms_projection/__init__.py
@@ -1,0 +1,19 @@
+# Split note:
+# 本目录承载 WMS 对 PMS 商品主数据的本地投影边界。
+# projection 是 WMS 执行侧本地 read model，不是 PMS owner 表，也不允许反向维护 PMS 主数据。
+
+from app.wms.pms_projection.models import (
+    WmsPmsItemBarcodeProjection,
+    WmsPmsItemPolicyProjection,
+    WmsPmsItemProjection,
+    WmsPmsItemSkuCodeProjection,
+    WmsPmsItemUomProjection,
+)
+
+__all__ = [
+    "WmsPmsItemProjection",
+    "WmsPmsItemUomProjection",
+    "WmsPmsItemBarcodeProjection",
+    "WmsPmsItemSkuCodeProjection",
+    "WmsPmsItemPolicyProjection",
+]

--- a/app/wms/pms_projection/models/__init__.py
+++ b/app/wms/pms_projection/models/__init__.py
@@ -1,0 +1,19 @@
+# Split note:
+# 本目录只定义 WMS PMS projection ORM。
+# 这些表只引用 WMS 本地 projection，不对 PMS owner 表建立数据库外键。
+
+from app.wms.pms_projection.models.projection import (
+    WmsPmsItemBarcodeProjection,
+    WmsPmsItemPolicyProjection,
+    WmsPmsItemProjection,
+    WmsPmsItemSkuCodeProjection,
+    WmsPmsItemUomProjection,
+)
+
+__all__ = [
+    "WmsPmsItemProjection",
+    "WmsPmsItemUomProjection",
+    "WmsPmsItemBarcodeProjection",
+    "WmsPmsItemSkuCodeProjection",
+    "WmsPmsItemPolicyProjection",
+]

--- a/app/wms/pms_projection/models/projection.py
+++ b/app/wms/pms_projection/models/projection.py
@@ -1,0 +1,358 @@
+# app/wms/pms_projection/models/projection.py
+# Split note:
+# WMS PMS projection 是 PMS 商品主数据在 WMS 执行侧的本地镜像。
+# 库存事务后续只能读取这些本地 projection，不应在事务内远程依赖 PMS owner API。
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Optional
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class WmsPmsItemProjection(Base):
+    """
+    PMS item 在 WMS 的本地投影。
+
+    注意：
+    - item_id 保留 PMS owner item id，用作逻辑外键。
+    - 不对 items 表建立数据库外键，避免 PMS 物理独立时再次被跨库 FK 绑住。
+    """
+
+    __tablename__ = "wms_pms_item_projection"
+
+    item_id: Mapped[int] = mapped_column(sa.Integer, primary_key=True, autoincrement=False)
+    sku: Mapped[str] = mapped_column(sa.String(128), nullable=False, unique=True)
+    name: Mapped[str] = mapped_column(sa.String(128), nullable=False)
+    spec: Mapped[Optional[str]] = mapped_column(sa.String(128), nullable=True)
+    enabled: Mapped[bool] = mapped_column(sa.Boolean, nullable=False)
+
+    brand_id: Mapped[Optional[int]] = mapped_column(sa.Integer, nullable=True)
+    category_id: Mapped[Optional[int]] = mapped_column(sa.Integer, nullable=True)
+
+    source_updated_at: Mapped[datetime] = mapped_column(sa.DateTime(timezone=True), nullable=False)
+    source_event_id: Mapped[Optional[str]] = mapped_column(sa.String(64), nullable=True)
+    source_version: Mapped[Optional[int]] = mapped_column(sa.BigInteger, nullable=True)
+
+    synced_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+
+    __table_args__ = (
+        sa.Index("ix_wms_pms_item_projection_enabled", "enabled"),
+        sa.Index("ix_wms_pms_item_projection_brand_id", "brand_id"),
+        sa.Index("ix_wms_pms_item_projection_category_id", "category_id"),
+    )
+
+
+class WmsPmsItemUomProjection(Base):
+    """
+    PMS item_uoms 在 WMS 的本地投影。
+
+    ratio_to_base 是 WMS 执行期换算 qty_base 的本地读取值。
+    一旦形成库存事实，必须冻结为对应 *_ratio_to_base_snapshot。
+    """
+
+    __tablename__ = "wms_pms_item_uom_projection"
+
+    item_uom_id: Mapped[int] = mapped_column(sa.Integer, primary_key=True, autoincrement=False)
+    item_id: Mapped[int] = mapped_column(
+        sa.Integer,
+        sa.ForeignKey("wms_pms_item_projection.item_id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+
+    uom: Mapped[str] = mapped_column(sa.String(16), nullable=False)
+    display_name: Mapped[Optional[str]] = mapped_column(sa.String(32), nullable=True)
+    ratio_to_base: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+
+    is_base: Mapped[bool] = mapped_column(sa.Boolean, nullable=False)
+    is_purchase_default: Mapped[bool] = mapped_column(sa.Boolean, nullable=False)
+    is_inbound_default: Mapped[bool] = mapped_column(sa.Boolean, nullable=False)
+    is_outbound_default: Mapped[bool] = mapped_column(sa.Boolean, nullable=False)
+
+    net_weight_kg: Mapped[Optional[Decimal]] = mapped_column(sa.Numeric(10, 3), nullable=True)
+
+    source_updated_at: Mapped[datetime] = mapped_column(sa.DateTime(timezone=True), nullable=False)
+    source_event_id: Mapped[Optional[str]] = mapped_column(sa.String(64), nullable=True)
+    source_version: Mapped[Optional[int]] = mapped_column(sa.BigInteger, nullable=True)
+
+    synced_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+
+    __table_args__ = (
+        sa.UniqueConstraint("item_uom_id", "item_id", name="uq_wms_pms_item_uom_id_item_id"),
+        sa.UniqueConstraint("item_id", "uom", name="uq_wms_pms_item_uom_item_uom"),
+        sa.CheckConstraint("ratio_to_base >= 1", name="ck_wms_pms_item_uom_ratio_ge_1"),
+        sa.Index("ix_wms_pms_item_uom_item_id", "item_id"),
+        sa.Index(
+            "uq_wms_pms_item_uom_one_base",
+            "item_id",
+            unique=True,
+            postgresql_where=sa.text("is_base = true"),
+        ),
+        sa.Index(
+            "uq_wms_pms_item_uom_one_purchase_default",
+            "item_id",
+            unique=True,
+            postgresql_where=sa.text("is_purchase_default = true"),
+        ),
+        sa.Index(
+            "uq_wms_pms_item_uom_one_inbound_default",
+            "item_id",
+            unique=True,
+            postgresql_where=sa.text("is_inbound_default = true"),
+        ),
+        sa.Index(
+            "uq_wms_pms_item_uom_one_outbound_default",
+            "item_id",
+            unique=True,
+            postgresql_where=sa.text("is_outbound_default = true"),
+        ),
+    )
+
+
+class WmsPmsItemPolicyProjection(Base):
+    """
+    PMS item policy 在 WMS 的本地投影。
+
+    后续 lot 创建、效期判断、批次来源判断应读取本表，
+    不应直接读取 PMS owner items 表。
+    """
+
+    __tablename__ = "wms_pms_item_policy_projection"
+
+    item_id: Mapped[int] = mapped_column(
+        sa.Integer,
+        sa.ForeignKey("wms_pms_item_projection.item_id", ondelete="RESTRICT"),
+        primary_key=True,
+    )
+
+    lot_source_policy: Mapped[str] = mapped_column(
+        sa.Enum("INTERNAL_ONLY", "SUPPLIER_ONLY", name="lot_source_policy"),
+        nullable=False,
+    )
+    expiry_policy: Mapped[str] = mapped_column(
+        sa.Enum("NONE", "REQUIRED", name="expiry_policy"),
+        nullable=False,
+    )
+    shelf_life_value: Mapped[Optional[int]] = mapped_column(sa.Integer, nullable=True)
+    shelf_life_unit: Mapped[Optional[str]] = mapped_column(sa.String(16), nullable=True)
+
+    derivation_allowed: Mapped[bool] = mapped_column(sa.Boolean, nullable=False)
+    uom_governance_enabled: Mapped[bool] = mapped_column(sa.Boolean, nullable=False)
+
+    source_updated_at: Mapped[datetime] = mapped_column(sa.DateTime(timezone=True), nullable=False)
+    source_event_id: Mapped[Optional[str]] = mapped_column(sa.String(64), nullable=True)
+    source_version: Mapped[Optional[int]] = mapped_column(sa.BigInteger, nullable=True)
+
+    synced_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+
+    __table_args__ = (
+        sa.CheckConstraint(
+            "expiry_policy = 'REQUIRED' OR "
+            "(shelf_life_value IS NULL AND shelf_life_unit IS NULL)",
+            name="ck_wms_pms_policy_shelf_life_by_expiry",
+        ),
+        sa.CheckConstraint(
+            "(shelf_life_value IS NULL) = (shelf_life_unit IS NULL)",
+            name="ck_wms_pms_policy_shelf_life_pair",
+        ),
+        sa.CheckConstraint(
+            "shelf_life_unit IS NULL OR shelf_life_unit IN ('DAY','WEEK','MONTH','YEAR')",
+            name="ck_wms_pms_policy_shelf_life_unit",
+        ),
+        sa.CheckConstraint(
+            "shelf_life_value IS NULL OR shelf_life_value > 0",
+            name="ck_wms_pms_policy_shelf_life_value_pos",
+        ),
+    )
+
+
+class WmsPmsItemSkuCodeProjection(Base):
+    """
+    PMS item_sku_codes 在 WMS 的本地投影。
+
+    用于后续 WMS scan / 查询中的 SKU 文本解析。
+    """
+
+    __tablename__ = "wms_pms_item_sku_code_projection"
+
+    sku_code_id: Mapped[int] = mapped_column(sa.Integer, primary_key=True, autoincrement=False)
+    item_id: Mapped[int] = mapped_column(
+        sa.Integer,
+        sa.ForeignKey("wms_pms_item_projection.item_id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+
+    code: Mapped[str] = mapped_column(sa.String(128), nullable=False, unique=True)
+    code_type: Mapped[str] = mapped_column(sa.String(16), nullable=False)
+    is_primary: Mapped[bool] = mapped_column(sa.Boolean, nullable=False)
+    is_active: Mapped[bool] = mapped_column(sa.Boolean, nullable=False)
+
+    effective_from: Mapped[Optional[datetime]] = mapped_column(sa.DateTime(timezone=True), nullable=True)
+    effective_to: Mapped[Optional[datetime]] = mapped_column(sa.DateTime(timezone=True), nullable=True)
+    remark: Mapped[Optional[str]] = mapped_column(sa.String(255), nullable=True)
+
+    source_updated_at: Mapped[datetime] = mapped_column(sa.DateTime(timezone=True), nullable=False)
+    source_event_id: Mapped[Optional[str]] = mapped_column(sa.String(64), nullable=True)
+    source_version: Mapped[Optional[int]] = mapped_column(sa.BigInteger, nullable=True)
+
+    synced_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "sku_code_id",
+            "item_id",
+            name="uq_wms_pms_item_sku_code_id_item_id",
+        ),
+        sa.CheckConstraint(
+            "length(trim(code)) > 0",
+            name="ck_wms_pms_sku_code_non_empty",
+        ),
+        sa.CheckConstraint(
+            "code_type IN ('PRIMARY','ALIAS','LEGACY','MANUAL')",
+            name="ck_wms_pms_sku_code_type",
+        ),
+        sa.CheckConstraint(
+            "is_primary = false OR is_active = true",
+            name="ck_wms_pms_sku_primary_active",
+        ),
+        sa.CheckConstraint(
+            "is_primary = false OR effective_to IS NULL",
+            name="ck_wms_pms_sku_primary_no_effective_to",
+        ),
+        sa.CheckConstraint(
+            "(code_type = 'PRIMARY') = (is_primary = true)",
+            name="ck_wms_pms_sku_primary_type",
+        ),
+        sa.Index("ix_wms_pms_item_sku_code_item_id", "item_id"),
+        sa.Index(
+            "uq_wms_pms_item_sku_code_one_primary",
+            "item_id",
+            unique=True,
+            postgresql_where=sa.text("is_primary = true"),
+        ),
+    )
+
+
+class WmsPmsItemBarcodeProjection(Base):
+    """
+    PMS item_barcodes 在 WMS 的本地投影。
+
+    用于后续 WMS scan / inbound barcode resolve / return inbound probe。
+    """
+
+    __tablename__ = "wms_pms_item_barcode_projection"
+
+    barcode_id: Mapped[int] = mapped_column(sa.BigInteger, primary_key=True, autoincrement=False)
+
+    item_id: Mapped[int] = mapped_column(
+        sa.Integer,
+        sa.ForeignKey("wms_pms_item_projection.item_id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    item_uom_id: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+
+    barcode: Mapped[str] = mapped_column(sa.Text, nullable=False, unique=True)
+    active: Mapped[bool] = mapped_column(sa.Boolean, nullable=False)
+    is_primary: Mapped[bool] = mapped_column(sa.Boolean, nullable=False)
+    symbology: Mapped[str] = mapped_column(sa.Text, nullable=False)
+
+    source_updated_at: Mapped[datetime] = mapped_column(sa.DateTime(timezone=True), nullable=False)
+    source_event_id: Mapped[Optional[str]] = mapped_column(sa.String(64), nullable=True)
+    source_version: Mapped[Optional[int]] = mapped_column(sa.BigInteger, nullable=True)
+
+    synced_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+
+    __table_args__ = (
+        sa.ForeignKeyConstraint(
+            ["item_uom_id", "item_id"],
+            ["wms_pms_item_uom_projection.item_uom_id", "wms_pms_item_uom_projection.item_id"],
+            name="fk_wms_pms_item_barcode_projection_uom_pair",
+            ondelete="RESTRICT",
+        ),
+        sa.CheckConstraint(
+            "NOT is_primary OR active",
+            name="ck_wms_pms_barcode_primary_active",
+        ),
+        sa.Index("ix_wms_pms_item_barcode_item_id", "item_id"),
+        sa.Index("ix_wms_pms_item_barcode_item_uom_id", "item_uom_id"),
+        sa.Index(
+            "uq_wms_pms_item_barcode_one_primary",
+            "item_id",
+            unique=True,
+            postgresql_where=sa.text("is_primary = true"),
+        ),
+    )


### PR DESCRIPTION
## Summary
- add WMS-local PMS item projection table
- add WMS-local PMS UOM, barcode, SKU code, and policy projection tables
- keep projection foreign keys local to WMS projection tables
- do not connect scan, inbound, ledger, count, or return inbound logic yet

## Validation
- python3 -m compileall alembic/versions/e7b9c2a4d6f8_add_wms_pms_projection_tables.py app/wms/pms_projection
- make upgrade-dev
- make alembic-check
- verified source ID columns have no autoincrement defaults
- verified projection foreign keys do not reference PMS owner tables