### PR TITLE
refactor(wms): read inventory item metadata through pms export

### DIFF
--- a/app/wms/stock/repos/inventory_read_repo.py
+++ b/app/wms/stock/repos/inventory_read_repo.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Any
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.pms.export.barcodes.services.barcode_read_service import PmsExportBarcodeReadService
+from app.pms.export.items.contracts.item_query import ItemReadQuery
+from app.pms.export.items.services.item_read_service import ItemReadService
+from app.pms.export.uoms.services.uom_read_service import PmsExportUomReadService
 
 
 def _norm_text(v: str | None) -> str | None:
@@ -13,9 +19,129 @@ def _norm_text(v: str | None) -> str | None:
     return s or None
 
 
+def _clean_item_ids(values: Iterable[int] | None) -> list[int]:
+    if values is None:
+        return []
+    out: set[int] = set()
+    for value in values:
+        if value is None:
+            continue
+        item_id = int(value)
+        if item_id > 0:
+            out.add(item_id)
+    return sorted(out)
+
+
+async def _resolve_inventory_q_item_ids(
+    session: AsyncSession,
+    *,
+    q: str | None,
+) -> list[int] | None:
+    """
+    将库存页 q 搜索交给 PMS export item read service。
+
+    返回语义：
+    - None：未传 q，不加商品过滤；
+    - []：传了 q，但 PMS 没有匹配商品，应返回空库存结果；
+    - [ids...]：按 item_id 集合过滤库存事实。
+    """
+    q_norm = _norm_text(q)
+    if q_norm is None:
+        return None
+
+    items = await ItemReadService(session).alist_basic(
+        query=ItemReadQuery(
+            q=q_norm,
+            limit=None,
+        )
+    )
+    return [int(item.id) for item in items]
+
+
+async def _load_inventory_display_maps(
+    session: AsyncSession,
+    *,
+    item_ids: Iterable[int],
+    include_main_barcode: bool,
+):
+    ids = _clean_item_ids(item_ids)
+    if not ids:
+        return {}, {}, {}
+
+    item_map = await ItemReadService(session).aget_basics_by_item_ids(item_ids=ids)
+
+    base_uom_map: dict[int, dict[str, object | None]] = {
+        item_id: {"base_item_uom_id": None, "base_uom_name": None}
+        for item_id in ids
+    }
+    uoms = await PmsExportUomReadService(session).alist_uoms(item_ids=ids)
+    for uom in uoms:
+        if not bool(getattr(uom, "is_base", False)):
+            continue
+        item_id = int(uom.item_id)
+        if item_id not in base_uom_map:
+            continue
+        if base_uom_map[item_id]["base_item_uom_id"] is not None:
+            continue
+
+        base_uom_map[item_id] = {
+            "base_item_uom_id": int(uom.id),
+            "base_uom_name": str(uom.uom_name or uom.display_name or uom.uom or "").strip() or None,
+        }
+
+    main_barcode_map: dict[int, str | None] = {}
+    if include_main_barcode:
+        barcodes = await PmsExportBarcodeReadService(session).alist_barcodes(
+            item_ids=ids,
+            active=True,
+        )
+        for barcode in barcodes:
+            item_id = int(barcode.item_id)
+            if item_id in main_barcode_map:
+                continue
+            main_barcode_map[item_id] = str(barcode.barcode).strip() or None
+
+    return item_map, base_uom_map, main_barcode_map
+
+
+async def _enrich_inventory_rows(
+    session: AsyncSession,
+    *,
+    rows: Iterable[dict[str, Any]],
+    include_main_barcode: bool,
+) -> list[dict[str, Any]]:
+    out = [dict(row) for row in rows]
+    item_ids = _clean_item_ids(row.get("item_id") for row in out)
+
+    item_map, base_uom_map, main_barcode_map = await _load_inventory_display_maps(
+        session,
+        item_ids=item_ids,
+        include_main_barcode=include_main_barcode,
+    )
+
+    for row in out:
+        item_id = int(row["item_id"])
+        item = item_map.get(item_id)
+        base_uom = base_uom_map.get(item_id, {})
+
+        row["item_name"] = str(getattr(item, "name", "") or f"ITEM-{item_id}")
+        row["item_code"] = getattr(item, "sku", None) if item is not None else None
+        row["spec"] = getattr(item, "spec", None) if item is not None else None
+        row["brand"] = getattr(item, "brand", None) if item is not None else None
+        row["category"] = getattr(item, "category", None) if item is not None else None
+        row["base_item_uom_id"] = base_uom.get("base_item_uom_id")
+        row["base_uom_name"] = base_uom.get("base_uom_name")
+
+        if include_main_barcode:
+            row["main_barcode"] = main_barcode_map.get(item_id)
+
+    return out
+
+
 def _build_inventory_where(
     *,
     q: str | None,
+    q_item_ids: Iterable[int] | None,
     item_id: int | None,
     warehouse_id: int | None,
     lot_code: str | None,
@@ -28,8 +154,12 @@ def _build_inventory_where(
     lot_norm = _norm_text(lot_code)
 
     if q_norm is not None:
-        cond.append("(i.name ILIKE :q OR i.sku ILIKE :q)")
-        params["q"] = f"%{q_norm}%"
+        item_ids = _clean_item_ids(q_item_ids)
+        if item_ids:
+            cond.append("s.item_id = ANY(:q_item_ids)")
+            params["q_item_ids"] = item_ids
+        else:
+            cond.append("FALSE")
 
     if item_id is not None:
         cond.append("s.item_id = :item_id")
@@ -64,8 +194,10 @@ async def query_inventory_rows(
     offset: int,
     limit: int,
 ) -> tuple[int, list[dict[str, Any]]]:
+    q_item_ids = await _resolve_inventory_q_item_ids(session, q=q)
     where_sql, params = _build_inventory_where(
         q=q,
+        q_item_ids=q_item_ids,
         item_id=item_id,
         warehouse_id=warehouse_id,
         lot_code=lot_code,
@@ -82,15 +214,10 @@ async def query_inventory_rows(
                 s.warehouse_id,
                 s.lot_id
             FROM stocks_lot AS s
-            JOIN items AS i
-              ON i.id = s.item_id
             JOIN warehouses AS w
               ON w.id = s.warehouse_id
             LEFT JOIN lots AS l
               ON l.id = s.lot_id
-            LEFT JOIN item_uoms AS iu
-              ON iu.item_id = s.item_id
-             AND iu.is_base IS TRUE
             WHERE {where_sql}
         )
         SELECT COUNT(*)::int AS total
@@ -104,49 +231,30 @@ async def query_inventory_rows(
         f"""
         SELECT
             s.item_id,
-            i.name AS item_name,
-            i.sku AS item_code,
-            i.spec AS spec,
-            b.name_cn AS brand,
-            c.category_name AS category,
             s.warehouse_id,
             w.name AS warehouse_name,
             l.lot_code AS lot_code,
             l.production_date AS production_date,
             l.expiry_date AS expiry_date,
-            s.qty,
-            iu.id AS base_item_uom_id,
-            COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS base_uom_name,
-            (
-                SELECT ib.barcode
-                FROM item_barcodes AS ib
-                WHERE ib.item_id = s.item_id
-                  AND ib.active = TRUE
-                ORDER BY ib.is_primary DESC, ib.id ASC
-                LIMIT 1
-            ) AS main_barcode
+            s.qty
         FROM stocks_lot AS s
-        JOIN items AS i
-          ON i.id = s.item_id
-        LEFT JOIN pms_brands AS b
-          ON b.id = i.brand_id
-        LEFT JOIN pms_business_categories AS c
-          ON c.id = i.category_id
         JOIN warehouses AS w
           ON w.id = s.warehouse_id
         LEFT JOIN lots AS l
           ON l.id = s.lot_id
-        LEFT JOIN item_uoms AS iu
-          ON iu.item_id = s.item_id
-         AND iu.is_base IS TRUE
         WHERE {where_sql}
-        ORDER BY i.name ASC, s.item_id ASC, s.warehouse_id ASC, l.lot_code NULLS FIRST
+        ORDER BY s.item_id ASC, s.warehouse_id ASC, l.lot_code NULLS FIRST
         OFFSET :offset
         LIMIT :limit
         """
     )
     rows = (await session.execute(list_sql, params)).mappings().all()
-    return total, [dict(r) for r in rows]
+    enriched = await _enrich_inventory_rows(
+        session,
+        rows=[dict(r) for r in rows],
+        include_main_barcode=True,
+    )
+    return total, enriched
 
 
 async def query_inventory_detail_rows(
@@ -174,9 +282,6 @@ async def query_inventory_detail_rows(
         f"""
         SELECT
             s.item_id,
-            i.name AS item_name,
-            iu.id AS base_item_uom_id,
-            COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS base_uom_name,
             s.warehouse_id,
             w.name AS warehouse_name,
             l.lot_code AS lot_code,
@@ -184,25 +289,20 @@ async def query_inventory_detail_rows(
             l.expiry_date AS expiry_date,
             s.qty
         FROM stocks_lot AS s
-        JOIN items AS i
-          ON i.id = s.item_id
-        LEFT JOIN pms_brands AS b
-          ON b.id = i.brand_id
-        LEFT JOIN pms_business_categories AS c
-          ON c.id = i.category_id
         JOIN warehouses AS w
           ON w.id = s.warehouse_id
         LEFT JOIN lots AS l
           ON l.id = s.lot_id
-        LEFT JOIN item_uoms AS iu
-          ON iu.item_id = s.item_id
-         AND iu.is_base IS TRUE
         WHERE {" AND ".join(cond)}
         ORDER BY s.warehouse_id ASC, l.lot_code NULLS FIRST
         """
     )
     rows = (await session.execute(sql, params)).mappings().all()
-    return [dict(r) for r in rows]
+    return await _enrich_inventory_rows(
+        session,
+        rows=[dict(r) for r in rows],
+        include_main_barcode=False,
+    )
 
 
 __all__ = [

--- a/tests/api/test_stock_inventory_read_api.py
+++ b/tests/api/test_stock_inventory_read_api.py
@@ -85,6 +85,45 @@ async def test_stock_inventory_returns_inventory_rows_with_lot_code_only(client:
 
 
 @pytest.mark.asyncio
+async def test_stock_inventory_q_filter_uses_pms_export_item_search(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+
+    item_id = 910002
+    warehouse_id = 1
+    lot_code = "UT-STOCK-Q-001"
+
+    await ensure_wh_loc_item(session, wh=warehouse_id, loc=warehouse_id, item=item_id)
+    await session.execute(
+        text("UPDATE items SET expiry_policy='REQUIRED'::expiry_policy WHERE id=:i"),
+        {"i": int(item_id)},
+    )
+    await seed_supplier_lot_slot(
+        session,
+        item=item_id,
+        loc=warehouse_id,
+        lot_code=lot_code,
+        qty=5,
+        days=120,
+    )
+    await session.commit()
+
+    resp = await client.get(
+        f"/stock/inventory?q=SKU-{item_id}&warehouse_id={warehouse_id}&limit=20&offset=0",
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    data = resp.json()
+    rows = data.get("rows") or []
+    assert any(int(row["item_id"]) == item_id for row in rows), data
+    assert all("batch_code" not in row for row in rows)
+
+
+
+@pytest.mark.asyncio
 async def test_stock_inventory_detail_returns_totals_and_slices(
     client: AsyncClient,
     session: AsyncSession,


### PR DESCRIPTION
## Summary
- route WMS stock inventory item keyword search through PMS export ItemReadService
- enrich inventory rows with item/basic UOM/barcode metadata through PMS export services
- remove direct stock inventory read dependency on PMS owner items/item_uoms/item_barcodes tables
- add coverage for inventory q filtering through PMS export item search

## Scope
- no DB change
- no FK change
- no inventory explain rewrite
- no inbound/outbound/adjustment execution chain changes
- no PMS projection

## Tests
- make dev-reset-test-db
- make test TESTS="tests/api/test_stock_inventory_read_api.py tests/services/test_pms_export_item_read_service.py tests/services/test_shared_inventory_hint.py"
- make alembic-check
