### PR TITLE
refactor(wms): read inventory explain item metadata through pms export

### DIFF
--- a/app/wms/stock/repos/inventory_explain_repo.py
+++ b/app/wms/stock/repos/inventory_explain_repo.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Any
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.pms.export.items.services.item_read_service import ItemReadService
+from app.pms.export.uoms.services.uom_read_service import PmsExportUomReadService
 
 
 def _norm_text(v: str | None) -> str | None:
@@ -11,6 +15,89 @@ def _norm_text(v: str | None) -> str | None:
         return None
     s = str(v).strip()
     return s or None
+
+
+def _clean_item_ids(values: Iterable[int] | None) -> list[int]:
+    if values is None:
+        return []
+    out: set[int] = set()
+    for value in values:
+        if value is None:
+            continue
+        item_id = int(value)
+        if item_id > 0:
+            out.add(item_id)
+    return sorted(out)
+
+
+async def _load_item_display_maps(
+    session: AsyncSession,
+    *,
+    item_ids: Iterable[int],
+) -> tuple[dict[int, str], dict[int, dict[str, object | None]]]:
+    """
+    通过 PMS export read service 批量读取库存解释页展示所需商品信息。
+
+    注意：
+    - 这里只补当前查询展示信息；
+    - WMS inventory explain 不直接读取 PMS owner items / item_uoms；
+    - 历史事实解释仍以 ledger / lot / snapshot 等 WMS 事实为准。
+    """
+    ids = _clean_item_ids(item_ids)
+    if not ids:
+        return {}, {}
+
+    basics = await ItemReadService(session).aget_basics_by_item_ids(item_ids=ids)
+    item_name_map = {
+        int(item_id): str(item.name).strip()
+        for item_id, item in basics.items()
+        if str(item.name or "").strip()
+    }
+
+    base_uom_map: dict[int, dict[str, object | None]] = {
+        item_id: {"base_item_uom_id": None, "base_uom_name": None}
+        for item_id in ids
+    }
+    uoms = await PmsExportUomReadService(session).alist_uoms(item_ids=ids)
+    for uom in uoms:
+        if not bool(getattr(uom, "is_base", False)):
+            continue
+
+        item_id = int(uom.item_id)
+        if item_id not in base_uom_map:
+            continue
+        if base_uom_map[item_id]["base_item_uom_id"] is not None:
+            continue
+
+        base_uom_map[item_id] = {
+            "base_item_uom_id": int(uom.id),
+            "base_uom_name": str(uom.uom_name or uom.display_name or uom.uom or "").strip() or None,
+        }
+
+    return item_name_map, base_uom_map
+
+
+async def _enrich_item_display(
+    session: AsyncSession,
+    *,
+    rows: Iterable[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    out = [dict(row) for row in rows]
+    item_ids = _clean_item_ids(row.get("item_id") for row in out)
+    item_name_map, base_uom_map = await _load_item_display_maps(
+        session,
+        item_ids=item_ids,
+    )
+
+    for row in out:
+        item_id = int(row["item_id"])
+        base_uom = base_uom_map.get(item_id, {})
+
+        row["item_name"] = item_name_map.get(item_id) or f"ITEM-{item_id}"
+        row["base_item_uom_id"] = base_uom.get("base_item_uom_id")
+        row["base_uom_name"] = base_uom.get("base_uom_name")
+
+    return out
 
 
 async def resolve_inventory_explain_anchor(
@@ -46,24 +133,16 @@ async def resolve_inventory_explain_anchor(
         f"""
         SELECT
             s.item_id,
-            i.name AS item_name,
             s.warehouse_id,
             w.name AS warehouse_name,
             s.lot_id,
             l.lot_code,
-            s.qty AS current_qty,
-            iu.id AS base_item_uom_id,
-            COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS base_uom_name
+            s.qty AS current_qty
         FROM stocks_lot AS s
-        JOIN items AS i
-          ON i.id = s.item_id
         JOIN warehouses AS w
           ON w.id = s.warehouse_id
         LEFT JOIN lots AS l
           ON l.id = s.lot_id
-        LEFT JOIN item_uoms AS iu
-          ON iu.item_id = s.item_id
-         AND iu.is_base IS TRUE
         WHERE {" AND ".join(cond)}
         ORDER BY s.id ASC
         """
@@ -73,7 +152,9 @@ async def resolve_inventory_explain_anchor(
         return None
     if len(rows) > 1:
         raise RuntimeError("ambiguous_inventory_explain_anchor")
-    return dict(rows[0])
+
+    enriched = await _enrich_item_display(session, rows=[dict(rows[0])])
+    return enriched[0]
 
 
 async def count_inventory_explain_ledger_rows(
@@ -127,20 +208,12 @@ async def query_inventory_explain_ledger_rows(
                 sl.after_qty,
                 sl.trace_id,
                 sl.item_id,
-                i.name AS item_name,
                 sl.warehouse_id,
                 sl.lot_id,
-                l.lot_code,
-                iu.id AS base_item_uom_id,
-                COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS base_uom_name
+                l.lot_code
             FROM stock_ledger AS sl
-            JOIN items AS i
-              ON i.id = sl.item_id
             LEFT JOIN lots AS l
               ON l.id = sl.lot_id
-            LEFT JOIN item_uoms AS iu
-              ON iu.item_id = sl.item_id
-             AND iu.is_base IS TRUE
             WHERE sl.item_id = :item_id
               AND sl.warehouse_id = :warehouse_id
               AND sl.lot_id = :lot_id
@@ -161,7 +234,7 @@ async def query_inventory_explain_ledger_rows(
             "limit": int(limit),
         },
     )).mappings().all()
-    return [dict(r) for r in rows]
+    return await _enrich_item_display(session, rows=[dict(r) for r in rows])
 
 
 async def query_inventory_explain_latest_after_qty(

--- a/tests/api/test_stock_inventory_read_api.py
+++ b/tests/api/test_stock_inventory_read_api.py
@@ -124,6 +124,63 @@ async def test_stock_inventory_q_filter_uses_pms_export_item_search(
 
 
 @pytest.mark.asyncio
+async def test_stock_inventory_explain_uses_pms_export_item_metadata(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+
+    item_id = 910003
+    warehouse_id = 1
+    lot_code = "UT-STOCK-EXPLAIN-001"
+
+    await ensure_wh_loc_item(session, wh=warehouse_id, loc=warehouse_id, item=item_id)
+    await session.execute(
+        text("UPDATE items SET expiry_policy='REQUIRED'::expiry_policy WHERE id=:i"),
+        {"i": int(item_id)},
+    )
+    await seed_supplier_lot_slot(
+        session,
+        item=item_id,
+        loc=warehouse_id,
+        lot_code=lot_code,
+        qty=6,
+        days=150,
+    )
+    await session.commit()
+
+    resp = await client.post(
+        "/stock/inventory/explain",
+        json={
+            "item_id": item_id,
+            "warehouse_id": warehouse_id,
+            "lot_code": lot_code,
+            "limit": 20,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    data = resp.json()
+    assert data["anchor"]["item_id"] == item_id
+    assert data["anchor"]["item_name"] == f"ITEM-{item_id}"
+    assert data["anchor"]["lot_code"] == lot_code
+    assert data["anchor"]["base_item_uom_id"] is None or isinstance(
+        data["anchor"]["base_item_uom_id"], int
+    )
+    assert data["anchor"]["base_uom_name"] is None or isinstance(
+        data["anchor"]["base_uom_name"], str
+    )
+
+    rows = data["ledger_rows"]
+    assert rows, data
+    assert all(int(row["item_id"]) == item_id for row in rows)
+    assert all(row["item_name"] == f"ITEM-{item_id}" for row in rows)
+    assert all("batch_code" not in row for row in rows)
+
+
+
+@pytest.mark.asyncio
 async def test_stock_inventory_detail_returns_totals_and_slices(
     client: AsyncClient,
     session: AsyncSession,


### PR DESCRIPTION
## Summary
- route WMS inventory explain item display/base UOM enrichment through PMS export services
- remove direct inventory explain dependency on PMS owner items/item_uoms tables
- keep inventory facts and ledger explanation inside WMS
- add coverage for inventory explain PMS export metadata path

## Scope
- no DB change
- no FK change
- no inbound/outbound/adjustment execution chain changes
- no PMS projection
- limited to WMS inventory explain read boundary

## Tests
- make dev-reset-test-db
- make test TESTS="tests/api/test_stock_inventory_read_api.py tests/services/test_pms_export_item_read_service.py tests/services/test_shared_inventory_hint.py"
- make alembic-check
