### PR TITLE
refactor(wms): read return order ref item metadata through pms export

### DIFF
--- a/app/wms/inventory_adjustment/return_inbound/routers/order_refs.py
+++ b/app/wms/inventory_adjustment/return_inbound/routers/order_refs.py
@@ -1,6 +1,7 @@
 # app/wms/inventory_adjustment/return_inbound/routers/order_refs.py
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query
@@ -8,6 +9,7 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_session
+from app.pms.export.items.services.item_read_service import ItemReadService
 from app.wms.inventory_adjustment.return_inbound.contracts.return_task import (
     ReturnOrderRefDetailOut,
     ReturnOrderRefItem,
@@ -18,6 +20,105 @@ from app.wms.inventory_adjustment.return_inbound.contracts.return_task import (
 )
 
 from ._common import SHIP_OUT_REASONS, calc_remaining_qty, parse_ext_order_no, safe_meta_to_dict
+
+
+def _clean_item_ids(values: Iterable[int] | None) -> list[int]:
+    if values is None:
+        return []
+
+    out: set[int] = set()
+    for value in values:
+        if value is None:
+            continue
+        item_id = int(value)
+        if item_id > 0:
+            out.add(item_id)
+    return sorted(out)
+
+
+async def _enrich_order_ref_summary_lines(
+    session: AsyncSession,
+    *,
+    rows: Iterable[dict],
+) -> list[dict]:
+    """
+    退货 order_ref 摘要行商品展示补齐。
+
+    WMS 事实仍来自 stock_ledger / lots；
+    商品名通过 PMS export read service 获取，
+    不在 return inbound order_refs 里直接读取 PMS owner items。
+    """
+    out = [dict(row) for row in rows]
+    item_ids = _clean_item_ids(row.get("item_id") for row in out)
+    if not item_ids:
+        return out
+
+    item_map = await ItemReadService(session).aget_basics_by_item_ids(item_ids=item_ids)
+
+    for row in out:
+        item_id = int(row["item_id"])
+        item = item_map.get(item_id)
+        row["item_name"] = (
+            str(item.name).strip()
+            if item is not None and str(item.name or "").strip()
+            else None
+        )
+
+    return out
+
+
+async def load_return_order_ref_summary(
+    *,
+    order_ref: str,
+    session: AsyncSession,
+    warehouse_id: Optional[int] = None,
+) -> ReturnOrderRefSummaryOut:
+    wh_cond = ""
+    params: dict = {"ref": order_ref, "reasons": list(SHIP_OUT_REASONS)}
+    if warehouse_id is not None:
+        wh_cond = "AND l.warehouse_id = :wid"
+        params["wid"] = int(warehouse_id)
+
+    # 维度封板：GROUP BY lot_id；lot_code_snapshot 仅展示，来自 lots.lot_code
+    sql = f"""
+    SELECT l.warehouse_id,
+           l.item_id,
+           NULL::text AS item_name,
+           l.lot_id,
+           MAX(lo.lot_code) AS lot_code_snapshot,
+           COALESCE(SUM(-l.delta), 0)::int AS shipped_qty
+      FROM stock_ledger l
+      LEFT JOIN lots lo ON lo.id = l.lot_id
+     WHERE l.ref = :ref
+       AND l.delta < 0
+       AND l.reason = ANY(:reasons)
+       {wh_cond}
+     GROUP BY l.warehouse_id, l.item_id, l.lot_id
+     ORDER BY l.warehouse_id, l.item_id, l.lot_id
+    """
+
+    lines_raw = (await session.execute(sa.text(sql), params)).mappings().all()
+    lines_data = await _enrich_order_ref_summary_lines(
+        session,
+        rows=[dict(r) for r in lines_raw],
+    )
+    lines = [ReturnOrderRefSummaryLine(**r) for r in lines_data]
+
+    rs = await session.execute(
+        sa.text(
+            """
+            SELECT DISTINCT reason
+              FROM stock_ledger
+             WHERE ref=:ref
+               AND delta<0
+               AND reason = ANY(:reasons)
+             ORDER BY reason
+            """
+        ),
+        {"ref": order_ref, "reasons": list(SHIP_OUT_REASONS)},
+    )
+    reasons = [str(x[0]) for x in rs.all()]
+    return ReturnOrderRefSummaryOut(order_ref=order_ref, ship_reasons=reasons, lines=lines)
 
 
 def register_order_refs(router: APIRouter) -> None:
@@ -112,49 +213,11 @@ def register_order_refs(router: APIRouter) -> None:
         session: AsyncSession = Depends(get_session),
         warehouse_id: Optional[int] = Query(None),
     ) -> ReturnOrderRefSummaryOut:
-        wh_cond = ""
-        params: dict = {"ref": order_ref, "reasons": list(SHIP_OUT_REASONS)}
-        if warehouse_id is not None:
-            wh_cond = "AND l.warehouse_id = :wid"
-            params["wid"] = int(warehouse_id)
-
-        # 维度封板：GROUP BY lot_id；lot_code_snapshot 仅展示，来自 lots.lot_code
-        sql = f"""
-        SELECT l.warehouse_id,
-               l.item_id,
-               i.name AS item_name,
-               l.lot_id,
-               MAX(lo.lot_code) AS lot_code_snapshot,
-               COALESCE(SUM(-l.delta), 0)::int AS shipped_qty
-          FROM stock_ledger l
-          LEFT JOIN items i ON i.id = l.item_id
-          LEFT JOIN lots lo ON lo.id = l.lot_id
-         WHERE l.ref = :ref
-           AND l.delta < 0
-           AND l.reason = ANY(:reasons)
-           {wh_cond}
-         GROUP BY l.warehouse_id, l.item_id, i.name, l.lot_id
-         ORDER BY l.warehouse_id, l.item_id, l.lot_id
-        """
-
-        lines_raw = (await session.execute(sa.text(sql), params)).mappings().all()
-        lines = [ReturnOrderRefSummaryLine(**dict(r)) for r in lines_raw]
-
-        rs = await session.execute(
-            sa.text(
-                """
-                SELECT DISTINCT reason
-                  FROM stock_ledger
-                 WHERE ref=:ref
-                   AND delta<0
-                   AND reason = ANY(:reasons)
-                 ORDER BY reason
-                """
-            ),
-            {"ref": order_ref, "reasons": list(SHIP_OUT_REASONS)},
+        return await load_return_order_ref_summary(
+            order_ref=order_ref,
+            session=session,
+            warehouse_id=warehouse_id,
         )
-        reasons = [str(x[0]) for x in rs.all()]
-        return ReturnOrderRefSummaryOut(order_ref=order_ref, ship_reasons=reasons, lines=lines)
 
     # ---------------------------------------------------------
     # /order-refs/{order_ref}/detail：订单详情（只读）

--- a/tests/services/test_order_rma_and_reconcile.py
+++ b/tests/services/test_order_rma_and_reconcile.py
@@ -14,6 +14,9 @@ from app.oms.services.order_service import OrderService
 from app.wms.inventory_adjustment.return_inbound.repos.inbound_receipt_read_repo import (
     get_inbound_return_source_repo,
 )
+from app.wms.inventory_adjustment.return_inbound.routers.order_refs import (
+    load_return_order_ref_summary,
+)
 from app.wms.stock.services.lots import ensure_internal_lot_singleton, ensure_lot_full
 from app.wms.stock.services.stock_adjust import adjust_lot_impl
 
@@ -791,3 +794,85 @@ async def test_return_source_reads_item_and_uom_through_pms_export(session: Asyn
     assert int(line.ratio_to_base_snapshot) >= 1
     assert int(line.qty_remaining_refundable) == 2
     assert int(line.suggested_planned_qty) == 2
+
+@pytest.mark.asyncio
+async def test_return_order_ref_summary_item_display_uses_pms_export(
+    session: AsyncSession,
+) -> None:
+    platform = "PDD"
+    store_code = "RMA_TEST_SUMMARY_STORE"
+    ext_order_no = "RMA-TEST-SUMMARY-001"
+    trace_id = "TRACE-RMA-TEST-SUMMARY-001"
+
+    item_id = 1
+    required = await _item_batch_mode_is_required(session, item_id=item_id)
+
+    if required:
+        bc: Optional[str] = "RMA-SUMMARY-BATCH-1"
+        pd = date.today()
+        ed = pd + timedelta(days=30)
+    else:
+        bc = None
+        pd = None
+        ed = None
+
+    result = await OrderService.ingest(
+        session,
+        platform=platform,
+        store_code=store_code,
+        ext_order_no=ext_order_no,
+        occurred_at=datetime.now(UTC),
+        buyer_name="RMA 摘要测试用户",
+        buyer_phone="13900000001",
+        order_amount=20,
+        pay_amount=20,
+        items=[
+            {"item_id": item_id, "qty": 2},
+        ],
+        address=None,
+        extras=None,
+        trace_id=trace_id,
+    )
+    order_ref = result["ref"]
+
+    await _write_stock_delta_for_test(
+        session,
+        item_id=item_id,
+        warehouse_id=1,
+        delta=2,
+        reason=MovementType.INBOUND,
+        ref=f"IN-{order_ref}",
+        ref_line=1,
+        occurred_at=datetime.now(UTC),
+        batch_code=bc,
+        production_date=pd,
+        expiry_date=ed,
+    )
+    await _write_stock_delta_for_test(
+        session,
+        item_id=item_id,
+        warehouse_id=1,
+        delta=-2,
+        reason=MovementType.SHIP,
+        ref=order_ref,
+        ref_line=1,
+        occurred_at=datetime.now(UTC),
+        batch_code=bc,
+        production_date=pd,
+        expiry_date=ed,
+    )
+
+    summary = await load_return_order_ref_summary(
+        order_ref=order_ref,
+        session=session,
+        warehouse_id=1,
+    )
+
+    assert summary.order_ref == order_ref
+    assert summary.lines
+
+    line = summary.lines[0]
+    assert line.warehouse_id == 1
+    assert line.item_id == item_id
+    assert line.item_name
+    assert line.shipped_qty == 2


### PR DESCRIPTION
## Summary
- route return order ref summary item display through PMS export ItemReadService
- remove direct LEFT JOIN to PMS owner items table from return inbound order_refs
- keep WMS shipment facts in stock_ledger / lots
- add coverage for return order ref summary item display through PMS export

## Scope
- no DB change
- no FK change
- no return inbound write-chain rewrite
- no receipt write / operation write changes
- no inbound commit / lots rewrite
- no PMS projection

## Tests
- make dev-reset-test-db
- make test TESTS="tests/services/test_order_rma_and_reconcile.py tests/services/test_inbound_reversal_service.py tests/api/test_wms_receiving_batch_no_lot_code_contract_api.py tests/test_phase3_three_books_receive_commit.py"
- make alembic-check
