### PR TITLE
refactor(wms): use pms projection for manual inbound receipt lines

### DIFF
--- a/app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_write_repo.py
+++ b/app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_write_repo.py
@@ -133,17 +133,17 @@ async def _load_manual_line_snapshot(
             text(
                 """
                 SELECT
-                  i.id AS item_id,
-                  i.name AS item_name,
-                  i.spec AS item_spec,
-                  u.id AS item_uom_id,
+                  p.item_id AS item_id,
+                  p.name AS item_name,
+                  p.spec AS item_spec,
+                  u.item_uom_id AS item_uom_id,
                   COALESCE(NULLIF(u.display_name, ''), u.uom) AS uom_name,
                   u.ratio_to_base AS ratio_to_base
-                FROM items i
-                JOIN item_uoms u
-                  ON u.item_id = i.id
-                WHERE i.id = :item_id
-                  AND u.id = :item_uom_id
+                FROM wms_pms_item_projection p
+                JOIN wms_pms_item_uom_projection u
+                  ON u.item_id = p.item_id
+                WHERE p.item_id = :item_id
+                  AND u.item_uom_id = :item_uom_id
                 LIMIT 1
                 """
             ),
@@ -159,7 +159,14 @@ async def _load_manual_line_snapshot(
 
     item_exists = (
         await session.execute(
-            text("SELECT 1 FROM items WHERE id = :item_id LIMIT 1"),
+            text(
+                """
+                SELECT 1
+                FROM wms_pms_item_projection
+                WHERE item_id = :item_id
+                LIMIT 1
+                """
+            ),
             {"item_id": int(item_id)},
         )
     ).scalar_one_or_none()
@@ -168,7 +175,14 @@ async def _load_manual_line_snapshot(
 
     uom_exists = (
         await session.execute(
-            text("SELECT 1 FROM item_uoms WHERE id = :item_uom_id LIMIT 1"),
+            text(
+                """
+                SELECT 1
+                FROM wms_pms_item_uom_projection
+                WHERE item_uom_id = :item_uom_id
+                LIMIT 1
+                """
+            ),
             {"item_uom_id": int(item_uom_id)},
         )
     ).scalar_one_or_none()


### PR DESCRIPTION
## Summary
- switch manual inbound receipt line item/uom snapshot lookup from PMS owner items/item_uoms to WMS-local PMS projections
- keep purchase-order sourced receipt lines, return-order sourced receipt lines, release logic, inbound operation write, stock writes, ledger writes, and structural FKs unchanged
- keep this PR narrowly scoped to _load_manual_line_snapshot

## Validation
- python3 -m compileall app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_write_repo.py app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_read_repo.py
- make upgrade-test
- make rebuild-wms-pms-projection-test
- TESTS="tests/api/test_inbound_receipts_manual_api.py tests/api/test_wms_receiving_batch_no_lot_code_contract_api.py tests/services/test_wms_pms_projection_read_service.py tests/services/test_wms_pms_projection_rebuild_service.py" make test
- make alembic-check
- git diff --check