### PR TITLE
refactor(wms): use pms projection for return inbound read surfaces

### DIFF
--- a/app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_read_repo.py
+++ b/app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_read_repo.py
@@ -116,33 +116,33 @@ async def get_inbound_return_source_repo(
                 SELECT
                   oi.id AS order_line_id,
                   oi.item_id AS item_id,
-                  COALESCE(i.name, oi.title) AS item_name_snapshot,
-                  i.spec AS item_spec_snapshot,
+                  COALESCE(p.name, oi.title) AS item_name_snapshot,
+                  p.spec AS item_spec_snapshot,
                   (
-                    SELECT u.id
-                    FROM item_uoms u
+                    SELECT u.item_uom_id
+                    FROM wms_pms_item_uom_projection u
                     WHERE u.item_id = oi.item_id
                     ORDER BY
                       CASE WHEN u.is_inbound_default THEN 0 WHEN u.is_base THEN 1 ELSE 2 END,
-                      u.id
+                      u.item_uom_id
                     LIMIT 1
                   ) AS item_uom_id,
                   (
                     SELECT COALESCE(NULLIF(u.display_name, ''), u.uom)
-                    FROM item_uoms u
+                    FROM wms_pms_item_uom_projection u
                     WHERE u.item_id = oi.item_id
                     ORDER BY
                       CASE WHEN u.is_inbound_default THEN 0 WHEN u.is_base THEN 1 ELSE 2 END,
-                      u.id
+                      u.item_uom_id
                     LIMIT 1
                   ) AS uom_name_snapshot,
                   (
                     SELECT u.ratio_to_base::numeric
-                    FROM item_uoms u
+                    FROM wms_pms_item_uom_projection u
                     WHERE u.item_id = oi.item_id
                     ORDER BY
                       CASE WHEN u.is_inbound_default THEN 0 WHEN u.is_base THEN 1 ELSE 2 END,
-                      u.id
+                      u.item_uom_id
                     LIMIT 1
                   ) AS ratio_to_base_snapshot,
                   COALESCE(oi.qty, 0)::numeric AS qty_ordered,
@@ -150,7 +150,7 @@ async def get_inbound_return_source_repo(
                   COALESCE(oi.returned_qty, 0)::numeric AS qty_returned,
                   GREATEST(COALESCE(oi.shipped_qty, 0) - COALESCE(oi.returned_qty, 0), 0)::numeric AS qty_remaining_refundable
                 FROM order_items oi
-                LEFT JOIN items i ON i.id = oi.item_id
+                LEFT JOIN wms_pms_item_projection p ON p.item_id = oi.item_id
                 WHERE oi.order_id = :order_id
                   AND GREATEST(COALESCE(oi.shipped_qty, 0) - COALESCE(oi.returned_qty, 0), 0) > 0
                 ORDER BY oi.id ASC

--- a/app/wms/inventory_adjustment/return_inbound/routers/order_refs.py
+++ b/app/wms/inventory_adjustment/return_inbound/routers/order_refs.py
@@ -122,18 +122,18 @@ def register_order_refs(router: APIRouter) -> None:
         sql = f"""
         SELECT l.warehouse_id,
                l.item_id,
-               i.name AS item_name,
+               p.name AS item_name,
                l.lot_id,
                MAX(lo.lot_code) AS lot_code_snapshot,
                COALESCE(SUM(-l.delta), 0)::int AS shipped_qty
           FROM stock_ledger l
-          LEFT JOIN items i ON i.id = l.item_id
+          LEFT JOIN wms_pms_item_projection p ON p.item_id = l.item_id
           LEFT JOIN lots lo ON lo.id = l.lot_id
          WHERE l.ref = :ref
            AND l.delta < 0
            AND l.reason = ANY(:reasons)
            {wh_cond}
-         GROUP BY l.warehouse_id, l.item_id, i.name, l.lot_id
+         GROUP BY l.warehouse_id, l.item_id, p.name, l.lot_id
          ORDER BY l.warehouse_id, l.item_id, l.lot_id
         """
 

--- a/tests/services/test_order_rma_and_reconcile.py
+++ b/tests/services/test_order_rma_and_reconcile.py
@@ -13,6 +13,7 @@ from app.oms.orders.services.order_reconcile_service import OrderReconcileServic
 from app.oms.services.order_service import OrderService
 from app.wms.stock.services.lots import ensure_internal_lot_singleton, ensure_lot_full
 from app.wms.stock.services.stock_adjust import adjust_lot_impl
+from tests.helpers.wms_pms_projection import force_wms_pms_projection_supplier_required_item
 
 UTC = timezone.utc
 
@@ -74,6 +75,11 @@ async def _ensure_supplier_lot(session: AsyncSession, *, warehouse_id: int, item
     """
     code_raw = str(code).strip()
     assert code_raw, {"msg": "empty lot_code", "warehouse_id": warehouse_id, "item_id": item_id}
+
+    await force_wms_pms_projection_supplier_required_item(
+        session,
+        item_id=int(item_id),
+    )
 
     required = await _item_batch_mode_is_required(session, item_id=int(item_id))
     production_date = date.today() if required else None

--- a/tests/test_phase3_three_books_return_commit.py
+++ b/tests/test_phase3_three_books_return_commit.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.wms.inventory_adjustment.return_inbound.services.return_task_service_impl import ReturnTaskServiceImpl
 from app.wms.snapshot.services.snapshot_run import run_snapshot
 from app.wms.stock.services.lots import ensure_lot_full
+from tests.helpers.wms_pms_projection import force_wms_pms_projection_supplier_required_item
 from app.wms.stock.services.stock_adjust import adjust_lot_impl
 from app.wms.shared.services.three_books_consistency import verify_commit_three_books
 
@@ -50,6 +51,20 @@ async def _ensure_supplier_lot(
     production_date,
     expiry_date,
 ) -> int:
+    """
+    测试造数专用：创建 SUPPLIER lot 前必须把测试 item 提升为 REQUIRED projection。
+
+    WMS lot 创建现在只读 wms_pms_item_policy_projection；
+    不能再依赖 owner items 的旧状态。
+    """
+    await force_wms_pms_projection_supplier_required_item(
+        session,
+        item_id=int(item_id),
+    )
+
+    if expiry_date is None and production_date is not None:
+        expiry_date = production_date + timedelta(days=365)
+
     lot_id = await ensure_lot_full(
         session,
         item_id=int(item_id),


### PR DESCRIPTION
## Summary
- switch return order ref summary item display from PMS owner items to WMS-local PMS item projection
- switch return inbound source item display, suggested inbound UOM, and ratio lookup from PMS owner items/item_uoms to WMS-local PMS projections
- update return-related tests to sync WMS PMS projection before supplier lot creation
- keep inbound receipt write, inbound operation write, lot resolution, stock writes, ledger writes, and structural FKs unchanged

## Validation
- python3 -m compileall app/wms/inventory_adjustment/return_inbound/routers/order_refs.py app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_read_repo.py tests/services/test_order_rma_and_reconcile.py tests/test_phase3_three_books_return_commit.py
- make upgrade-test
- make rebuild-wms-pms-projection-test
- TESTS="tests/services/test_order_rma_and_reconcile.py tests/test_phase3_three_books_return_commit.py tests/api/test_inbound_receipts_manual_api.py tests/api/test_wms_receiving_batch_no_lot_code_contract_api.py tests/services/test_wms_pms_projection_read_service.py tests/services/test_wms_pms_projection_rebuild_service.py" make test
- make alembic-check
- git diff --check
- rg audit confirms return inbound read surfaces no longer use PMS owner items/item_uoms