### PR TITLE
refactor(wms): read return operation snapshots through pms export

### DIFF
--- a/app/wms/inventory_adjustment/return_inbound/repos/inbound_operation_write_repo.py
+++ b/app/wms/inventory_adjustment/return_inbound/repos/inbound_operation_write_repo.py
@@ -7,6 +7,9 @@ from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.pms.export.items.contracts.barcode_probe import BarcodeProbeStatus
+from app.pms.export.items.services.barcode_probe_service import BarcodeProbeService
+from app.pms.export.uoms.services.uom_read_service import PmsExportUomReadService
 from app.wms.inbound.repos.item_lookup_repo import get_item_policy_by_id
 from app.wms.inbound.repos.lot_resolve_repo import resolve_inbound_lot
 from app.wms.inventory_adjustment.count.services.count_freeze_guard_service import (
@@ -51,37 +54,19 @@ async def _load_item_uom_snapshot(
     item_id: int,
     item_uom_id: int,
 ) -> tuple[int, str | None, int]:
-    row = (
-        await session.execute(
-            text(
-                """
-                SELECT
-                  iu.id AS actual_item_uom_id,
-                  COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS actual_uom_name_snapshot,
-                  iu.ratio_to_base AS actual_ratio_to_base_snapshot
-                FROM item_uoms iu
-                WHERE iu.id = :item_uom_id
-                  AND iu.item_id = :item_id
-                LIMIT 1
-                """
-            ),
-            {
-                "item_uom_id": int(item_uom_id),
-                "item_id": int(item_id),
-            },
-        )
-    ).mappings().first()
-
-    if row is None:
+    uom = await PmsExportUomReadService(session).aget_by_id(
+        item_uom_id=int(item_uom_id),
+    )
+    if uom is None or int(uom.item_id) != int(item_id):
         raise HTTPException(
             status_code=409,
             detail=f"actual_item_uom_not_found_or_item_mismatch:{item_id}:{item_uom_id}",
         )
 
     return (
-        int(row["actual_item_uom_id"]),
-        row["actual_uom_name_snapshot"],
-        int(row["actual_ratio_to_base_snapshot"]),
+        int(uom.id),
+        str(uom.uom_name or uom.display_name or uom.uom or "").strip() or None,
+        int(uom.ratio_to_base),
     )
 
 
@@ -92,42 +77,33 @@ async def _resolve_barcode_uom_snapshot(
     barcode: str,
 ) -> tuple[int, str | None, int]:
     code = (barcode or "").strip()
-    row = (
-        await session.execute(
-            text(
-                """
-                SELECT
-                  iu.id AS actual_item_uom_id,
-                  COALESCE(NULLIF(iu.display_name, ''), iu.uom) AS actual_uom_name_snapshot,
-                  iu.ratio_to_base AS actual_ratio_to_base_snapshot
-                FROM item_barcodes ib
-                JOIN item_uoms iu
-                  ON iu.id = ib.item_uom_id
-                 AND iu.item_id = ib.item_id
-                WHERE ib.barcode = :barcode
-                  AND ib.active = TRUE
-                  AND ib.item_id = :item_id
-                ORDER BY ib.is_primary DESC, ib.id ASC
-                LIMIT 1
-                """
-            ),
-            {
-                "barcode": code,
-                "item_id": int(item_id),
-            },
-        )
-    ).mappings().first()
+    probe = await BarcodeProbeService(session).aprobe(barcode=code)
 
-    if row is None:
+    if (
+        probe.status != BarcodeProbeStatus.BOUND
+        or probe.active is not True
+        or probe.item_id is None
+        or probe.item_uom_id is None
+        or int(probe.item_id) != int(item_id)
+    ):
+        raise HTTPException(
+            status_code=422,
+            detail=f"barcode_unbound_or_item_mismatch:{code}",
+        )
+
+    uom = await PmsExportUomReadService(session).aget_by_id(
+        item_uom_id=int(probe.item_uom_id),
+    )
+    if uom is None or int(uom.item_id) != int(item_id):
         raise HTTPException(
             status_code=422,
             detail=f"barcode_unbound_or_item_mismatch:{code}",
         )
 
     return (
-        int(row["actual_item_uom_id"]),
-        row["actual_uom_name_snapshot"],
-        int(row["actual_ratio_to_base_snapshot"]),
+        int(uom.id),
+        str(uom.uom_name or uom.display_name or uom.uom or "").strip() or None,
+        int(uom.ratio_to_base),
     )
 
 

--- a/tests/services/test_order_rma_and_reconcile.py
+++ b/tests/services/test_order_rma_and_reconcile.py
@@ -11,6 +11,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.wms.shared.enums import MovementType
 from app.oms.orders.services.order_reconcile_service import OrderReconcileService
 from app.oms.services.order_service import OrderService
+from app.wms.inventory_adjustment.return_inbound.repos.inbound_operation_write_repo import (
+    _load_item_uom_snapshot,
+    _resolve_barcode_uom_snapshot,
+)
 from app.wms.inventory_adjustment.return_inbound.repos.inbound_receipt_write_repo import (
     _load_manual_line_snapshot,
 )
@@ -1005,3 +1009,109 @@ async def test_return_inbound_manual_line_snapshot_rejects_mismatched_uom(
 
     assert exc_info.value.status_code == 409
     assert "item_uom_item_mismatch" in str(exc_info.value.detail)
+
+@pytest.mark.asyncio
+async def test_return_inbound_operation_loads_uom_snapshot_through_pms_export(
+    session: AsyncSession,
+) -> None:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  id AS item_uom_id,
+                  item_id,
+                  COALESCE(NULLIF(display_name, ''), uom) AS uom_name,
+                  ratio_to_base
+                FROM item_uoms
+                ORDER BY item_id ASC, id ASC
+                LIMIT 1
+                """
+            )
+        )
+    ).mappings().first()
+    assert row is not None
+
+    actual_item_uom_id, actual_uom_name_snapshot, actual_ratio = await _load_item_uom_snapshot(
+        session,
+        item_id=int(row["item_id"]),
+        item_uom_id=int(row["item_uom_id"]),
+    )
+
+    assert actual_item_uom_id == int(row["item_uom_id"])
+    assert actual_uom_name_snapshot == str(row["uom_name"])
+    assert actual_ratio == int(row["ratio_to_base"])
+
+
+@pytest.mark.asyncio
+async def test_return_inbound_operation_resolves_barcode_through_pms_export(
+    session: AsyncSession,
+) -> None:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  ib.barcode,
+                  ib.item_id,
+                  ib.item_uom_id,
+                  COALESCE(NULLIF(u.display_name, ''), u.uom) AS uom_name,
+                  u.ratio_to_base
+                FROM item_barcodes ib
+                JOIN item_uoms u
+                  ON u.id = ib.item_uom_id
+                 AND u.item_id = ib.item_id
+                WHERE ib.active IS TRUE
+                ORDER BY ib.is_primary DESC, ib.id ASC
+                LIMIT 1
+                """
+            )
+        )
+    ).mappings().first()
+    if row is None:
+        pytest.skip("no active barcode seed available")
+
+    actual_item_uom_id, actual_uom_name_snapshot, actual_ratio = await _resolve_barcode_uom_snapshot(
+        session,
+        item_id=int(row["item_id"]),
+        barcode=str(row["barcode"]),
+    )
+
+    assert actual_item_uom_id == int(row["item_uom_id"])
+    assert actual_uom_name_snapshot == str(row["uom_name"])
+    assert actual_ratio == int(row["ratio_to_base"])
+
+
+@pytest.mark.asyncio
+async def test_return_inbound_operation_rejects_barcode_item_mismatch(
+    session: AsyncSession,
+) -> None:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  ib.barcode,
+                  ib.item_id
+                FROM item_barcodes ib
+                WHERE ib.active IS TRUE
+                ORDER BY ib.is_primary DESC, ib.id ASC
+                LIMIT 1
+                """
+            )
+        )
+    ).mappings().first()
+    if row is None:
+        pytest.skip("no active barcode seed available")
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _resolve_barcode_uom_snapshot(
+            session,
+            item_id=int(row["item_id"]) + 999999,
+            barcode=str(row["barcode"]),
+        )
+
+    assert exc_info.value.status_code == 422
+    assert "barcode_unbound_or_item_mismatch" in str(exc_info.value.detail)


### PR DESCRIPTION
## Summary
- route return inbound operation UOM snapshot lookup through PMS export UOM read service
- route return inbound operation barcode-to-UOM lookup through PMS export barcode probe and UOM read services
- remove direct item_uoms/item_barcodes SQL reads from inbound_operation_write_repo.py
- add coverage for UOM snapshot lookup, barcode resolution, and barcode item mismatch rejection

## Scope
- no DB change
- no FK change
- no receipt write rewrite
- no release rewrite
- no stock write change
- no ledger write change
- no lots.py rewrite
- no PMS projection

## Tests
- make dev-reset-test-db
- make test TESTS="tests/services/test_order_rma_and_reconcile.py tests/services/test_inbound_reversal_service.py tests/api/test_wms_receiving_batch_no_lot_code_contract_api.py tests/test_phase3_three_books_receive_commit.py tests/services/test_pms_export_item_read_service.py"
- make alembic-check
