### PR TITLE
refactor(wms): use pms projection for inventory reads

### DIFF
--- a/app/wms/stock/repos/inventory_explain_repo.py
+++ b/app/wms/stock/repos/inventory_explain_repo.py
@@ -46,24 +46,24 @@ async def resolve_inventory_explain_anchor(
         f"""
         SELECT
             s.item_id,
-            i.name AS item_name,
+            COALESCE(p.name, '') AS item_name,
             s.warehouse_id,
             w.name AS warehouse_name,
             s.lot_id,
             l.lot_code,
             s.qty AS current_qty,
-            iu.id AS base_item_uom_id,
-            COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS base_uom_name
+            bu.item_uom_id AS base_item_uom_id,
+            COALESCE(NULLIF(bu.display_name, ''), bu.uom) AS base_uom_name
         FROM stocks_lot AS s
-        JOIN items AS i
-          ON i.id = s.item_id
+        LEFT JOIN wms_pms_item_projection AS p
+          ON p.item_id = s.item_id
         JOIN warehouses AS w
           ON w.id = s.warehouse_id
         LEFT JOIN lots AS l
           ON l.id = s.lot_id
-        LEFT JOIN item_uoms AS iu
-          ON iu.item_id = s.item_id
-         AND iu.is_base IS TRUE
+        LEFT JOIN wms_pms_item_uom_projection AS bu
+          ON bu.item_id = s.item_id
+         AND bu.is_base IS TRUE
         WHERE {" AND ".join(cond)}
         ORDER BY s.id ASC
         """
@@ -127,20 +127,20 @@ async def query_inventory_explain_ledger_rows(
                 sl.after_qty,
                 sl.trace_id,
                 sl.item_id,
-                i.name AS item_name,
+                COALESCE(p.name, '') AS item_name,
                 sl.warehouse_id,
                 sl.lot_id,
                 l.lot_code,
-                iu.id AS base_item_uom_id,
-                COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS base_uom_name
+                bu.item_uom_id AS base_item_uom_id,
+                COALESCE(NULLIF(bu.display_name, ''), bu.uom) AS base_uom_name
             FROM stock_ledger AS sl
-            JOIN items AS i
-              ON i.id = sl.item_id
+            LEFT JOIN wms_pms_item_projection AS p
+              ON p.item_id = sl.item_id
             LEFT JOIN lots AS l
               ON l.id = sl.lot_id
-            LEFT JOIN item_uoms AS iu
-              ON iu.item_id = sl.item_id
-             AND iu.is_base IS TRUE
+            LEFT JOIN wms_pms_item_uom_projection AS bu
+              ON bu.item_id = sl.item_id
+             AND bu.is_base IS TRUE
             WHERE sl.item_id = :item_id
               AND sl.warehouse_id = :warehouse_id
               AND sl.lot_id = :lot_id

--- a/app/wms/stock/repos/inventory_options_repo.py
+++ b/app/wms/stock/repos/inventory_options_repo.py
@@ -41,23 +41,23 @@ async def list_public_items(
     q: str | None,
     limit: int,
 ) -> list[dict[str, Any]]:
-    cond = ["i.enabled = TRUE"]
+    cond = ["p.enabled = TRUE"]
     params: dict[str, Any] = {"limit": int(limit)}
 
     q_norm = _norm_text(q)
     if q_norm is not None:
-        cond.append("(i.name ILIKE :q OR i.sku ILIKE :q)")
+        cond.append("(p.name ILIKE :q OR p.sku ILIKE :q)")
         params["q"] = f"%{q_norm}%"
 
     sql = text(
         f"""
         SELECT
-            i.id,
-            i.sku,
-            i.name
-        FROM items AS i
+            p.item_id AS id,
+            p.sku,
+            p.name
+        FROM wms_pms_item_projection AS p
         WHERE {" AND ".join(cond)}
-        ORDER BY i.name ASC, i.id ASC
+        ORDER BY p.name ASC, p.item_id ASC
         LIMIT :limit
         """
     )

--- a/app/wms/stock/repos/inventory_read_repo.py
+++ b/app/wms/stock/repos/inventory_read_repo.py
@@ -28,7 +28,7 @@ def _build_inventory_where(
     lot_norm = _norm_text(lot_code)
 
     if q_norm is not None:
-        cond.append("(i.name ILIKE :q OR i.sku ILIKE :q)")
+        cond.append("(p.name ILIKE :q OR p.sku ILIKE :q)")
         params["q"] = f"%{q_norm}%"
 
     if item_id is not None:
@@ -82,15 +82,10 @@ async def query_inventory_rows(
                 s.warehouse_id,
                 s.lot_id
             FROM stocks_lot AS s
-            JOIN items AS i
-              ON i.id = s.item_id
-            JOIN warehouses AS w
-              ON w.id = s.warehouse_id
+            LEFT JOIN wms_pms_item_projection AS p
+              ON p.item_id = s.item_id
             LEFT JOIN lots AS l
               ON l.id = s.lot_id
-            LEFT JOIN item_uoms AS iu
-              ON iu.item_id = s.item_id
-             AND iu.is_base IS TRUE
             WHERE {where_sql}
         )
         SELECT COUNT(*)::int AS total
@@ -102,45 +97,44 @@ async def query_inventory_rows(
 
     list_sql = text(
         f"""
+        WITH primary_barcodes AS (
+            SELECT DISTINCT ON (pb.item_id)
+                pb.item_id,
+                pb.barcode
+            FROM wms_pms_item_barcode_projection AS pb
+            WHERE pb.active IS TRUE
+            ORDER BY pb.item_id ASC, pb.is_primary DESC, pb.barcode_id ASC
+        )
         SELECT
             s.item_id,
-            i.name AS item_name,
-            i.sku AS item_code,
-            i.spec AS spec,
-            b.name_cn AS brand,
-            c.category_name AS category,
+            COALESCE(p.name, '') AS item_name,
+            p.sku AS item_code,
+            p.spec AS spec,
+            NULL::text AS brand,
+            NULL::text AS category,
             s.warehouse_id,
             w.name AS warehouse_name,
             l.lot_code AS lot_code,
             l.production_date AS production_date,
             l.expiry_date AS expiry_date,
             s.qty,
-            iu.id AS base_item_uom_id,
-            COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS base_uom_name,
-            (
-                SELECT ib.barcode
-                FROM item_barcodes AS ib
-                WHERE ib.item_id = s.item_id
-                  AND ib.active = TRUE
-                ORDER BY ib.is_primary DESC, ib.id ASC
-                LIMIT 1
-            ) AS main_barcode
+            bu.item_uom_id AS base_item_uom_id,
+            COALESCE(NULLIF(bu.display_name, ''), bu.uom) AS base_uom_name,
+            pb.barcode AS main_barcode
         FROM stocks_lot AS s
-        JOIN items AS i
-          ON i.id = s.item_id
-        LEFT JOIN pms_brands AS b
-          ON b.id = i.brand_id
-        LEFT JOIN pms_business_categories AS c
-          ON c.id = i.category_id
+        LEFT JOIN wms_pms_item_projection AS p
+          ON p.item_id = s.item_id
         JOIN warehouses AS w
           ON w.id = s.warehouse_id
         LEFT JOIN lots AS l
           ON l.id = s.lot_id
-        LEFT JOIN item_uoms AS iu
-          ON iu.item_id = s.item_id
-         AND iu.is_base IS TRUE
+        LEFT JOIN wms_pms_item_uom_projection AS bu
+          ON bu.item_id = s.item_id
+         AND bu.is_base IS TRUE
+        LEFT JOIN primary_barcodes AS pb
+          ON pb.item_id = s.item_id
         WHERE {where_sql}
-        ORDER BY i.name ASC, s.item_id ASC, s.warehouse_id ASC, l.lot_code NULLS FIRST
+        ORDER BY COALESCE(p.name, '') ASC, s.item_id ASC, s.warehouse_id ASC, l.lot_code NULLS FIRST
         OFFSET :offset
         LIMIT :limit
         """
@@ -174,9 +168,9 @@ async def query_inventory_detail_rows(
         f"""
         SELECT
             s.item_id,
-            i.name AS item_name,
-            iu.id AS base_item_uom_id,
-            COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS base_uom_name,
+            COALESCE(p.name, '') AS item_name,
+            bu.item_uom_id AS base_item_uom_id,
+            COALESCE(NULLIF(bu.display_name, ''), bu.uom) AS base_uom_name,
             s.warehouse_id,
             w.name AS warehouse_name,
             l.lot_code AS lot_code,
@@ -184,19 +178,15 @@ async def query_inventory_detail_rows(
             l.expiry_date AS expiry_date,
             s.qty
         FROM stocks_lot AS s
-        JOIN items AS i
-          ON i.id = s.item_id
-        LEFT JOIN pms_brands AS b
-          ON b.id = i.brand_id
-        LEFT JOIN pms_business_categories AS c
-          ON c.id = i.category_id
+        LEFT JOIN wms_pms_item_projection AS p
+          ON p.item_id = s.item_id
         JOIN warehouses AS w
           ON w.id = s.warehouse_id
         LEFT JOIN lots AS l
           ON l.id = s.lot_id
-        LEFT JOIN item_uoms AS iu
-          ON iu.item_id = s.item_id
-         AND iu.is_base IS TRUE
+        LEFT JOIN wms_pms_item_uom_projection AS bu
+          ON bu.item_id = s.item_id
+         AND bu.is_base IS TRUE
         WHERE {" AND ".join(cond)}
         ORDER BY s.warehouse_id ASC, l.lot_code NULLS FIRST
         """


### PR DESCRIPTION
## Summary
- switch WMS inventory options to WMS-local PMS item projection
- switch stock inventory list/detail display reads to WMS-local PMS projection
- switch inventory explain anchor and ledger display joins to WMS-local PMS projection
- remove direct PMS owner table reads from PR-5A target repos
- do not change inbound commit, return inbound operation submit, count, lot creation, ledger write, or stock write paths

## Validation
- python3 -m compileall app/wms/stock/repos/inventory_options_repo.py app/wms/stock/repos/inventory_read_repo.py app/wms/stock/repos/inventory_explain_repo.py
- make upgrade-test
- make rebuild-wms-pms-projection-test
- TESTS="tests/api/test_stock_inventory_read_api.py tests/services/test_wms_pms_projection_rebuild_service.py tests/services/test_wms_pms_projection_read_service.py" make test
- make alembic-check
- git diff --check
- rg audit confirms PR-5A target repos no longer directly read PMS owner tables