### PR TITLE
refactor(wms): use pms projection for stock adjust policy

### DIFF
--- a/app/wms/stock/services/stock_adjust/db_items.py
+++ b/app/wms/stock/services/stock_adjust/db_items.py
@@ -1,35 +1,34 @@
 # app/wms/stock/services/stock_adjust/db_items.py
 from __future__ import annotations
 
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.wms.pms_projection.services.read_service import WmsPmsProjectionReadService
 
 
 async def item_requires_batch(session: AsyncSession, *, item_id: int) -> bool:
     """
-    Phase M 第一阶段：执行层禁止读取 items.has_shelf_life。
+    WMS stock_adjust 执行层批次策略判断。
 
-    批次受控唯一真相源：items.expiry_policy
+    策略真相源：
+    - wms_pms_item_policy_projection.expiry_policy
+
+    规则：
     - expiry_policy='REQUIRED' => requires_batch=True
     - expiry_policy='NONE'     => requires_batch=False
 
-    重要：item 不存在时必须明确失败（unknown item 不能默认成 NONE）。
+    重要：
+    - item policy projection 不存在时必须明确失败；
+    - 禁止 fallback 回 PMS owner items；
+    - 禁止把 unknown item 默认成 NONE。
     """
-    row = (
-        await session.execute(
-            text(
-                """
-                SELECT expiry_policy
-                  FROM items
-                 WHERE id = :item_id
-                 LIMIT 1
-                """
-            ),
-            {"item_id": int(item_id)},
-        )
-    ).first()
-
-    if not row:
+    policy = await WmsPmsProjectionReadService(session).aget_policy_snapshot(
+        item_id=int(item_id),
+    )
+    if policy is None:
         raise ValueError("item_not_found")
 
-    return str(row[0] or "").upper() == "REQUIRED"
+    return str(policy.expiry_policy or "").upper() == "REQUIRED"
+
+
+__all__ = ["item_requires_batch"]


### PR DESCRIPTION
## Summary
- switch stock_adjust item_requires_batch policy lookup from PMS owner items to WMS-local PMS policy projection
- keep adjust_lot_impl, stock writes, ledger writes, count, stock_ship, and structural FKs unchanged
- keep this PR narrowly scoped to stock_adjust policy lookup

## Validation
- python3 -m compileall app/wms/stock/services/stock_adjust/db_items.py app/wms/stock/services/stock_adjust/adjust_lot_impl.py app/wms/stock/services/stock_service.py app/wms/pms_projection/services/read_service.py
- make upgrade-test
- make rebuild-wms-pms-projection-test
- TESTS="tests/unit/test_stock_service_v2.py tests/services/test_stock_adjust_trace_id.py tests/api/test_inventory_adjustment_count_doc_execution_api.py tests/api/test_inventory_adjustment_count_doc_mainline_api.py tests/api/test_stock_inventory_recount_freeze_guard_api.py tests/services/test_wms_pms_projection_read_service.py tests/services/test_wms_pms_projection_rebuild_service.py" make test
- make alembic-check
- git diff --check
- rg audit confirms stock_adjust db_items no longer uses PMS owner items for policy reads