### PR TITLE
refactor(wms): use pms projection for scan probe resolution

### DIFF
--- a/app/wms/inventory_adjustment/return_inbound/services/inbound_task_probe_service.py
+++ b/app/wms/inventory_adjustment/return_inbound/services/inbound_task_probe_service.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.services.barcode_probe_service import BarcodeProbeService
 from app.wms.inventory_adjustment.return_inbound.contracts.probe import (
     InboundTaskProbeOut,
     InboundTaskProbeStatus,
@@ -12,39 +10,7 @@ from app.wms.inventory_adjustment.return_inbound.repos.inbound_task_probe_repo i
     InboundTaskProbeLine,
     get_inbound_task_probe_lines,
 )
-
-
-async def _load_actual_uom_name(
-    session: AsyncSession,
-    *,
-    item_id: int,
-    item_uom_id: int | None,
-) -> str | None:
-    if item_uom_id is None:
-        return None
-
-    row = (
-        await session.execute(
-            text(
-                """
-                SELECT
-                  COALESCE(NULLIF(display_name, ''), uom) AS uom_name_snapshot
-                FROM item_uoms
-                WHERE id = :item_uom_id
-                  AND item_id = :item_id
-                LIMIT 1
-                """
-            ),
-            {
-                "item_uom_id": int(item_uom_id),
-                "item_id": int(item_id),
-            },
-        )
-    ).mappings().first()
-
-    if row is None:
-        return None
-    return row["uom_name_snapshot"]
+from app.wms.pms_projection.services.read_service import WmsPmsProjectionReadService
 
 
 def _match_line(
@@ -94,8 +60,11 @@ async def probe_inbound_task_barcode(
     code = (barcode or "").strip()
     lines = await get_inbound_task_probe_lines(session, receipt_no=receipt_no)
 
-    probe = await BarcodeProbeService(session).aprobe(barcode=code)
-    if probe.status != "BOUND" or probe.item_id is None:
+    probe = await WmsPmsProjectionReadService(session).aprobe_barcode(
+        barcode=code,
+        active_only=True,
+    )
+    if probe is None:
         return InboundTaskProbeOut(
             ok=True,
             status=InboundTaskProbeStatus.UNBOUND,
@@ -104,17 +73,11 @@ async def probe_inbound_task_barcode(
         )
 
     item_id = int(probe.item_id)
-    item_uom_id = int(probe.item_uom_id) if probe.item_uom_id is not None else None
-    ratio_to_base = int(probe.ratio_to_base) if probe.ratio_to_base is not None else None
+    item_uom_id = int(probe.item_uom_id)
+    ratio_to_base = int(probe.ratio_to_base)
 
     status, matched, message = _match_line(
         lines=lines,
-        item_id=item_id,
-        item_uom_id=item_uom_id,
-    )
-
-    actual_uom_name_snapshot = await _load_actual_uom_name(
-        session,
         item_id=item_id,
         item_uom_id=item_uom_id,
     )
@@ -129,8 +92,8 @@ async def probe_inbound_task_barcode(
         matched_line_no=(matched.line_no if matched else None),
         item_name_snapshot=(matched.item_name_snapshot if matched else None),
         uom_name_snapshot=(
-            actual_uom_name_snapshot
-            if actual_uom_name_snapshot is not None
+            probe.uom_name
+            if probe.uom_name is not None
             else (matched.uom_name_snapshot if matched else None)
         ),
         message=message,

--- a/app/wms/pms_projection/services/__init__.py
+++ b/app/wms/pms_projection/services/__init__.py
@@ -1,8 +1,12 @@
 # Split note:
-# 本目录承载 WMS PMS projection 的初始化 / 重建服务。
-# 当前阶段允许本目录作为唯一适配层读取 PMS owner 表；
-# 业务执行链不得直接读取 PMS owner 表。
+# 本目录承载 WMS PMS projection 的初始化 / 重建 / 只读服务。
+# 当前阶段允许 rebuild_service 作为唯一适配层读取 PMS owner 表；
+# 业务执行链只能通过 read_service 读取 WMS 本地 projection。
 
+from app.wms.pms_projection.services.read_service import (
+    WmsPmsBarcodeProjectionResolution,
+    WmsPmsProjectionReadService,
+)
 from app.wms.pms_projection.services.rebuild_service import (
     WmsPmsProjectionRebuildResult,
     WmsPmsProjectionRebuildService,
@@ -11,4 +15,6 @@ from app.wms.pms_projection.services.rebuild_service import (
 __all__ = [
     "WmsPmsProjectionRebuildResult",
     "WmsPmsProjectionRebuildService",
+    "WmsPmsBarcodeProjectionResolution",
+    "WmsPmsProjectionReadService",
 ]

--- a/app/wms/pms_projection/services/read_service.py
+++ b/app/wms/pms_projection/services/read_service.py
@@ -1,0 +1,157 @@
+# app/wms/pms_projection/services/read_service.py
+# Split note:
+# WMS PMS projection read service 是 WMS 执行侧读取 PMS 本地投影的统一入口。
+# 业务链路不得绕过本服务直接读取 PMS owner 表。
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import sqlalchemy as sa
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.wms.pms_projection.models.projection import (
+    WmsPmsItemBarcodeProjection,
+    WmsPmsItemSkuCodeProjection,
+    WmsPmsItemUomProjection,
+)
+
+
+def _norm_text(value: object) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _uom_name(*, uom: str, display_name: str | None) -> str:
+    name = str(display_name or "").strip()
+    if name:
+        return name
+    return str(uom or "").strip()
+
+
+@dataclass(frozen=True, slots=True)
+class WmsPmsBarcodeProjectionResolution:
+    item_id: int
+    item_uom_id: int
+    ratio_to_base: int
+    symbology: str
+    active: bool
+    uom: str
+    display_name: str | None
+    uom_name: str
+
+
+class WmsPmsProjectionReadService:
+    """
+    WMS PMS projection 只读服务。
+
+    当前职责：
+    - barcode -> item / item_uom / ratio_to_base；
+    - sku code -> item_id；
+    - item_uom -> uom_name。
+
+    明确不负责：
+    - 不读取 PMS owner 表；
+    - 不修改 projection；
+    - 不承担库存提交语义。
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def aprobe_barcode(
+        self,
+        *,
+        barcode: str,
+        active_only: bool = True,
+    ) -> WmsPmsBarcodeProjectionResolution | None:
+        code = _norm_text(barcode)
+        if code is None:
+            return None
+
+        stmt = (
+            select(WmsPmsItemBarcodeProjection, WmsPmsItemUomProjection)
+            .join(
+                WmsPmsItemUomProjection,
+                (WmsPmsItemUomProjection.item_uom_id == WmsPmsItemBarcodeProjection.item_uom_id)
+                & (WmsPmsItemUomProjection.item_id == WmsPmsItemBarcodeProjection.item_id),
+            )
+            .where(WmsPmsItemBarcodeProjection.barcode == code)
+            .order_by(
+                WmsPmsItemBarcodeProjection.is_primary.desc(),
+                WmsPmsItemBarcodeProjection.active.desc(),
+                WmsPmsItemBarcodeProjection.barcode_id.asc(),
+            )
+            .limit(1)
+        )
+        if active_only:
+            stmt = stmt.where(WmsPmsItemBarcodeProjection.active.is_(True))
+
+        row = (await self.session.execute(stmt)).first()
+        if row is None:
+            return None
+
+        barcode_row, uom_row = row
+        return WmsPmsBarcodeProjectionResolution(
+            item_id=int(barcode_row.item_id),
+            item_uom_id=int(barcode_row.item_uom_id),
+            ratio_to_base=int(uom_row.ratio_to_base),
+            symbology=str(barcode_row.symbology),
+            active=bool(barcode_row.active),
+            uom=str(uom_row.uom),
+            display_name=(
+                str(uom_row.display_name).strip()
+                if uom_row.display_name is not None
+                else None
+            ),
+            uom_name=_uom_name(
+                uom=str(uom_row.uom),
+                display_name=uom_row.display_name,
+            ),
+        )
+
+    async def aresolve_active_sku_code_item_id(self, *, code: str) -> int | None:
+        norm = _norm_text(code)
+        if norm is None:
+            return None
+
+        stmt = (
+            select(WmsPmsItemSkuCodeProjection.item_id)
+            .where(sa.func.lower(WmsPmsItemSkuCodeProjection.code) == norm.lower())
+            .where(WmsPmsItemSkuCodeProjection.is_active.is_(True))
+            .order_by(
+                WmsPmsItemSkuCodeProjection.is_primary.desc(),
+                WmsPmsItemSkuCodeProjection.sku_code_id.asc(),
+            )
+            .limit(1)
+        )
+        value = (await self.session.execute(stmt)).scalar_one_or_none()
+        return int(value) if value is not None else None
+
+    async def aget_uom_name(
+        self,
+        *,
+        item_id: int,
+        item_uom_id: int | None,
+    ) -> str | None:
+        if item_uom_id is None:
+            return None
+
+        stmt = (
+            select(WmsPmsItemUomProjection.uom, WmsPmsItemUomProjection.display_name)
+            .where(WmsPmsItemUomProjection.item_uom_id == int(item_uom_id))
+            .where(WmsPmsItemUomProjection.item_id == int(item_id))
+            .limit(1)
+        )
+        row = (await self.session.execute(stmt)).first()
+        if row is None:
+            return None
+
+        uom, display_name = row
+        return _uom_name(uom=str(uom), display_name=display_name)
+
+
+__all__ = [
+    "WmsPmsBarcodeProjectionResolution",
+    "WmsPmsProjectionReadService",
+]

--- a/app/wms/scan/services/scan_orchestrator_item_resolver.py
+++ b/app/wms/scan/services/scan_orchestrator_item_resolver.py
@@ -6,10 +6,7 @@ from typing import Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.services.barcode_probe_service import BarcodeProbeService
-from app.pms.export.sku_codes.services.sku_code_read_service import (
-    PmsExportSkuCodeReadService,
-)
+from app.wms.pms_projection.services.read_service import WmsPmsProjectionReadService
 
 
 @dataclass(frozen=True)
@@ -26,33 +23,30 @@ async def probe_item_from_barcode(
     barcode: str,
 ) -> Optional[ScanBarcodeResolved]:
     """
-    WMS scan 读取链复用 PMS export barcode probe：
+    WMS scan 读取 WMS 本地 PMS projection：
 
-    - 不再直接查询 item_barcodes
-    - 从 PMS BarcodeProbeService 获取主数据解析结果
-    - 当前返回 richer 结构，供 parse_scan 后续阶段继续透传
+    - 不直接查询 PMS owner item_barcodes；
+    - 不远程依赖 PMS export barcode probe；
+    - 只返回 /scan probe 所需的商品 / 包装识别结果。
     """
     code = (barcode or "").strip()
     if not code:
         return None
 
     try:
-        probe = await BarcodeProbeService(session).aprobe(barcode=code)
-        if probe.status != "BOUND":
-            return None
-        if probe.item_id is None:
+        probe = await WmsPmsProjectionReadService(session).aprobe_barcode(
+            barcode=code,
+            active_only=True,
+        )
+        if probe is None:
             return None
 
         return ScanBarcodeResolved(
             item_id=int(probe.item_id),
-            item_uom_id=(
-                int(probe.item_uom_id) if probe.item_uom_id is not None else None
-            ),
-            ratio_to_base=(
-                int(probe.ratio_to_base) if probe.ratio_to_base is not None else None
-            ),
-            symbology=(str(probe.symbology) if probe.symbology is not None else None),
-            active=probe.active if probe.active is not None else None,
+            item_uom_id=int(probe.item_uom_id),
+            ratio_to_base=int(probe.ratio_to_base),
+            symbology=str(probe.symbology),
+            active=bool(probe.active),
         )
     except Exception:
         return None
@@ -64,8 +58,8 @@ async def resolve_item_id_from_barcode(
 ) -> Optional[int]:
     """
     兼容壳：
-    - 现阶段 parse_scan 仍只消费 item_id
-    - 后续阶段将逐步改为直接消费 probe_item_from_barcode 的 richer 结果
+    - 现阶段 parse_scan 仍只消费 item_id；
+    - richer 结果继续由 probe_item_from_barcode 提供。
     """
     resolved = await probe_item_from_barcode(session, barcode)
     if resolved is None:
@@ -75,7 +69,7 @@ async def resolve_item_id_from_barcode(
 
 async def resolve_item_id_from_sku(session: AsyncSession, sku: str) -> Optional[int]:
     """
-    WMS scan SKU 文本解析复用 PMS export SKU code read service。
+    WMS scan SKU 文本解析读取 WMS 本地 PMS sku-code projection。
 
     保持原语义：
     - 只要求命中 active SKU code；
@@ -87,12 +81,8 @@ async def resolve_item_id_from_sku(session: AsyncSession, sku: str) -> Optional[
         return None
 
     try:
-        rows = await PmsExportSkuCodeReadService(session).alist_sku_codes(
+        return await WmsPmsProjectionReadService(session).aresolve_active_sku_code_item_id(
             code=s,
-            active=True,
         )
-        if not rows:
-            return None
-        return int(rows[0].item_id)
     except Exception:
         return None

--- a/tests/services/test_wms_pms_projection_read_service.py
+++ b/tests/services/test_wms_pms_projection_read_service.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.wms.pms_projection.services.read_service import WmsPmsProjectionReadService
+from app.wms.pms_projection.services.rebuild_service import WmsPmsProjectionRebuildService
+from app.wms.scan.services.scan_orchestrator_item_resolver import (
+    probe_item_from_barcode,
+    resolve_item_id_from_sku,
+)
+
+
+async def _rebuild(session: AsyncSession) -> None:
+    await WmsPmsProjectionRebuildService(session).rebuild_all()
+    await session.flush()
+
+
+async def test_wms_pms_projection_read_service_resolves_barcode_and_sku_code(
+    session: AsyncSession,
+) -> None:
+    await _rebuild(session)
+
+    barcode_row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  b.barcode,
+                  b.item_id,
+                  b.item_uom_id,
+                  b.symbology,
+                  u.ratio_to_base,
+                  COALESCE(NULLIF(u.display_name, ''), u.uom) AS uom_name
+                FROM item_barcodes b
+                JOIN item_uoms u
+                  ON u.id = b.item_uom_id
+                 AND u.item_id = b.item_id
+                WHERE b.active = true
+                ORDER BY b.id ASC
+                LIMIT 1
+                """
+            )
+        )
+    ).mappings().one()
+
+    svc = WmsPmsProjectionReadService(session)
+    resolved = await svc.aprobe_barcode(barcode=str(barcode_row["barcode"]))
+
+    assert resolved is not None
+    assert resolved.item_id == int(barcode_row["item_id"])
+    assert resolved.item_uom_id == int(barcode_row["item_uom_id"])
+    assert resolved.ratio_to_base == int(barcode_row["ratio_to_base"])
+    assert resolved.symbology == str(barcode_row["symbology"])
+    assert resolved.active is True
+    assert resolved.uom_name == str(barcode_row["uom_name"])
+
+    sku_row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  id,
+                  item_id,
+                  code
+                FROM item_sku_codes
+                WHERE is_active = true
+                ORDER BY id ASC
+                LIMIT 1
+                """
+            )
+        )
+    ).mappings().one()
+
+    item_id = await svc.aresolve_active_sku_code_item_id(code=str(sku_row["code"]).lower())
+    assert item_id == int(sku_row["item_id"])
+
+
+async def test_scan_resolver_uses_wms_projection_not_pms_owner_tables(
+    session: AsyncSession,
+) -> None:
+    await _rebuild(session)
+
+    suffix = uuid4().hex[:10]
+    barcode = f"PRJ4-BAR-{suffix}"
+    sku_code = f"PRJ4-SKU-{suffix}"
+
+    barcode_projection = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  b.barcode_id,
+                  b.item_id,
+                  b.item_uom_id,
+                  u.ratio_to_base
+                FROM wms_pms_item_barcode_projection b
+                JOIN wms_pms_item_uom_projection u
+                  ON u.item_uom_id = b.item_uom_id
+                 AND u.item_id = b.item_id
+                ORDER BY b.barcode_id ASC
+                LIMIT 1
+                """
+            )
+        )
+    ).mappings().one()
+
+    sku_projection = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  sku_code_id,
+                  item_id
+                FROM wms_pms_item_sku_code_projection
+                ORDER BY sku_code_id ASC
+                LIMIT 1
+                """
+            )
+        )
+    ).mappings().one()
+
+    await session.execute(
+        text(
+            """
+            UPDATE wms_pms_item_barcode_projection
+            SET
+              barcode = :barcode,
+              updated_at = now()
+            WHERE barcode_id = :barcode_id
+            """
+        ),
+        {
+            "barcode": barcode,
+            "barcode_id": int(barcode_projection["barcode_id"]),
+        },
+    )
+
+    await session.execute(
+        text(
+            """
+            UPDATE wms_pms_item_sku_code_projection
+            SET
+              code = :code,
+              updated_at = now()
+            WHERE sku_code_id = :sku_code_id
+            """
+        ),
+        {
+            "code": sku_code,
+            "sku_code_id": int(sku_projection["sku_code_id"]),
+        },
+    )
+
+    resolved_barcode = await probe_item_from_barcode(session, barcode)
+    assert resolved_barcode is not None
+    assert resolved_barcode.item_id == int(barcode_projection["item_id"])
+    assert resolved_barcode.item_uom_id == int(barcode_projection["item_uom_id"])
+    assert resolved_barcode.ratio_to_base == int(barcode_projection["ratio_to_base"])
+
+    resolved_sku_item_id = await resolve_item_id_from_sku(session, sku_code.lower())
+    assert resolved_sku_item_id == int(sku_projection["item_id"])


### PR DESCRIPTION
## Summary
- add WMS PMS projection read service
- switch WMS scan barcode and SKU-code resolution to local PMS projection
- switch return inbound task barcode probe to local PMS projection
- keep inbound commit barcode resolver unchanged for later high-risk core fact-chain work
- do not change ledger, inventory, count, lot, or stock write paths

## Validation
- python3 -m compileall app/wms/pms_projection app/wms/scan/services/scan_orchestrator_item_resolver.py app/wms/inventory_adjustment/return_inbound/services/inbound_task_probe_service.py tests/services/test_wms_pms_projection_read_service.py
- make upgrade-test
- TESTS="tests/services/test_wms_pms_projection_read_service.py tests/services/test_wms_pms_projection_rebuild_service.py" make test
- make rebuild-wms-pms-projection-test
- make alembic-check
- git diff --check