### PR TITLE
refactor(wms): read count doc item metadata through pms export

### DIFF
--- a/app/wms/inventory_adjustment/count/repos/count_doc_repo.py
+++ b/app/wms/inventory_adjustment/count/repos/count_doc_repo.py
@@ -8,6 +8,8 @@ from sqlalchemy import case, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.pms.export.items.services.item_read_service import ItemReadService
+from app.pms.export.uoms.services.uom_read_service import PmsExportUomReadService
 from app.wms.inventory_adjustment.count.models.count_doc import (
     CountDoc,
     CountDocLine,
@@ -287,34 +289,24 @@ class CountDocRepo:
         *,
         item_ids: Sequence[int],
     ) -> dict[int, dict[str, Any]]:
-        ids = [int(x) for x in item_ids]
+        ids = sorted({int(x) for x in item_ids if x is not None and int(x) > 0})
         if not ids:
             return {}
 
-        rows = await session.execute(
-            text(
-                """
-                SELECT
-                  iu.item_id,
-                  iu.id AS base_item_uom_id,
-                  COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS base_uom_name
-                FROM item_uoms iu
-                WHERE iu.item_id = ANY(:item_ids)
-                  AND iu.is_base IS TRUE
-                """
-            ),
-            {"item_ids": ids},
-        )
+        uoms = await PmsExportUomReadService(session).alist_uoms(item_ids=ids)
 
         out: dict[int, dict[str, Any]] = {}
-        for row in rows.mappings().all():
-            out[int(row["item_id"])] = {
-                "base_item_uom_id": (
-                    int(row["base_item_uom_id"])
-                    if row.get("base_item_uom_id") is not None
-                    else None
-                ),
-                "base_uom_name": row.get("base_uom_name"),
+        for uom in uoms:
+            if not bool(getattr(uom, "is_base", False)):
+                continue
+
+            item_id = int(uom.item_id)
+            if item_id in out:
+                continue
+
+            out[item_id] = {
+                "base_item_uom_id": int(uom.id),
+                "base_uom_name": str(uom.uom_name or uom.display_name or uom.uom or "").strip() or None,
             }
         return out
 
@@ -361,12 +353,10 @@ class CountDocRepo:
                   :doc_id AS doc_id,
                   ROW_NUMBER() OVER (ORDER BY s.item_id ASC) AS line_no,
                   s.item_id,
-                  MAX(i.name) AS item_name_snapshot,
-                  MAX(i.spec) AS item_spec_snapshot,
+                  NULL::text AS item_name_snapshot,
+                  NULL::text AS item_spec_snapshot,
                   SUM(s.qty) AS snapshot_qty_base
                   FROM stocks_lot s
-                  JOIN items i
-                    ON i.id = s.item_id
                  WHERE s.warehouse_id = :warehouse_id
                  GROUP BY s.item_id
                 HAVING SUM(s.qty) > 0
@@ -377,6 +367,49 @@ class CountDocRepo:
                 "warehouse_id": int(doc.warehouse_id),
             },
         )
+
+        line_rows = (
+            await session.execute(
+                text(
+                    """
+                    SELECT id, item_id
+                      FROM count_doc_lines
+                     WHERE doc_id = :doc_id
+                     ORDER BY line_no ASC, id ASC
+                    """
+                ),
+                {"doc_id": int(doc_id)},
+            )
+        ).mappings().all()
+
+        item_ids = sorted({int(row["item_id"]) for row in line_rows})
+        item_map = await ItemReadService(session).aget_basics_by_item_ids(item_ids=item_ids)
+
+        for row in line_rows:
+            item_id = int(row["item_id"])
+            item = item_map.get(item_id)
+            if item is None:
+                continue
+
+            await session.execute(
+                text(
+                    """
+                    UPDATE count_doc_lines
+                       SET item_name_snapshot = :item_name_snapshot,
+                           item_spec_snapshot = :item_spec_snapshot
+                     WHERE id = :line_id
+                    """
+                ),
+                {
+                    "line_id": int(row["id"]),
+                    "item_name_snapshot": str(item.name).strip() if str(item.name or "").strip() else None,
+                    "item_spec_snapshot": (
+                        str(item.spec).strip()
+                        if getattr(item, "spec", None) is not None and str(item.spec or "").strip()
+                        else None
+                    ),
+                },
+            )
 
         await session.execute(
             text(
@@ -476,33 +509,19 @@ class CountDocRepo:
             if line is None:
                 raise LookupError(f"count_doc_line_not_found:{line_id}")
 
-            base_uom_row = (
-                await session.execute(
-                    text(
-                        """
-                        SELECT
-                          iu.id,
-                          COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS uom_name_snapshot
-                          FROM item_uoms iu
-                         WHERE iu.item_id = :item_id
-                           AND iu.is_base IS TRUE
-                         ORDER BY iu.id ASC
-                         LIMIT 1
-                        """
-                    ),
-                    {
-                        "item_id": int(line.item_id),
-                    },
-                )
-            ).mappings().first()
-            if base_uom_row is None:
+            base_uom_map = await self.get_base_uom_map(
+                session,
+                item_ids=[int(line.item_id)],
+            )
+            base_uom = base_uom_map.get(int(line.item_id))
+            if base_uom is None or base_uom.get("base_item_uom_id") is None:
                 raise LookupError(f"count_doc_line_base_uom_not_found:item_id={int(line.item_id)}")
 
             counted_qty_base = int(counted_qty_input)
             diff_qty_base = int(counted_qty_base) - int(line.snapshot_qty_base)
 
-            line.counted_item_uom_id = int(base_uom_row["id"])
-            line.counted_uom_name_snapshot = str(base_uom_row["uom_name_snapshot"])
+            line.counted_item_uom_id = int(base_uom["base_item_uom_id"])
+            line.counted_uom_name_snapshot = str(base_uom["base_uom_name"])
             line.counted_ratio_to_base_snapshot = 1
             line.counted_qty_input = int(counted_qty_input)
             line.counted_qty_base = int(counted_qty_base)

--- a/tests/services/test_shared_inventory_hint.py
+++ b/tests/services/test_shared_inventory_hint.py
@@ -1,6 +1,9 @@
+from datetime import UTC, datetime
+
 import pytest
 from sqlalchemy import text
 
+from app.wms.inventory_adjustment.count.repos.count_doc_repo import CountDocRepo
 from app.wms.stock.services.lot_resolver import LotResolver
 from app.wms.stock.services.stock_adjust.db_items import item_requires_batch
 from app.wms.shared.services.lot_code_contract import (
@@ -169,3 +172,129 @@ async def test_stock_adjust_item_requires_batch_reads_policy_through_pms_export(
 async def test_stock_adjust_item_requires_batch_unknown_item_raises(session):
     with pytest.raises(ValueError, match="item_not_found"):
         await item_requires_batch(session, item_id=999999999)
+
+@pytest.mark.asyncio
+async def test_count_doc_repo_reads_base_uom_through_pms_export(session):
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT item_id, id, COALESCE(NULLIF(display_name, ''), uom) AS uom_name
+                  FROM item_uoms
+                 WHERE is_base IS TRUE
+                 ORDER BY item_id ASC, id ASC
+                 LIMIT 1
+                """
+            )
+        )
+    ).mappings().first()
+    assert row is not None
+
+    item_id = int(row["item_id"])
+    got = await CountDocRepo().get_base_uom_map(session, item_ids=[item_id])
+
+    assert item_id in got
+    assert got[item_id]["base_item_uom_id"] == int(row["id"])
+    assert got[item_id]["base_uom_name"] == str(row["uom_name"])
+
+
+@pytest.mark.asyncio
+async def test_count_doc_repo_update_line_counts_reads_base_uom_through_pms_export(session):
+    item_row = (
+        await session.execute(
+            text(
+                """
+                SELECT item_id, id, COALESCE(NULLIF(display_name, ''), uom) AS uom_name
+                  FROM item_uoms
+                 WHERE is_base IS TRUE
+                 ORDER BY item_id ASC, id ASC
+                 LIMIT 1
+                """
+            )
+        )
+    ).mappings().first()
+    assert item_row is not None
+
+    item_id = int(item_row["item_id"])
+    repo = CountDocRepo()
+    doc = await repo.create_doc(
+        session,
+        count_no=f"UT-COUNT-{item_id}",
+        warehouse_id=1,
+        snapshot_at=datetime.now(UTC),
+        created_by=None,
+        remark="ut count doc repo uom",
+    )
+    await session.flush()
+
+    line_row = (
+        await session.execute(
+            text(
+                """
+                INSERT INTO count_doc_lines (
+                  doc_id,
+                  line_no,
+                  item_id,
+                  item_name_snapshot,
+                  item_spec_snapshot,
+                  snapshot_qty_base
+                )
+                VALUES (
+                  :doc_id,
+                  1,
+                  :item_id,
+                  'UT-ITEM',
+                  NULL,
+                  5
+                )
+                RETURNING id
+                """
+            ),
+            {
+                "doc_id": int(doc.id),
+                "item_id": item_id,
+            },
+        )
+    ).first()
+    assert line_row is not None
+
+    line_id = int(line_row[0])
+    updated = await repo.update_line_counts(
+        session,
+        doc_id=int(doc.id),
+        counted_by_name_snapshot="UT_COUNTER",
+        lines=[
+            {
+                "line_id": line_id,
+                "counted_qty_input": 7,
+            }
+        ],
+    )
+    assert updated == 1
+
+    line = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  counted_item_uom_id,
+                  counted_uom_name_snapshot,
+                  counted_ratio_to_base_snapshot,
+                  counted_qty_input,
+                  counted_qty_base,
+                  diff_qty_base
+                FROM count_doc_lines
+                WHERE id = :line_id
+                LIMIT 1
+                """
+            ),
+            {"line_id": line_id},
+        )
+    ).mappings().first()
+    assert line is not None
+    assert int(line["counted_item_uom_id"]) == int(item_row["id"])
+    assert str(line["counted_uom_name_snapshot"]) == str(item_row["uom_name"])
+    assert int(line["counted_ratio_to_base_snapshot"]) == 1
+    assert int(line["counted_qty_input"]) == 7
+    assert int(line["counted_qty_base"]) == 7
+    assert int(line["diff_qty_base"]) == 2


### PR DESCRIPTION
## Summary
- route count doc base UOM lookup through PMS export UOM read service
- route count doc freeze item snapshot enrichment through PMS export item read service
- remove direct items/item_uoms SQL reads from count_doc_repo.py
- keep count posting, StockService.adjust_lot, stock ledger, and stocks_lot write logic unchanged

## Scope
- no DB change
- no FK change
- no post_doc rewrite
- no StockService.adjust_lot rewrite
- no stocks_lot / stock_ledger write change
- no inbound / return inbound / lots.py rewrite
- no PMS projection

## Tests
- make dev-reset-test-db
- make test TESTS="tests/services/test_shared_inventory_hint.py tests/unit/test_ledger_lot_code_aliases.py tests/api/test_wms_receiving_batch_no_lot_code_contract_api.py tests/services/test_pms_export_item_read_service.py tests/api/test_inventory_adjustment_count_doc_execution_api.py tests/api/test_inventory_adjustment_count_doc_guard_api.py tests/api/test_inventory_adjustment_count_doc_mainline_api.py tests/api/test_stock_inventory_recount_freeze_guard_api.py"
- make alembic-check
