### PR TITLE
feat(wms): add pms projection incremental sync

### DIFF
--- a/app/wms/pms_projection/services/rebuild_service.py
+++ b/app/wms/pms_projection/services/rebuild_service.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from decimal import Decimal
 
 import sqlalchemy as sa
@@ -85,13 +85,14 @@ class WmsPmsProjectionRebuildService:
     - 写入 WMS 本地 wms_pms_*_projection；
     - 支持幂等重复执行；
     - 支持全量 rebuild_all；
-    - 支持按 item_id 局部 rebuild_items，供后续增量 sync 复用。
+    - 支持按 item_id 局部 rebuild_items，供后续增量 sync 复用；
+    - 支持按 owner updated_at 查找受影响 item_id。
 
     明确不负责：
     - 不接入 WMS scan；
     - 不接入 inbound commit；
     - 不接入 ledger / count / return inbound；
-    - 不实现 PMS outbox / changes 增量同步。
+    - 不实现 PMS outbox / CDC。
     """
 
     def __init__(self, session: AsyncSession) -> None:
@@ -116,6 +117,66 @@ class WmsPmsProjectionRebuildService:
                 deleted_barcodes=0,
             )
         return await self._rebuild(item_ids=clean_item_ids)
+
+    async def changed_item_ids_since(
+        self,
+        source_updated_at: datetime,
+        *,
+        overlap_seconds: int = 0,
+    ) -> list[int]:
+        """
+        从 PMS owner 表按 updated_at 找到受影响 item_id。
+
+        说明：
+        - 当前仍处于单库阶段，updated_at 是第一版增量水位；
+        - owner 读取仍集中在本 rebuild_service，避免扩大 WMS runtime 白名单；
+        - overlap_seconds 默认为 0，避免重复重建；如线上需要抗时钟/精度误差，可显式传入。
+        """
+
+        cutoff = _required_datetime(
+            source_updated_at,
+            label="source_updated_at cursor",
+        )
+        if overlap_seconds > 0:
+            cutoff = cutoff - timedelta(seconds=int(overlap_seconds))
+
+        source = sa.union_all(
+            select(Item.id.label("item_id")).where(Item.updated_at > cutoff),
+            select(ItemUOM.item_id.label("item_id")).where(ItemUOM.updated_at > cutoff),
+            select(ItemSkuCode.item_id.label("item_id")).where(ItemSkuCode.updated_at > cutoff),
+            select(ItemBarcode.item_id.label("item_id")).where(ItemBarcode.updated_at > cutoff),
+        ).subquery()
+
+        rows = await self.session.execute(
+            select(source.c.item_id).distinct().order_by(source.c.item_id.asc())
+        )
+        return [int(x) for x in rows.scalars().all()]
+
+    async def max_owner_source_updated_at(
+        self,
+        *,
+        item_ids: Sequence[int] | None = None,
+    ) -> datetime | None:
+        clean_item_ids = _clean_item_ids(item_ids) if item_ids is not None else None
+        if clean_item_ids is not None and not clean_item_ids:
+            return None
+
+        item_stmt = select(Item.updated_at.label("source_updated_at"))
+        uom_stmt = select(ItemUOM.updated_at.label("source_updated_at"))
+        sku_stmt = select(ItemSkuCode.updated_at.label("source_updated_at"))
+        barcode_stmt = select(ItemBarcode.updated_at.label("source_updated_at"))
+
+        if clean_item_ids is not None:
+            item_stmt = item_stmt.where(Item.id.in_(clean_item_ids))
+            uom_stmt = uom_stmt.where(ItemUOM.item_id.in_(clean_item_ids))
+            sku_stmt = sku_stmt.where(ItemSkuCode.item_id.in_(clean_item_ids))
+            barcode_stmt = barcode_stmt.where(ItemBarcode.item_id.in_(clean_item_ids))
+
+        source = sa.union_all(item_stmt, uom_stmt, sku_stmt, barcode_stmt).subquery()
+        value = await self.session.scalar(select(sa.func.max(source.c.source_updated_at)))
+        if value is None:
+            return None
+        return _required_datetime(value, label="max owner source updated_at")
 
     async def _rebuild(
         self,

--- a/app/wms/pms_projection/services/sync_service.py
+++ b/app/wms/pms_projection/services/sync_service.py
@@ -1,0 +1,265 @@
+# app/wms/pms_projection/services/sync_service.py
+# Split note:
+# WMS PMS projection 增量同步入口。
+# 本服务不直接读取 PMS owner 表；owner 表读取仍集中在 rebuild_service.py，
+# 以保持 PR-7A 的 PMS owner 边界守卫不扩大白名单。
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.wms.pms_projection.services.rebuild_service import (
+    WmsPmsProjectionRebuildResult,
+    WmsPmsProjectionRebuildService,
+)
+
+
+SOURCE_NAME = "pms_owner_updated_at"
+
+
+@dataclass(frozen=True, slots=True)
+class WmsPmsProjectionSyncResult:
+    source_name: str
+    initialized: bool
+    changed_items: int
+    previous_source_updated_at: datetime | None
+    last_source_updated_at: datetime
+    source_items: int
+    source_uoms: int
+    source_policies: int
+    source_sku_codes: int
+    source_barcodes: int
+    deleted_items: int
+    deleted_uoms: int
+    deleted_policies: int
+    deleted_sku_codes: int
+    deleted_barcodes: int
+
+
+def _epoch() -> datetime:
+    return datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+def _as_datetime(value: object, *, label: str) -> datetime:
+    if not isinstance(value, datetime):
+        raise RuntimeError(f"{label} must be datetime, got {type(value)!r}")
+    return value
+
+
+def _zero_rebuild_result() -> WmsPmsProjectionRebuildResult:
+    return WmsPmsProjectionRebuildResult(
+        source_items=0,
+        source_uoms=0,
+        source_policies=0,
+        source_sku_codes=0,
+        source_barcodes=0,
+        deleted_items=0,
+        deleted_uoms=0,
+        deleted_policies=0,
+        deleted_sku_codes=0,
+        deleted_barcodes=0,
+    )
+
+
+class WmsPmsProjectionSyncService:
+    """
+    WMS PMS projection 增量同步服务。
+
+    第一版语义：
+    - 无 cursor：执行 rebuild_all 初始化，然后保存 owner 最大 updated_at；
+    - 有 cursor：扫描 owner updated_at > cursor 的 item_id；
+    - 对 changed item_id 调用 rebuild_items；
+    - 成功后推进 cursor；
+    - 失败时 cursor 不前进，只记录 FAILED / last_error / retry_count。
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+        self.rebuild_service = WmsPmsProjectionRebuildService(session)
+
+    async def sync_once(self, *, overlap_seconds: int = 0) -> WmsPmsProjectionSyncResult:
+        cursor = await self._load_cursor()
+        previous_source_updated_at = (
+            _as_datetime(cursor["last_source_updated_at"], label="cursor.last_source_updated_at")
+            if cursor is not None
+            else None
+        )
+
+        try:
+            if previous_source_updated_at is None:
+                rebuild_result = await self.rebuild_service.rebuild_all()
+                latest = await self.rebuild_service.max_owner_source_updated_at()
+                last_source_updated_at = latest or _epoch()
+                await self._mark_success(last_source_updated_at=last_source_updated_at)
+                return self._build_result(
+                    initialized=True,
+                    changed_items=rebuild_result.source_items,
+                    previous_source_updated_at=None,
+                    last_source_updated_at=last_source_updated_at,
+                    rebuild_result=rebuild_result,
+                )
+
+            changed_item_ids = await self.rebuild_service.changed_item_ids_since(
+                previous_source_updated_at,
+                overlap_seconds=overlap_seconds,
+            )
+            if not changed_item_ids:
+                await self._mark_success(last_source_updated_at=previous_source_updated_at)
+                return self._build_result(
+                    initialized=False,
+                    changed_items=0,
+                    previous_source_updated_at=previous_source_updated_at,
+                    last_source_updated_at=previous_source_updated_at,
+                    rebuild_result=_zero_rebuild_result(),
+                )
+
+            rebuild_result = await self.rebuild_service.rebuild_items(changed_item_ids)
+            latest = await self.rebuild_service.max_owner_source_updated_at()
+            last_source_updated_at = latest or previous_source_updated_at
+            if last_source_updated_at < previous_source_updated_at:
+                last_source_updated_at = previous_source_updated_at
+
+            await self._mark_success(last_source_updated_at=last_source_updated_at)
+            return self._build_result(
+                initialized=False,
+                changed_items=len(changed_item_ids),
+                previous_source_updated_at=previous_source_updated_at,
+                last_source_updated_at=last_source_updated_at,
+                rebuild_result=rebuild_result,
+            )
+        except Exception as exc:
+            await self._mark_failed(
+                last_source_updated_at=previous_source_updated_at or _epoch(),
+                error=str(exc),
+            )
+            raise
+
+    async def _load_cursor(self) -> dict[str, object] | None:
+        row = (
+            await self.session.execute(
+                text(
+                    """
+                    SELECT
+                      source_name,
+                      last_source_updated_at,
+                      last_synced_at,
+                      last_status,
+                      last_error,
+                      retry_count
+                    FROM wms_pms_projection_sync_cursors
+                    WHERE source_name = :source_name
+                    LIMIT 1
+                    """
+                ),
+                {"source_name": SOURCE_NAME},
+            )
+        ).mappings().first()
+        return dict(row) if row is not None else None
+
+    async def _mark_success(self, *, last_source_updated_at: datetime) -> None:
+        await self.session.execute(
+            text(
+                """
+                INSERT INTO wms_pms_projection_sync_cursors (
+                  source_name,
+                  last_source_updated_at,
+                  last_synced_at,
+                  last_status,
+                  last_error,
+                  retry_count,
+                  created_at,
+                  updated_at
+                )
+                VALUES (
+                  :source_name,
+                  :last_source_updated_at,
+                  now(),
+                  'SUCCESS',
+                  NULL,
+                  0,
+                  now(),
+                  now()
+                )
+                ON CONFLICT (source_name) DO UPDATE SET
+                  last_source_updated_at = EXCLUDED.last_source_updated_at,
+                  last_synced_at = now(),
+                  last_status = 'SUCCESS',
+                  last_error = NULL,
+                  retry_count = 0,
+                  updated_at = now()
+                """
+            ),
+            {
+                "source_name": SOURCE_NAME,
+                "last_source_updated_at": last_source_updated_at,
+            },
+        )
+
+    async def _mark_failed(self, *, last_source_updated_at: datetime, error: str) -> None:
+        await self.session.execute(
+            text(
+                """
+                INSERT INTO wms_pms_projection_sync_cursors (
+                  source_name,
+                  last_source_updated_at,
+                  last_synced_at,
+                  last_status,
+                  last_error,
+                  retry_count,
+                  created_at,
+                  updated_at
+                )
+                VALUES (
+                  :source_name,
+                  :last_source_updated_at,
+                  now(),
+                  'FAILED',
+                  :last_error,
+                  1,
+                  now(),
+                  now()
+                )
+                ON CONFLICT (source_name) DO UPDATE SET
+                  last_synced_at = now(),
+                  last_status = 'FAILED',
+                  last_error = EXCLUDED.last_error,
+                  retry_count = wms_pms_projection_sync_cursors.retry_count + 1,
+                  updated_at = now()
+                """
+            ),
+            {
+                "source_name": SOURCE_NAME,
+                "last_source_updated_at": last_source_updated_at,
+                "last_error": error,
+            },
+        )
+
+    def _build_result(
+        self,
+        *,
+        initialized: bool,
+        changed_items: int,
+        previous_source_updated_at: datetime | None,
+        last_source_updated_at: datetime,
+        rebuild_result: WmsPmsProjectionRebuildResult,
+    ) -> WmsPmsProjectionSyncResult:
+        return WmsPmsProjectionSyncResult(
+            source_name=SOURCE_NAME,
+            initialized=bool(initialized),
+            changed_items=int(changed_items),
+            previous_source_updated_at=previous_source_updated_at,
+            last_source_updated_at=last_source_updated_at,
+            source_items=int(rebuild_result.source_items),
+            source_uoms=int(rebuild_result.source_uoms),
+            source_policies=int(rebuild_result.source_policies),
+            source_sku_codes=int(rebuild_result.source_sku_codes),
+            source_barcodes=int(rebuild_result.source_barcodes),
+            deleted_items=int(rebuild_result.deleted_items),
+            deleted_uoms=int(rebuild_result.deleted_uoms),
+            deleted_policies=int(rebuild_result.deleted_policies),
+            deleted_sku_codes=int(rebuild_result.deleted_sku_codes),
+            deleted_barcodes=int(rebuild_result.deleted_barcodes),
+        )

--- a/scripts/make/db.mk
+++ b/scripts/make/db.mk
@@ -4,7 +4,7 @@
 
 # ✅ 关键原则：
 # - 通用目标默认绑定 DEV_DB_DSN，避免误跑到 TEST/PILOT。
-# - pytest 默认绑定 DEV_TEST_DB_DSN（wms_test），避免误伤 DEV_DB_DSN（wms）。
+# - pytest 默认绑定 DEV_TEST_DB_DSN（wms_test），避免误伤 DEV_DB_DSN。
 
 .PHONY: alembic-check
 alembic-check: venv
@@ -96,7 +96,7 @@ check-test: venv
 
 
 # =================================
-# WMS PMS projection rebuild
+# WMS PMS projection rebuild / sync
 # =================================
 .PHONY: rebuild-wms-pms-projection-dev rebuild-wms-pms-projection-test
 rebuild-wms-pms-projection-dev: venv upgrade-dev
@@ -112,6 +112,21 @@ rebuild-wms-pms-projection-test: venv upgrade-dev-test-db
 	  WMS_DATABASE_URL="$(DEV_TEST_DB_DSN)" \
 	  WMS_TEST_DATABASE_URL="$(DEV_TEST_DB_DSN)" \
 	  $(PY) scripts/rebuild_wms_pms_projection.py
+
+.PHONY: sync-wms-pms-projection-dev sync-wms-pms-projection-test
+sync-wms-pms-projection-dev: venv upgrade-dev
+	@echo ">>> Sync WMS PMS projection on DEV_DB_DSN ($(DEV_DB_DSN))"
+	@PYTHONPATH=. WMS_ENV=dev \
+	  WMS_DATABASE_URL="$(DEV_DB_DSN)" \
+	  WMS_TEST_DATABASE_URL="$(DEV_DB_DSN)" \
+	  $(PY) scripts/sync_wms_pms_projection.py $(PMS_PROJECTION_SYNC_ARGS)
+
+sync-wms-pms-projection-test: venv upgrade-dev-test-db
+	@echo ">>> Sync WMS PMS projection on DEV_TEST_DB_DSN ($(DEV_TEST_DB_DSN))"
+	@PYTHONPATH=. WMS_ENV=test \
+	  WMS_DATABASE_URL="$(DEV_TEST_DB_DSN)" \
+	  WMS_TEST_DATABASE_URL="$(DEV_TEST_DB_DSN)" \
+	  $(PY) scripts/sync_wms_pms_projection.py $(PMS_PROJECTION_SYNC_ARGS)
 
 # =================================
 # Pilot DB 备份（在中试服务器上运行）

--- a/scripts/sync_wms_pms_projection.py
+++ b/scripts/sync_wms_pms_projection.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# scripts/sync_wms_pms_projection.py
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from dataclasses import asdict
+from datetime import datetime
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Sync WMS-local PMS projection incrementally from PMS owner updated_at.",
+    )
+    parser.add_argument(
+        "--dsn",
+        default=None,
+        help=(
+            "Database DSN. If provided, both WMS_DATABASE_URL and "
+            "WMS_TEST_DATABASE_URL are set to this value before opening the session."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run sync inside a transaction and roll it back after reporting counts.",
+    )
+    parser.add_argument(
+        "--overlap-seconds",
+        type=int,
+        default=0,
+        help="Optional updated_at overlap window. Defaults to 0 to avoid repeated rebuild.",
+    )
+    return parser.parse_args()
+
+
+def _json_default(value: object) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
+async def _run() -> int:
+    args = _parse_args()
+
+    if args.dsn:
+        dsn = str(args.dsn).strip()
+        if not dsn:
+            raise SystemExit("--dsn cannot be blank")
+        os.environ["WMS_DATABASE_URL"] = dsn
+        os.environ["WMS_TEST_DATABASE_URL"] = dsn
+
+    # Import after env setup: app.db.session reads env vars at import time.
+    from app.db.session import AsyncSessionLocal, close_engines
+    from app.wms.pms_projection.services.sync_service import WmsPmsProjectionSyncService
+
+    try:
+        async with AsyncSessionLocal() as session:
+            tx = await session.begin()
+            try:
+                result = await WmsPmsProjectionSyncService(session).sync_once(
+                    overlap_seconds=int(args.overlap_seconds),
+                )
+                payload = asdict(result)
+                payload["dry_run"] = bool(args.dry_run)
+
+                if args.dry_run:
+                    await tx.rollback()
+                else:
+                    await tx.commit()
+
+                print(json.dumps(payload, ensure_ascii=False, sort_keys=True, default=_json_default))
+                return 0
+            except Exception:
+                if args.dry_run:
+                    await tx.rollback()
+                else:
+                    # sync_once records FAILED / last_error / retry_count before re-raising.
+                    # Commit that diagnostic state when possible; cursor itself is not advanced.
+                    await tx.commit()
+                raise
+    finally:
+        await close_engines()
+
+
+def main() -> int:
+    return asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/services/test_wms_pms_projection_sync_service.py
+++ b/tests/services/test_wms_pms_projection_sync_service.py
@@ -1,0 +1,385 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.wms.pms_projection.models.projection import WmsPmsItemProjection
+from app.wms.pms_projection.services.rebuild_service import WmsPmsProjectionRebuildService
+from app.wms.pms_projection.services.sync_service import (
+    SOURCE_NAME,
+    WmsPmsProjectionSyncService,
+)
+
+
+async def _insert_scalar_int(
+    session: AsyncSession,
+    sql: str,
+    params: dict[str, object],
+) -> int:
+    result = await session.execute(text(sql), params)
+    return int(result.scalar_one())
+
+
+async def _insert_owner_item_bundle(
+    session: AsyncSession,
+    *,
+    prefix: str,
+    updated_at: datetime,
+) -> dict[str, int | str]:
+    item_id = await _insert_scalar_int(
+        session,
+        """
+        INSERT INTO items (
+          sku,
+          name,
+          spec,
+          enabled,
+          lot_source_policy,
+          expiry_policy,
+          derivation_allowed,
+          uom_governance_enabled,
+          updated_at
+        )
+        VALUES (
+          :sku,
+          :name,
+          :spec,
+          true,
+          'INTERNAL_ONLY',
+          'NONE',
+          false,
+          true,
+          :updated_at
+        )
+        RETURNING id
+        """,
+        {
+            "sku": f"{prefix}-SKU",
+            "name": f"{prefix} item before",
+            "spec": "before",
+            "updated_at": updated_at,
+        },
+    )
+
+    item_uom_id = await _insert_scalar_int(
+        session,
+        """
+        INSERT INTO item_uoms (
+          item_id,
+          uom,
+          ratio_to_base,
+          display_name,
+          net_weight_kg,
+          is_base,
+          is_purchase_default,
+          is_inbound_default,
+          is_outbound_default,
+          updated_at
+        )
+        VALUES (
+          :item_id,
+          'PCS',
+          1,
+          :display_name,
+          0.125,
+          true,
+          true,
+          true,
+          true,
+          :updated_at
+        )
+        RETURNING id
+        """,
+        {
+            "item_id": item_id,
+            "display_name": f"{prefix} 件",
+            "updated_at": updated_at,
+        },
+    )
+
+    sku_code_id = await _insert_scalar_int(
+        session,
+        """
+        INSERT INTO item_sku_codes (
+          item_id,
+          code,
+          code_type,
+          is_primary,
+          is_active,
+          remark,
+          updated_at
+        )
+        VALUES (
+          :item_id,
+          :code,
+          'PRIMARY',
+          true,
+          true,
+          'before',
+          :updated_at
+        )
+        RETURNING id
+        """,
+        {
+            "item_id": item_id,
+            "code": f"{prefix}-CODE",
+            "updated_at": updated_at,
+        },
+    )
+
+    barcode_id = await _insert_scalar_int(
+        session,
+        """
+        INSERT INTO item_barcodes (
+          item_id,
+          item_uom_id,
+          barcode,
+          symbology,
+          active,
+          is_primary,
+          updated_at
+        )
+        VALUES (
+          :item_id,
+          :item_uom_id,
+          :barcode,
+          'CUSTOM',
+          true,
+          true,
+          :updated_at
+        )
+        RETURNING id
+        """,
+        {
+            "item_id": item_id,
+            "item_uom_id": item_uom_id,
+            "barcode": f"{prefix}-BAR",
+            "updated_at": updated_at,
+        },
+    )
+
+    return {
+        "item_id": item_id,
+        "item_uom_id": item_uom_id,
+        "sku_code_id": sku_code_id,
+        "barcode_id": barcode_id,
+    }
+
+
+async def _cursor_row(session: AsyncSession) -> dict[str, object] | None:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  source_name,
+                  last_source_updated_at,
+                  last_status,
+                  last_error,
+                  retry_count
+                FROM wms_pms_projection_sync_cursors
+                WHERE source_name = :source_name
+                LIMIT 1
+                """
+            ),
+            {"source_name": SOURCE_NAME},
+        )
+    ).mappings().first()
+    return dict(row) if row is not None else None
+
+
+
+async def _reset_sync_cursor(session: AsyncSession) -> None:
+    await session.execute(
+        text(
+            """
+            DELETE FROM wms_pms_projection_sync_cursors
+            WHERE source_name = :source_name
+            """
+        ),
+        {"source_name": SOURCE_NAME},
+    )
+
+
+async def test_sync_once_initializes_cursor_and_rebuilds_projection(
+    session: AsyncSession,
+) -> None:
+    await _reset_sync_cursor(session)
+
+    suffix = uuid4().hex[:10]
+    ts = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+    bundle = await _insert_owner_item_bundle(
+        session,
+        prefix=f"SYNC-I-{suffix}",
+        updated_at=ts,
+    )
+
+    result = await WmsPmsProjectionSyncService(session).sync_once()
+
+    assert result.initialized is True
+    assert result.changed_items >= 1
+    assert result.source_items >= 1
+    assert result.last_source_updated_at >= ts
+
+    projection = await session.get(WmsPmsItemProjection, int(bundle["item_id"]))
+    assert projection is not None
+    assert projection.name == f"SYNC-I-{suffix} item before"
+
+    cursor = await _cursor_row(session)
+    assert cursor is not None
+    assert cursor["source_name"] == SOURCE_NAME
+    assert cursor["last_status"] == "SUCCESS"
+    assert int(cursor["retry_count"]) == 0
+
+
+async def test_sync_once_rebuilds_only_changed_items_and_advances_cursor(
+    session: AsyncSession,
+) -> None:
+    await _reset_sync_cursor(session)
+
+    suffix = uuid4().hex[:10]
+    base_ts = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+
+    target = await _insert_owner_item_bundle(
+        session,
+        prefix=f"SYNC-T-{suffix}",
+        updated_at=base_ts,
+    )
+    other = await _insert_owner_item_bundle(
+        session,
+        prefix=f"SYNC-O-{suffix}",
+        updated_at=base_ts,
+    )
+
+    service = WmsPmsProjectionSyncService(session)
+    first = await service.sync_once()
+    assert first.initialized is True
+    target_ts = first.last_source_updated_at + timedelta(seconds=10)
+
+    target_item_id = int(target["item_id"])
+    other_item_id = int(other["item_id"])
+
+    await session.execute(
+        text(
+            """
+            UPDATE items
+            SET
+              name = :name,
+              spec = 'after',
+              enabled = false,
+              updated_at = :updated_at
+            WHERE id = :item_id
+            """
+        ),
+        {
+            "item_id": target_item_id,
+            "name": f"SYNC-T-{suffix} item after",
+            "updated_at": target_ts,
+        },
+    )
+    await session.execute(
+        text(
+            """
+            UPDATE item_uoms
+            SET updated_at = :updated_at
+            WHERE item_id = :item_id
+            """
+        ),
+        {"item_id": target_item_id, "updated_at": target_ts},
+    )
+    await session.execute(
+        text(
+            """
+            UPDATE wms_pms_item_projection
+            SET name = 'non-target projection marker'
+            WHERE item_id = :item_id
+            """
+        ),
+        {"item_id": other_item_id},
+    )
+
+    second = await service.sync_once()
+
+    assert second.initialized is False
+    assert second.changed_items == 1
+    assert second.source_items == 1
+    assert second.last_source_updated_at >= target_ts
+
+    session.expire_all()
+
+    target_projection = await session.get(WmsPmsItemProjection, target_item_id)
+    assert target_projection is not None
+    assert target_projection.name == f"SYNC-T-{suffix} item after"
+    assert target_projection.spec == "after"
+    assert target_projection.enabled is False
+
+    other_projection = await session.get(WmsPmsItemProjection, other_item_id)
+    assert other_projection is not None
+    assert other_projection.name == "non-target projection marker"
+
+    cursor = await _cursor_row(session)
+    assert cursor is not None
+    assert cursor["last_status"] == "SUCCESS"
+    assert cursor["last_source_updated_at"] >= target_ts
+
+
+async def test_sync_once_records_failure_without_advancing_cursor(
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await _reset_sync_cursor(session)
+
+    suffix = uuid4().hex[:10]
+    base_ts = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+
+    bundle = await _insert_owner_item_bundle(
+        session,
+        prefix=f"SYNC-F-{suffix}",
+        updated_at=base_ts,
+    )
+
+    service = WmsPmsProjectionSyncService(session)
+    first = await service.sync_once()
+    assert first.initialized is True
+    target_ts = first.last_source_updated_at + timedelta(seconds=10)
+
+    cursor_before = await _cursor_row(session)
+    assert cursor_before is not None
+    previous_cursor = cursor_before["last_source_updated_at"]
+
+    await session.execute(
+        text(
+            """
+            UPDATE items
+            SET updated_at = :updated_at
+            WHERE id = :item_id
+            """
+        ),
+        {
+            "item_id": int(bundle["item_id"]),
+            "updated_at": target_ts,
+        },
+    )
+
+    async def _raise_on_rebuild_items(self: WmsPmsProjectionRebuildService, item_ids: list[int]):
+        raise RuntimeError("forced sync failure")
+
+    monkeypatch.setattr(
+        WmsPmsProjectionRebuildService,
+        "rebuild_items",
+        _raise_on_rebuild_items,
+    )
+
+    with pytest.raises(RuntimeError, match="forced sync failure"):
+        await WmsPmsProjectionSyncService(session).sync_once()
+
+    cursor_after = await _cursor_row(session)
+    assert cursor_after is not None
+    assert cursor_after["last_status"] == "FAILED"
+    assert cursor_after["last_source_updated_at"] == previous_cursor
+    assert "forced sync failure" in str(cursor_after["last_error"])
+    assert int(cursor_after["retry_count"]) == 1


### PR DESCRIPTION
## Summary
- add WMS PMS projection sync_once service backed by owner updated_at cursor
- keep PMS owner reads concentrated in rebuild_service
- add incremental sync script and make targets
- add tests for initialization, targeted incremental sync, and failure cursor handling

## Tests
- python3 -m compileall app/wms/pms_projection/services/rebuild_service.py app/wms/pms_projection/services/sync_service.py scripts/sync_wms_pms_projection.py scripts/make/db.mk tests/services/test_wms_pms_projection_sync_service.py
- make test TESTS="tests/services/test_wms_pms_projection_rebuild_service.py tests/services/test_wms_pms_projection_rebuild_items_service.py tests/services/test_wms_pms_projection_sync_service.py tests/services/test_wms_pms_projection_read_service.py"
- make sync-wms-pms-projection-test PMS_PROJECTION_SYNC_ARGS="--dry-run"
- make alembic-check
- make audit-all