### PR TITLE
feat(wms): add pms projection rebuild service

### DIFF
--- a/app/wms/pms_projection/services/__init__.py
+++ b/app/wms/pms_projection/services/__init__.py
@@ -1,0 +1,14 @@
+# Split note:
+# 本目录承载 WMS PMS projection 的初始化 / 重建服务。
+# 当前阶段允许本目录作为唯一适配层读取 PMS owner 表；
+# 业务执行链不得直接读取 PMS owner 表。
+
+from app.wms.pms_projection.services.rebuild_service import (
+    WmsPmsProjectionRebuildResult,
+    WmsPmsProjectionRebuildService,
+)
+
+__all__ = [
+    "WmsPmsProjectionRebuildResult",
+    "WmsPmsProjectionRebuildService",
+]

--- a/app/wms/pms_projection/services/rebuild_service.py
+++ b/app/wms/pms_projection/services/rebuild_service.py
@@ -1,0 +1,486 @@
+# app/wms/pms_projection/services/rebuild_service.py
+# Split note:
+# 本服务是 WMS PMS projection 的全量初始化 / 重建适配层。
+# 在 PMS 物理独立前，只有本边界允许集中读取 PMS owner 表并写入 WMS 本地 projection。
+# 业务执行链不得绕过 projection 直接读取 PMS owner 表。
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+
+import sqlalchemy as sa
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.pms.items.models.item import Item
+from app.pms.items.models.item_barcode import ItemBarcode
+from app.pms.items.models.item_sku_code import ItemSkuCode
+from app.pms.items.models.item_uom import ItemUOM
+from app.wms.pms_projection.models.projection import (
+    WmsPmsItemBarcodeProjection,
+    WmsPmsItemPolicyProjection,
+    WmsPmsItemProjection,
+    WmsPmsItemSkuCodeProjection,
+    WmsPmsItemUomProjection,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class WmsPmsProjectionRebuildResult:
+    source_items: int
+    source_uoms: int
+    source_policies: int
+    source_sku_codes: int
+    source_barcodes: int
+    deleted_items: int
+    deleted_uoms: int
+    deleted_policies: int
+    deleted_sku_codes: int
+    deleted_barcodes: int
+
+
+def _rowcount(result: object) -> int:
+    raw = getattr(result, "rowcount", 0)
+    if isinstance(raw, int) and raw > 0:
+        return raw
+    return 0
+
+
+def _enum_text(value: object, *, label: str) -> str:
+    raw = getattr(value, "value", value)
+    if raw is None:
+        raise RuntimeError(f"{label} is required")
+    text = str(raw).strip()
+    if text == "":
+        raise RuntimeError(f"{label} is blank")
+    return text
+
+
+def _optional_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _required_datetime(value: object, *, label: str) -> datetime:
+    if not isinstance(value, datetime):
+        raise RuntimeError(f"{label} must be datetime, got {type(value)!r}")
+    return value
+
+
+class WmsPmsProjectionRebuildService:
+    """
+    WMS PMS projection 全量重建服务。
+
+    当前阶段职责：
+    - 从 PMS owner 表读取商品、包装单位、条码、SKU code、策略；
+    - 写入 WMS 本地 wms_pms_*_projection；
+    - 支持幂等重复执行；
+    - 清理 projection 中已不存在于 PMS owner 的陈旧行。
+
+    明确不负责：
+    - 不接入 WMS scan；
+    - 不接入 inbound commit；
+    - 不接入 ledger / count / return inbound；
+    - 不实现 PMS outbox / changes 增量同步。
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def rebuild_all(self) -> WmsPmsProjectionRebuildResult:
+        item_rows = (await self.session.execute(self._items_stmt())).mappings().all()
+        uom_rows = (await self.session.execute(self._uoms_stmt())).mappings().all()
+        sku_code_rows = (await self.session.execute(self._sku_codes_stmt())).mappings().all()
+        barcode_rows = (await self.session.execute(self._barcodes_stmt())).mappings().all()
+
+        item_ids = {int(row["id"]) for row in item_rows}
+        uom_ids = {int(row["id"]) for row in uom_rows}
+        sku_code_ids = {int(row["id"]) for row in sku_code_rows}
+        barcode_ids = {int(row["id"]) for row in barcode_rows}
+
+        deleted_barcodes = await self._delete_stale(
+            WmsPmsItemBarcodeProjection,
+            WmsPmsItemBarcodeProjection.barcode_id,
+            barcode_ids,
+        )
+        deleted_sku_codes = await self._delete_stale(
+            WmsPmsItemSkuCodeProjection,
+            WmsPmsItemSkuCodeProjection.sku_code_id,
+            sku_code_ids,
+        )
+        deleted_policies = await self._delete_stale(
+            WmsPmsItemPolicyProjection,
+            WmsPmsItemPolicyProjection.item_id,
+            item_ids,
+        )
+        deleted_uoms = await self._delete_stale(
+            WmsPmsItemUomProjection,
+            WmsPmsItemUomProjection.item_uom_id,
+            uom_ids,
+        )
+        deleted_items = await self._delete_stale(
+            WmsPmsItemProjection,
+            WmsPmsItemProjection.item_id,
+            item_ids,
+        )
+
+        await self._upsert_items(item_rows)
+        await self._upsert_uoms(uom_rows)
+        await self._upsert_policies(item_rows)
+        await self._upsert_sku_codes(sku_code_rows)
+        await self._upsert_barcodes(barcode_rows)
+
+        await self.session.flush()
+
+        return WmsPmsProjectionRebuildResult(
+            source_items=len(item_rows),
+            source_uoms=len(uom_rows),
+            source_policies=len(item_rows),
+            source_sku_codes=len(sku_code_rows),
+            source_barcodes=len(barcode_rows),
+            deleted_items=deleted_items,
+            deleted_uoms=deleted_uoms,
+            deleted_policies=deleted_policies,
+            deleted_sku_codes=deleted_sku_codes,
+            deleted_barcodes=deleted_barcodes,
+        )
+
+    @staticmethod
+    def _items_stmt():
+        return (
+            select(
+                Item.id,
+                Item.sku,
+                Item.name,
+                Item.spec,
+                Item.enabled,
+                Item.brand_id,
+                Item.category_id,
+                Item.updated_at,
+                Item.lot_source_policy,
+                Item.expiry_policy,
+                Item.shelf_life_value,
+                Item.shelf_life_unit,
+                Item.derivation_allowed,
+                Item.uom_governance_enabled,
+            )
+            .order_by(Item.id.asc())
+        )
+
+    @staticmethod
+    def _uoms_stmt():
+        return (
+            select(
+                ItemUOM.id,
+                ItemUOM.item_id,
+                ItemUOM.uom,
+                ItemUOM.display_name,
+                ItemUOM.ratio_to_base,
+                ItemUOM.is_base,
+                ItemUOM.is_purchase_default,
+                ItemUOM.is_inbound_default,
+                ItemUOM.is_outbound_default,
+                ItemUOM.net_weight_kg,
+                ItemUOM.updated_at,
+            )
+            .order_by(ItemUOM.item_id.asc(), ItemUOM.id.asc())
+        )
+
+    @staticmethod
+    def _sku_codes_stmt():
+        return (
+            select(
+                ItemSkuCode.id,
+                ItemSkuCode.item_id,
+                ItemSkuCode.code,
+                ItemSkuCode.code_type,
+                ItemSkuCode.is_primary,
+                ItemSkuCode.is_active,
+                ItemSkuCode.effective_from,
+                ItemSkuCode.effective_to,
+                ItemSkuCode.remark,
+                ItemSkuCode.updated_at,
+            )
+            .order_by(ItemSkuCode.item_id.asc(), ItemSkuCode.id.asc())
+        )
+
+    @staticmethod
+    def _barcodes_stmt():
+        return (
+            select(
+                ItemBarcode.id,
+                ItemBarcode.item_id,
+                ItemBarcode.item_uom_id,
+                ItemBarcode.barcode,
+                ItemBarcode.active,
+                ItemBarcode.is_primary,
+                ItemBarcode.symbology,
+                ItemBarcode.updated_at,
+            )
+            .order_by(ItemBarcode.item_id.asc(), ItemBarcode.id.asc())
+        )
+
+    async def _delete_stale(
+        self,
+        model: type[object],
+        id_column: sa.ColumnElement[int],
+        source_ids: set[int],
+    ) -> int:
+        stmt = sa.delete(model)
+        if source_ids:
+            stmt = stmt.where(~id_column.in_(sorted(source_ids)))
+        result = await self.session.execute(stmt)
+        return _rowcount(result)
+
+    async def _upsert_items(self, rows: list[sa.RowMapping]) -> None:
+        values: list[dict[str, object]] = []
+        for row in rows:
+            values.append(
+                {
+                    "item_id": int(row["id"]),
+                    "sku": str(row["sku"]),
+                    "name": str(row["name"]),
+                    "spec": _optional_text(row["spec"]),
+                    "enabled": bool(row["enabled"]),
+                    "brand_id": int(row["brand_id"]) if row["brand_id"] is not None else None,
+                    "category_id": (
+                        int(row["category_id"])
+                        if row["category_id"] is not None
+                        else None
+                    ),
+                    "source_updated_at": _required_datetime(
+                        row["updated_at"],
+                        label=f"items.updated_at item_id={int(row['id'])}",
+                    ),
+                    "source_event_id": None,
+                    "source_version": None,
+                }
+            )
+
+        if not values:
+            return
+
+        stmt = pg_insert(WmsPmsItemProjection).values(values)
+        await self.session.execute(
+            stmt.on_conflict_do_update(
+                index_elements=["item_id"],
+                set_={
+                    "sku": stmt.excluded.sku,
+                    "name": stmt.excluded.name,
+                    "spec": stmt.excluded.spec,
+                    "enabled": stmt.excluded.enabled,
+                    "brand_id": stmt.excluded.brand_id,
+                    "category_id": stmt.excluded.category_id,
+                    "source_updated_at": stmt.excluded.source_updated_at,
+                    "source_event_id": stmt.excluded.source_event_id,
+                    "source_version": stmt.excluded.source_version,
+                    "synced_at": sa.func.now(),
+                    "updated_at": sa.func.now(),
+                },
+            )
+        )
+
+    async def _upsert_uoms(self, rows: list[sa.RowMapping]) -> None:
+        values: list[dict[str, object]] = []
+        for row in rows:
+            values.append(
+                {
+                    "item_uom_id": int(row["id"]),
+                    "item_id": int(row["item_id"]),
+                    "uom": str(row["uom"]),
+                    "display_name": _optional_text(row["display_name"]),
+                    "ratio_to_base": int(row["ratio_to_base"]),
+                    "is_base": bool(row["is_base"]),
+                    "is_purchase_default": bool(row["is_purchase_default"]),
+                    "is_inbound_default": bool(row["is_inbound_default"]),
+                    "is_outbound_default": bool(row["is_outbound_default"]),
+                    "net_weight_kg": (
+                        Decimal(str(row["net_weight_kg"]))
+                        if row["net_weight_kg"] is not None
+                        else None
+                    ),
+                    "source_updated_at": _required_datetime(
+                        row["updated_at"],
+                        label=f"item_uoms.updated_at item_uom_id={int(row['id'])}",
+                    ),
+                    "source_event_id": None,
+                    "source_version": None,
+                }
+            )
+
+        if not values:
+            return
+
+        stmt = pg_insert(WmsPmsItemUomProjection).values(values)
+        await self.session.execute(
+            stmt.on_conflict_do_update(
+                index_elements=["item_uom_id"],
+                set_={
+                    "item_id": stmt.excluded.item_id,
+                    "uom": stmt.excluded.uom,
+                    "display_name": stmt.excluded.display_name,
+                    "ratio_to_base": stmt.excluded.ratio_to_base,
+                    "is_base": stmt.excluded.is_base,
+                    "is_purchase_default": stmt.excluded.is_purchase_default,
+                    "is_inbound_default": stmt.excluded.is_inbound_default,
+                    "is_outbound_default": stmt.excluded.is_outbound_default,
+                    "net_weight_kg": stmt.excluded.net_weight_kg,
+                    "source_updated_at": stmt.excluded.source_updated_at,
+                    "source_event_id": stmt.excluded.source_event_id,
+                    "source_version": stmt.excluded.source_version,
+                    "synced_at": sa.func.now(),
+                    "updated_at": sa.func.now(),
+                },
+            )
+        )
+
+    async def _upsert_policies(self, rows: list[sa.RowMapping]) -> None:
+        values: list[dict[str, object]] = []
+        for row in rows:
+            item_id = int(row["id"])
+            values.append(
+                {
+                    "item_id": item_id,
+                    "lot_source_policy": _enum_text(
+                        row["lot_source_policy"],
+                        label=f"items.lot_source_policy item_id={item_id}",
+                    ),
+                    "expiry_policy": _enum_text(
+                        row["expiry_policy"],
+                        label=f"items.expiry_policy item_id={item_id}",
+                    ),
+                    "shelf_life_value": (
+                        int(row["shelf_life_value"])
+                        if row["shelf_life_value"] is not None
+                        else None
+                    ),
+                    "shelf_life_unit": _optional_text(row["shelf_life_unit"]),
+                    "derivation_allowed": bool(row["derivation_allowed"]),
+                    "uom_governance_enabled": bool(row["uom_governance_enabled"]),
+                    "source_updated_at": _required_datetime(
+                        row["updated_at"],
+                        label=f"items.updated_at item_id={item_id}",
+                    ),
+                    "source_event_id": None,
+                    "source_version": None,
+                }
+            )
+
+        if not values:
+            return
+
+        stmt = pg_insert(WmsPmsItemPolicyProjection).values(values)
+        await self.session.execute(
+            stmt.on_conflict_do_update(
+                index_elements=["item_id"],
+                set_={
+                    "lot_source_policy": stmt.excluded.lot_source_policy,
+                    "expiry_policy": stmt.excluded.expiry_policy,
+                    "shelf_life_value": stmt.excluded.shelf_life_value,
+                    "shelf_life_unit": stmt.excluded.shelf_life_unit,
+                    "derivation_allowed": stmt.excluded.derivation_allowed,
+                    "uom_governance_enabled": stmt.excluded.uom_governance_enabled,
+                    "source_updated_at": stmt.excluded.source_updated_at,
+                    "source_event_id": stmt.excluded.source_event_id,
+                    "source_version": stmt.excluded.source_version,
+                    "synced_at": sa.func.now(),
+                    "updated_at": sa.func.now(),
+                },
+            )
+        )
+
+    async def _upsert_sku_codes(self, rows: list[sa.RowMapping]) -> None:
+        values: list[dict[str, object]] = []
+        for row in rows:
+            values.append(
+                {
+                    "sku_code_id": int(row["id"]),
+                    "item_id": int(row["item_id"]),
+                    "code": str(row["code"]),
+                    "code_type": str(row["code_type"]),
+                    "is_primary": bool(row["is_primary"]),
+                    "is_active": bool(row["is_active"]),
+                    "effective_from": row["effective_from"],
+                    "effective_to": row["effective_to"],
+                    "remark": _optional_text(row["remark"]),
+                    "source_updated_at": _required_datetime(
+                        row["updated_at"],
+                        label=f"item_sku_codes.updated_at sku_code_id={int(row['id'])}",
+                    ),
+                    "source_event_id": None,
+                    "source_version": None,
+                }
+            )
+
+        if not values:
+            return
+
+        stmt = pg_insert(WmsPmsItemSkuCodeProjection).values(values)
+        await self.session.execute(
+            stmt.on_conflict_do_update(
+                index_elements=["sku_code_id"],
+                set_={
+                    "item_id": stmt.excluded.item_id,
+                    "code": stmt.excluded.code,
+                    "code_type": stmt.excluded.code_type,
+                    "is_primary": stmt.excluded.is_primary,
+                    "is_active": stmt.excluded.is_active,
+                    "effective_from": stmt.excluded.effective_from,
+                    "effective_to": stmt.excluded.effective_to,
+                    "remark": stmt.excluded.remark,
+                    "source_updated_at": stmt.excluded.source_updated_at,
+                    "source_event_id": stmt.excluded.source_event_id,
+                    "source_version": stmt.excluded.source_version,
+                    "synced_at": sa.func.now(),
+                    "updated_at": sa.func.now(),
+                },
+            )
+        )
+
+    async def _upsert_barcodes(self, rows: list[sa.RowMapping]) -> None:
+        values: list[dict[str, object]] = []
+        for row in rows:
+            values.append(
+                {
+                    "barcode_id": int(row["id"]),
+                    "item_id": int(row["item_id"]),
+                    "item_uom_id": int(row["item_uom_id"]),
+                    "barcode": str(row["barcode"]),
+                    "active": bool(row["active"]),
+                    "is_primary": bool(row["is_primary"]),
+                    "symbology": str(row["symbology"]),
+                    "source_updated_at": _required_datetime(
+                        row["updated_at"],
+                        label=f"item_barcodes.updated_at barcode_id={int(row['id'])}",
+                    ),
+                    "source_event_id": None,
+                    "source_version": None,
+                }
+            )
+
+        if not values:
+            return
+
+        stmt = pg_insert(WmsPmsItemBarcodeProjection).values(values)
+        await self.session.execute(
+            stmt.on_conflict_do_update(
+                index_elements=["barcode_id"],
+                set_={
+                    "item_id": stmt.excluded.item_id,
+                    "item_uom_id": stmt.excluded.item_uom_id,
+                    "barcode": stmt.excluded.barcode,
+                    "active": stmt.excluded.active,
+                    "is_primary": stmt.excluded.is_primary,
+                    "symbology": stmt.excluded.symbology,
+                    "source_updated_at": stmt.excluded.source_updated_at,
+                    "source_event_id": stmt.excluded.source_event_id,
+                    "source_version": stmt.excluded.source_version,
+                    "synced_at": sa.func.now(),
+                    "updated_at": sa.func.now(),
+                },
+            )
+        )

--- a/tests/services/test_wms_pms_projection_rebuild_service.py
+++ b/tests/services/test_wms_pms_projection_rebuild_service.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import sqlalchemy as sa
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.wms.pms_projection.models.projection import (
+    WmsPmsItemBarcodeProjection,
+    WmsPmsItemPolicyProjection,
+    WmsPmsItemProjection,
+    WmsPmsItemSkuCodeProjection,
+    WmsPmsItemUomProjection,
+)
+from app.wms.pms_projection.services.rebuild_service import (
+    WmsPmsProjectionRebuildService,
+)
+
+
+async def _insert_scalar_int(
+    session: AsyncSession,
+    sql: str,
+    params: dict[str, object],
+) -> int:
+    result = await session.execute(text(sql), params)
+    return int(result.scalar_one())
+
+
+async def test_wms_pms_projection_rebuild_is_idempotent_and_updates_source_rows(
+    session: AsyncSession,
+) -> None:
+    suffix = uuid4().hex[:10]
+    sku = f"PRJ2-SKU-{suffix}"
+    sku_code = f"PRJ2-CODE-{suffix}"
+    barcode = f"PRJ2-BAR-{suffix}"
+    stale_item_id = 900_000_000
+
+    item_id = await _insert_scalar_int(
+        session,
+        """
+        INSERT INTO items (
+          sku,
+          name,
+          spec,
+          enabled,
+          lot_source_policy,
+          expiry_policy,
+          derivation_allowed,
+          uom_governance_enabled
+        )
+        VALUES (
+          :sku,
+          :name,
+          :spec,
+          true,
+          'INTERNAL_ONLY',
+          'NONE',
+          false,
+          true
+        )
+        RETURNING id
+        """,
+        {
+            "sku": sku,
+            "name": f"Projection Test Item {suffix}",
+            "spec": "before",
+        },
+    )
+
+    item_uom_id = await _insert_scalar_int(
+        session,
+        """
+        INSERT INTO item_uoms (
+          item_id,
+          uom,
+          ratio_to_base,
+          display_name,
+          net_weight_kg,
+          is_base,
+          is_purchase_default,
+          is_inbound_default,
+          is_outbound_default
+        )
+        VALUES (
+          :item_id,
+          'PCS',
+          1,
+          :display_name,
+          0.125,
+          true,
+          true,
+          true,
+          true
+        )
+        RETURNING id
+        """,
+        {
+            "item_id": item_id,
+            "display_name": "件",
+        },
+    )
+
+    sku_code_id = await _insert_scalar_int(
+        session,
+        """
+        INSERT INTO item_sku_codes (
+          item_id,
+          code,
+          code_type,
+          is_primary,
+          is_active,
+          remark
+        )
+        VALUES (
+          :item_id,
+          :code,
+          'PRIMARY',
+          true,
+          true,
+          'before'
+        )
+        RETURNING id
+        """,
+        {
+            "item_id": item_id,
+            "code": sku_code,
+        },
+    )
+
+    barcode_id = await _insert_scalar_int(
+        session,
+        """
+        INSERT INTO item_barcodes (
+          item_id,
+          item_uom_id,
+          barcode,
+          symbology,
+          active,
+          is_primary
+        )
+        VALUES (
+          :item_id,
+          :item_uom_id,
+          :barcode,
+          'CUSTOM',
+          true,
+          true
+        )
+        RETURNING id
+        """,
+        {
+            "item_id": item_id,
+            "item_uom_id": item_uom_id,
+            "barcode": barcode,
+        },
+    )
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_pms_item_projection (
+              item_id,
+              sku,
+              name,
+              enabled,
+              source_updated_at
+            )
+            VALUES (
+              :item_id,
+              :sku,
+              :name,
+              true,
+              now()
+            )
+            """
+        ),
+        {
+            "item_id": stale_item_id,
+            "sku": f"STALE-{suffix}",
+            "name": "stale projection row",
+        },
+    )
+
+    service = WmsPmsProjectionRebuildService(session)
+    first_result = await service.rebuild_all()
+
+    assert first_result.source_items >= 1
+    assert first_result.source_uoms >= 1
+    assert first_result.source_policies >= 1
+    assert first_result.source_sku_codes >= 1
+    assert first_result.source_barcodes >= 1
+    assert first_result.deleted_items >= 1
+
+    session.expire_all()
+
+    item_projection = await session.get(WmsPmsItemProjection, item_id)
+    assert item_projection is not None
+    assert item_projection.sku == sku
+    assert item_projection.name == f"Projection Test Item {suffix}"
+    assert item_projection.spec == "before"
+    assert item_projection.enabled is True
+    assert item_projection.source_event_id is None
+    assert item_projection.source_version is None
+
+    policy_projection = await session.get(WmsPmsItemPolicyProjection, item_id)
+    assert policy_projection is not None
+    assert policy_projection.lot_source_policy == "INTERNAL_ONLY"
+    assert policy_projection.expiry_policy == "NONE"
+    assert policy_projection.shelf_life_value is None
+    assert policy_projection.shelf_life_unit is None
+    assert policy_projection.derivation_allowed is False
+    assert policy_projection.uom_governance_enabled is True
+
+    uom_projection = await session.get(WmsPmsItemUomProjection, item_uom_id)
+    assert uom_projection is not None
+    assert uom_projection.item_id == item_id
+    assert uom_projection.uom == "PCS"
+    assert uom_projection.display_name == "件"
+    assert uom_projection.ratio_to_base == 1
+    assert uom_projection.is_base is True
+
+    sku_projection = await session.get(WmsPmsItemSkuCodeProjection, sku_code_id)
+    assert sku_projection is not None
+    assert sku_projection.item_id == item_id
+    assert sku_projection.code == sku_code
+    assert sku_projection.code_type == "PRIMARY"
+    assert sku_projection.is_primary is True
+    assert sku_projection.is_active is True
+    assert sku_projection.remark == "before"
+
+    barcode_projection = await session.get(WmsPmsItemBarcodeProjection, barcode_id)
+    assert barcode_projection is not None
+    assert barcode_projection.item_id == item_id
+    assert barcode_projection.item_uom_id == item_uom_id
+    assert barcode_projection.barcode == barcode
+    assert barcode_projection.active is True
+    assert barcode_projection.is_primary is True
+    assert barcode_projection.symbology == "CUSTOM"
+
+    stale_projection = await session.get(WmsPmsItemProjection, stale_item_id)
+    assert stale_projection is None
+
+    second_result = await service.rebuild_all()
+    assert second_result.source_items == first_result.source_items
+    assert second_result.source_uoms == first_result.source_uoms
+    assert second_result.source_policies == first_result.source_policies
+    assert second_result.source_sku_codes == first_result.source_sku_codes
+    assert second_result.source_barcodes == first_result.source_barcodes
+
+    await session.execute(
+        text(
+            """
+            UPDATE items
+            SET
+              name = :name,
+              spec = :spec,
+              enabled = false,
+              updated_at = now()
+            WHERE id = :item_id
+            """
+        ),
+        {
+            "item_id": item_id,
+            "name": f"Projection Test Item Updated {suffix}",
+            "spec": "after",
+        },
+    )
+    await session.execute(
+        text(
+            """
+            UPDATE item_uoms
+            SET
+              display_name = :display_name,
+              updated_at = now()
+            WHERE id = :item_uom_id
+            """
+        ),
+        {
+            "item_uom_id": item_uom_id,
+            "display_name": "单件",
+        },
+    )
+    await session.execute(
+        text(
+            """
+            UPDATE item_sku_codes
+            SET
+              remark = :remark,
+              updated_at = now()
+            WHERE id = :sku_code_id
+            """
+        ),
+        {
+            "sku_code_id": sku_code_id,
+            "remark": "after",
+        },
+    )
+    await session.execute(
+        text(
+            """
+            UPDATE item_barcodes
+            SET
+              symbology = :symbology,
+              updated_at = now()
+            WHERE id = :barcode_id
+            """
+        ),
+        {
+            "barcode_id": barcode_id,
+            "symbology": "GS1",
+        },
+    )
+
+    await service.rebuild_all()
+    session.expire_all()
+
+    item_projection = await session.get(WmsPmsItemProjection, item_id)
+    assert item_projection is not None
+    assert item_projection.name == f"Projection Test Item Updated {suffix}"
+    assert item_projection.spec == "after"
+    assert item_projection.enabled is False
+
+    uom_projection = await session.get(WmsPmsItemUomProjection, item_uom_id)
+    assert uom_projection is not None
+    assert uom_projection.display_name == "单件"
+
+    sku_projection = await session.get(WmsPmsItemSkuCodeProjection, sku_code_id)
+    assert sku_projection is not None
+    assert sku_projection.remark == "after"
+
+    barcode_projection = await session.get(WmsPmsItemBarcodeProjection, barcode_id)
+    assert barcode_projection is not None
+    assert barcode_projection.symbology == "GS1"
+
+    item_count = await session.scalar(sa.select(sa.func.count(WmsPmsItemProjection.item_id)))
+    uom_count = await session.scalar(sa.select(sa.func.count(WmsPmsItemUomProjection.item_uom_id)))
+    policy_count = await session.scalar(sa.select(sa.func.count(WmsPmsItemPolicyProjection.item_id)))
+    sku_code_count = await session.scalar(
+        sa.select(sa.func.count(WmsPmsItemSkuCodeProjection.sku_code_id))
+    )
+    barcode_count = await session.scalar(
+        sa.select(sa.func.count(WmsPmsItemBarcodeProjection.barcode_id))
+    )
+
+    assert int(item_count or 0) == second_result.source_items
+    assert int(uom_count or 0) == second_result.source_uoms
+    assert int(policy_count or 0) == second_result.source_policies
+    assert int(sku_code_count or 0) == second_result.source_sku_codes
+    assert int(barcode_count or 0) == second_result.source_barcodes


### PR DESCRIPTION
## Summary
- add WMS PMS projection rebuild service
- rebuild item, UOM, barcode, SKU code, and policy projections from current PMS owner tables
- support idempotent full rebuild and stale projection cleanup
- keep rebuild logic inside app/wms/pms_projection boundary
- do not connect scan, inbound commit, ledger, count, or return inbound logic yet

## Validation
- python3 -m compileall app/wms/pms_projection tests/services/test_wms_pms_projection_rebuild_service.py
- make upgrade-test
- TESTS=tests/services/test_wms_pms_projection_rebuild_service.py make test
- make alembic-check
- git diff --check