### PR TITLE
refactor(wms): use pms projection for item policy lookup

### DIFF
--- a/app/wms/inbound/repos/item_lookup_repo.py
+++ b/app/wms/inbound/repos/item_lookup_repo.py
@@ -2,17 +2,28 @@ from __future__ import annotations
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.contracts.item_policy import ItemPolicy
-from app.pms.export.items.services.item_read_service import ItemReadService
+from app.wms.pms_projection.services.read_service import (
+    WmsPmsPolicyProjectionSnapshot,
+    WmsPmsProjectionReadService,
+)
 
 
 async def get_item_policy_by_id(
     session: AsyncSession,
     *,
     item_id: int,
-) -> ItemPolicy | None:
-    svc = ItemReadService(session)
-    return await svc.aget_policy_by_id(item_id=int(item_id))
+) -> WmsPmsPolicyProjectionSnapshot | None:
+    """
+    WMS 执行侧商品策略读取入口。
+
+    策略必须来自 WMS 本地 PMS projection：
+    - 不直接读取 PMS owner items；
+    - 不远程依赖 PMS export API；
+    - 调用方拿到后必须继续把策略冻结进 lot / event / count 快照。
+    """
+    return await WmsPmsProjectionReadService(session).aget_policy_snapshot(
+        item_id=int(item_id),
+    )
 
 
 __all__ = ["get_item_policy_by_id"]


### PR DESCRIPTION
## Summary
- switch WMS item policy lookup from PMS export to WMS-local PMS policy projection
- keep inbound commit, expiry resolver, lot resolver, lot creation, count, and stock adjust logic otherwise unchanged
- keep this PR narrowly scoped to item policy lookup adapter

## Validation
- python3 -m compileall app/wms/inbound/repos/item_lookup_repo.py app/wms/inbound/services/inbound_commit_service.py app/wms/inbound/repos/lot_resolve_repo.py app/wms/stock/services/lot_service.py app/wms/pms_projection/services/read_service.py
- make upgrade-test
- make rebuild-wms-pms-projection-test
- TESTS="tests/services/test_inbound_commit_event_link.py tests/services/test_inbound_service.py tests/services/test_inbound_reversal_service.py tests/api/test_wms_receiving_batch_no_lot_code_contract_api.py tests/services/test_wms_pms_projection_read_service.py tests/services/test_wms_pms_projection_rebuild_service.py" make test
- make alembic-check
- git diff --check
- rg audit confirms item policy lookup no longer uses PMS export / owner tables