### PR TITLE
refactor(wms): read inventory item options through pms export

### DIFF
--- a/app/pms/export/items/contracts/item_query.py
+++ b/app/pms/export/items/contracts/item_query.py
@@ -20,7 +20,7 @@ class ItemReadQuery(BaseModel):
     supplier_id: Annotated[int | None, Field(default=None, ge=1)] = None
     enabled: bool | None = None
     q: str | None = None
-    limit: Annotated[int | None, Field(default=None, ge=1, le=200)] = None
+    limit: Annotated[int | None, Field(default=None, ge=1, le=500)] = None
 
     @field_validator("q", mode="before")
     @classmethod

--- a/app/pms/export/items/services/item_read_service.py
+++ b/app/pms/export/items/services/item_read_service.py
@@ -85,6 +85,36 @@ class ItemReadService:
         )
         return self._map_items_to_basic(rows)
 
+    async def alist_basic(self, *, query: ItemReadQuery | None = None) -> list[ItemBasic]:
+        """
+        PMS export async 商品基础读面。
+
+        用于 WMS / OMS / Procurement 等 async 调用方读取商品下拉和轻量展示信息；
+        不暴露 PMS owner ORM，不承载写入语义。
+        """
+        db = self._require_async_db()
+        q = query or ItemReadQuery()
+
+        stmt = select(Item)
+
+        if q.supplier_id is not None:
+            stmt = stmt.where(Item.supplier_id == int(q.supplier_id))
+        if q.enabled is not None:
+            stmt = stmt.where(Item.enabled.is_(bool(q.enabled)))
+
+        keyword = str(q.q or "").strip()
+        if keyword:
+            like_kw = f"%{keyword}%"
+            stmt = stmt.where(or_(Item.name.ilike(like_kw), Item.sku.ilike(like_kw)))
+
+        stmt = stmt.order_by(Item.name.asc(), Item.id.asc())
+
+        if q.limit is not None and int(q.limit) > 0:
+            stmt = stmt.limit(int(q.limit))
+
+        rows = (await db.execute(stmt)).scalars().all()
+        return self._map_items_to_basic(list(rows))
+
     def get_basic_by_id(self, *, item_id: int) -> ItemBasic | None:
         db = self._require_sync_db()
         obj = repo_get_item_by_id(db, int(item_id))

--- a/app/wms/stock/repos/inventory_options_repo.py
+++ b/app/wms/stock/repos/inventory_options_repo.py
@@ -5,12 +5,8 @@ from typing import Any
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-
-def _norm_text(v: str | None) -> str | None:
-    if v is None:
-        return None
-    s = str(v).strip()
-    return s or None
+from app.pms.export.items.contracts.item_query import ItemReadQuery
+from app.pms.export.items.services.item_read_service import ItemReadService
 
 
 async def list_active_warehouses(
@@ -41,28 +37,21 @@ async def list_public_items(
     q: str | None,
     limit: int,
 ) -> list[dict[str, Any]]:
-    cond = ["i.enabled = TRUE"]
-    params: dict[str, Any] = {"limit": int(limit)}
-
-    q_norm = _norm_text(q)
-    if q_norm is not None:
-        cond.append("(i.name ILIKE :q OR i.sku ILIKE :q)")
-        params["q"] = f"%{q_norm}%"
-
-    sql = text(
-        f"""
-        SELECT
-            i.id,
-            i.sku,
-            i.name
-        FROM items AS i
-        WHERE {" AND ".join(cond)}
-        ORDER BY i.name ASC, i.id ASC
-        LIMIT :limit
-        """
+    items = await ItemReadService(session).alist_basic(
+        query=ItemReadQuery(
+            enabled=True,
+            q=q,
+            limit=int(limit),
+        )
     )
-    rows = (await session.execute(sql, params)).mappings().all()
-    return [dict(r) for r in rows]
+    return [
+        {
+            "id": int(item.id),
+            "sku": str(item.sku),
+            "name": str(item.name),
+        }
+        for item in items
+    ]
 
 
 __all__ = [

--- a/tests/services/test_pms_export_item_read_service.py
+++ b/tests/services/test_pms_export_item_read_service.py
@@ -5,6 +5,7 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.pms.export.items.contracts.item_query import ItemReadQuery
 from app.pms.export.items.services.item_read_service import ItemReadService
 
 pytestmark = pytest.mark.asyncio
@@ -103,3 +104,34 @@ async def test_item_read_service_aget_basics_by_item_ids_returns_items_table_fie
             str(row["category"]).strip() if row["category"] is not None else None
         )
         assert not hasattr(basic, "primary_barcode")
+
+async def test_item_read_service_alist_basic_filters_enabled_and_keyword(
+    session: AsyncSession,
+) -> None:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT id, sku, name
+                FROM items
+                WHERE enabled IS TRUE
+                ORDER BY id
+                LIMIT 1
+                """
+            )
+        )
+    ).mappings().first()
+
+    assert row is not None
+
+    got = await ItemReadService(session).alist_basic(
+        query=ItemReadQuery(
+            enabled=True,
+            q=str(row["sku"]),
+            limit=500,
+        )
+    )
+
+    assert any(item.id == int(row["id"]) for item in got)
+    assert all(item.enabled is True for item in got)
+    assert len(got) <= 500


### PR DESCRIPTION
## Summary
- add async PMS export item basic listing
- route WMS stock item options through PMS export ItemReadService
- stop stock options repo from directly querying PMS owner items table
- add PMS export service coverage for async list_basic

## Scope
- no DB change
- no FK change
- no inventory read/explain query rewrite
- no PMS projection
- limited to WMS stock options item dropdown boundary

## Tests
- make dev-reset-test-db
- make test TESTS="tests/services/test_pms_export_item_read_service.py tests/api/test_stock_inventory_read_api.py tests/services/test_shared_inventory_hint.py"
- make alembic-check
