### PR TITLE
refactor(wms): use pms projection for count doc snapshots

### DIFF
--- a/app/wms/inventory_adjustment/count/repos/count_doc_repo.py
+++ b/app/wms/inventory_adjustment/count/repos/count_doc_repo.py
@@ -296,9 +296,9 @@ class CountDocRepo:
                 """
                 SELECT
                   iu.item_id,
-                  iu.id AS base_item_uom_id,
+                  iu.item_uom_id AS base_item_uom_id,
                   COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS base_uom_name
-                FROM item_uoms iu
+                FROM wms_pms_item_uom_projection iu
                 WHERE iu.item_id = ANY(:item_ids)
                   AND iu.is_base IS TRUE
                 """
@@ -361,12 +361,12 @@ class CountDocRepo:
                   :doc_id AS doc_id,
                   ROW_NUMBER() OVER (ORDER BY s.item_id ASC) AS line_no,
                   s.item_id,
-                  MAX(i.name) AS item_name_snapshot,
-                  MAX(i.spec) AS item_spec_snapshot,
+                  MAX(p.name) AS item_name_snapshot,
+                  MAX(p.spec) AS item_spec_snapshot,
                   SUM(s.qty) AS snapshot_qty_base
                   FROM stocks_lot s
-                  JOIN items i
-                    ON i.id = s.item_id
+                  JOIN wms_pms_item_projection p
+                    ON p.item_id = s.item_id
                  WHERE s.warehouse_id = :warehouse_id
                  GROUP BY s.item_id
                 HAVING SUM(s.qty) > 0
@@ -481,12 +481,12 @@ class CountDocRepo:
                     text(
                         """
                         SELECT
-                          iu.id,
+                          iu.item_uom_id AS id,
                           COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS uom_name_snapshot
-                          FROM item_uoms iu
+                          FROM wms_pms_item_uom_projection iu
                          WHERE iu.item_id = :item_id
                            AND iu.is_base IS TRUE
-                         ORDER BY iu.id ASC
+                         ORDER BY iu.item_uom_id ASC
                          LIMIT 1
                         """
                     ),


### PR DESCRIPTION
## Summary
- switch count doc base UOM lookup from PMS owner item_uoms to WMS-local PMS UOM projection
- switch count doc freeze item display snapshots from PMS owner items to WMS-local PMS item projection
- switch count line update base UOM snapshot from PMS owner item_uoms to WMS-local PMS UOM projection
- keep count doc schema, count post logic, stock writes, ledger writes, and structural FKs unchanged

## Validation
- python3 -m compileall app/wms/inventory_adjustment/count/repos/count_doc_repo.py app/wms/inventory_adjustment/count/services/count_doc_service.py app/wms/pms_projection/services/read_service.py
- make upgrade-test
- make rebuild-wms-pms-projection-test
- TESTS="tests/api/test_inventory_adjustment_count_doc_execution_api.py tests/api/test_inventory_adjustment_count_doc_mainline_api.py tests/api/test_inventory_adjustment_count_doc_guard_api.py tests/api/test_stock_inventory_recount_freeze_guard_api.py tests/test_phase3_three_books_count_contract.py tests/services/test_wms_pms_projection_read_service.py tests/services/test_wms_pms_projection_rebuild_service.py" make test
- make alembic-check
- git diff --check
- rg audit confirms count_doc_repo no longer uses PMS owner items/item_uoms for count snapshots