### PR TITLE
refactor(wms): use pms projection for low risk reads

### DIFF
--- a/app/wms/inbound/services/inbound_event_read_service.py
+++ b/app/wms/inbound/services/inbound_event_read_service.py
@@ -188,10 +188,14 @@ async def get_inbound_event_detail(
         SELECT
             iel.line_no,
             iel.item_id,
-            it.name AS item_name,
-            it.sku AS item_sku,
+            COALESCE(NULLIF(iel.item_name_snapshot, ''), p.name) AS item_name,
+            p.sku AS item_sku,
             iel.actual_uom_id,
-            COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS actual_uom_name,
+            COALESCE(
+              NULLIF(iel.actual_uom_name_snapshot, ''),
+              NULLIF(pu.display_name, ''),
+              pu.uom
+            ) AS actual_uom_name,
             iel.barcode_input,
             iel.actual_qty_input,
             iel.actual_ratio_to_base_snapshot,
@@ -204,10 +208,11 @@ async def get_inbound_event_detail(
             iel.po_line_id,
             iel.remark
           FROM inbound_event_lines AS iel
-          LEFT JOIN items AS it
-            ON it.id = iel.item_id
-          LEFT JOIN item_uoms AS iu
-            ON iu.id = iel.actual_uom_id
+          LEFT JOIN wms_pms_item_projection AS p
+            ON p.item_id = iel.item_id
+          LEFT JOIN wms_pms_item_uom_projection AS pu
+            ON pu.item_uom_id = iel.actual_uom_id
+           AND pu.item_id = iel.item_id
           LEFT JOIN lots AS lo
             ON lo.id = iel.lot_id
          WHERE iel.event_id = :event_id

--- a/app/wms/inventory_adjustment/summary/repos/summary_repo.py
+++ b/app/wms/inventory_adjustment/summary/repos/summary_repo.py
@@ -323,7 +323,6 @@ async def list_inventory_adjustment_summary_rows(
     return total, [dict(r) for r in rows]
 
 
-
 async def get_inventory_adjustment_summary_row(
     session: AsyncSession,
     *,
@@ -406,11 +405,11 @@ async def list_inventory_adjustment_summary_ledger_rows(
           l.trace_id,
           l.warehouse_id,
           l.item_id,
-          i.name AS item_name,
+          p.name AS item_name,
           l.lot_id,
           lo.lot_code,
-          iu.id AS base_item_uom_id,
-          COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS base_uom_name,
+          bu.item_uom_id AS base_item_uom_id,
+          COALESCE(NULLIF(bu.display_name, ''), bu.uom) AS base_uom_name,
           l.reason,
           l.reason_canon,
           l.sub_reason,
@@ -421,11 +420,11 @@ async def list_inventory_adjustment_summary_ledger_rows(
         FROM target_event t
         JOIN stock_ledger l
           ON l.event_id = t.event_id
-        LEFT JOIN items i
-          ON i.id = l.item_id
-        LEFT JOIN item_uoms iu
-          ON iu.item_id = l.item_id
-         AND iu.is_base IS TRUE
+        LEFT JOIN wms_pms_item_projection p
+          ON p.item_id = l.item_id
+        LEFT JOIN wms_pms_item_uom_projection bu
+          ON bu.item_id = l.item_id
+         AND bu.is_base IS TRUE
         LEFT JOIN lots lo
           ON lo.id = l.lot_id
         ORDER BY l.ref_line ASC, l.id ASC


### PR DESCRIPTION
## Summary
- switch inbound event detail display enrichment to WMS-local PMS projection
- switch inventory adjustment summary ledger display enrichment to WMS-local PMS projection
- remove direct PMS owner table reads from PR-5C target read files
- do not change inbound commit, return inbound write, count submit, lot creation, stock adjust, ledger write, or stock write paths

## Validation
- python3 -m compileall app/wms/inbound/services/inbound_event_read_service.py app/wms/inventory_adjustment/summary/repos/summary_repo.py
- make upgrade-test
- make rebuild-wms-pms-projection-test
- TESTS="tests/api/test_inventory_adjustment_summary_api.py tests/api/test_inbound_receipts_manual_api.py tests/services/test_inbound_commit_event_link.py tests/services/test_wms_pms_projection_rebuild_service.py tests/services/test_wms_pms_projection_read_service.py" make test
- make alembic-check
- git diff --check
- rg audit confirms PR-5C target files no longer directly read PMS owner tables