### PR TITLE
refactor(wms): read return inbound probe uom through pms export

### DIFF
--- a/app/wms/inventory_adjustment/return_inbound/services/inbound_task_probe_service.py
+++ b/app/wms/inventory_adjustment/return_inbound/services/inbound_task_probe_service.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.pms.export.items.services.barcode_probe_service import BarcodeProbeService
+from app.pms.export.uoms.services.uom_read_service import PmsExportUomReadService
 from app.wms.inventory_adjustment.return_inbound.contracts.probe import (
     InboundTaskProbeOut,
     InboundTaskProbeStatus,
@@ -23,28 +23,15 @@ async def _load_actual_uom_name(
     if item_uom_id is None:
         return None
 
-    row = (
-        await session.execute(
-            text(
-                """
-                SELECT
-                  COALESCE(NULLIF(display_name, ''), uom) AS uom_name_snapshot
-                FROM item_uoms
-                WHERE id = :item_uom_id
-                  AND item_id = :item_id
-                LIMIT 1
-                """
-            ),
-            {
-                "item_uom_id": int(item_uom_id),
-                "item_id": int(item_id),
-            },
-        )
-    ).mappings().first()
-
-    if row is None:
+    uom = await PmsExportUomReadService(session).aget_by_id(
+        item_uom_id=int(item_uom_id),
+    )
+    if uom is None:
         return None
-    return row["uom_name_snapshot"]
+    if int(uom.item_id) != int(item_id):
+        return None
+
+    return str(uom.uom_name or uom.display_name or uom.uom or "").strip() or None
 
 
 def _match_line(

--- a/tests/services/test_order_rma_and_reconcile.py
+++ b/tests/services/test_order_rma_and_reconcile.py
@@ -11,6 +11,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.wms.shared.enums import MovementType
 from app.oms.orders.services.order_reconcile_service import OrderReconcileService
 from app.oms.services.order_service import OrderService
+from app.wms.inventory_adjustment.return_inbound.services.inbound_task_probe_service import (
+    _load_actual_uom_name,
+)
 from app.wms.inventory_adjustment.return_inbound.repos.inbound_receipt_read_repo import (
     get_inbound_return_source_repo,
 )
@@ -876,3 +879,46 @@ async def test_return_order_ref_summary_item_display_uses_pms_export(
     assert line.item_id == item_id
     assert line.item_name
     assert line.shipped_qty == 2
+
+@pytest.mark.asyncio
+async def test_return_inbound_probe_loads_uom_name_through_pms_export(
+    session: AsyncSession,
+) -> None:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT id, item_id, COALESCE(NULLIF(display_name, ''), uom) AS uom_name
+                FROM item_uoms
+                ORDER BY id
+                LIMIT 1
+                """
+            )
+        )
+    ).mappings().first()
+    assert row is not None
+
+    item_uom_id = int(row["id"])
+    item_id = int(row["item_id"])
+    expected_name = str(row["uom_name"])
+
+    got = await _load_actual_uom_name(
+        session,
+        item_id=item_id,
+        item_uom_id=item_uom_id,
+    )
+    assert got == expected_name
+
+    mismatch = await _load_actual_uom_name(
+        session,
+        item_id=item_id + 999999,
+        item_uom_id=item_uom_id,
+    )
+    assert mismatch is None
+
+    none_value = await _load_actual_uom_name(
+        session,
+        item_id=item_id,
+        item_uom_id=None,
+    )
+    assert none_value is None


### PR DESCRIPTION
## Summary
- route return inbound probe UOM display through PMS export UOM read service
- remove direct item_uoms SQL read from inbound_task_probe_service
- keep barcode probe and task probe flow unchanged
- add coverage for UOM name loading through PMS export

## Scope
- no DB change
- no FK change
- no operation write rewrite
- no receipt write rewrite
- no inbound_commit rewrite
- no lots.py rewrite
- no PMS projection

## Tests
- make dev-reset-test-db
- make test TESTS="tests/services/test_order_rma_and_reconcile.py tests/services/test_inbound_reversal_service.py tests/api/test_wms_receiving_batch_no_lot_code_contract_api.py tests/test_phase3_three_books_receive_commit.py"
- make alembic-check
