### PR TITLE
refactor(pms): retire cross-domain owner orm relationships

### DIFF
--- a/app/oms/orders/models/order.py
+++ b/app/oms/orders/models/order.py
@@ -15,7 +15,6 @@ from app.oms.orders.models.order_logistics import OrderLogistics  # noqa: F401
 from app.oms.stores.models.store import Store  # noqa: F401
 
 if TYPE_CHECKING:
-    from app.pms.items.models.item import Item
     from app.oms.orders.models.order_item import OrderItem
     from app.oms.orders.models.order_logistics import OrderLogistics
     from app.oms.stores.models.store import Store
@@ -120,14 +119,6 @@ class Order(Base):
         back_populates="order",
         lazy="selectin",
         cascade="all, delete-orphan",
-    )
-
-    items: Mapped[List["Item"]] = relationship(
-        "Item",
-        secondary="order_items",
-        viewonly=True,
-        lazy="selectin",
-        back_populates="orders",
     )
 
     logistics: Mapped[List["OrderLogistics"]] = relationship(

--- a/app/oms/orders/models/order_item.py
+++ b/app/oms/orders/models/order_item.py
@@ -12,7 +12,6 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.db.base import Base
 
 if TYPE_CHECKING:
-    from app.pms.items.models.item import Item
     from app.oms.orders.models.order import Order
 
 
@@ -48,11 +47,6 @@ class OrderItem(Base):
 
     order: Mapped["Order"] = relationship(
         "Order",
-        back_populates="order_items",
-        lazy="selectin",
-    )
-    item: Mapped["Item"] = relationship(
-        "Item",
         back_populates="order_items",
         lazy="selectin",
     )

--- a/app/pms/items/models/item.py
+++ b/app/pms/items/models/item.py
@@ -9,16 +9,12 @@ from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Integer, String, tex
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
-from app.oms.orders.models.order import Order  # noqa: F401
-from app.oms.orders.models.order_item import OrderItem  # noqa: F401
 from app.pms.items.models.item_master import ItemAttributeValue, PmsBrand, PmsBusinessCategory  # noqa: F401
 from app.pms.items.models.item_sku_code import ItemSkuCode  # noqa: F401
 from app.pms.items.models.item_uom import ItemUOM  # noqa: F401
 from app.partners.suppliers.models.supplier import Supplier  # noqa: F401
 
 if TYPE_CHECKING:
-    from app.oms.orders.models.order import Order
-    from app.oms.orders.models.order_item import OrderItem
     from app.pms.items.models.item_master import ItemAttributeValue, PmsBrand, PmsBusinessCategory
     from app.pms.items.models.item_sku_code import ItemSkuCode
     from app.pms.items.models.item_uom import ItemUOM
@@ -218,20 +214,6 @@ class Item(Base):
             if getattr(u, "is_outbound_default", False):
                 return u
         return self.get_base_uom()
-
-    order_items: Mapped[List["OrderItem"]] = relationship(
-        "OrderItem",
-        back_populates="item",
-        lazy="selectin",
-    )
-
-    orders: Mapped[List["Order"]] = relationship(
-        "Order",
-        secondary="order_items",
-        viewonly=True,
-        lazy="selectin",
-        back_populates="items",
-    )
 
     def __repr__(self) -> str:
         return (

--- a/app/wms/stock/models/stock_snapshot.py
+++ b/app/wms/stock/models/stock_snapshot.py
@@ -3,16 +3,12 @@ from __future__ import annotations
 
 from datetime import date
 from decimal import Decimal
-from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
 from sqlalchemy import Date, Index, Integer, Numeric, text
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
-
-if TYPE_CHECKING:
-    from app.pms.items.models.item import Item
 
 
 class StockSnapshot(Base):
@@ -54,5 +50,3 @@ class StockSnapshot(Base):
         Index("ix_stock_snapshots_wh_item_lot", "warehouse_id", "item_id", "lot_id"),
         {"info": {"skip_autogen": True}},
     )
-
-    item: Mapped["Item"] = relationship("Item", lazy="selectin")

--- a/tests/ci/test_pms_owner_boundary_contract.py
+++ b/tests/ci/test_pms_owner_boundary_contract.py
@@ -34,23 +34,6 @@ DIRECT_PMS_OWNER_IMPORT_RE = re.compile(
     r"|from\s+app\.pms\.items\.services\b"
 )
 
-# 暂时保留的 ORM relationship 类型引用。
-# 这些不是业务读 owner 表，不在本轮合同化里处理。
-ALLOWED_DIRECT_PMS_OWNER_IMPORTS = {
-    (
-        "app/wms/stock/models/stock_snapshot.py",
-        "from app.pms.items.models.item import Item",
-    ),
-    (
-        "app/oms/orders/models/order.py",
-        "from app.pms.items.models.item import Item",
-    ),
-    (
-        "app/oms/orders/models/order_item.py",
-        "from app.pms.items.models.item import Item",
-    ),
-}
-
 
 def _iter_python_files() -> list[Path]:
     files: list[Path] = []
@@ -82,7 +65,7 @@ def test_no_raw_pms_owner_table_reads_outside_pms() -> None:
     assert violations == []
 
 
-def test_no_direct_pms_owner_imports_outside_pms_except_relationship_typing() -> None:
+def test_no_direct_pms_owner_imports_outside_pms() -> None:
     violations: list[str] = []
 
     for path in _iter_python_files():
@@ -91,9 +74,6 @@ def test_no_direct_pms_owner_imports_outside_pms_except_relationship_typing() ->
         for line_no, line in enumerate(text.splitlines(), start=1):
             stripped = line.strip()
             if not DIRECT_PMS_OWNER_IMPORT_RE.search(stripped):
-                continue
-
-            if (rel, stripped) in ALLOWED_DIRECT_PMS_OWNER_IMPORTS:
                 continue
 
             violations.append(f"{rel}:{line_no}: {stripped}")


### PR DESCRIPTION
## Summary
- remove PMS Item ORM navigation from OMS Order / OrderItem models
- remove StockSnapshot.item ORM navigation
- remove OMS reverse relationships from PMS Item model
- tighten PMS owner boundary guard by removing temporary relationship import allowlist

## Scope
- ORM model boundary only
- no database schema change
- no FK removal
- no PMS physical split
- cross-domain current item metadata remains behind PMS export contracts

## Validation
- python3 -m compileall target files
- SQLAlchemy configure_mappers OK
- pytest targeted PMS boundary/export tests: 17 passed
- final PMS owner direct import scan is empty