### PR TITLE
refactor(wms): read return receipt line snapshots through pms export

### DIFF
--- a/app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_write_repo.py
+++ b/app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_write_repo.py
@@ -7,6 +7,8 @@ from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.pms.export.items.services.item_read_service import ItemReadService
+from app.pms.export.uoms.services.uom_read_service import PmsExportUomReadService
 from app.wms.inventory_adjustment.return_inbound.contracts.receipt_create_from_purchase import (
     InboundReceiptCreateFromPurchaseIn,
     InboundReceiptCreateFromPurchaseOut,
@@ -128,57 +130,30 @@ async def _load_manual_line_snapshot(
     item_id: int,
     item_uom_id: int,
 ) -> dict[str, object]:
-    row = (
-        await session.execute(
-            text(
-                """
-                SELECT
-                  i.id AS item_id,
-                  i.name AS item_name,
-                  i.spec AS item_spec,
-                  u.id AS item_uom_id,
-                  COALESCE(NULLIF(u.display_name, ''), u.uom) AS uom_name,
-                  u.ratio_to_base AS ratio_to_base
-                FROM items i
-                JOIN item_uoms u
-                  ON u.item_id = i.id
-                WHERE i.id = :item_id
-                  AND u.id = :item_uom_id
-                LIMIT 1
-                """
-            ),
-            {
-                "item_id": int(item_id),
-                "item_uom_id": int(item_uom_id),
-            },
-        )
-    ).mappings().first()
-
-    if row is not None:
-        return dict(row)
-
-    item_exists = (
-        await session.execute(
-            text("SELECT 1 FROM items WHERE id = :item_id LIMIT 1"),
-            {"item_id": int(item_id)},
-        )
-    ).scalar_one_or_none()
-    if item_exists is None:
+    item = await ItemReadService(session).aget_basic_by_id(item_id=int(item_id))
+    if item is None:
         raise HTTPException(status_code=404, detail="item_not_found")
 
-    uom_exists = (
-        await session.execute(
-            text("SELECT 1 FROM item_uoms WHERE id = :item_uom_id LIMIT 1"),
-            {"item_uom_id": int(item_uom_id)},
-        )
-    ).scalar_one_or_none()
-    if uom_exists is None:
+    uom = await PmsExportUomReadService(session).aget_by_id(
+        item_uom_id=int(item_uom_id),
+    )
+    if uom is None:
         raise HTTPException(status_code=404, detail="item_uom_not_found")
 
-    raise HTTPException(
-        status_code=409,
-        detail=f"item_uom_item_mismatch:item_id={int(item_id)},item_uom_id={int(item_uom_id)}",
-    )
+    if int(uom.item_id) != int(item_id):
+        raise HTTPException(
+            status_code=409,
+            detail=f"item_uom_item_mismatch:item_id={int(item_id)},item_uom_id={int(item_uom_id)}",
+        )
+
+    return {
+        "item_id": int(item.id),
+        "item_name": item.name,
+        "item_spec": item.spec,
+        "item_uom_id": int(uom.id),
+        "uom_name": str(uom.uom_name or uom.display_name or uom.uom or "").strip() or None,
+        "ratio_to_base": int(uom.ratio_to_base),
+    }
 
 
 async def create_inbound_receipt_from_purchase_repo(

--- a/tests/services/test_order_rma_and_reconcile.py
+++ b/tests/services/test_order_rma_and_reconcile.py
@@ -11,6 +11,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.wms.shared.enums import MovementType
 from app.oms.orders.services.order_reconcile_service import OrderReconcileService
 from app.oms.services.order_service import OrderService
+from app.wms.inventory_adjustment.return_inbound.repos.inbound_receipt_write_repo import (
+    _load_manual_line_snapshot,
+)
 from app.wms.inventory_adjustment.return_inbound.services.inbound_task_probe_service import (
     _load_actual_uom_name,
 )
@@ -922,3 +925,83 @@ async def test_return_inbound_probe_loads_uom_name_through_pms_export(
         item_uom_id=None,
     )
     assert none_value is None
+
+@pytest.mark.asyncio
+async def test_return_inbound_manual_line_snapshot_reads_through_pms_export(
+    session: AsyncSession,
+) -> None:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  i.id AS item_id,
+                  i.name AS item_name,
+                  i.spec AS item_spec,
+                  u.id AS item_uom_id,
+                  COALESCE(NULLIF(u.display_name, ''), u.uom) AS uom_name,
+                  u.ratio_to_base AS ratio_to_base
+                FROM items i
+                JOIN item_uoms u
+                  ON u.item_id = i.id
+                ORDER BY i.id ASC, u.id ASC
+                LIMIT 1
+                """
+            )
+        )
+    ).mappings().first()
+    assert row is not None
+
+    snap = await _load_manual_line_snapshot(
+        session,
+        item_id=int(row["item_id"]),
+        item_uom_id=int(row["item_uom_id"]),
+    )
+
+    assert snap["item_id"] == int(row["item_id"])
+    assert snap["item_name"] == row["item_name"]
+    assert snap["item_spec"] == row["item_spec"]
+    assert snap["item_uom_id"] == int(row["item_uom_id"])
+    assert snap["uom_name"] == row["uom_name"]
+    assert snap["ratio_to_base"] == int(row["ratio_to_base"])
+
+
+@pytest.mark.asyncio
+async def test_return_inbound_manual_line_snapshot_rejects_mismatched_uom(
+    session: AsyncSession,
+) -> None:
+    rows = (
+        await session.execute(
+            text(
+                """
+                SELECT item_id, id AS item_uom_id
+                FROM item_uoms
+                ORDER BY item_id ASC, id ASC
+                LIMIT 20
+                """
+            )
+        )
+    ).mappings().all()
+
+    by_item = {}
+    for row in rows:
+        by_item.setdefault(int(row["item_id"]), int(row["item_uom_id"]))
+
+    if len(by_item) < 2:
+        pytest.skip("need at least two items with uoms for mismatch coverage")
+
+    item_ids = sorted(by_item)
+    item_id = item_ids[0]
+    other_uom_id = by_item[item_ids[1]]
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _load_manual_line_snapshot(
+            session,
+            item_id=item_id,
+            item_uom_id=other_uom_id,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert "item_uom_item_mismatch" in str(exc_info.value.detail)


### PR DESCRIPTION
## Summary
- route return inbound manual receipt line item/UOM snapshots through PMS export services
- remove direct items/item_uoms SQL reads from inbound_receipt_write_repo.py
- preserve item/uom existence and mismatch error semantics
- add coverage for snapshot lookup and mismatched UOM rejection

## Scope
- no DB change
- no FK change
- no inbound_operation_write_repo rewrite
- no receipt release rewrite
- no stock write change
- no ledger write change
- no PMS projection

## Tests
- make dev-reset-test-db
- make test TESTS="tests/services/test_order_rma_and_reconcile.py tests/services/test_inbound_reversal_service.py tests/api/test_wms_receiving_batch_no_lot_code_contract_api.py tests/test_phase3_three_books_receive_commit.py tests/services/test_pms_export_item_read_service.py"
- make alembic-check
