### PR TITLE
feat(wms): add pms projection sync cursor

### DIFF
--- a/alembic/versions/d4f8c2b1a790_add_wms_pms_projection_sync_cursor.py
+++ b/alembic/versions/d4f8c2b1a790_add_wms_pms_projection_sync_cursor.py
@@ -1,0 +1,92 @@
+"""add_wms_pms_projection_sync_cursor
+
+Revision ID: d4f8c2b1a790
+Revises: e7b9c2a4d6f8
+Create Date: 2026-05-09 20:10:00.000000
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d4f8c2b1a790"
+down_revision: Union[str, Sequence[str], None] = "e7b9c2a4d6f8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+
+    op.create_table(
+        "wms_pms_projection_sync_cursors",
+        sa.Column("source_name", sa.String(length=64), nullable=False),
+        sa.Column("last_source_updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "last_synced_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "last_status",
+            sa.String(length=16),
+            nullable=False,
+            server_default=sa.text("'IDLE'"),
+        ),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column(
+            "retry_count",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint(
+            "source_name",
+            name="pk_wms_pms_projection_sync_cursors",
+        ),
+        sa.CheckConstraint(
+            "length(trim(source_name)) > 0",
+            name="ck_wms_pms_projection_sync_cursor_source_name_non_empty",
+        ),
+        sa.CheckConstraint(
+            "last_status IN ('IDLE', 'SUCCESS', 'FAILED')",
+            name="ck_wms_pms_projection_sync_cursor_status",
+        ),
+        sa.CheckConstraint(
+            "retry_count >= 0",
+            name="ck_wms_pms_projection_sync_cursor_retry_non_negative",
+        ),
+    )
+    op.create_index(
+        "ix_wms_pms_projection_sync_cursors_status",
+        "wms_pms_projection_sync_cursors",
+        ["last_status"],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+
+    op.drop_index(
+        "ix_wms_pms_projection_sync_cursors_status",
+        table_name="wms_pms_projection_sync_cursors",
+    )
+    op.drop_table("wms_pms_projection_sync_cursors")

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -138,6 +138,7 @@ def init_models(
         "app.pms.items.models",
         "app.pms.sku_coding.models",
         "app.partners.suppliers.models",
+        "app.wms.pms_projection.models",
         "app.wms.inventory_adjustment.return_inbound.models",
         "app.wms.inventory_adjustment.count.models",
         "app.wms.inbound.models",

--- a/app/wms/pms_projection/models/projection.py
+++ b/app/wms/pms_projection/models/projection.py
@@ -356,3 +356,62 @@ class WmsPmsItemBarcodeProjection(Base):
             postgresql_where=sa.text("is_primary = true"),
         ),
     )
+
+
+class WmsPmsProjectionSyncCursor(Base):
+    """
+    WMS PMS projection 增量同步水位。
+
+    第一版同步不引入 PMS outbox / CDC：
+    - source_name 标识同步来源；
+    - last_source_updated_at 是 owner updated_at 扫描水位；
+    - last_status / last_error / retry_count 用于失败后重复扫描与人工排查。
+    """
+
+    __tablename__ = "wms_pms_projection_sync_cursors"
+
+    source_name: Mapped[str] = mapped_column(sa.String(64), primary_key=True)
+    last_source_updated_at: Mapped[datetime] = mapped_column(sa.DateTime(timezone=True), nullable=False)
+    last_synced_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    last_status: Mapped[str] = mapped_column(
+        sa.String(16),
+        nullable=False,
+        server_default=sa.text("'IDLE'"),
+    )
+    last_error: Mapped[Optional[str]] = mapped_column(sa.Text, nullable=True)
+    retry_count: Mapped[int] = mapped_column(
+        sa.Integer,
+        nullable=False,
+        server_default=sa.text("0"),
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+
+    __table_args__ = (
+        sa.CheckConstraint(
+            "length(trim(source_name)) > 0",
+            name="ck_wms_pms_projection_sync_cursor_source_name_non_empty",
+        ),
+        sa.CheckConstraint(
+            "last_status IN ('IDLE', 'SUCCESS', 'FAILED')",
+            name="ck_wms_pms_projection_sync_cursor_status",
+        ),
+        sa.CheckConstraint(
+            "retry_count >= 0",
+            name="ck_wms_pms_projection_sync_cursor_retry_non_negative",
+        ),
+        sa.Index("ix_wms_pms_projection_sync_cursors_status", "last_status"),
+    )

--- a/tests/ci/test_wms_pms_projection_sync_cursor_schema.py
+++ b/tests/ci/test_wms_pms_projection_sync_cursor_schema.py
@@ -1,0 +1,67 @@
+# tests/ci/test_wms_pms_projection_sync_cursor_schema.py
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_wms_pms_projection_sync_cursor_schema(session: AsyncSession) -> None:
+    rows = await session.execute(
+        text(
+            """
+            SELECT
+              column_name,
+              is_nullable,
+              data_type,
+              column_default
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'wms_pms_projection_sync_cursors'
+            """
+        )
+    )
+    columns = {str(row["column_name"]): row for row in rows.mappings().all()}
+
+    required_columns = {
+        "source_name",
+        "last_source_updated_at",
+        "last_synced_at",
+        "last_status",
+        "last_error",
+        "retry_count",
+        "created_at",
+        "updated_at",
+    }
+    assert required_columns <= set(columns)
+
+    assert columns["source_name"]["is_nullable"] == "NO"
+    assert columns["last_source_updated_at"]["is_nullable"] == "NO"
+    assert columns["last_synced_at"]["is_nullable"] == "NO"
+    assert columns["last_status"]["is_nullable"] == "NO"
+    assert columns["retry_count"]["is_nullable"] == "NO"
+
+    constraints = await session.execute(
+        text(
+            """
+            SELECT c.conname
+            FROM pg_constraint c
+            JOIN pg_class t
+              ON t.oid = c.conrelid
+            JOIN pg_namespace n
+              ON n.oid = t.relnamespace
+            WHERE n.nspname = 'public'
+              AND t.relname = 'wms_pms_projection_sync_cursors'
+            """
+        )
+    )
+    constraint_names = {str(row["conname"]) for row in constraints.mappings().all()}
+
+    assert {
+        "pk_wms_pms_projection_sync_cursors",
+        "ck_wms_pms_projection_sync_cursor_source_name_non_empty",
+        "ck_wms_pms_projection_sync_cursor_status",
+        "ck_wms_pms_projection_sync_cursor_retry_non_negative",
+    } <= constraint_names


### PR DESCRIPTION
## Summary
- add WMS PMS projection sync cursor table
- add ORM model for projection sync cursor
- import WMS PMS projection models into ORM metadata
- add schema contract test for the cursor table

## Tests
- python3 -m compileall app/db/base.py app/wms/pms_projection/models/projection.py alembic/versions/d4f8c2b1a790_add_wms_pms_projection_sync_cursor.py tests/ci/test_wms_pms_projection_sync_cursor_schema.py
- make upgrade-dev
- make alembic-check
- make test TESTS=tests/ci/test_wms_pms_projection_sync_cursor_schema.py
- make audit-all