### PR TITLE
refactor(wms): remove pms type imports from wms boundary

### DIFF
--- a/app/wms/inbound/contracts/inbound_commit.py
+++ b/app/wms/inbound/contracts/inbound_commit.py
@@ -30,7 +30,7 @@ class InboundCommitLineIn(_Base):
 
     设计原则：
     - 输入只接用户事实：商品/条码、包装单位、输入数量、批号/日期
-    - 不接 qty_base，qty_base 由后端根据 PMS item_uoms.ratio_to_base 计算
+    - 不接 qty_base，qty_base 由后端根据 WMS PMS projection 的 ratio_to_base 计算
     - 采购来源时允许显式带 po_line_id；其他来源不需要 source_line_ref 这种泛字段
     """
 

--- a/app/wms/inbound/repos/lot_resolve_repo.py
+++ b/app/wms/inbound/repos/lot_resolve_repo.py
@@ -4,11 +4,11 @@ from datetime import date
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.contracts.item_policy import ItemPolicy
+from app.wms.pms_projection.services.read_service import WmsPmsPolicyProjectionSnapshot
 from app.wms.stock.services.lot_service import resolve_or_create_lot
 
 
-def infer_lot_code_source_from_policy(item_policy: ItemPolicy) -> str:
+def infer_lot_code_source_from_policy(item_policy: WmsPmsPolicyProjectionSnapshot) -> str:
     """
     lot 来源必须以后端 PMS 策略真相为准，不再把 expiry_policy 和 lot_source_policy 混为一谈。
 
@@ -25,7 +25,7 @@ async def resolve_inbound_lot(
     session: AsyncSession,
     *,
     warehouse_id: int,
-    item_policy: ItemPolicy,
+    item_policy: WmsPmsPolicyProjectionSnapshot,
     lot_code: str | None,
     production_date: date | None,
     expiry_date: date | None,

--- a/app/wms/inventory_adjustment/return_inbound/contracts/inbound_task_read.py
+++ b/app/wms/inventory_adjustment/return_inbound/contracts/inbound_task_read.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -10,11 +10,9 @@ from app.wms.inventory_adjustment.return_inbound.contracts.enums import (
     InboundReceiptSourceType,
     InboundReceiptStatus,
 )
-from app.pms.export.items.contracts.item_policy import (
-    ExpiryPolicy,
-    LotSourcePolicy,
-    ShelfLifeUnit,
-)
+ExpiryPolicy = Literal["NONE", "REQUIRED"]
+LotSourcePolicy = Literal["INTERNAL_ONLY", "SUPPLIER_ONLY"]
+ShelfLifeUnit = Literal["DAY", "WEEK", "MONTH", "YEAR"]
 
 
 class _Base(BaseModel):

--- a/app/wms/stock/models/stock_snapshot.py
+++ b/app/wms/stock/models/stock_snapshot.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import date
 from decimal import Decimal
-from typing import TYPE_CHECKING
+from typing import Any
 
 import sqlalchemy as sa
 from sqlalchemy import Date, Index, Integer, Numeric, text
@@ -11,8 +11,6 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
 
-if TYPE_CHECKING:
-    from app.pms.items.models.item import Item
 
 
 class StockSnapshot(Base):
@@ -55,4 +53,4 @@ class StockSnapshot(Base):
         {"info": {"skip_autogen": True}},
     )
 
-    item: Mapped["Item"] = relationship("Item", lazy="selectin")
+    item: Mapped[Any] = relationship("Item", lazy="selectin")

--- a/app/wms/stock/services/lot_service.py
+++ b/app/wms/stock/services/lot_service.py
@@ -9,7 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.wms.stock.models.lot import Lot
-from app.pms.export.items.contracts.item_policy import ItemPolicy
+from app.wms.pms_projection.services.read_service import WmsPmsPolicyProjectionSnapshot
 from app.wms.stock.services.lots import ensure_internal_lot_singleton, ensure_lot_full
 
 
@@ -33,7 +33,7 @@ async def resolve_or_create_lot(
     db: AsyncSession,
     *,
     warehouse_id: int,
-    item_policy: ItemPolicy,
+    item_policy: WmsPmsPolicyProjectionSnapshot,
     lot_code_source: str,
     lot_code: Optional[str],
     production_date: Optional[date],

--- a/app/wms/stock/services/stock_contract_resolver.py
+++ b/app/wms/stock/services/stock_contract_resolver.py
@@ -28,7 +28,7 @@ async def resolve_lot_for_stock_adjust(
 
     约束：
     - 本模块只负责：
-        1) requires_batch（items.expiry_policy 投影）
+        1) requires_batch（WMS PMS policy projection）
         2) validate_lot_code_contract（REQUIRED/NONE 合同裁决）
         3) ensure_*_lot_id（lot identity 解析 / 创建入口）
     - 不负责写库存（不得调用 adjust_lot_impl），以保持“执行器单入口”铁律。


### PR DESCRIPTION
## Summary
- replace remaining WMS ItemPolicy type imports from PMS export with WMS PMS projection snapshot type
- replace return inbound task read PMS export policy types with local Literal aliases
- remove TYPE_CHECKING dependency on PMS Item model from stock snapshot model
- update stale comments that still referenced PMS owner item_uoms/items policy sources
- keep projection rebuild service as the only allowed WMS-side PMS owner reader

## Validation
- python3 -m compileall app/wms/inbound/contracts/inbound_commit.py app/wms/inbound/repos/lot_resolve_repo.py app/wms/stock/models/stock_snapshot.py app/wms/stock/services/stock_contract_resolver.py app/wms/stock/services/lot_service.py app/wms/inventory_adjustment/return_inbound/contracts/inbound_task_read.py
- make upgrade-test
- make rebuild-wms-pms-projection-test
- TESTS="tests/api/test_inbound_receipts_manual_api.py tests/api/test_wms_receiving_batch_no_lot_code_contract_api.py tests/services/test_order_rma_and_reconcile.py tests/test_phase3_three_books_return_commit.py tests/services/test_wms_pms_projection_read_service.py tests/services/test_wms_pms_projection_rebuild_service.py" make test
- make alembic-check
- git diff --check
- rg audit confirms app/wms no longer imports PMS owner/export types outside pms_projection rebuild