### PR TITLE
refactor(wms): support item scoped pms projection rebuild

### DIFF
--- a/app/wms/pms_projection/services/rebuild_service.py
+++ b/app/wms/pms_projection/services/rebuild_service.py
@@ -5,6 +5,7 @@
 # 业务执行链不得绕过 projection 直接读取 PMS owner 表。
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
@@ -71,15 +72,20 @@ def _required_datetime(value: object, *, label: str) -> datetime:
     return value
 
 
+def _clean_item_ids(item_ids: Sequence[int]) -> list[int]:
+    return sorted({int(item_id) for item_id in item_ids})
+
+
 class WmsPmsProjectionRebuildService:
     """
-    WMS PMS projection 全量重建服务。
+    WMS PMS projection 重建服务。
 
     当前阶段职责：
     - 从 PMS owner 表读取商品、包装单位、条码、SKU code、策略；
     - 写入 WMS 本地 wms_pms_*_projection；
     - 支持幂等重复执行；
-    - 清理 projection 中已不存在于 PMS owner 的陈旧行。
+    - 支持全量 rebuild_all；
+    - 支持按 item_id 局部 rebuild_items，供后续增量 sync 复用。
 
     明确不负责：
     - 不接入 WMS scan；
@@ -92,41 +98,103 @@ class WmsPmsProjectionRebuildService:
         self.session = session
 
     async def rebuild_all(self) -> WmsPmsProjectionRebuildResult:
-        item_rows = (await self.session.execute(self._items_stmt())).mappings().all()
-        uom_rows = (await self.session.execute(self._uoms_stmt())).mappings().all()
-        sku_code_rows = (await self.session.execute(self._sku_codes_stmt())).mappings().all()
-        barcode_rows = (await self.session.execute(self._barcodes_stmt())).mappings().all()
+        return await self._rebuild(item_ids=None)
 
-        item_ids = {int(row["id"]) for row in item_rows}
+    async def rebuild_items(self, item_ids: Sequence[int]) -> WmsPmsProjectionRebuildResult:
+        clean_item_ids = _clean_item_ids(item_ids)
+        if not clean_item_ids:
+            return WmsPmsProjectionRebuildResult(
+                source_items=0,
+                source_uoms=0,
+                source_policies=0,
+                source_sku_codes=0,
+                source_barcodes=0,
+                deleted_items=0,
+                deleted_uoms=0,
+                deleted_policies=0,
+                deleted_sku_codes=0,
+                deleted_barcodes=0,
+            )
+        return await self._rebuild(item_ids=clean_item_ids)
+
+    async def _rebuild(
+        self,
+        *,
+        item_ids: Sequence[int] | None,
+    ) -> WmsPmsProjectionRebuildResult:
+        item_rows = (await self.session.execute(self._items_stmt(item_ids))).mappings().all()
+        uom_rows = (await self.session.execute(self._uoms_stmt(item_ids))).mappings().all()
+        sku_code_rows = (await self.session.execute(self._sku_codes_stmt(item_ids))).mappings().all()
+        barcode_rows = (await self.session.execute(self._barcodes_stmt(item_ids))).mappings().all()
+
+        source_item_ids = {int(row["id"]) for row in item_rows}
         uom_ids = {int(row["id"]) for row in uom_rows}
         sku_code_ids = {int(row["id"]) for row in sku_code_rows}
         barcode_ids = {int(row["id"]) for row in barcode_rows}
 
-        deleted_barcodes = await self._delete_stale(
-            WmsPmsItemBarcodeProjection,
-            WmsPmsItemBarcodeProjection.barcode_id,
-            barcode_ids,
-        )
-        deleted_sku_codes = await self._delete_stale(
-            WmsPmsItemSkuCodeProjection,
-            WmsPmsItemSkuCodeProjection.sku_code_id,
-            sku_code_ids,
-        )
-        deleted_policies = await self._delete_stale(
-            WmsPmsItemPolicyProjection,
-            WmsPmsItemPolicyProjection.item_id,
-            item_ids,
-        )
-        deleted_uoms = await self._delete_stale(
-            WmsPmsItemUomProjection,
-            WmsPmsItemUomProjection.item_uom_id,
-            uom_ids,
-        )
-        deleted_items = await self._delete_stale(
-            WmsPmsItemProjection,
-            WmsPmsItemProjection.item_id,
-            item_ids,
-        )
+        if item_ids is None:
+            deleted_barcodes = await self._delete_stale(
+                WmsPmsItemBarcodeProjection,
+                WmsPmsItemBarcodeProjection.barcode_id,
+                barcode_ids,
+            )
+            deleted_sku_codes = await self._delete_stale(
+                WmsPmsItemSkuCodeProjection,
+                WmsPmsItemSkuCodeProjection.sku_code_id,
+                sku_code_ids,
+            )
+            deleted_policies = await self._delete_stale(
+                WmsPmsItemPolicyProjection,
+                WmsPmsItemPolicyProjection.item_id,
+                source_item_ids,
+            )
+            deleted_uoms = await self._delete_stale(
+                WmsPmsItemUomProjection,
+                WmsPmsItemUomProjection.item_uom_id,
+                uom_ids,
+            )
+            deleted_items = await self._delete_stale(
+                WmsPmsItemProjection,
+                WmsPmsItemProjection.item_id,
+                source_item_ids,
+            )
+        else:
+            target_item_ids = set(_clean_item_ids(item_ids))
+            deleted_barcodes = await self._delete_stale_for_items(
+                WmsPmsItemBarcodeProjection,
+                WmsPmsItemBarcodeProjection.barcode_id,
+                WmsPmsItemBarcodeProjection.item_id,
+                barcode_ids,
+                target_item_ids,
+            )
+            deleted_sku_codes = await self._delete_stale_for_items(
+                WmsPmsItemSkuCodeProjection,
+                WmsPmsItemSkuCodeProjection.sku_code_id,
+                WmsPmsItemSkuCodeProjection.item_id,
+                sku_code_ids,
+                target_item_ids,
+            )
+            deleted_policies = await self._delete_stale_for_items(
+                WmsPmsItemPolicyProjection,
+                WmsPmsItemPolicyProjection.item_id,
+                WmsPmsItemPolicyProjection.item_id,
+                source_item_ids,
+                target_item_ids,
+            )
+            deleted_uoms = await self._delete_stale_for_items(
+                WmsPmsItemUomProjection,
+                WmsPmsItemUomProjection.item_uom_id,
+                WmsPmsItemUomProjection.item_id,
+                uom_ids,
+                target_item_ids,
+            )
+            deleted_items = await self._delete_stale_for_items(
+                WmsPmsItemProjection,
+                WmsPmsItemProjection.item_id,
+                WmsPmsItemProjection.item_id,
+                source_item_ids,
+                target_item_ids,
+            )
 
         await self._upsert_items(item_rows)
         await self._upsert_uoms(uom_rows)
@@ -150,79 +218,79 @@ class WmsPmsProjectionRebuildService:
         )
 
     @staticmethod
-    def _items_stmt():
-        return (
-            select(
-                Item.id,
-                Item.sku,
-                Item.name,
-                Item.spec,
-                Item.enabled,
-                Item.brand_id,
-                Item.category_id,
-                Item.updated_at,
-                Item.lot_source_policy,
-                Item.expiry_policy,
-                Item.shelf_life_value,
-                Item.shelf_life_unit,
-                Item.derivation_allowed,
-                Item.uom_governance_enabled,
-            )
-            .order_by(Item.id.asc())
+    def _items_stmt(item_ids: Sequence[int] | None = None):
+        stmt = select(
+            Item.id,
+            Item.sku,
+            Item.name,
+            Item.spec,
+            Item.enabled,
+            Item.brand_id,
+            Item.category_id,
+            Item.updated_at,
+            Item.lot_source_policy,
+            Item.expiry_policy,
+            Item.shelf_life_value,
+            Item.shelf_life_unit,
+            Item.derivation_allowed,
+            Item.uom_governance_enabled,
         )
+        if item_ids is not None:
+            stmt = stmt.where(Item.id.in_(_clean_item_ids(item_ids)))
+        return stmt.order_by(Item.id.asc())
 
     @staticmethod
-    def _uoms_stmt():
-        return (
-            select(
-                ItemUOM.id,
-                ItemUOM.item_id,
-                ItemUOM.uom,
-                ItemUOM.display_name,
-                ItemUOM.ratio_to_base,
-                ItemUOM.is_base,
-                ItemUOM.is_purchase_default,
-                ItemUOM.is_inbound_default,
-                ItemUOM.is_outbound_default,
-                ItemUOM.net_weight_kg,
-                ItemUOM.updated_at,
-            )
-            .order_by(ItemUOM.item_id.asc(), ItemUOM.id.asc())
+    def _uoms_stmt(item_ids: Sequence[int] | None = None):
+        stmt = select(
+            ItemUOM.id,
+            ItemUOM.item_id,
+            ItemUOM.uom,
+            ItemUOM.display_name,
+            ItemUOM.ratio_to_base,
+            ItemUOM.is_base,
+            ItemUOM.is_purchase_default,
+            ItemUOM.is_inbound_default,
+            ItemUOM.is_outbound_default,
+            ItemUOM.net_weight_kg,
+            ItemUOM.updated_at,
         )
+        if item_ids is not None:
+            stmt = stmt.where(ItemUOM.item_id.in_(_clean_item_ids(item_ids)))
+        return stmt.order_by(ItemUOM.item_id.asc(), ItemUOM.id.asc())
 
     @staticmethod
-    def _sku_codes_stmt():
-        return (
-            select(
-                ItemSkuCode.id,
-                ItemSkuCode.item_id,
-                ItemSkuCode.code,
-                ItemSkuCode.code_type,
-                ItemSkuCode.is_primary,
-                ItemSkuCode.is_active,
-                ItemSkuCode.effective_from,
-                ItemSkuCode.effective_to,
-                ItemSkuCode.remark,
-                ItemSkuCode.updated_at,
-            )
-            .order_by(ItemSkuCode.item_id.asc(), ItemSkuCode.id.asc())
+    def _sku_codes_stmt(item_ids: Sequence[int] | None = None):
+        stmt = select(
+            ItemSkuCode.id,
+            ItemSkuCode.item_id,
+            ItemSkuCode.code,
+            ItemSkuCode.code_type,
+            ItemSkuCode.is_primary,
+            ItemSkuCode.is_active,
+            ItemSkuCode.effective_from,
+            ItemSkuCode.effective_to,
+            ItemSkuCode.remark,
+            ItemSkuCode.updated_at,
         )
+        if item_ids is not None:
+            stmt = stmt.where(ItemSkuCode.item_id.in_(_clean_item_ids(item_ids)))
+        return stmt.order_by(ItemSkuCode.item_id.asc(), ItemSkuCode.id.asc())
 
     @staticmethod
-    def _barcodes_stmt():
-        return (
-            select(
-                ItemBarcode.id,
-                ItemBarcode.item_id,
-                ItemBarcode.item_uom_id,
-                ItemBarcode.barcode,
-                ItemBarcode.active,
-                ItemBarcode.is_primary,
-                ItemBarcode.symbology,
-                ItemBarcode.updated_at,
-            )
-            .order_by(ItemBarcode.item_id.asc(), ItemBarcode.id.asc())
+    def _barcodes_stmt(item_ids: Sequence[int] | None = None):
+        stmt = select(
+            ItemBarcode.id,
+            ItemBarcode.item_id,
+            ItemBarcode.item_uom_id,
+            ItemBarcode.barcode,
+            ItemBarcode.active,
+            ItemBarcode.is_primary,
+            ItemBarcode.symbology,
+            ItemBarcode.updated_at,
         )
+        if item_ids is not None:
+            stmt = stmt.where(ItemBarcode.item_id.in_(_clean_item_ids(item_ids)))
+        return stmt.order_by(ItemBarcode.item_id.asc(), ItemBarcode.id.asc())
 
     async def _delete_stale(
         self,
@@ -231,6 +299,23 @@ class WmsPmsProjectionRebuildService:
         source_ids: set[int],
     ) -> int:
         stmt = sa.delete(model)
+        if source_ids:
+            stmt = stmt.where(~id_column.in_(sorted(source_ids)))
+        result = await self.session.execute(stmt)
+        return _rowcount(result)
+
+    async def _delete_stale_for_items(
+        self,
+        model: type[object],
+        id_column: sa.ColumnElement[int],
+        item_column: sa.ColumnElement[int],
+        source_ids: set[int],
+        target_item_ids: set[int],
+    ) -> int:
+        if not target_item_ids:
+            return 0
+
+        stmt = sa.delete(model).where(item_column.in_(sorted(target_item_ids)))
         if source_ids:
             stmt = stmt.where(~id_column.in_(sorted(source_ids)))
         result = await self.session.execute(stmt)

--- a/tests/services/test_wms_pms_projection_rebuild_items_service.py
+++ b/tests/services/test_wms_pms_projection_rebuild_items_service.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import sqlalchemy as sa
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.wms.pms_projection.models.projection import (
+    WmsPmsItemProjection,
+    WmsPmsItemUomProjection,
+)
+from app.wms.pms_projection.services.rebuild_service import (
+    WmsPmsProjectionRebuildService,
+)
+
+
+async def _insert_scalar_int(
+    session: AsyncSession,
+    sql: str,
+    params: dict[str, object],
+) -> int:
+    result = await session.execute(text(sql), params)
+    return int(result.scalar_one())
+
+
+async def _insert_owner_item_bundle(
+    session: AsyncSession,
+    *,
+    prefix: str,
+) -> dict[str, int | str]:
+    item_id = await _insert_scalar_int(
+        session,
+        """
+        INSERT INTO items (
+          sku,
+          name,
+          spec,
+          enabled,
+          lot_source_policy,
+          expiry_policy,
+          derivation_allowed,
+          uom_governance_enabled
+        )
+        VALUES (
+          :sku,
+          :name,
+          :spec,
+          true,
+          'INTERNAL_ONLY',
+          'NONE',
+          false,
+          true
+        )
+        RETURNING id
+        """,
+        {
+            "sku": f"{prefix}-SKU",
+            "name": f"{prefix} item before",
+            "spec": "before",
+        },
+    )
+
+    item_uom_id = await _insert_scalar_int(
+        session,
+        """
+        INSERT INTO item_uoms (
+          item_id,
+          uom,
+          ratio_to_base,
+          display_name,
+          net_weight_kg,
+          is_base,
+          is_purchase_default,
+          is_inbound_default,
+          is_outbound_default
+        )
+        VALUES (
+          :item_id,
+          'PCS',
+          1,
+          :display_name,
+          0.125,
+          true,
+          true,
+          true,
+          true
+        )
+        RETURNING id
+        """,
+        {
+            "item_id": item_id,
+            "display_name": f"{prefix} 件",
+        },
+    )
+
+    sku_code_id = await _insert_scalar_int(
+        session,
+        """
+        INSERT INTO item_sku_codes (
+          item_id,
+          code,
+          code_type,
+          is_primary,
+          is_active,
+          remark
+        )
+        VALUES (
+          :item_id,
+          :code,
+          'PRIMARY',
+          true,
+          true,
+          'before'
+        )
+        RETURNING id
+        """,
+        {
+            "item_id": item_id,
+            "code": f"{prefix}-CODE",
+        },
+    )
+
+    barcode_id = await _insert_scalar_int(
+        session,
+        """
+        INSERT INTO item_barcodes (
+          item_id,
+          item_uom_id,
+          barcode,
+          symbology,
+          active,
+          is_primary
+        )
+        VALUES (
+          :item_id,
+          :item_uom_id,
+          :barcode,
+          'CUSTOM',
+          true,
+          true
+        )
+        RETURNING id
+        """,
+        {
+            "item_id": item_id,
+            "item_uom_id": item_uom_id,
+            "barcode": f"{prefix}-BAR",
+        },
+    )
+
+    return {
+        "item_id": item_id,
+        "item_uom_id": item_uom_id,
+        "sku_code_id": sku_code_id,
+        "barcode_id": barcode_id,
+        "sku": f"{prefix}-SKU",
+        "code": f"{prefix}-CODE",
+        "barcode": f"{prefix}-BAR",
+    }
+
+
+async def _insert_stale_uom_projection(
+    session: AsyncSession,
+    *,
+    item_id: int,
+    item_uom_id: int,
+    uom: str,
+) -> None:
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_pms_item_uom_projection (
+              item_uom_id,
+              item_id,
+              uom,
+              display_name,
+              ratio_to_base,
+              is_base,
+              is_purchase_default,
+              is_inbound_default,
+              is_outbound_default,
+              source_updated_at
+            )
+            VALUES (
+              :item_uom_id,
+              :item_id,
+              :uom,
+              :display_name,
+              1,
+              false,
+              false,
+              false,
+              false,
+              now()
+            )
+            """
+        ),
+        {
+            "item_uom_id": item_uom_id,
+            "item_id": item_id,
+            "uom": uom,
+            "display_name": f"{uom} stale",
+        },
+    )
+
+
+async def test_rebuild_items_updates_target_and_preserves_non_target_projection(
+    session: AsyncSession,
+) -> None:
+    suffix = uuid4().hex[:10]
+    target = await _insert_owner_item_bundle(session, prefix=f"RBITEM-T-{suffix}")
+    other = await _insert_owner_item_bundle(session, prefix=f"RBITEM-O-{suffix}")
+
+    service = WmsPmsProjectionRebuildService(session)
+    await service.rebuild_all()
+
+    target_item_id = int(target["item_id"])
+    other_item_id = int(other["item_id"])
+
+    target_stale_uom_id = 991_000_000
+    other_stale_uom_id = 992_000_000
+
+    await _insert_stale_uom_projection(
+        session,
+        item_id=target_item_id,
+        item_uom_id=target_stale_uom_id,
+        uom=f"TSTALE{suffix[:4]}",
+    )
+    await _insert_stale_uom_projection(
+        session,
+        item_id=other_item_id,
+        item_uom_id=other_stale_uom_id,
+        uom=f"OSTALE{suffix[:4]}",
+    )
+
+    await session.execute(
+        text(
+            """
+            UPDATE items
+            SET
+              name = :name,
+              spec = 'after',
+              enabled = false,
+              updated_at = now()
+            WHERE id = :item_id
+            """
+        ),
+        {
+            "item_id": target_item_id,
+            "name": f"RBITEM-T-{suffix} item after",
+        },
+    )
+    await session.execute(
+        text(
+            """
+            UPDATE item_uoms
+            SET
+              display_name = :display_name,
+              updated_at = now()
+            WHERE id = :item_uom_id
+            """
+        ),
+        {
+            "item_uom_id": int(target["item_uom_id"]),
+            "display_name": f"RBITEM-T-{suffix} 单件",
+        },
+    )
+    await session.execute(
+        text(
+            """
+            UPDATE wms_pms_item_projection
+            SET
+              name = :name,
+              updated_at = now()
+            WHERE item_id = :item_id
+            """
+        ),
+        {
+            "item_id": other_item_id,
+            "name": "non-target projection marker",
+        },
+    )
+
+    result = await service.rebuild_items([target_item_id])
+
+    assert result.source_items == 1
+    assert result.source_uoms == 1
+    assert result.source_policies == 1
+    assert result.source_sku_codes == 1
+    assert result.source_barcodes == 1
+    assert result.deleted_items == 0
+    assert result.deleted_policies == 0
+    assert result.deleted_uoms >= 1
+
+    session.expire_all()
+
+    target_projection = await session.get(WmsPmsItemProjection, target_item_id)
+    assert target_projection is not None
+    assert target_projection.name == f"RBITEM-T-{suffix} item after"
+    assert target_projection.spec == "after"
+    assert target_projection.enabled is False
+
+    target_uom_projection = await session.get(WmsPmsItemUomProjection, int(target["item_uom_id"]))
+    assert target_uom_projection is not None
+    assert target_uom_projection.display_name == f"RBITEM-T-{suffix} 单件"
+
+    deleted_target_stale = await session.get(WmsPmsItemUomProjection, target_stale_uom_id)
+    assert deleted_target_stale is None
+
+    other_projection = await session.get(WmsPmsItemProjection, other_item_id)
+    assert other_projection is not None
+    assert other_projection.name == "non-target projection marker"
+
+    other_stale = await session.get(WmsPmsItemUomProjection, other_stale_uom_id)
+    assert other_stale is not None
+
+
+async def test_rebuild_items_empty_input_is_noop(session: AsyncSession) -> None:
+    result = await WmsPmsProjectionRebuildService(session).rebuild_items([])
+
+    assert result.source_items == 0
+    assert result.source_uoms == 0
+    assert result.source_policies == 0
+    assert result.source_sku_codes == 0
+    assert result.source_barcodes == 0
+    assert result.deleted_items == 0
+    assert result.deleted_uoms == 0
+    assert result.deleted_policies == 0
+    assert result.deleted_sku_codes == 0
+    assert result.deleted_barcodes == 0
+
+
+async def test_rebuild_items_removes_projection_for_missing_owner_item(
+    session: AsyncSession,
+) -> None:
+    suffix = uuid4().hex[:10]
+    bundle = await _insert_owner_item_bundle(session, prefix=f"RBITEM-D-{suffix}")
+
+    service = WmsPmsProjectionRebuildService(session)
+    await service.rebuild_all()
+
+    item_id = int(bundle["item_id"])
+    item_uom_id = int(bundle["item_uom_id"])
+
+    assert await session.get(WmsPmsItemProjection, item_id) is not None
+    assert await session.get(WmsPmsItemUomProjection, item_uom_id) is not None
+
+    await session.execute(
+        text("DELETE FROM item_barcodes WHERE item_id = :item_id"),
+        {"item_id": item_id},
+    )
+    await session.execute(
+        text("DELETE FROM item_sku_codes WHERE item_id = :item_id"),
+        {"item_id": item_id},
+    )
+    await session.execute(
+        text("DELETE FROM item_uoms WHERE item_id = :item_id"),
+        {"item_id": item_id},
+    )
+    await session.execute(
+        text("DELETE FROM items WHERE id = :item_id"),
+        {"item_id": item_id},
+    )
+
+    result = await service.rebuild_items([item_id])
+
+    assert result.source_items == 0
+    assert result.source_uoms == 0
+    assert result.source_policies == 0
+    assert result.source_sku_codes == 0
+    assert result.source_barcodes == 0
+    assert result.deleted_items == 1
+    assert result.deleted_policies == 1
+    assert result.deleted_uoms >= 1
+
+    session.expire_all()
+
+    assert await session.get(WmsPmsItemProjection, item_id) is None
+    assert await session.get(WmsPmsItemUomProjection, item_uom_id) is None


### PR DESCRIPTION
## Summary
- keep rebuild_all behavior unchanged
- add rebuild_items(item_ids) for item-scoped WMS PMS projection rebuild
- clean stale projection rows only inside the requested item scope
- add tests for targeted rebuild, empty input, and missing owner item cleanup

## Tests
- python3 -m compileall app/wms/pms_projection/services/rebuild_service.py tests/services/test_wms_pms_projection_rebuild_items_service.py
- make test TESTS="tests/services/test_wms_pms_projection_rebuild_service.py tests/services/test_wms_pms_projection_rebuild_items_service.py tests/services/test_wms_pms_projection_read_service.py"
- make alembic-check
- make audit-all