### PR TITLE
refactor(wms): use pms projection for ledger reads

### DIFF
--- a/app/wms/ledger/helpers/__init__.py
+++ b/app/wms/ledger/helpers/__init__.py
@@ -1,7 +1,7 @@
 # app/wms/ledger/helpers/__init__.py
 
 from app.wms.ledger.helpers.stock_ledger import (
-    ITEMS_TABLE,
+    PMS_ITEM_PROJECTION_TABLE,
     apply_common_filters_rows,
     build_base_ids_stmt,
     build_common_filters,
@@ -13,7 +13,7 @@ from app.wms.ledger.helpers.stock_ledger import (
 )
 
 __all__ = [
-    "ITEMS_TABLE",
+    "PMS_ITEM_PROJECTION_TABLE",
     "apply_common_filters_rows",
     "build_base_ids_stmt",
     "build_common_filters",

--- a/app/wms/ledger/helpers/stock_ledger.py
+++ b/app/wms/ledger/helpers/stock_ledger.py
@@ -12,12 +12,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.wms.shared.services.lot_code_contract import normalize_optional_lot_code
-from app.pms.items.models.item import Item
+from app.wms.pms_projection.models.projection import WmsPmsItemProjection
 from app.wms.stock.models.lot import Lot
 from app.wms.ledger.models.stock_ledger import StockLedger
 from app.wms.ledger.contracts.stock_ledger import LedgerQuery
 
-ITEMS_TABLE = Item.__table__
+PMS_ITEM_PROJECTION_TABLE = WmsPmsItemProjection.__table__
 
 
 def normalize_time_range(q: LedgerQuery) -> Tuple[datetime, datetime]:
@@ -233,7 +233,7 @@ def build_base_ids_stmt(q: LedgerQuery, time_from: datetime, time_to: datetime):
     按查询条件构造基础 SQL（只选中符合条件的 id 列表）：
 
     - 支持按 item_id / warehouse_id / lot_id / lot_code / reason / reason_canon / sub_reason / ref / trace_id / 时间过滤；
-    - 支持按 item_keyword 模糊匹配 items.name / items.sku；
+    - 支持按 item_keyword 模糊匹配 wms_pms_item_projection.name / sku；
     - 不再依赖 stock_id / batch_id，完全对齐当前 StockLedger 模型。
     """
     stmt = select(StockLedger.id).select_from(StockLedger)
@@ -242,11 +242,14 @@ def build_base_ids_stmt(q: LedgerQuery, time_from: datetime, time_to: datetime):
     # item_keyword 模糊搜索：name/sku
     if q.item_keyword:
         kw = f"%{q.item_keyword.strip()}%"
-        stmt = stmt.join(Item, Item.id == StockLedger.item_id)
+        stmt = stmt.join(
+            WmsPmsItemProjection,
+            WmsPmsItemProjection.item_id == StockLedger.item_id,
+        )
         conditions.append(
             sa.or_(
-                Item.name.ilike(kw),
-                Item.sku.ilike(kw),
+                WmsPmsItemProjection.name.ilike(kw),
+                WmsPmsItemProjection.sku.ilike(kw),
             )
         )
 

--- a/app/wms/ledger/routers/stock_ledger_routes_query.py
+++ b/app/wms/ledger/routers/stock_ledger_routes_query.py
@@ -78,15 +78,15 @@ def register(router: APIRouter) -> None:
                 sa.text(
                     """
                     SELECT
-                      i.id,
-                      i.name,
-                      iu.id AS base_item_uom_id,
-                      COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS base_uom_name
-                    FROM items AS i
-                    LEFT JOIN item_uoms AS iu
-                      ON iu.item_id = i.id
-                     AND iu.is_base IS TRUE
-                    WHERE i.id = ANY(:ids)
+                      p.item_id AS id,
+                      p.name,
+                      bu.item_uom_id AS base_item_uom_id,
+                      COALESCE(NULLIF(bu.display_name, ''), bu.uom) AS base_uom_name
+                    FROM wms_pms_item_projection AS p
+                    LEFT JOIN wms_pms_item_uom_projection AS bu
+                      ON bu.item_id = p.item_id
+                     AND bu.is_base IS TRUE
+                    WHERE p.item_id = ANY(:ids)
                     """
                 ),
                 {"ids": item_ids},

--- a/app/wms/ledger/routers/stock_ledger_routes_query_history.py
+++ b/app/wms/ledger/routers/stock_ledger_routes_query_history.py
@@ -306,15 +306,15 @@ def register(router: APIRouter) -> None:
                 text(
                     """
                     SELECT
-                      i.id,
-                      i.name,
-                      iu.id AS base_item_uom_id,
-                      COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS base_uom_name
-                    FROM items AS i
-                    LEFT JOIN item_uoms AS iu
-                      ON iu.item_id = i.id
-                     AND iu.is_base IS TRUE
-                    WHERE i.id = ANY(:ids)
+                      p.item_id AS id,
+                      p.name,
+                      bu.item_uom_id AS base_item_uom_id,
+                      COALESCE(NULLIF(bu.display_name, ''), bu.uom) AS base_uom_name
+                    FROM wms_pms_item_projection AS p
+                    LEFT JOIN wms_pms_item_uom_projection AS bu
+                      ON bu.item_id = p.item_id
+                     AND bu.is_base IS TRUE
+                    WHERE p.item_id = ANY(:ids)
                     """
                 ),
                 {"ids": item_ids},

--- a/app/wms/ledger/routers/stock_ledger_routes_summary.py
+++ b/app/wms/ledger/routers/stock_ledger_routes_summary.py
@@ -12,7 +12,7 @@ from app.db.session import get_session
 from app.wms.ledger.models.stock_ledger import StockLedger
 from app.wms.ledger.contracts.stock_ledger import LedgerQuery, LedgerReasonStat, LedgerSummary
 from app.wms.ledger.helpers.stock_ledger import (
-    ITEMS_TABLE,
+    PMS_ITEM_PROJECTION_TABLE,
     build_common_filters,
     normalize_time_range,
 )
@@ -38,11 +38,14 @@ def register(router: APIRouter) -> None:
 
         if payload.item_keyword:
             kw = f"%{payload.item_keyword.strip()}%"
-            stmt = stmt.join(ITEMS_TABLE, ITEMS_TABLE.c.id == StockLedger.item_id)
+            stmt = stmt.join(
+                PMS_ITEM_PROJECTION_TABLE,
+                PMS_ITEM_PROJECTION_TABLE.c.item_id == StockLedger.item_id,
+            )
             conditions.append(
                 sa.or_(
-                    ITEMS_TABLE.c.name.ilike(kw),
-                    ITEMS_TABLE.c.sku.ilike(kw),
+                    PMS_ITEM_PROJECTION_TABLE.c.name.ilike(kw),
+                    PMS_ITEM_PROJECTION_TABLE.c.sku.ilike(kw),
                 )
             )
 


### PR DESCRIPTION
## Summary
- switch ledger query/history display enrichment to WMS-local PMS projection
- switch ledger item_keyword filtering to WMS-local PMS projection
- switch ledger summary item_keyword filtering to WMS-local PMS projection
- remove direct PMS owner table reads from PR-5B target ledger read files
- do not change stock_ledger writing, inbound commit, return inbound operation submit, count, lot creation, or stock write paths

## Validation
- python3 -m compileall app/wms/ledger/helpers/stock_ledger.py app/wms/ledger/helpers/__init__.py app/wms/ledger/routers/stock_ledger_routes_query.py app/wms/ledger/routers/stock_ledger_routes_query_history.py app/wms/ledger/routers/stock_ledger_routes_summary.py
- make upgrade-test
- make rebuild-wms-pms-projection-test
- TESTS="tests/api/test_stock_ledger_lot_code_alias_api.py tests/contracts/test_stock_ledger_sub_reason_contract.py tests/unit/test_ledger_lot_code_aliases.py tests/services/test_wms_pms_projection_rebuild_service.py tests/services/test_wms_pms_projection_read_service.py" make test
- make alembic-check
- git diff --check
- rg audit confirms PR-5B target ledger read files no longer directly read PMS owner tables