### PR TITLE
refactor(wms): use pms projection for lot code policy

### DIFF
--- a/app/wms/shared/services/lot_code_contract.py
+++ b/app/wms/shared/services/lot_code_contract.py
@@ -21,7 +21,6 @@ def http_422(detail: str, *, error_code: str = "lot_code_contract_reject") -> HT
     - message 文案保持原样（沿用 batch_code 字段名以兼容旧客户端）
     - error_code 用于上层/测试分类（如 batch_required）
     """
-    # ✅ pytest warning fix: HTTP_422_UNPROCESSABLE_ENTITY deprecated in recent FastAPI/Starlette
     return HTTPException(
         status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
         detail={
@@ -58,7 +57,7 @@ def normalize_optional_lot_code(raw: Optional[str]) -> Optional[str]:
 
 def validate_lot_code_contract(*, requires_batch: bool, lot_code: Optional[str]) -> Optional[str]:
     """
-    Phase M：lot_code 合同收紧（422 拦假码），策略真相源来自 items.expiry_policy：
+    Phase M：lot_code 合同收紧（422 拦假码），策略真相源来自 WMS PMS projection：
 
     - requires_batch=True（expiry_policy=REQUIRED）：
         lot_code 必填且非空（strip 后长度>0），禁止 'none'（大小写不敏感）
@@ -109,26 +108,31 @@ def validate_lot_code_contract(*, requires_batch: bool, lot_code: Optional[str])
 
 
 def _requires_batch_from_expiry_policy(expiry_policy: Optional[str]) -> bool:
-    # DB enum: 'NONE' | 'REQUIRED'
     return str(expiry_policy or "").upper() == "REQUIRED"
 
 
 async def fetch_item_expiry_policy_map(session: AsyncSession, item_ids: Set[int]) -> Dict[int, str]:
     """
-    真相源：items.expiry_policy（Phase M Rule 层）
+    真相源：wms_pms_item_policy_projection.expiry_policy
     返回：{item_id: 'NONE' | 'REQUIRED'}
     """
-    if not item_ids:
+    ids = {int(i) for i in item_ids}
+    if not ids:
         return {}
 
     rows = await session.execute(
-        text("select id, expiry_policy from items where id = any(:ids)"),
-        {"ids": list(item_ids)},
+        text(
+            """
+            SELECT item_id, expiry_policy::text AS expiry_policy
+            FROM wms_pms_item_policy_projection
+            WHERE item_id = ANY(:ids)
+            """
+        ),
+        {"ids": list(ids)},
     )
 
     m: Dict[int, str] = {}
     for item_id, expiry_policy in rows.fetchall():
-        # expiry_policy 是 enum，psycopg 返回可能是 str / Enum-like；统一转 str
         m[int(item_id)] = str(expiry_policy)
     return m
 
@@ -136,18 +140,30 @@ async def fetch_item_expiry_policy_map(session: AsyncSession, item_ids: Set[int]
 async def fetch_item_by_sku(session: AsyncSession, sku: str) -> Optional[Tuple[int, bool]]:
     """
     返回 (item_id, requires_batch)
-    requires_batch 由 expiry_policy 投影得出。
+    requires_batch 由 WMS PMS projection 的 expiry_policy 得出。
     """
     s = (sku or "").strip()
     if not s:
         return None
 
     row = await session.execute(
-        text("select id, expiry_policy from items where sku = :sku limit 1"),
+        text(
+            """
+            SELECT
+              p.item_id,
+              pp.expiry_policy::text AS expiry_policy
+            FROM wms_pms_item_projection p
+            JOIN wms_pms_item_policy_projection pp
+              ON pp.item_id = p.item_id
+            WHERE p.sku = :sku
+            LIMIT 1
+            """
+        ),
         {"sku": s},
     )
     r = row.first()
     if not r:
         return None
+
     item_id, expiry_policy = r[0], r[1]
     return int(item_id), _requires_batch_from_expiry_policy(str(expiry_policy))

--- a/tests/utils/ensure_minimal.py
+++ b/tests/utils/ensure_minimal.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.wms.stock.services.lot_service import ensure_internal_lot_singleton as ensure_internal_lot_singleton_svc
 from app.wms.stock.services.lot_service import ensure_lot_full as ensure_lot_full_svc
 from app.wms.stock.services.stock_adjust import adjust_lot_impl
+from tests.helpers.wms_pms_projection import force_wms_pms_projection_supplier_required_item
 
 UTC = timezone.utc
 
@@ -236,6 +237,10 @@ async def ensure_supplier_lot(
         sku=f"SKU-{item_id}",
         name=f"ITEM-{item_id}",
         expiry_required=True,
+    )
+    await force_wms_pms_projection_supplier_required_item(
+        session,
+        item_id=int(item_id),
     )
 
     expiry_policy = await _load_item_expiry_policy(session, item_id=int(item_id))


### PR DESCRIPTION
## Summary
- switch lot_code_contract policy map lookup from PMS owner items to WMS-local PMS policy projection
- switch SKU-to-policy lookup from PMS owner items to WMS-local PMS projection
- update test stock seed helper to sync WMS PMS projection before creating supplier lots
- keep count, stock_adjust, stock_ship, and structural FKs unchanged

## Validation
- python3 -m compileall tests/utils/ensure_minimal.py tests/helpers/wms_pms_projection.py app/wms/shared/services/lot_code_contract.py app/wms/stock/services/lots.py app/wms/stock/services/lot_resolver.py
- make upgrade-test
- make rebuild-wms-pms-projection-test
- TESTS="tests/api/test_inventory_adjustment_count_doc_execution_api.py tests/api/test_inventory_adjustment_count_doc_mainline_api.py tests/api/test_stock_inventory_recount_freeze_guard_api.py" make test
- TESTS="tests/unit/test_stock_service_v2.py tests/api/test_inventory_adjustment_count_doc_execution_api.py tests/api/test_inventory_adjustment_count_doc_mainline_api.py tests/api/test_stock_inventory_recount_freeze_guard_api.py tests/services/test_wms_pms_projection_read_service.py tests/services/test_wms_pms_projection_rebuild_service.py" make test
- make alembic-check
- git diff --check
- rg audit confirms lot_code_contract no longer uses PMS owner items for policy reads