### PR TITLE
refactor(wms): use pms projection for lot policy

### DIFF
--- a/app/wms/stock/services/lot_resolver.py
+++ b/app/wms/stock/services/lot_resolver.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 from datetime import date, datetime
 from typing import Optional
 
-from sqlalchemy import text as SA
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.wms.pms_projection.services.read_service import WmsPmsProjectionReadService
 from app.wms.stock.services.lots import ensure_internal_lot_singleton, ensure_lot_full
 
 
@@ -22,14 +22,12 @@ class LotResolver:
     """
 
     async def requires_batch(self, session: AsyncSession, *, item_id: int) -> bool:
-        row = await session.execute(
-            SA("SELECT expiry_policy FROM items WHERE id=:i LIMIT 1"),
-            {"i": int(item_id)},
+        policy = await WmsPmsProjectionReadService(session).aget_policy_snapshot(
+            item_id=int(item_id),
         )
-        v = row.scalar_one_or_none()
-        if v is None:
+        if policy is None:
             raise ValueError("item_not_found")
-        return str(v or "").upper() == "REQUIRED"
+        return str(policy.expiry_policy or "").upper() == "REQUIRED"
 
     async def ensure_supplier_lot_id(
         self,

--- a/app/wms/stock/services/lots.py
+++ b/app/wms/stock/services/lots.py
@@ -9,6 +9,8 @@ from typing import Optional
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.wms.pms_projection.services.read_service import WmsPmsProjectionReadService
+
 
 def normalize_lot_code(code: str | None) -> tuple[str, str]:
     """
@@ -150,27 +152,15 @@ async def _load_item_expiry_context(
     *,
     item_id: int,
 ) -> tuple[str, int | None, str | None]:
-    row = await session.execute(
-        text(
-            """
-            SELECT
-                expiry_policy,
-                shelf_life_value,
-                shelf_life_unit
-              FROM items
-             WHERE id = :i
-             LIMIT 1
-            """
-        ),
-        {"i": int(item_id)},
+    policy = await WmsPmsProjectionReadService(session).aget_policy_snapshot(
+        item_id=int(item_id),
     )
-    got = row.mappings().first()
-    if got is None:
+    if policy is None:
         raise ValueError("item_not_found")
 
-    expiry_policy = str(got["expiry_policy"] or "").strip().upper()
-    shelf_life_value = _normalize_positive_int(got["shelf_life_value"])
-    shelf_life_unit = _normalize_shelf_life_unit(got["shelf_life_unit"])
+    expiry_policy = str(policy.expiry_policy or "").strip().upper()
+    shelf_life_value = _normalize_positive_int(policy.shelf_life_value)
+    shelf_life_unit = _normalize_shelf_life_unit(policy.shelf_life_unit)
     return expiry_policy, shelf_life_value, shelf_life_unit
 
 
@@ -323,14 +313,14 @@ async def ensure_internal_lot_singleton(
                 NULL,
                 :rid,
                 :rln,
-                it.lot_source_policy,
-                it.expiry_policy,
-                it.derivation_allowed,
-                it.uom_governance_enabled,
-                it.shelf_life_value,
-                it.shelf_life_unit
-              FROM items it
-             WHERE it.id = :i
+                pp.lot_source_policy,
+                pp.expiry_policy,
+                pp.derivation_allowed,
+                pp.uom_governance_enabled,
+                pp.shelf_life_value,
+                pp.shelf_life_unit
+              FROM wms_pms_item_policy_projection pp
+             WHERE pp.item_id = :i
             ON CONFLICT DO NOTHING
             RETURNING id
             """
@@ -464,14 +454,14 @@ async def ensure_lot_full(
                     :ed,
                     NULL,
                     NULL,
-                    it.lot_source_policy,
-                    it.expiry_policy,
-                    it.derivation_allowed,
-                    it.uom_governance_enabled,
-                    it.shelf_life_value,
-                    it.shelf_life_unit
-                  FROM items it
-                 WHERE it.id = :i
+                    pp.lot_source_policy,
+                    pp.expiry_policy,
+                    pp.derivation_allowed,
+                    pp.uom_governance_enabled,
+                    pp.shelf_life_value,
+                    pp.shelf_life_unit
+                  FROM wms_pms_item_policy_projection pp
+                 WHERE pp.item_id = :i
                 ON CONFLICT (warehouse_id, item_id, production_date)
                 WHERE lot_code_source = 'SUPPLIER'
                   AND item_expiry_policy_snapshot = 'REQUIRED'

--- a/scripts/seed_test_baseline.py
+++ b/scripts/seed_test_baseline.py
@@ -21,6 +21,183 @@ def _load_sql(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
+async def _sync_wms_pms_projection_baseline(conn) -> None:
+    """
+    测试基线同步 WMS PMS projection。
+
+    pytest 每个用例都会 TRUNCATE + seed owner PMS 表；
+    WMS 执行链现在只读 wms_pms_*_projection，因此 seed 后必须同步 projection。
+    这里先按 FK 顺序清空 projection，再从当前 owner 表重建测试基线。
+    """
+    for table_name in (
+        "wms_pms_item_barcode_projection",
+        "wms_pms_item_sku_code_projection",
+        "wms_pms_item_policy_projection",
+        "wms_pms_item_uom_projection",
+        "wms_pms_item_projection",
+    ):
+        await conn.execute(text(f"DELETE FROM {table_name}"))
+
+    await conn.execute(
+        text(
+            """
+            INSERT INTO wms_pms_item_projection (
+              item_id,
+              sku,
+              name,
+              spec,
+              enabled,
+              brand_id,
+              category_id,
+              source_updated_at
+            )
+            SELECT
+              i.id,
+              i.sku,
+              i.name,
+              i.spec,
+              i.enabled,
+              i.brand_id,
+              i.category_id,
+              COALESCE(i.updated_at, now())
+            FROM items i
+            ORDER BY i.id ASC
+            """
+        )
+    )
+
+    await conn.execute(
+        text(
+            """
+            INSERT INTO wms_pms_item_uom_projection (
+              item_uom_id,
+              item_id,
+              uom,
+              display_name,
+              ratio_to_base,
+              is_base,
+              is_purchase_default,
+              is_inbound_default,
+              is_outbound_default,
+              net_weight_kg,
+              source_updated_at
+            )
+            SELECT
+              u.id,
+              u.item_id,
+              u.uom,
+              u.display_name,
+              u.ratio_to_base,
+              u.is_base,
+              u.is_purchase_default,
+              u.is_inbound_default,
+              u.is_outbound_default,
+              u.net_weight_kg,
+              COALESCE(u.updated_at, now())
+            FROM item_uoms u
+            JOIN wms_pms_item_projection p
+              ON p.item_id = u.item_id
+            ORDER BY u.item_id ASC, u.id ASC
+            """
+        )
+    )
+
+    await conn.execute(
+        text(
+            """
+            INSERT INTO wms_pms_item_policy_projection (
+              item_id,
+              lot_source_policy,
+              expiry_policy,
+              shelf_life_value,
+              shelf_life_unit,
+              derivation_allowed,
+              uom_governance_enabled,
+              source_updated_at
+            )
+            SELECT
+              i.id,
+              i.lot_source_policy,
+              i.expiry_policy,
+              i.shelf_life_value,
+              i.shelf_life_unit,
+              i.derivation_allowed,
+              i.uom_governance_enabled,
+              COALESCE(i.updated_at, now())
+            FROM items i
+            JOIN wms_pms_item_projection p
+              ON p.item_id = i.id
+            ORDER BY i.id ASC
+            """
+        )
+    )
+
+    await conn.execute(
+        text(
+            """
+            INSERT INTO wms_pms_item_sku_code_projection (
+              sku_code_id,
+              item_id,
+              code,
+              code_type,
+              is_primary,
+              is_active,
+              effective_from,
+              effective_to,
+              remark,
+              source_updated_at
+            )
+            SELECT
+              sc.id,
+              sc.item_id,
+              sc.code,
+              sc.code_type,
+              sc.is_primary,
+              sc.is_active,
+              sc.effective_from,
+              sc.effective_to,
+              sc.remark,
+              COALESCE(sc.updated_at, now())
+            FROM item_sku_codes sc
+            JOIN wms_pms_item_projection p
+              ON p.item_id = sc.item_id
+            ORDER BY sc.item_id ASC, sc.id ASC
+            """
+        )
+    )
+
+    await conn.execute(
+        text(
+            """
+            INSERT INTO wms_pms_item_barcode_projection (
+              barcode_id,
+              item_id,
+              item_uom_id,
+              barcode,
+              active,
+              is_primary,
+              symbology,
+              source_updated_at
+            )
+            SELECT
+              b.id,
+              b.item_id,
+              b.item_uom_id,
+              b.barcode,
+              b.active,
+              b.is_primary,
+              COALESCE(NULLIF(b.symbology, ''), 'CUSTOM'),
+              COALESCE(b.updated_at, now())
+            FROM item_barcodes b
+            JOIN wms_pms_item_uom_projection u
+              ON u.item_uom_id = b.item_uom_id
+             AND u.item_id = b.item_id
+            ORDER BY b.item_id ASC, b.id ASC
+            """
+        )
+    )
+
+
 @lru_cache(maxsize=1)
 def discover_permission_names() -> list[str]:
     app_dir = _repo_root() / "app"
@@ -66,6 +243,8 @@ async def seed_in_conn(conn) -> None:
 
     # 1) 主数据基线
     await conn.execute(text(_load_sql(base_sql_path)))
+
+    await _sync_wms_pms_projection_baseline(conn)
 
     # 2) admin 用户（可登录）
     await ensure_admin_user(username="admin", password="admin123", full_name="Dev Admin")

--- a/tests/api/test_wms_receiving_batch_no_lot_code_contract_api.py
+++ b/tests/api/test_wms_receiving_batch_no_lot_code_contract_api.py
@@ -9,6 +9,8 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tests.helpers.wms_pms_projection import sync_wms_pms_projection_for_item
+
 
 async def _login_admin_headers(client: httpx.AsyncClient) -> dict[str, str]:
     response = await client.post(
@@ -88,6 +90,7 @@ async def _force_supplier_required_item_policy(
         ),
         {"item_id": int(item_id)},
     )
+    await sync_wms_pms_projection_for_item(session, item_id=int(item_id))
 
 
 async def _load_operation_line(

--- a/tests/helpers/wms_pms_projection.py
+++ b/tests/helpers/wms_pms_projection.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def sync_wms_pms_projection_for_item(
+    session: AsyncSession,
+    *,
+    item_id: int,
+) -> None:
+    """
+    测试专用：把单个 owner item 当前状态同步到 WMS PMS projection。
+
+    适用场景：
+    - 测试内直接 INSERT / UPDATE items、item_uoms、item_barcodes、item_sku_codes；
+    - 随后调用 WMS lot / receiving / inbound commit / stock adjust 等只读 projection 的执行链。
+    """
+    item_id = int(item_id)
+
+    for table_name in (
+        "wms_pms_item_barcode_projection",
+        "wms_pms_item_sku_code_projection",
+        "wms_pms_item_policy_projection",
+        "wms_pms_item_uom_projection",
+        "wms_pms_item_projection",
+    ):
+        await session.execute(
+            text(f"DELETE FROM {table_name} WHERE item_id = :item_id"),
+            {"item_id": item_id},
+        )
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_pms_item_projection (
+              item_id,
+              sku,
+              name,
+              spec,
+              enabled,
+              brand_id,
+              category_id,
+              source_updated_at
+            )
+            SELECT
+              i.id,
+              i.sku,
+              i.name,
+              i.spec,
+              i.enabled,
+              i.brand_id,
+              i.category_id,
+              COALESCE(i.updated_at, now())
+            FROM items i
+            WHERE i.id = :item_id
+            """
+        ),
+        {"item_id": item_id},
+    )
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_pms_item_uom_projection (
+              item_uom_id,
+              item_id,
+              uom,
+              display_name,
+              ratio_to_base,
+              is_base,
+              is_purchase_default,
+              is_inbound_default,
+              is_outbound_default,
+              net_weight_kg,
+              source_updated_at
+            )
+            SELECT
+              u.id,
+              u.item_id,
+              u.uom,
+              u.display_name,
+              u.ratio_to_base,
+              u.is_base,
+              u.is_purchase_default,
+              u.is_inbound_default,
+              u.is_outbound_default,
+              u.net_weight_kg,
+              COALESCE(u.updated_at, now())
+            FROM item_uoms u
+            JOIN wms_pms_item_projection p
+              ON p.item_id = u.item_id
+            WHERE u.item_id = :item_id
+            ORDER BY u.id ASC
+            """
+        ),
+        {"item_id": item_id},
+    )
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_pms_item_policy_projection (
+              item_id,
+              lot_source_policy,
+              expiry_policy,
+              shelf_life_value,
+              shelf_life_unit,
+              derivation_allowed,
+              uom_governance_enabled,
+              source_updated_at
+            )
+            SELECT
+              i.id,
+              i.lot_source_policy,
+              i.expiry_policy,
+              i.shelf_life_value,
+              i.shelf_life_unit,
+              i.derivation_allowed,
+              i.uom_governance_enabled,
+              COALESCE(i.updated_at, now())
+            FROM items i
+            JOIN wms_pms_item_projection p
+              ON p.item_id = i.id
+            WHERE i.id = :item_id
+            """
+        ),
+        {"item_id": item_id},
+    )
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_pms_item_sku_code_projection (
+              sku_code_id,
+              item_id,
+              code,
+              code_type,
+              is_primary,
+              is_active,
+              effective_from,
+              effective_to,
+              remark,
+              source_updated_at
+            )
+            SELECT
+              sc.id,
+              sc.item_id,
+              sc.code,
+              sc.code_type,
+              sc.is_primary,
+              sc.is_active,
+              sc.effective_from,
+              sc.effective_to,
+              sc.remark,
+              COALESCE(sc.updated_at, now())
+            FROM item_sku_codes sc
+            JOIN wms_pms_item_projection p
+              ON p.item_id = sc.item_id
+            WHERE sc.item_id = :item_id
+            ORDER BY sc.id ASC
+            """
+        ),
+        {"item_id": item_id},
+    )
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_pms_item_barcode_projection (
+              barcode_id,
+              item_id,
+              item_uom_id,
+              barcode,
+              active,
+              is_primary,
+              symbology,
+              source_updated_at
+            )
+            SELECT
+              b.id,
+              b.item_id,
+              b.item_uom_id,
+              b.barcode,
+              b.active,
+              b.is_primary,
+              COALESCE(NULLIF(b.symbology, ''), 'CUSTOM'),
+              COALESCE(b.updated_at, now())
+            FROM item_barcodes b
+            JOIN wms_pms_item_uom_projection u
+              ON u.item_uom_id = b.item_uom_id
+             AND u.item_id = b.item_id
+            WHERE b.item_id = :item_id
+            ORDER BY b.id ASC
+            """
+        ),
+        {"item_id": item_id},
+    )
+
+    await session.flush()
+
+
+async def force_wms_pms_projection_supplier_required_item(
+    session: AsyncSession,
+    *,
+    item_id: int,
+) -> None:
+    """
+    测试专用：把测试 item 提升为可创建 SUPPLIER lot 的策略，并同步 projection。
+    """
+    item_id = int(item_id)
+    await session.execute(
+        text(
+            """
+            UPDATE items
+               SET lot_source_policy = 'SUPPLIER_ONLY'::lot_source_policy,
+                   expiry_policy = 'REQUIRED'::expiry_policy,
+                   derivation_allowed = TRUE,
+                   uom_governance_enabled = TRUE,
+                   updated_at = now()
+             WHERE id = :item_id
+            """
+        ),
+        {"item_id": item_id},
+    )
+    await sync_wms_pms_projection_for_item(session, item_id=item_id)

--- a/tests/services/test_inbound_commit_event_link.py
+++ b/tests/services/test_inbound_commit_event_link.py
@@ -25,19 +25,26 @@ async def _pick_seed_item_uom(session):
         text(
             """
             SELECT
-              i.id AS item_id,
-              u.id AS uom_id,
-              i.lot_source_policy::text AS lot_source_policy,
-              i.expiry_policy::text AS expiry_policy
-            FROM item_uoms u
-            JOIN items i
-              ON i.id = u.item_id
+              p.item_id AS item_id,
+              u.item_uom_id AS uom_id,
+              pp.lot_source_policy::text AS lot_source_policy,
+              pp.expiry_policy::text AS expiry_policy
+            FROM wms_pms_item_uom_projection u
+            JOIN wms_pms_item_projection p
+              ON p.item_id = u.item_id
+            JOIN wms_pms_item_policy_projection pp
+              ON pp.item_id = p.item_id
+            WHERE NOT (
+              pp.lot_source_policy::text IN ('SUPPLIER_ONLY', 'SUPPLIER')
+              AND pp.expiry_policy::text <> 'REQUIRED'
+            )
             ORDER BY
               CASE
-                WHEN i.lot_source_policy::text IN ('SUPPLIER_ONLY', 'SUPPLIER') THEN 0
+                WHEN pp.lot_source_policy::text IN ('SUPPLIER_ONLY', 'SUPPLIER')
+                 AND pp.expiry_policy::text = 'REQUIRED' THEN 0
                 ELSE 1
               END,
-              u.id ASC
+              u.item_uom_id ASC
             LIMIT 1
             """
         )

--- a/tests/services/test_inbound_reversal_service.py
+++ b/tests/services/test_inbound_reversal_service.py
@@ -34,19 +34,26 @@ async def _pick_seed_item_uom(session):
         text(
             """
             SELECT
-              i.id AS item_id,
-              u.id AS uom_id,
-              i.lot_source_policy::text AS lot_source_policy,
-              i.expiry_policy::text AS expiry_policy
-            FROM item_uoms u
-            JOIN items i
-              ON i.id = u.item_id
+              p.item_id AS item_id,
+              u.item_uom_id AS uom_id,
+              pp.lot_source_policy::text AS lot_source_policy,
+              pp.expiry_policy::text AS expiry_policy
+            FROM wms_pms_item_uom_projection u
+            JOIN wms_pms_item_projection p
+              ON p.item_id = u.item_id
+            JOIN wms_pms_item_policy_projection pp
+              ON pp.item_id = p.item_id
+            WHERE NOT (
+              pp.lot_source_policy::text IN ('SUPPLIER_ONLY', 'SUPPLIER')
+              AND pp.expiry_policy::text <> 'REQUIRED'
+            )
             ORDER BY
               CASE
-                WHEN i.lot_source_policy::text IN ('SUPPLIER_ONLY', 'SUPPLIER') THEN 0
+                WHEN pp.lot_source_policy::text IN ('SUPPLIER_ONLY', 'SUPPLIER')
+                 AND pp.expiry_policy::text = 'REQUIRED' THEN 0
                 ELSE 1
               END,
-              u.id ASC
+              u.item_uom_id ASC
             LIMIT 1
             """
         )

--- a/tests/services/test_inbound_service.py
+++ b/tests/services/test_inbound_service.py
@@ -11,6 +11,7 @@ from tests.helpers.inventory import ensure_wh_loc_item, qty_by_lot_code
 from app.wms.shared.enums import MovementType
 from app.wms.stock.services.lots import ensure_lot_full
 from app.wms.stock.services.stock_service import StockService
+from tests.helpers.wms_pms_projection import sync_wms_pms_projection_for_item
 
 UTC = timezone.utc
 pytestmark = pytest.mark.grp_core
@@ -49,6 +50,8 @@ async def test_inbound_creates_batch_and_increases_stock(session: AsyncSession):
     exp = prod + timedelta(days=365)
 
     # 当前终态：supplier lot 必须走 ensure_lot_full，且 REQUIRED 商品必须给 production_date + expiry_date
+    await sync_wms_pms_projection_for_item(session, item_id=int(item))
+
     lot_id = await ensure_lot_full(
         session,
         item_id=int(item),

--- a/tests/services/test_stock_adjust_trace_id.py
+++ b/tests/services/test_stock_adjust_trace_id.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.wms.stock.services.lots import ensure_lot_full
 from app.wms.stock.services.stock_adjust import adjust_lot_impl
+from tests.helpers.wms_pms_projection import force_wms_pms_projection_supplier_required_item
 
 pytestmark = pytest.mark.asyncio
 UTC = timezone.utc
@@ -33,6 +34,7 @@ async def test_stock_adjust_writes_trace_id(session: AsyncSession):
     row = await session.execute(text("SELECT id FROM items ORDER BY id ASC LIMIT 1"))
     item_id = row.scalar_one()
     assert item_id is not None
+    await force_wms_pms_projection_supplier_required_item(session, item_id=int(item_id))
 
     # 2) 入库：让 lot-only primitive 写入 lot-world：lots + stocks_lot + ledger
     ref = "UT-ADJUST-1"

--- a/tests/unit/test_fefo_query_v2.py
+++ b/tests/unit/test_fefo_query_v2.py
@@ -11,6 +11,7 @@ from app.wms.shared.services.expiry_analytics_allocator import ExpiryAnalyticsAl
 from app.wms.stock.services.lots import ensure_lot_full
 from app.wms.stock.services.stock_adjust import adjust_lot_impl
 from tests.utils.ensure_minimal import ensure_item
+from tests.helpers.wms_pms_projection import sync_wms_pms_projection_for_item
 
 UTC = timezone.utc
 
@@ -37,6 +38,7 @@ async def test_expiry_analytics_query_returns_sorted_not_enforcing(session: Asyn
       * 第一条的 take_qty = 2（在最早批次中优先消耗）。
     """
     await ensure_item(session, id=3003, sku="SKU-3003", name="ITEM-3003", expiry_required=True)
+    await sync_wms_pms_projection_for_item(session, item_id=3003)
 
     now = datetime.now(UTC)
     prod = date.today()

--- a/tests/unit/test_stock_service_v2.py
+++ b/tests/unit/test_stock_service_v2.py
@@ -10,17 +10,17 @@ from app.wms.shared.enums import MovementType
 from app.wms.shared.services.lot_code_contract import validate_lot_code_contract
 from app.wms.stock.services.lots import ensure_internal_lot_singleton, ensure_lot_full
 from app.wms.stock.services.stock_service import StockService
+from tests.helpers.wms_pms_projection import force_wms_pms_projection_supplier_required_item
 
 UTC = timezone.utc
 
 
 async def _requires_batch(session: AsyncSession, item_id: int) -> bool:
     """
-    Phase M 第一阶段：测试也不再读取 has_shelf_life（镜像字段）。
-    批次受控唯一真相源：items.expiry_policy == 'REQUIRED'
+    测试与 WMS 执行链保持一致：批次受控真相源来自 WMS PMS projection。
     """
     row = await session.execute(
-        text("SELECT expiry_policy FROM items WHERE id=:i LIMIT 1"),
+        text("SELECT expiry_policy::text FROM wms_pms_item_policy_projection WHERE item_id=:i LIMIT 1"),
         {"i": int(item_id)},
     )
     v = row.scalar_one_or_none()
@@ -54,6 +54,11 @@ async def _ensure_supplier_lot(
     lot_code = str(code).strip()
     if not lot_code:
         raise ValueError("lot_code required")
+
+    await force_wms_pms_projection_supplier_required_item(
+        session,
+        item_id=int(item_id),
+    )
 
     requires_batch = await _requires_batch(session, int(item_id))
     pd, ed = _required_lot_dates(requires_batch)
@@ -334,6 +339,11 @@ async def _insert_supplier_lot(session: AsyncSession, *, warehouse_id: int, item
     终态收口后不允许 tests 直接 INSERT INTO lots。
     这里通过 ensure_lot_full 造出一个合法 lot_id，再用于 mismatch 测试。
     """
+    await force_wms_pms_projection_supplier_required_item(
+        session,
+        item_id=int(item_id),
+    )
+
     requires_batch = await _requires_batch(session, int(item_id))
     pd, ed = _required_lot_dates(requires_batch)
 


### PR DESCRIPTION
## Summary
- switch lot expiry context lookup to WMS-local PMS policy projection
- switch INTERNAL lot snapshot freeze from PMS owner items to WMS-local PMS policy projection
- switch SUPPLIER lot snapshot freeze from PMS owner items to WMS-local PMS policy projection
- switch lot resolver requires_batch lookup to WMS-local PMS policy projection
- sync WMS PMS projection in test baseline and add test helper for item-level projection sync
- keep lot_service, count, stock_adjust, stock_ship, return inbound, and structural FKs unchanged

## Validation
- python3 -m compileall tests/helpers/wms_pms_projection.py scripts/seed_test_baseline.py tests/services/test_inbound_service.py tests/services/test_inbound_commit_event_link.py tests/services/test_inbound_reversal_service.py tests/api/test_wms_receiving_batch_no_lot_code_contract_api.py tests/unit/test_stock_service_v2.py tests/unit/test_fefo_query_v2.py tests/services/test_stock_adjust_trace_id.py app/wms/stock/services/lots.py app/wms/stock/services/lot_resolver.py
- make upgrade-test
- make rebuild-wms-pms-projection-test
- TESTS="tests/services/test_inbound_commit_event_link.py tests/services/test_inbound_service.py tests/services/test_inbound_reversal_service.py tests/api/test_wms_receiving_batch_no_lot_code_contract_api.py tests/unit/test_stock_service_v2.py tests/unit/test_fefo_query_v2.py tests/services/test_stock_adjust_trace_id.py tests/services/test_wms_pms_projection_read_service.py tests/services/test_wms_pms_projection_rebuild_service.py" make test
- make alembic-check
- git diff --check
- rg audit confirms lots.py and lot_resolver.py no longer use PMS owner items for policy reads