### PR TITLE
refactor(wms): use pms projection for expiry resolver

### DIFF
--- a/app/wms/shared/services/expiry_resolver.py
+++ b/app/wms/shared/services/expiry_resolver.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.services.item_read_service import ItemReadService
+from app.wms.pms_projection.services.read_service import WmsPmsProjectionReadService
 from app.wms.shared.services.expiry_rules import (
     ShelfLife,
     ShelfLifeUnit,
@@ -117,10 +117,11 @@ async def normalize_batch_dates_for_item(
     if production_date is None and expiry_date is None:
         return None, None, None
 
-    svc = ItemReadService(session)
-    policy = await svc.aget_policy_by_id(item_id=int(item_id))
+    policy = await WmsPmsProjectionReadService(session).aget_policy_snapshot(
+        item_id=int(item_id),
+    )
     if policy is None:
-        # 未找到 item：保守返回原值，不在共享层擅自抛错
+        # 未找到 item policy projection：保守返回原值，不在共享层擅自抛错
         if production_date is not None and expiry_date is not None:
             if production_date > expiry_date:
                 raise ValueError("production_date cannot be later than expiry_date")


### PR DESCRIPTION
## Summary
- switch expiry resolver policy lookup from PMS export to WMS-local PMS policy projection
- preserve existing fallback behavior when policy projection is missing
- keep lot resolver, lot creation, count, stock adjust, and stock write logic unchanged
- keep this PR narrowly scoped to expiry date normalization policy lookup

## Validation
- python3 -m compileall app/wms/shared/services/expiry_resolver.py app/wms/inbound/services/inbound_commit_service.py app/wms/pms_projection/services/read_service.py
- make upgrade-test
- make rebuild-wms-pms-projection-test
- TESTS="tests/services/test_inbound_commit_event_link.py tests/services/test_inbound_service.py tests/services/test_inbound_reversal_service.py tests/api/test_wms_receiving_batch_no_lot_code_contract_api.py tests/services/test_wms_pms_projection_read_service.py tests/services/test_wms_pms_projection_rebuild_service.py tests/unit/test_expiry_calc.py" make test
- make alembic-check
- git diff --check
- rg audit confirms expiry_resolver no longer uses PMS export / owner tables