### PR TITLE
refactor(wms): use pms projection for inbound operation uom resolution

### DIFF
--- a/app/wms/inventory_adjustment/return_inbound/repos/inbound_operation_write_repo.py
+++ b/app/wms/inventory_adjustment/return_inbound/repos/inbound_operation_write_repo.py
@@ -12,6 +12,7 @@ from app.wms.inbound.repos.lot_resolve_repo import resolve_inbound_lot
 from app.wms.inventory_adjustment.count.services.count_freeze_guard_service import (
     ensure_warehouse_not_frozen,
 )
+from app.wms.pms_projection.services.read_service import WmsPmsProjectionReadService
 from app.wms.inventory_adjustment.return_inbound.contracts.operation_submit import (
     InboundOperationLineOut,
     InboundOperationSubmitIn,
@@ -51,37 +52,21 @@ async def _load_item_uom_snapshot(
     item_id: int,
     item_uom_id: int,
 ) -> tuple[int, str | None, int]:
-    row = (
-        await session.execute(
-            text(
-                """
-                SELECT
-                  iu.id AS actual_item_uom_id,
-                  COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS actual_uom_name_snapshot,
-                  iu.ratio_to_base AS actual_ratio_to_base_snapshot
-                FROM item_uoms iu
-                WHERE iu.id = :item_uom_id
-                  AND iu.item_id = :item_id
-                LIMIT 1
-                """
-            ),
-            {
-                "item_uom_id": int(item_uom_id),
-                "item_id": int(item_id),
-            },
-        )
-    ).mappings().first()
+    uom = await WmsPmsProjectionReadService(session).aget_uom_snapshot(
+        item_id=int(item_id),
+        item_uom_id=int(item_uom_id),
+    )
 
-    if row is None:
+    if uom is None:
         raise HTTPException(
             status_code=409,
             detail=f"actual_item_uom_not_found_or_item_mismatch:{item_id}:{item_uom_id}",
         )
 
     return (
-        int(row["actual_item_uom_id"]),
-        row["actual_uom_name_snapshot"],
-        int(row["actual_ratio_to_base_snapshot"]),
+        int(uom.item_uom_id),
+        uom.uom_name,
+        int(uom.ratio_to_base),
     )
 
 
@@ -92,42 +77,21 @@ async def _resolve_barcode_uom_snapshot(
     barcode: str,
 ) -> tuple[int, str | None, int]:
     code = (barcode or "").strip()
-    row = (
-        await session.execute(
-            text(
-                """
-                SELECT
-                  iu.id AS actual_item_uom_id,
-                  COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS actual_uom_name_snapshot,
-                  iu.ratio_to_base AS actual_ratio_to_base_snapshot
-                FROM item_barcodes ib
-                JOIN item_uoms iu
-                  ON iu.id = ib.item_uom_id
-                 AND iu.item_id = ib.item_id
-                WHERE ib.barcode = :barcode
-                  AND ib.active = TRUE
-                  AND ib.item_id = :item_id
-                ORDER BY ib.is_primary DESC, ib.id ASC
-                LIMIT 1
-                """
-            ),
-            {
-                "barcode": code,
-                "item_id": int(item_id),
-            },
-        )
-    ).mappings().first()
+    probe = await WmsPmsProjectionReadService(session).aprobe_barcode(
+        barcode=code,
+        active_only=True,
+    )
 
-    if row is None:
+    if probe is None or int(probe.item_id) != int(item_id):
         raise HTTPException(
             status_code=422,
             detail=f"barcode_unbound_or_item_mismatch:{code}",
         )
 
     return (
-        int(row["actual_item_uom_id"]),
-        row["actual_uom_name_snapshot"],
-        int(row["actual_ratio_to_base_snapshot"]),
+        int(probe.item_uom_id),
+        probe.uom_name,
+        int(probe.ratio_to_base),
     )
 
 


### PR DESCRIPTION
## Summary
- switch inbound operation explicit actual UOM snapshot lookup from PMS owner item_uoms to WMS-local PMS UOM projection
- switch inbound operation barcode-to-UOM resolution from PMS owner item_barcodes/item_uoms to WMS-local PMS barcode projection
- keep task line reads, lot resolution, stock writes, ledger writes, events, and structural FKs unchanged

## Validation
- python3 -m compileall app/wms/inventory_adjustment/return_inbound/repos/inbound_operation_write_repo.py app/wms/inventory_adjustment/return_inbound/services/inbound_task_probe_service.py app/wms/pms_projection/services/read_service.py
- make upgrade-test
- make rebuild-wms-pms-projection-test
- TESTS="tests/api/test_inbound_receipts_manual_api.py tests/api/test_wms_receiving_batch_no_lot_code_contract_api.py tests/services/test_order_rma_and_reconcile.py tests/test_phase3_three_books_return_commit.py tests/services/test_wms_pms_projection_read_service.py tests/services/test_wms_pms_projection_rebuild_service.py" make test
- make alembic-check
- git diff --check
- rg audit confirms inbound operation UOM/barcode helpers no longer use PMS owner item_uoms/item_barcodes