### PR TITLE
refactor(wms): use pms projection for inbound barcode resolve

### DIFF
--- a/app/wms/inbound/repos/barcode_resolve_repo.py
+++ b/app/wms/inbound/repos/barcode_resolve_repo.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.services.barcode_probe_service import BarcodeProbeService
+from app.wms.pms_projection.services.read_service import WmsPmsProjectionReadService
 
 
 @dataclass(frozen=True)
@@ -14,9 +14,9 @@ class InboundBarcodeResolved:
     入库条码解析结果。
 
     说明：
-    - 这是 WMS inbound 对 PMS export barcode probe 的轻包装
-    - 只承载入库提交链真正需要的最小字段
-    - 不承载 qty / event_id / lot 等仓内执行语义
+    - 这是 WMS inbound 对 WMS 本地 PMS projection 的轻包装；
+    - 只承载入库提交链真正需要的最小字段；
+    - 不承载 qty / event_id / lot 等仓内执行语义。
     """
 
     item_id: int
@@ -32,33 +32,30 @@ async def resolve_inbound_barcode(
     barcode: str,
 ) -> InboundBarcodeResolved | None:
     """
-    通过 PMS export barcode probe 解析入库条码。
+    通过 WMS PMS projection 解析入库条码。
 
     规则：
     - 空条码 => None
-    - 未绑定/异常 => None
+    - 未绑定/非 active => None
     - 已绑定 => 返回 item_id / item_uom_id / ratio_to_base 等最小结果
     """
     code = (barcode or "").strip()
     if not code:
         return None
 
-    probe = await BarcodeProbeService(session).aprobe(barcode=code)
-    if probe.status != "BOUND":
-        return None
-    if probe.item_id is None:
+    probe = await WmsPmsProjectionReadService(session).aprobe_barcode(
+        barcode=code,
+        active_only=True,
+    )
+    if probe is None:
         return None
 
     return InboundBarcodeResolved(
         item_id=int(probe.item_id),
-        item_uom_id=(
-            int(probe.item_uom_id) if probe.item_uom_id is not None else None
-        ),
-        ratio_to_base=(
-            int(probe.ratio_to_base) if probe.ratio_to_base is not None else None
-        ),
-        symbology=str(probe.symbology) if probe.symbology is not None else None,
-        active=bool(probe.active) if probe.active is not None else None,
+        item_uom_id=int(probe.item_uom_id),
+        ratio_to_base=int(probe.ratio_to_base),
+        symbology=str(probe.symbology),
+        active=bool(probe.active),
     )
 
 


### PR DESCRIPTION
## Summary
- switch inbound barcode resolver from PMS export barcode probe to WMS-local PMS projection
- keep inbound commit ratio lookup, item policy, lot resolution, and stock write logic unchanged
- keep this PR narrowly scoped to barcode resolution only

## Validation
- python3 -m compileall app/wms/inbound/repos/barcode_resolve_repo.py app/wms/pms_projection/services/read_service.py
- make upgrade-test
- make rebuild-wms-pms-projection-test
- TESTS="tests/services/test_inbound_commit_event_link.py tests/api/test_inbound_receipts_manual_api.py tests/services/test_wms_pms_projection_read_service.py tests/services/test_wms_pms_projection_rebuild_service.py" make test
- make alembic-check
- git diff --check
- rg audit confirms inbound barcode resolver no longer uses PMS export / owner tables