### PR TITLE
refactor(wms): read lot code policy through pms export

### DIFF
--- a/app/pms/export/items/services/item_read_service.py
+++ b/app/pms/export/items/services/item_read_service.py
@@ -172,6 +172,39 @@ class ItemReadService:
         basics = [self._build_item_basic(x) for x in rows]
         return {int(x.id): x for x in basics}
 
+    async def aget_policies_by_item_ids(self, *, item_ids: Iterable[int]) -> dict[int, ItemPolicy]:
+        """
+        PMS export async 商品策略批量读面。
+
+        用于 WMS 等调用方批量读取 lot / expiry 策略；
+        不暴露 PMS owner ORM。
+        """
+        db = self._require_async_db()
+        ids = sorted({int(x) for x in item_ids if x is not None and int(x) > 0})
+        if not ids:
+            return {}
+
+        stmt = select(Item).where(Item.id.in_(ids)).order_by(Item.id.asc())
+        rows = (await db.execute(stmt)).scalars().all()
+        return {int(item.id): self._map_item_to_policy(item) for item in rows}
+
+    async def aget_policy_by_sku(self, *, sku: str) -> ItemPolicy | None:
+        """
+        PMS export async SKU -> 商品策略读面。
+
+        仅按 items.sku 精确匹配；不做模糊搜索，不暴露 owner ORM。
+        """
+        db = self._require_async_db()
+        code = str(sku or "").strip()
+        if not code:
+            return None
+
+        stmt = select(Item).where(Item.sku == code).limit(1)
+        obj = (await db.execute(stmt)).scalars().first()
+        if obj is None:
+            return None
+        return self._map_item_to_policy(obj)
+
     async def aget_policy_by_id(self, *, item_id: int) -> ItemPolicy | None:
         db = self._require_async_db()
         stmt = select(Item).where(Item.id == int(item_id))

--- a/app/wms/shared/services/lot_code_contract.py
+++ b/app/wms/shared/services/lot_code_contract.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 from typing import Dict, Optional, Set, Tuple
 
 from fastapi import HTTPException, status
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.pms.export.items.services.item_read_service import ItemReadService
 
 # 非批次商品禁止的历史假码（严格 422）
 _FORBIDDEN_FAKE_CODES: Set[str] = {"NOEXP", "NEAR", "FAR", "IDEM"}
@@ -115,39 +116,31 @@ def _requires_batch_from_expiry_policy(expiry_policy: Optional[str]) -> bool:
 
 async def fetch_item_expiry_policy_map(session: AsyncSession, item_ids: Set[int]) -> Dict[int, str]:
     """
-    真相源：items.expiry_policy（Phase M Rule 层）
+    真相源：PMS export item policy read service。
+
     返回：{item_id: 'NONE' | 'REQUIRED'}
     """
     if not item_ids:
         return {}
 
-    rows = await session.execute(
-        text("select id, expiry_policy from items where id = any(:ids)"),
-        {"ids": list(item_ids)},
-    )
-
-    m: Dict[int, str] = {}
-    for item_id, expiry_policy in rows.fetchall():
-        # expiry_policy 是 enum，psycopg 返回可能是 str / Enum-like；统一转 str
-        m[int(item_id)] = str(expiry_policy)
-    return m
+    policies = await ItemReadService(session).aget_policies_by_item_ids(item_ids=item_ids)
+    return {
+        int(item_id): str(policy.expiry_policy)
+        for item_id, policy in policies.items()
+    }
 
 
 async def fetch_item_by_sku(session: AsyncSession, sku: str) -> Optional[Tuple[int, bool]]:
     """
     返回 (item_id, requires_batch)
-    requires_batch 由 expiry_policy 投影得出。
+    requires_batch 由 PMS export item policy 投影得出。
     """
     s = (sku or "").strip()
     if not s:
         return None
 
-    row = await session.execute(
-        text("select id, expiry_policy from items where sku = :sku limit 1"),
-        {"sku": s},
-    )
-    r = row.first()
-    if not r:
+    policy = await ItemReadService(session).aget_policy_by_sku(sku=s)
+    if policy is None:
         return None
-    item_id, expiry_policy = r[0], r[1]
-    return int(item_id), _requires_batch_from_expiry_policy(str(expiry_policy))
+
+    return int(policy.item_id), _requires_batch_from_expiry_policy(str(policy.expiry_policy))

--- a/tests/services/test_shared_inventory_hint.py
+++ b/tests/services/test_shared_inventory_hint.py
@@ -1,6 +1,11 @@
 import pytest
 from sqlalchemy import text
 
+from app.wms.shared.services.lot_code_contract import (
+    fetch_item_by_sku,
+    fetch_item_expiry_policy_map,
+)
+
 pytestmark = pytest.mark.asyncio
 
 
@@ -10,3 +15,52 @@ async def test_shared_inventory_statement(session):
     # 这里只做口径约定，不做真实库存运算（待主线库存裁决链路接入后替换）
     row = await session.execute(text("SELECT 1"))
     assert row.scalar() == 1
+
+@pytest.mark.asyncio
+async def test_lot_code_contract_reads_policy_through_pms_export(session):
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT id
+                FROM items
+                ORDER BY id
+                LIMIT 1
+                """
+            )
+        )
+    ).first()
+    assert row is not None
+
+    item_id = int(row[0])
+    sku = f"UT-LOT-CONTRACT-{item_id}"
+
+    await session.execute(
+        text(
+            """
+            UPDATE items
+               SET sku = :sku,
+                   expiry_policy = 'REQUIRED'::expiry_policy,
+                   lot_source_policy = 'SUPPLIER_ONLY'::lot_source_policy,
+                   derivation_allowed = TRUE
+             WHERE id = :item_id
+            """
+        ),
+        {
+            "sku": sku,
+            "item_id": item_id,
+        },
+    )
+    await session.flush()
+
+    policy_map = await fetch_item_expiry_policy_map(session, {item_id})
+    assert policy_map == {item_id: "REQUIRED"}
+
+    resolved = await fetch_item_by_sku(session, sku)
+    assert resolved == (item_id, True)
+
+
+@pytest.mark.asyncio
+async def test_lot_code_contract_returns_none_for_unknown_sku(session):
+    resolved = await fetch_item_by_sku(session, "UT-LOT-CONTRACT-NOT-FOUND")
+    assert resolved is None


### PR DESCRIPTION
## Summary
- add async PMS export item policy helpers
- route WMS lot code policy lookup through PMS export ItemReadService
- remove lot_code_contract direct SQL reads from PMS owner items table
- add coverage for SKU and item-id policy lookup through the contract boundary

## Scope
- no DB change
- no FK change
- no lot resolver rewrite
- no inbound / stock adjust / lots execution-chain rewrite
- no PMS projection

## Tests
- make dev-reset-test-db
- make test TESTS="tests/services/test_shared_inventory_hint.py tests/unit/test_ledger_lot_code_aliases.py tests/api/test_wms_receiving_batch_no_lot_code_contract_api.py tests/services/test_pms_export_item_read_service.py"
- make alembic-check
