### PR TITLE
refactor(wms): read lot resolver policy through pms export

### DIFF
--- a/app/wms/stock/services/lot_resolver.py
+++ b/app/wms/stock/services/lot_resolver.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 from datetime import date, datetime
 from typing import Optional
 
-from sqlalchemy import text as SA
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.pms.export.items.services.item_read_service import ItemReadService
 from app.wms.stock.services.lots import ensure_internal_lot_singleton, ensure_lot_full
 
 
@@ -22,14 +22,10 @@ class LotResolver:
     """
 
     async def requires_batch(self, session: AsyncSession, *, item_id: int) -> bool:
-        row = await session.execute(
-            SA("SELECT expiry_policy FROM items WHERE id=:i LIMIT 1"),
-            {"i": int(item_id)},
-        )
-        v = row.scalar_one_or_none()
-        if v is None:
+        policy = await ItemReadService(session).aget_policy_by_id(item_id=int(item_id))
+        if policy is None:
             raise ValueError("item_not_found")
-        return str(v or "").upper() == "REQUIRED"
+        return str(policy.expiry_policy or "").upper() == "REQUIRED"
 
     async def ensure_supplier_lot_id(
         self,

--- a/tests/services/test_shared_inventory_hint.py
+++ b/tests/services/test_shared_inventory_hint.py
@@ -1,6 +1,7 @@
 import pytest
 from sqlalchemy import text
 
+from app.wms.stock.services.lot_resolver import LotResolver
 from app.wms.shared.services.lot_code_contract import (
     fetch_item_by_sku,
     fetch_item_expiry_policy_map,
@@ -64,3 +65,56 @@ async def test_lot_code_contract_reads_policy_through_pms_export(session):
 async def test_lot_code_contract_returns_none_for_unknown_sku(session):
     resolved = await fetch_item_by_sku(session, "UT-LOT-CONTRACT-NOT-FOUND")
     assert resolved is None
+
+@pytest.mark.asyncio
+async def test_lot_resolver_requires_batch_reads_policy_through_pms_export(session):
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT id
+                FROM items
+                ORDER BY id
+                LIMIT 1
+                """
+            )
+        )
+    ).first()
+    assert row is not None
+
+    item_id = int(row[0])
+    resolver = LotResolver()
+
+    await session.execute(
+        text(
+            """
+            UPDATE items
+               SET expiry_policy = 'REQUIRED'::expiry_policy
+             WHERE id = :item_id
+            """
+        ),
+        {"item_id": item_id},
+    )
+    await session.flush()
+    assert await resolver.requires_batch(session, item_id=item_id) is True
+
+    await session.execute(
+        text(
+            """
+            UPDATE items
+               SET expiry_policy = 'NONE'::expiry_policy
+             WHERE id = :item_id
+            """
+        ),
+        {"item_id": item_id},
+    )
+    await session.flush()
+    assert await resolver.requires_batch(session, item_id=item_id) is False
+
+
+@pytest.mark.asyncio
+async def test_lot_resolver_requires_batch_unknown_item_raises(session):
+    resolver = LotResolver()
+
+    with pytest.raises(ValueError, match="item_not_found"):
+        await resolver.requires_batch(session, item_id=999999999)


### PR DESCRIPTION
## Summary
- route LotResolver.requires_batch through PMS export ItemReadService
- remove direct SELECT expiry_policy FROM items from lot_resolver
- add coverage for REQUIRED / NONE / unknown item policy behavior

## Scope
- no DB change
- no FK change
- no lot creation rewrite
- no inbound / stock_adjust / lots execution-chain rewrite
- no PMS projection

## Tests
- make dev-reset-test-db
- make test TESTS="tests/services/test_shared_inventory_hint.py tests/api/test_wms_receiving_batch_no_lot_code_contract_api.py tests/services/test_order_rma_and_reconcile.py tests/services/test_inbound_commit_event_link.py tests/services/test_pms_export_item_read_service.py"
- make alembic-check
