### PR TITLE
feat(wms): expand pms projection read contract

### DIFF
--- a/app/wms/pms_projection/services/read_service.py
+++ b/app/wms/pms_projection/services/read_service.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
 
 import sqlalchemy as sa
 from sqlalchemy import select
@@ -12,6 +14,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.wms.pms_projection.models.projection import (
     WmsPmsItemBarcodeProjection,
+    WmsPmsItemPolicyProjection,
+    WmsPmsItemProjection,
     WmsPmsItemSkuCodeProjection,
     WmsPmsItemUomProjection,
 )
@@ -29,6 +33,51 @@ def _uom_name(*, uom: str, display_name: str | None) -> str:
     return str(uom or "").strip()
 
 
+def _enum_text(value: object) -> str:
+    raw = getattr(value, "value", value)
+    return str(raw or "").strip()
+
+
+@dataclass(frozen=True, slots=True)
+class WmsPmsItemProjectionSnapshot:
+    item_id: int
+    sku: str
+    name: str
+    spec: str | None
+    enabled: bool
+    brand_id: int | None
+    category_id: int | None
+    source_updated_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class WmsPmsUomProjectionSnapshot:
+    item_uom_id: int
+    item_id: int
+    uom: str
+    display_name: str | None
+    uom_name: str
+    ratio_to_base: int
+    is_base: bool
+    is_purchase_default: bool
+    is_inbound_default: bool
+    is_outbound_default: bool
+    net_weight_kg: Decimal | None
+    source_updated_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class WmsPmsPolicyProjectionSnapshot:
+    item_id: int
+    lot_source_policy: str
+    expiry_policy: str
+    shelf_life_value: int | None
+    shelf_life_unit: str | None
+    derivation_allowed: bool
+    uom_governance_enabled: bool
+    source_updated_at: datetime
+
+
 @dataclass(frozen=True, slots=True)
 class WmsPmsBarcodeProjectionResolution:
     item_id: int
@@ -41,6 +90,55 @@ class WmsPmsBarcodeProjectionResolution:
     uom_name: str
 
 
+def _item_snapshot(row: WmsPmsItemProjection) -> WmsPmsItemProjectionSnapshot:
+    return WmsPmsItemProjectionSnapshot(
+        item_id=int(row.item_id),
+        sku=str(row.sku),
+        name=str(row.name),
+        spec=_norm_text(row.spec),
+        enabled=bool(row.enabled),
+        brand_id=int(row.brand_id) if row.brand_id is not None else None,
+        category_id=int(row.category_id) if row.category_id is not None else None,
+        source_updated_at=row.source_updated_at,
+    )
+
+
+def _uom_snapshot(row: WmsPmsItemUomProjection) -> WmsPmsUomProjectionSnapshot:
+    display_name = _norm_text(row.display_name)
+    uom = str(row.uom)
+    return WmsPmsUomProjectionSnapshot(
+        item_uom_id=int(row.item_uom_id),
+        item_id=int(row.item_id),
+        uom=uom,
+        display_name=display_name,
+        uom_name=_uom_name(uom=uom, display_name=display_name),
+        ratio_to_base=int(row.ratio_to_base),
+        is_base=bool(row.is_base),
+        is_purchase_default=bool(row.is_purchase_default),
+        is_inbound_default=bool(row.is_inbound_default),
+        is_outbound_default=bool(row.is_outbound_default),
+        net_weight_kg=row.net_weight_kg,
+        source_updated_at=row.source_updated_at,
+    )
+
+
+def _policy_snapshot(row: WmsPmsItemPolicyProjection) -> WmsPmsPolicyProjectionSnapshot:
+    return WmsPmsPolicyProjectionSnapshot(
+        item_id=int(row.item_id),
+        lot_source_policy=_enum_text(row.lot_source_policy),
+        expiry_policy=_enum_text(row.expiry_policy),
+        shelf_life_value=(
+            int(row.shelf_life_value)
+            if row.shelf_life_value is not None
+            else None
+        ),
+        shelf_life_unit=_norm_text(row.shelf_life_unit),
+        derivation_allowed=bool(row.derivation_allowed),
+        uom_governance_enabled=bool(row.uom_governance_enabled),
+        source_updated_at=row.source_updated_at,
+    )
+
+
 class WmsPmsProjectionReadService:
     """
     WMS PMS projection 只读服务。
@@ -48,16 +146,103 @@ class WmsPmsProjectionReadService:
     当前职责：
     - barcode -> item / item_uom / ratio_to_base；
     - sku code -> item_id；
-    - item_uom -> uom_name。
+    - item / uom / policy projection snapshot；
+    - base / inbound default UOM lookup。
 
     明确不负责：
     - 不读取 PMS owner 表；
     - 不修改 projection；
-    - 不承担库存提交语义。
+    - 不承担库存提交语义；
+    - 不创建 lot / ledger / stock fact。
     """
 
     def __init__(self, session: AsyncSession) -> None:
         self.session = session
+
+    async def aget_item_snapshot(
+        self,
+        *,
+        item_id: int,
+        enabled_only: bool = False,
+    ) -> WmsPmsItemProjectionSnapshot | None:
+        stmt = (
+            select(WmsPmsItemProjection)
+            .where(WmsPmsItemProjection.item_id == int(item_id))
+            .limit(1)
+        )
+        if enabled_only:
+            stmt = stmt.where(WmsPmsItemProjection.enabled.is_(True))
+
+        row = (await self.session.execute(stmt)).scalar_one_or_none()
+        if row is None:
+            return None
+        return _item_snapshot(row)
+
+    async def aget_uom_snapshot(
+        self,
+        *,
+        item_id: int,
+        item_uom_id: int,
+    ) -> WmsPmsUomProjectionSnapshot | None:
+        stmt = (
+            select(WmsPmsItemUomProjection)
+            .where(WmsPmsItemUomProjection.item_id == int(item_id))
+            .where(WmsPmsItemUomProjection.item_uom_id == int(item_uom_id))
+            .limit(1)
+        )
+        row = (await self.session.execute(stmt)).scalar_one_or_none()
+        if row is None:
+            return None
+        return _uom_snapshot(row)
+
+    async def aget_base_uom_snapshot(
+        self,
+        *,
+        item_id: int,
+    ) -> WmsPmsUomProjectionSnapshot | None:
+        stmt = (
+            select(WmsPmsItemUomProjection)
+            .where(WmsPmsItemUomProjection.item_id == int(item_id))
+            .where(WmsPmsItemUomProjection.is_base.is_(True))
+            .order_by(WmsPmsItemUomProjection.item_uom_id.asc())
+            .limit(1)
+        )
+        row = (await self.session.execute(stmt)).scalar_one_or_none()
+        if row is None:
+            return None
+        return _uom_snapshot(row)
+
+    async def aget_inbound_default_uom_snapshot(
+        self,
+        *,
+        item_id: int,
+    ) -> WmsPmsUomProjectionSnapshot | None:
+        stmt = (
+            select(WmsPmsItemUomProjection)
+            .where(WmsPmsItemUomProjection.item_id == int(item_id))
+            .where(WmsPmsItemUomProjection.is_inbound_default.is_(True))
+            .order_by(WmsPmsItemUomProjection.item_uom_id.asc())
+            .limit(1)
+        )
+        row = (await self.session.execute(stmt)).scalar_one_or_none()
+        if row is None:
+            return None
+        return _uom_snapshot(row)
+
+    async def aget_policy_snapshot(
+        self,
+        *,
+        item_id: int,
+    ) -> WmsPmsPolicyProjectionSnapshot | None:
+        stmt = (
+            select(WmsPmsItemPolicyProjection)
+            .where(WmsPmsItemPolicyProjection.item_id == int(item_id))
+            .limit(1)
+        )
+        row = (await self.session.execute(stmt)).scalar_one_or_none()
+        if row is None:
+            return None
+        return _policy_snapshot(row)
 
     async def aprobe_barcode(
         self,
@@ -92,22 +277,17 @@ class WmsPmsProjectionReadService:
             return None
 
         barcode_row, uom_row = row
+        display_name = _norm_text(uom_row.display_name)
+        uom = str(uom_row.uom)
         return WmsPmsBarcodeProjectionResolution(
             item_id=int(barcode_row.item_id),
             item_uom_id=int(barcode_row.item_uom_id),
             ratio_to_base=int(uom_row.ratio_to_base),
             symbology=str(barcode_row.symbology),
             active=bool(barcode_row.active),
-            uom=str(uom_row.uom),
-            display_name=(
-                str(uom_row.display_name).strip()
-                if uom_row.display_name is not None
-                else None
-            ),
-            uom_name=_uom_name(
-                uom=str(uom_row.uom),
-                display_name=uom_row.display_name,
-            ),
+            uom=uom,
+            display_name=display_name,
+            uom_name=_uom_name(uom=uom, display_name=display_name),
         )
 
     async def aresolve_active_sku_code_item_id(self, *, code: str) -> int | None:
@@ -137,21 +317,19 @@ class WmsPmsProjectionReadService:
         if item_uom_id is None:
             return None
 
-        stmt = (
-            select(WmsPmsItemUomProjection.uom, WmsPmsItemUomProjection.display_name)
-            .where(WmsPmsItemUomProjection.item_uom_id == int(item_uom_id))
-            .where(WmsPmsItemUomProjection.item_id == int(item_id))
-            .limit(1)
+        uom = await self.aget_uom_snapshot(
+            item_id=int(item_id),
+            item_uom_id=int(item_uom_id),
         )
-        row = (await self.session.execute(stmt)).first()
-        if row is None:
+        if uom is None:
             return None
-
-        uom, display_name = row
-        return _uom_name(uom=str(uom), display_name=display_name)
+        return uom.uom_name
 
 
 __all__ = [
+    "WmsPmsItemProjectionSnapshot",
+    "WmsPmsUomProjectionSnapshot",
+    "WmsPmsPolicyProjectionSnapshot",
     "WmsPmsBarcodeProjectionResolution",
     "WmsPmsProjectionReadService",
 ]

--- a/tests/services/test_wms_pms_projection_read_service.py
+++ b/tests/services/test_wms_pms_projection_read_service.py
@@ -78,6 +78,150 @@ async def test_wms_pms_projection_read_service_resolves_barcode_and_sku_code(
     assert item_id == int(sku_row["item_id"])
 
 
+async def test_wms_pms_projection_read_service_returns_item_uom_policy_snapshots(
+    session: AsyncSession,
+) -> None:
+    await _rebuild(session)
+
+    source = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  p.item_id,
+                  p.sku,
+                  p.name,
+                  p.spec,
+                  p.enabled,
+                  p.brand_id,
+                  p.category_id,
+                  bu.item_uom_id AS base_item_uom_id,
+                  bu.uom AS base_uom,
+                  bu.display_name AS base_display_name,
+                  COALESCE(NULLIF(bu.display_name, ''), bu.uom) AS base_uom_name,
+                  bu.ratio_to_base AS base_ratio_to_base,
+                  bu.net_weight_kg AS base_net_weight_kg,
+                  iu.item_uom_id AS inbound_item_uom_id,
+                  iu.uom AS inbound_uom,
+                  iu.display_name AS inbound_display_name,
+                  COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS inbound_uom_name,
+                  iu.ratio_to_base AS inbound_ratio_to_base,
+                  pol.lot_source_policy::text AS lot_source_policy,
+                  pol.expiry_policy::text AS expiry_policy,
+                  pol.shelf_life_value,
+                  pol.shelf_life_unit,
+                  pol.derivation_allowed,
+                  pol.uom_governance_enabled
+                FROM wms_pms_item_projection p
+                JOIN wms_pms_item_uom_projection bu
+                  ON bu.item_id = p.item_id
+                 AND bu.is_base IS TRUE
+                JOIN wms_pms_item_uom_projection iu
+                  ON iu.item_id = p.item_id
+                 AND iu.is_inbound_default IS TRUE
+                JOIN wms_pms_item_policy_projection pol
+                  ON pol.item_id = p.item_id
+                WHERE p.enabled IS TRUE
+                ORDER BY p.item_id ASC
+                LIMIT 1
+                """
+            )
+        )
+    ).mappings().one()
+
+    svc = WmsPmsProjectionReadService(session)
+    item_id = int(source["item_id"])
+
+    item_snapshot = await svc.aget_item_snapshot(item_id=item_id)
+    assert item_snapshot is not None
+    assert item_snapshot.item_id == item_id
+    assert item_snapshot.sku == str(source["sku"])
+    assert item_snapshot.name == str(source["name"])
+    assert item_snapshot.spec == source["spec"]
+    assert item_snapshot.enabled is True
+    assert item_snapshot.brand_id == (
+        int(source["brand_id"]) if source["brand_id"] is not None else None
+    )
+    assert item_snapshot.category_id == (
+        int(source["category_id"]) if source["category_id"] is not None else None
+    )
+
+    enabled_item_snapshot = await svc.aget_item_snapshot(
+        item_id=item_id,
+        enabled_only=True,
+    )
+    assert enabled_item_snapshot is not None
+    assert enabled_item_snapshot.item_id == item_id
+
+    base_uom = await svc.aget_uom_snapshot(
+        item_id=item_id,
+        item_uom_id=int(source["base_item_uom_id"]),
+    )
+    assert base_uom is not None
+    assert base_uom.item_uom_id == int(source["base_item_uom_id"])
+    assert base_uom.item_id == item_id
+    assert base_uom.uom == str(source["base_uom"])
+    assert base_uom.display_name == source["base_display_name"]
+    assert base_uom.uom_name == str(source["base_uom_name"])
+    assert base_uom.ratio_to_base == int(source["base_ratio_to_base"])
+    assert base_uom.is_base is True
+    assert base_uom.net_weight_kg == source["base_net_weight_kg"]
+
+    base_uom_by_default = await svc.aget_base_uom_snapshot(item_id=item_id)
+    assert base_uom_by_default is not None
+    assert base_uom_by_default.item_uom_id == int(source["base_item_uom_id"])
+
+    inbound_uom = await svc.aget_inbound_default_uom_snapshot(item_id=item_id)
+    assert inbound_uom is not None
+    assert inbound_uom.item_uom_id == int(source["inbound_item_uom_id"])
+    assert inbound_uom.uom == str(source["inbound_uom"])
+    assert inbound_uom.display_name == source["inbound_display_name"]
+    assert inbound_uom.uom_name == str(source["inbound_uom_name"])
+    assert inbound_uom.ratio_to_base == int(source["inbound_ratio_to_base"])
+    assert inbound_uom.is_inbound_default is True
+
+    uom_name = await svc.aget_uom_name(
+        item_id=item_id,
+        item_uom_id=int(source["base_item_uom_id"]),
+    )
+    assert uom_name == str(source["base_uom_name"])
+
+    policy = await svc.aget_policy_snapshot(item_id=item_id)
+    assert policy is not None
+    assert policy.item_id == item_id
+    assert policy.lot_source_policy == str(source["lot_source_policy"])
+    assert policy.expiry_policy == str(source["expiry_policy"])
+    assert policy.shelf_life_value == (
+        int(source["shelf_life_value"])
+        if source["shelf_life_value"] is not None
+        else None
+    )
+    assert policy.shelf_life_unit == source["shelf_life_unit"]
+    assert policy.derivation_allowed is bool(source["derivation_allowed"])
+    assert policy.uom_governance_enabled is bool(source["uom_governance_enabled"])
+
+    await session.execute(
+        text(
+            """
+            UPDATE wms_pms_item_projection
+            SET enabled = false
+            WHERE item_id = :item_id
+            """
+        ),
+        {"item_id": item_id},
+    )
+    assert await svc.aget_item_snapshot(item_id=item_id, enabled_only=True) is None
+    assert await svc.aget_item_snapshot(item_id=item_id, enabled_only=False) is not None
+
+    missing_item_id = 999_999_991
+    assert await svc.aget_item_snapshot(item_id=missing_item_id) is None
+    assert await svc.aget_uom_snapshot(item_id=missing_item_id, item_uom_id=1) is None
+    assert await svc.aget_base_uom_snapshot(item_id=missing_item_id) is None
+    assert await svc.aget_inbound_default_uom_snapshot(item_id=missing_item_id) is None
+    assert await svc.aget_policy_snapshot(item_id=missing_item_id) is None
+    assert await svc.aget_uom_name(item_id=missing_item_id, item_uom_id=1) is None
+
+
 async def test_scan_resolver_uses_wms_projection_not_pms_owner_tables(
     session: AsyncSession,
 ) -> None:


### PR DESCRIPTION
## Summary
- add WMS PMS item projection snapshot read contract
- add WMS PMS UOM projection snapshot read contract
- add WMS PMS policy projection snapshot read contract
- add base and inbound-default UOM projection lookups
- keep this PR as read-service-only groundwork for later high-risk fact-chain work

## Validation
- python3 -m compileall app/wms/pms_projection/services/read_service.py tests/services/test_wms_pms_projection_read_service.py
- make upgrade-test
- make rebuild-wms-pms-projection-test
- TESTS="tests/services/test_wms_pms_projection_read_service.py tests/services/test_wms_pms_projection_rebuild_service.py" make test
- make alembic-check
- git diff --check
- rg audit confirms projection read service does not read PMS owner tables