### PR TITLE
refactor(wms): read inbound commit metadata through pms export

### DIFF
--- a/app/wms/inbound/services/inbound_commit_service.py
+++ b/app/wms/inbound/services/inbound_commit_service.py
@@ -6,9 +6,10 @@ from datetime import date, datetime, timezone
 from uuid import uuid4
 
 from fastapi import HTTPException
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.pms.export.items.services.item_read_service import ItemReadService
+from app.pms.export.uoms.services.uom_read_service import PmsExportUomReadService
 from app.procurement.services.purchase_order_completion_sync import (
     sync_purchase_completion_for_inbound_event,
 )
@@ -75,33 +76,14 @@ async def _require_ratio_to_base(
     item_id: int,
     uom_id: int,
 ) -> int:
-    row = await session.execute(
-        text(
-            """
-            SELECT ratio_to_base
-            FROM item_uoms
-            WHERE id = :uom_id
-              AND item_id = :item_id
-            LIMIT 1
-            """
-        ),
-        {
-            "uom_id": int(uom_id),
-            "item_id": int(item_id),
-        },
-    )
-    m = row.mappings().first()
-    if m is None:
+    uom = await PmsExportUomReadService(session).aget_by_id(item_uom_id=int(uom_id))
+    if uom is None or int(uom.item_id) != int(item_id):
         raise HTTPException(
             status_code=400,
             detail=f"uom_id 不存在或不属于该商品：item_id={int(item_id)} uom_id={int(uom_id)}",
         )
 
-    try:
-        ratio = int(m.get("ratio_to_base") or 0)
-    except Exception:
-        ratio = 0
-
+    ratio = int(uom.ratio_to_base or 0)
     if ratio <= 0:
         raise HTTPException(status_code=400, detail="item_uoms.ratio_to_base 非法（必须 >= 1）")
     return ratio
@@ -113,39 +95,19 @@ async def _load_item_display_snapshot(
     item_id: int,
     uom_id: int,
 ) -> tuple[str | None, str | None, str | None]:
-    row = (
-        await session.execute(
-            text(
-                """
-                SELECT
-                  i.name AS item_name_snapshot,
-                  i.spec AS item_spec_snapshot,
-                  COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS actual_uom_name_snapshot
-                FROM items i
-                JOIN item_uoms iu
-                  ON iu.id = :uom_id
-                 AND iu.item_id = i.id
-                WHERE i.id = :item_id
-                LIMIT 1
-                """
-            ),
-            {
-                "item_id": int(item_id),
-                "uom_id": int(uom_id),
-            },
-        )
-    ).mappings().first()
+    item = await ItemReadService(session).aget_basic_by_id(item_id=int(item_id))
+    uom = await PmsExportUomReadService(session).aget_by_id(item_uom_id=int(uom_id))
 
-    if row is None:
+    if item is None or uom is None or int(uom.item_id) != int(item_id):
         raise HTTPException(
             status_code=422,
             detail=f"item_display_snapshot_not_found:{int(item_id)}:{int(uom_id)}",
         )
 
     return (
-        _norm_text(row["item_name_snapshot"]),
-        _norm_text(row["item_spec_snapshot"]),
-        _norm_text(row["actual_uom_name_snapshot"]),
+        _norm_text(item.name),
+        _norm_text(item.spec),
+        _norm_text(uom.uom_name or uom.display_name or uom.uom),
     )
 
 

--- a/tests/services/test_inbound_commit_event_link.py
+++ b/tests/services/test_inbound_commit_event_link.py
@@ -302,3 +302,52 @@ async def test_inbound_event_detail_reads_line_snapshots_not_pms_current_state(s
     assert line.item_name != "MUTATED-CURRENT-NAME"
     assert line.actual_uom_name != "MUTATED-CURRENT-UOM"
     assert line.item_sku is None
+
+async def test_inbound_commit_rejects_uom_that_belongs_to_other_item(session):
+    picked = await _pick_seed_item_uom(session)
+
+    other_row = (
+        await session.execute(
+            text(
+                """
+                SELECT u.id AS uom_id
+                  FROM item_uoms u
+                 WHERE u.item_id <> :item_id
+                 ORDER BY u.id ASC
+                 LIMIT 1
+                """
+            ),
+            {"item_id": int(picked["item_id"])},
+        )
+    ).mappings().first()
+    assert other_row is not None, "expected another seeded item_uom"
+
+    payload = InboundCommitIn.model_validate(
+        {
+            "warehouse_id": int(picked["warehouse_id"]),
+            "source_type": "MANUAL",
+            "source_ref": None,
+            "occurred_at": date.today().isoformat() + "T00:00:00Z",
+            "remark": "ut inbound commit uom mismatch",
+            "lines": [
+                {
+                    "item_id": int(picked["item_id"]),
+                    "uom_id": int(other_row["uom_id"]),
+                    "qty_input": 1,
+                    "lot_code_input": None,
+                    "production_date": None,
+                    "expiry_date": None,
+                    "remark": "uom mismatch",
+                }
+            ],
+        }
+    )
+
+    import pytest
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc_info:
+        await commit_inbound(session, payload=payload, user_id=None)
+
+    assert exc_info.value.status_code == 400
+    assert "uom_id 不存在或不属于该商品" in str(exc_info.value.detail)


### PR DESCRIPTION
## Summary
- route inbound commit UOM ratio lookup through PMS export UOM read service
- route inbound commit item/uom display snapshots through PMS export item and UOM read services
- remove direct items/item_uoms SQL reads from inbound_commit_service.py
- add coverage rejecting UOMs that do not belong to the committed item

## Scope
- no DB change
- no FK change
- no commit_inbound flow rewrite
- no lot resolution rewrite
- no stocks_lot / stock_ledger write change
- no return inbound / lots.py rewrite
- no PMS projection

## Tests
- make dev-reset-test-db
- make test TESTS="tests/services/test_inbound_commit_event_link.py tests/services/test_inbound_reversal_service.py tests/api/test_wms_receiving_batch_no_lot_code_contract_api.py tests/test_phase3_three_books_receive_commit.py tests/services/test_pms_export_item_read_service.py"
- make alembic-check
