### PR TITLE
refactor(wms): read stock adjust item policy through pms export

### DIFF
--- a/app/wms/stock/services/stock_adjust/db_items.py
+++ b/app/wms/stock/services/stock_adjust/db_items.py
@@ -1,35 +1,21 @@
 # app/wms/stock/services/stock_adjust/db_items.py
 from __future__ import annotations
 
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.pms.export.items.services.item_read_service import ItemReadService
 
 
 async def item_requires_batch(session: AsyncSession, *, item_id: int) -> bool:
     """
-    Phase M 第一阶段：执行层禁止读取 items.has_shelf_life。
+    通过 PMS export 商品策略读面判断是否批次受控。
 
-    批次受控唯一真相源：items.expiry_policy
     - expiry_policy='REQUIRED' => requires_batch=True
     - expiry_policy='NONE'     => requires_batch=False
-
-    重要：item 不存在时必须明确失败（unknown item 不能默认成 NONE）。
+    - item 不存在时必须明确失败，unknown item 不能默认成 NONE。
     """
-    row = (
-        await session.execute(
-            text(
-                """
-                SELECT expiry_policy
-                  FROM items
-                 WHERE id = :item_id
-                 LIMIT 1
-                """
-            ),
-            {"item_id": int(item_id)},
-        )
-    ).first()
-
-    if not row:
+    policy = await ItemReadService(session).aget_policy_by_id(item_id=int(item_id))
+    if policy is None:
         raise ValueError("item_not_found")
 
-    return str(row[0] or "").upper() == "REQUIRED"
+    return str(policy.expiry_policy or "").upper() == "REQUIRED"

--- a/tests/services/test_shared_inventory_hint.py
+++ b/tests/services/test_shared_inventory_hint.py
@@ -2,6 +2,7 @@ import pytest
 from sqlalchemy import text
 
 from app.wms.stock.services.lot_resolver import LotResolver
+from app.wms.stock.services.stock_adjust.db_items import item_requires_batch
 from app.wms.shared.services.lot_code_contract import (
     fetch_item_by_sku,
     fetch_item_expiry_policy_map,
@@ -118,3 +119,53 @@ async def test_lot_resolver_requires_batch_unknown_item_raises(session):
 
     with pytest.raises(ValueError, match="item_not_found"):
         await resolver.requires_batch(session, item_id=999999999)
+
+@pytest.mark.asyncio
+async def test_stock_adjust_item_requires_batch_reads_policy_through_pms_export(session):
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT id
+                FROM items
+                ORDER BY id
+                LIMIT 1
+                """
+            )
+        )
+    ).first()
+    assert row is not None
+
+    item_id = int(row[0])
+
+    await session.execute(
+        text(
+            """
+            UPDATE items
+               SET expiry_policy = 'REQUIRED'::expiry_policy
+             WHERE id = :item_id
+            """
+        ),
+        {"item_id": item_id},
+    )
+    await session.flush()
+    assert await item_requires_batch(session, item_id=item_id) is True
+
+    await session.execute(
+        text(
+            """
+            UPDATE items
+               SET expiry_policy = 'NONE'::expiry_policy
+             WHERE id = :item_id
+            """
+        ),
+        {"item_id": item_id},
+    )
+    await session.flush()
+    assert await item_requires_batch(session, item_id=item_id) is False
+
+
+@pytest.mark.asyncio
+async def test_stock_adjust_item_requires_batch_unknown_item_raises(session):
+    with pytest.raises(ValueError, match="item_not_found"):
+        await item_requires_batch(session, item_id=999999999)


### PR DESCRIPTION
## Summary
- route stock_adjust item batch policy lookup through PMS export ItemReadService
- remove direct items.expiry_policy SQL read from stock_adjust/db_items.py
- keep adjust_lot_impl and stock/ledger write logic unchanged
- add coverage for REQUIRED / NONE / unknown item behavior through PMS export

## Scope
- no DB change
- no FK change
- no adjust_lot_impl rewrite
- no stocks_lot / stock_ledger write change
- no inbound / return inbound / lots.py rewrite
- no PMS projection

## Tests
- make dev-reset-test-db
- make test TESTS="tests/services/test_shared_inventory_hint.py tests/api/test_wms_receiving_batch_no_lot_code_contract_api.py tests/unit/test_ledger_lot_code_aliases.py tests/services/test_order_rma_and_reconcile.py tests/services/test_pms_export_item_read_service.py"
- make alembic-check
