### PR TITLE
refactor(wms): read ledger item metadata through pms export

### DIFF
--- a/app/wms/ledger/helpers/__init__.py
+++ b/app/wms/ledger/helpers/__init__.py
@@ -1,7 +1,6 @@
 # app/wms/ledger/helpers/__init__.py
 
 from app.wms.ledger.helpers.stock_ledger import (
-    ITEMS_TABLE,
     apply_common_filters_rows,
     build_base_ids_stmt,
     build_common_filters,
@@ -13,7 +12,6 @@ from app.wms.ledger.helpers.stock_ledger import (
 )
 
 __all__ = [
-    "ITEMS_TABLE",
     "apply_common_filters_rows",
     "build_base_ids_stmt",
     "build_common_filters",

--- a/app/wms/ledger/helpers/stock_ledger.py
+++ b/app/wms/ledger/helpers/stock_ledger.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import csv
+from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 from io import StringIO
 from typing import Tuple
@@ -11,13 +12,12 @@ from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.pms.export.items.services.item_read_service import ItemReadService
+from app.pms.export.uoms.services.uom_read_service import PmsExportUomReadService
 from app.wms.shared.services.lot_code_contract import normalize_optional_lot_code
-from app.pms.items.models.item import Item
 from app.wms.stock.models.lot import Lot
 from app.wms.ledger.models.stock_ledger import StockLedger
 from app.wms.ledger.contracts.stock_ledger import LedgerQuery
-
-ITEMS_TABLE = Item.__table__
 
 
 def normalize_time_range(q: LedgerQuery) -> Tuple[datetime, datetime]:
@@ -111,7 +111,86 @@ def resolve_ledger_lot_code_filter(q: LedgerQuery) -> tuple[bool, str | None]:
     return True, lot_code
 
 
-def build_common_filters(q: LedgerQuery, time_from: datetime, time_to: datetime):
+def _clean_item_ids(values: Iterable[int] | None) -> list[int]:
+    if values is None:
+        return []
+    return sorted({int(x) for x in values if x is not None and int(x) > 0})
+
+
+async def resolve_ledger_item_keyword_item_ids(
+    session: AsyncSession,
+    *,
+    payload: LedgerQuery,
+) -> list[int] | None:
+    """
+    将 ledger.item_keyword 通过 PMS export read service 解析为 item_id 集合。
+
+    返回语义：
+    - None：调用方未传 item_keyword，不应增加 item 过滤；
+    - []：调用方传了 item_keyword，但 PMS 没有匹配商品，应返回空结果；
+    - [ids...]：按 item_id 过滤 ledger。
+    """
+    keyword = str(getattr(payload, "item_keyword", None) or "").strip()
+    if not keyword:
+        return None
+    return await ItemReadService(session).asearch_report_item_ids_by_keyword(keyword=keyword)
+
+
+async def load_ledger_item_display_maps(
+    session: AsyncSession,
+    *,
+    item_ids: Iterable[int],
+) -> tuple[dict[int, str], dict[int, dict[str, object | None]]]:
+    """
+    通过 PMS export read service 批量读取 ledger 当前页展示所需商品信息。
+
+    注意：
+    - 这里只补查询页展示信息，不解释历史事实；
+    - 历史事实仍以各业务单据的 snapshot 字段为准；
+    - WMS ledger 不直接读取 PMS owner 表。
+    """
+    ids = _clean_item_ids(item_ids)
+    if not ids:
+        return {}, {}
+
+    item_meta_map = await ItemReadService(session).aget_report_meta_by_item_ids(item_ids=ids)
+    item_name_map = {
+        int(item_id): str(meta.name).strip()
+        for item_id, meta in item_meta_map.items()
+        if str(meta.name or "").strip()
+    }
+
+    uoms = await PmsExportUomReadService(session).alist_uoms(item_ids=ids)
+    base_uom_map: dict[int, dict[str, object | None]] = {
+        item_id: {"base_item_uom_id": None, "base_uom_name": None}
+        for item_id in ids
+    }
+
+    for uom in uoms:
+        if not bool(getattr(uom, "is_base", False)):
+            continue
+
+        item_id = int(uom.item_id)
+        if item_id not in base_uom_map:
+            continue
+        if base_uom_map[item_id]["base_item_uom_id"] is not None:
+            continue
+
+        base_uom_map[item_id] = {
+            "base_item_uom_id": int(uom.id),
+            "base_uom_name": str(uom.uom_name or uom.display_name or uom.uom or "").strip() or None,
+        }
+
+    return item_name_map, base_uom_map
+
+
+def build_common_filters(
+    q: LedgerQuery,
+    time_from: datetime,
+    time_to: datetime,
+    *,
+    item_keyword_item_ids: Iterable[int] | None = None,
+):
     """
     根据查询模型构建 SQLAlchemy 过滤条件列表（不包含 item_keyword 模糊搜索）。
 
@@ -127,6 +206,13 @@ def build_common_filters(q: LedgerQuery, time_from: datetime, time_to: datetime)
 
     if q.item_id is not None:
         conditions.append(StockLedger.item_id == q.item_id)
+
+    if item_keyword_item_ids is not None:
+        item_ids = _clean_item_ids(item_keyword_item_ids)
+        if item_ids:
+            conditions.append(StockLedger.item_id.in_(item_ids))
+        else:
+            conditions.append(sa.false())
 
     if q.warehouse_id is not None:
         conditions.append(StockLedger.warehouse_id == q.warehouse_id)
@@ -228,27 +314,27 @@ def infer_movement_type(reason: str | None) -> str | None:
     return "UNKNOWN"
 
 
-def build_base_ids_stmt(q: LedgerQuery, time_from: datetime, time_to: datetime):
+def build_base_ids_stmt(
+    q: LedgerQuery,
+    time_from: datetime,
+    time_to: datetime,
+    *,
+    item_keyword_item_ids: Iterable[int] | None = None,
+):
     """
     按查询条件构造基础 SQL（只选中符合条件的 id 列表）：
 
     - 支持按 item_id / warehouse_id / lot_id / lot_code / reason / reason_canon / sub_reason / ref / trace_id / 时间过滤；
-    - 支持按 item_keyword 模糊匹配 items.name / items.sku；
+    - item_keyword 由调用方先通过 PMS export read service 解析为 item_id 集合；
     - 不再依赖 stock_id / batch_id，完全对齐当前 StockLedger 模型。
     """
     stmt = select(StockLedger.id).select_from(StockLedger)
-    conditions = build_common_filters(q, time_from, time_to)
-
-    # item_keyword 模糊搜索：name/sku
-    if q.item_keyword:
-        kw = f"%{q.item_keyword.strip()}%"
-        stmt = stmt.join(Item, Item.id == StockLedger.item_id)
-        conditions.append(
-            sa.or_(
-                Item.name.ilike(kw),
-                Item.sku.ilike(kw),
-            )
-        )
+    conditions = build_common_filters(
+        q,
+        time_from,
+        time_to,
+        item_keyword_item_ids=item_keyword_item_ids,
+    )
 
     if conditions:
         stmt = stmt.where(sa.and_(*conditions))

--- a/app/wms/ledger/routers/stock_ledger_routes_query.py
+++ b/app/wms/ledger/routers/stock_ledger_routes_query.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from datetime import timezone
 
-import sqlalchemy as sa
 from fastapi import APIRouter, Depends
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -22,7 +21,9 @@ from app.wms.ledger.contracts.stock_ledger import (
 from app.wms.ledger.helpers.stock_ledger import (
     build_base_ids_stmt,
     infer_movement_type,
+    load_ledger_item_display_maps,
     normalize_time_range,
+    resolve_ledger_item_keyword_item_ids,
 )
 
 UTC = timezone.utc
@@ -54,7 +55,13 @@ def register(router: APIRouter) -> None:
         """
         time_from, time_to = normalize_time_range(payload)
 
-        ids_stmt = build_base_ids_stmt(payload, time_from, time_to)
+        item_keyword_item_ids = await resolve_ledger_item_keyword_item_ids(session, payload=payload)
+        ids_stmt = build_base_ids_stmt(
+            payload,
+            time_from,
+            time_to,
+            item_keyword_item_ids=item_keyword_item_ids,
+        )
         ids_subq = ids_stmt.subquery()
 
         total = (await session.execute(select(func.count()).select_from(ids_subq))).scalar_one()
@@ -70,40 +77,10 @@ def register(router: APIRouter) -> None:
 
         item_ids = sorted({int(r.item_id) for r in rows if r.item_id is not None})
 
-        item_name_map: dict[int, str] = {}
-        base_uom_map: dict[int, dict[str, object | None]] = {}
-
-        if item_ids:
-            res = await session.execute(
-                sa.text(
-                    """
-                    SELECT
-                      i.id,
-                      i.name,
-                      iu.id AS base_item_uom_id,
-                      COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS base_uom_name
-                    FROM items AS i
-                    LEFT JOIN item_uoms AS iu
-                      ON iu.item_id = i.id
-                     AND iu.is_base IS TRUE
-                    WHERE i.id = ANY(:ids)
-                    """
-                ),
-                {"ids": item_ids},
-            )
-            for x in res.mappings().all():
-                iid = int(x["id"])
-                nm = str(x["name"] or "").strip()
-                if nm:
-                    item_name_map[iid] = nm
-                base_uom_map[iid] = {
-                    "base_item_uom_id": (
-                        int(x["base_item_uom_id"])
-                        if x.get("base_item_uom_id") is not None
-                        else None
-                    ),
-                    "base_uom_name": x.get("base_uom_name"),
-                }
+        item_name_map, base_uom_map = await load_ledger_item_display_maps(
+            session,
+            item_ids=item_ids,
+        )
 
         lot_ids = sorted({int(getattr(r, "lot_id")) for r in rows if getattr(r, "lot_id", None) is not None})
         lot_code_map: dict[int, str | None] = {}

--- a/app/wms/ledger/routers/stock_ledger_routes_query_history.py
+++ b/app/wms/ledger/routers/stock_ledger_routes_query_history.py
@@ -23,7 +23,12 @@ from app.wms.ledger.contracts.stock_ledger_explain import (
     ExplainReceiptLine,
     LedgerExplainOut,
 )
-from app.wms.ledger.helpers.stock_ledger import build_base_ids_stmt, infer_movement_type
+from app.wms.ledger.helpers.stock_ledger import (
+    build_base_ids_stmt,
+    infer_movement_type,
+    load_ledger_item_display_maps,
+    resolve_ledger_item_keyword_item_ids,
+)
 
 UTC = timezone.utc
 MAX_HISTORY_DAYS = 3650
@@ -282,7 +287,13 @@ def register(router: APIRouter) -> None:
 
         time_from, time_to = _normalize_history_time_range(payload)
 
-        ids_stmt = build_base_ids_stmt(payload, time_from, time_to)
+        item_keyword_item_ids = await resolve_ledger_item_keyword_item_ids(session, payload=payload)
+        ids_stmt = build_base_ids_stmt(
+            payload,
+            time_from,
+            time_to,
+            item_keyword_item_ids=item_keyword_item_ids,
+        )
         ids_subq = ids_stmt.subquery()
 
         total = (await session.execute(select(func.count()).select_from(ids_subq))).scalar_one()
@@ -298,40 +309,10 @@ def register(router: APIRouter) -> None:
 
         item_ids = sorted({int(r.item_id) for r in rows if r.item_id is not None})
 
-        item_name_map: dict[int, str] = {}
-        base_uom_map: dict[int, dict[str, object | None]] = {}
-
-        if item_ids:
-            res = await session.execute(
-                text(
-                    """
-                    SELECT
-                      i.id,
-                      i.name,
-                      iu.id AS base_item_uom_id,
-                      COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS base_uom_name
-                    FROM items AS i
-                    LEFT JOIN item_uoms AS iu
-                      ON iu.item_id = i.id
-                     AND iu.is_base IS TRUE
-                    WHERE i.id = ANY(:ids)
-                    """
-                ),
-                {"ids": item_ids},
-            )
-            for x in res.mappings().all():
-                iid = int(x["id"])
-                nm = str(x["name"] or "").strip()
-                if nm:
-                    item_name_map[iid] = nm
-                base_uom_map[iid] = {
-                    "base_item_uom_id": (
-                        int(x["base_item_uom_id"])
-                        if x.get("base_item_uom_id") is not None
-                        else None
-                    ),
-                    "base_uom_name": x.get("base_uom_name"),
-                }
+        item_name_map, base_uom_map = await load_ledger_item_display_maps(
+            session,
+            item_ids=item_ids,
+        )
 
         lot_ids = sorted({int(getattr(r, "lot_id")) for r in rows if getattr(r, "lot_id", None) is not None})
         lot_code_map: dict[int, str | None] = {}

--- a/app/wms/ledger/routers/stock_ledger_routes_summary.py
+++ b/app/wms/ledger/routers/stock_ledger_routes_summary.py
@@ -12,9 +12,9 @@ from app.db.session import get_session
 from app.wms.ledger.models.stock_ledger import StockLedger
 from app.wms.ledger.contracts.stock_ledger import LedgerQuery, LedgerReasonStat, LedgerSummary
 from app.wms.ledger.helpers.stock_ledger import (
-    ITEMS_TABLE,
     build_common_filters,
     normalize_time_range,
+    resolve_ledger_item_keyword_item_ids,
 )
 
 
@@ -25,7 +25,13 @@ def register(router: APIRouter) -> None:
         session: AsyncSession = Depends(get_session),
     ) -> LedgerSummary:
         time_from, time_to = normalize_time_range(payload)
-        conditions = build_common_filters(payload, time_from, time_to)
+        item_keyword_item_ids = await resolve_ledger_item_keyword_item_ids(session, payload=payload)
+        conditions = build_common_filters(
+            payload,
+            time_from,
+            time_to,
+            item_keyword_item_ids=item_keyword_item_ids,
+        )
 
         stmt = (
             select(
@@ -35,16 +41,6 @@ def register(router: APIRouter) -> None:
             )
             .select_from(StockLedger)
         )
-
-        if payload.item_keyword:
-            kw = f"%{payload.item_keyword.strip()}%"
-            stmt = stmt.join(ITEMS_TABLE, ITEMS_TABLE.c.id == StockLedger.item_id)
-            conditions.append(
-                sa.or_(
-                    ITEMS_TABLE.c.name.ilike(kw),
-                    ITEMS_TABLE.c.sku.ilike(kw),
-                )
-            )
 
         if conditions:
             stmt = stmt.where(sa.and_(*conditions))

--- a/tests/unit/test_ledger_writer_idem_v2.py
+++ b/tests/unit/test_ledger_writer_idem_v2.py
@@ -32,31 +32,37 @@ async def test_write_ledger_idempotent(session: AsyncSession):
         expiry_date=exp,
     )
 
-    # 终态：本测试只验证 ledger writer 的幂等（不需要散装写 stocks_lot）
-    id1 = await write_ledger(
-        session,
-        warehouse_id=1,
-        item_id=3003,
-        reason="COUNT",
-        delta=1,
-        after_qty=6,
-        ref="LED-IDEM-1",
-        ref_line=1,
-        occurred_at=datetime.now(UTC),
-        lot_id=int(lot_id),
-    )
-    assert id1 > 0
+    # 本测试只验证 ledger writer 的幂等，不验证库存余额变更。
+    # make test 的后置 seed-opening-ledger-test 会检查 Σledger == stocks_lot，
+    # 因此这里必须清理本测试直接写入的 ledger 行，避免污染测试库三账一致性。
+    try:
+        id1 = await write_ledger(
+            session,
+            warehouse_id=1,
+            item_id=3003,
+            reason="COUNT",
+            delta=1,
+            after_qty=6,
+            ref="LED-IDEM-1",
+            ref_line=1,
+            occurred_at=datetime.now(UTC),
+            lot_id=int(lot_id),
+        )
+        assert id1 > 0
 
-    id2 = await write_ledger(
-        session,
-        warehouse_id=1,
-        item_id=3003,
-        reason="COUNT",
-        delta=1,
-        after_qty=6,
-        ref="LED-IDEM-1",
-        ref_line=1,
-        occurred_at=datetime.now(UTC),
-        lot_id=int(lot_id),
-    )
-    assert id2 == 0
+        id2 = await write_ledger(
+            session,
+            warehouse_id=1,
+            item_id=3003,
+            reason="COUNT",
+            delta=1,
+            after_qty=6,
+            ref="LED-IDEM-1",
+            ref_line=1,
+            occurred_at=datetime.now(UTC),
+            lot_id=int(lot_id),
+        )
+        assert id2 == 0
+    finally:
+        await session.execute(text("DELETE FROM stock_ledger WHERE ref = 'LED-IDEM-1'"))
+        await session.flush()


### PR DESCRIPTION
## Summary
- route stock ledger item keyword search through PMS export read service
- route ledger page item display/base UOM enrichment through PMS export services
- remove WMS ledger helper dependency on PMS owner Item model / ITEMS_TABLE re-export
- clean up ledger writer idempotency unit test so it does not pollute post-test stock ledger consistency checks

## Scope
- no DB change
- no FK change
- no PMS projection
- no business execution chain rewrite
- limited to WMS ledger read boundary and one test cleanup

## Tests
- make dev-reset-test-db
- make test TESTS="tests/services/test_pms_export_item_read_service.py tests/api/test_finance_purchase_sku_ledger_api.py tests/api/test_finance_shipping_cost_ledger_api.py tests/api/test_stock_ledger_lot_code_alias_api.py tests/ci/test_ledger_idem_constraint.py tests/contracts/test_event_to_ledger_contract.py tests/contracts/test_stock_ledger_sub_reason_contract.py tests/unit/test_ledger_lot_code_aliases.py tests/unit/test_ledger_writer_idem_v2.py"
- make alembic-check