### PR TITLE
refactor(pms): introduce integration read client boundary

### DIFF
--- a/app/integrations/__init__.py
+++ b/app/integrations/__init__.py
@@ -1,0 +1,7 @@
+# app/integrations/__init__.py
+"""
+Cross-domain integration clients.
+
+This package is the boundary where internal domain modules consume other
+domain-owned capabilities without importing their owner services directly.
+"""

--- a/app/integrations/pms/__init__.py
+++ b/app/integrations/pms/__init__.py
@@ -1,0 +1,11 @@
+# app/integrations/pms/__init__.py
+"""
+PMS integration boundary.
+
+Consumers outside PMS should depend on this package instead of importing
+PMS export services directly.
+"""
+
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+
+__all__ = ["InProcessPmsReadClient"]

--- a/app/integrations/pms/client.py
+++ b/app/integrations/pms/client.py
@@ -1,0 +1,168 @@
+# app/integrations/pms/client.py
+"""
+PMS read client protocol.
+
+This is the consumer-side PMS boundary. WMS / OMS / Procurement / Finance
+should gradually depend on this protocol instead of importing PMS export
+services directly.
+
+No fallback policy belongs here:
+- current implementation: InProcessPmsReadClient
+- future implementation: HttpPmsReadClient
+- one deployment must choose one implementation explicitly
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from typing import Protocol
+
+from app.integrations.pms.contracts import (
+    BarcodeProbeOut,
+    ItemBasic,
+    ItemPolicy,
+    ItemReadQuery,
+    PmsExportBarcode,
+    PmsExportSkuCode,
+    PmsExportSkuCodeResolution,
+    PmsExportUom,
+)
+
+
+class PmsReadClient(Protocol):
+    async def list_item_basics(
+        self,
+        *,
+        query: ItemReadQuery | None = None,
+    ) -> list[ItemBasic]:
+        ...
+
+    async def get_item_basic(self, *, item_id: int) -> ItemBasic | None:
+        ...
+
+    async def get_item_basics(
+        self,
+        *,
+        item_ids: Iterable[int],
+    ) -> dict[int, ItemBasic]:
+        ...
+
+    async def get_item_policy(self, *, item_id: int) -> ItemPolicy | None:
+        ...
+
+    async def get_item_policies(
+        self,
+        *,
+        item_ids: Iterable[int],
+    ) -> dict[int, ItemPolicy]:
+        ...
+
+    async def get_item_policy_by_sku(self, *, sku: str) -> ItemPolicy | None:
+        ...
+
+    async def search_report_item_ids_by_keyword(
+        self,
+        *,
+        keyword: str,
+        limit: int | None = None,
+    ) -> list[int]:
+        ...
+
+    async def get_report_meta_by_item_ids(
+        self,
+        *,
+        item_ids: Iterable[int],
+    ) -> dict[int, object]:
+        ...
+
+    async def get_uom(self, *, item_uom_id: int) -> PmsExportUom | None:
+        ...
+
+    async def list_uoms(
+        self,
+        *,
+        item_ids: Sequence[int] | None = None,
+        item_uom_ids: Sequence[int] | None = None,
+    ) -> list[PmsExportUom]:
+        ...
+
+    async def list_uoms_by_item_id(self, *, item_id: int) -> list[PmsExportUom]:
+        ...
+
+    async def get_purchase_default_or_base_uom(
+        self,
+        *,
+        item_id: int,
+    ) -> PmsExportUom | None:
+        ...
+
+    async def get_inbound_default_or_base_uom(
+        self,
+        *,
+        item_id: int,
+    ) -> PmsExportUom | None:
+        ...
+
+    async def get_outbound_default_or_base_uom(
+        self,
+        *,
+        item_id: int,
+    ) -> PmsExportUom | None:
+        ...
+
+    async def get_barcode(self, *, barcode_id: int) -> PmsExportBarcode | None:
+        ...
+
+    async def list_barcodes(
+        self,
+        *,
+        item_ids: Sequence[int] | None = None,
+        item_uom_ids: Sequence[int] | None = None,
+        barcode: str | None = None,
+        active: bool | None = None,
+        primary_only: bool = False,
+    ) -> list[PmsExportBarcode]:
+        ...
+
+    async def list_barcodes_by_item_id(
+        self,
+        *,
+        item_id: int,
+        active: bool | None = True,
+        primary_only: bool = False,
+    ) -> list[PmsExportBarcode]:
+        ...
+
+    async def probe_barcode(self, *, barcode: str) -> BarcodeProbeOut:
+        ...
+
+    async def get_sku_code(self, *, sku_code_id: int) -> PmsExportSkuCode | None:
+        ...
+
+    async def list_sku_codes(
+        self,
+        *,
+        item_ids: Sequence[int] | None = None,
+        sku_code_ids: Sequence[int] | None = None,
+        code: str | None = None,
+        active: bool | None = None,
+        primary_only: bool = False,
+    ) -> list[PmsExportSkuCode]:
+        ...
+
+    async def list_sku_codes_by_item_id(
+        self,
+        *,
+        item_id: int,
+        active: bool | None = True,
+        primary_only: bool = False,
+    ) -> list[PmsExportSkuCode]:
+        ...
+
+    async def resolve_active_code_for_outbound_default(
+        self,
+        *,
+        code: str,
+        enabled_only: bool = True,
+    ) -> PmsExportSkuCodeResolution | None:
+        ...

--- a/app/integrations/pms/contracts.py
+++ b/app/integrations/pms/contracts.py
@@ -1,0 +1,48 @@
+# app/integrations/pms/contracts.py
+"""
+PMS integration contracts.
+
+Temporary in-repo bridge:
+- The source of truth is still app.pms.export contracts.
+- Non-PMS domains should import these contracts from app.integrations.pms.
+- When PMS becomes an independent service/repo, this file is the cutover point
+  to generated SDK/OpenAPI contracts.
+"""
+
+from app.pms.export.barcodes.contracts.barcode import PmsExportBarcode
+from app.pms.export.items.contracts.barcode_probe import (
+    BarcodeProbeError,
+    BarcodeProbeIn,
+    BarcodeProbeOut,
+    BarcodeProbeStatus,
+)
+from app.pms.export.items.contracts.item_basic import ItemBasic
+from app.pms.export.items.contracts.item_policy import (
+    ExpiryPolicy,
+    ItemPolicy,
+    LotSourcePolicy,
+    ShelfLifeUnit,
+)
+from app.pms.export.items.contracts.item_query import ItemReadQuery
+from app.pms.export.sku_codes.contracts.sku_code import (
+    PmsExportSkuCode,
+    PmsExportSkuCodeResolution,
+)
+from app.pms.export.uoms.contracts.uom import PmsExportUom
+
+__all__ = [
+    "BarcodeProbeError",
+    "BarcodeProbeIn",
+    "BarcodeProbeOut",
+    "BarcodeProbeStatus",
+    "ExpiryPolicy",
+    "ItemBasic",
+    "ItemPolicy",
+    "ItemReadQuery",
+    "LotSourcePolicy",
+    "PmsExportBarcode",
+    "PmsExportSkuCode",
+    "PmsExportSkuCodeResolution",
+    "PmsExportUom",
+    "ShelfLifeUnit",
+]

--- a/app/integrations/pms/inprocess_client.py
+++ b/app/integrations/pms/inprocess_client.py
@@ -1,0 +1,232 @@
+# app/integrations/pms/inprocess_client.py
+"""
+In-process PMS read client.
+
+Current deployment mode:
+- PMS lives in the same wms-api codebase/process.
+- This client delegates to app.pms.export services.
+- Non-PMS domains should call this integration client, not app.pms.export
+  services directly.
+
+Future deployment mode:
+- Replace this implementation with an HTTP PMS client behind the same
+  PmsReadClient protocol.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.integrations.pms.contracts import (
+    BarcodeProbeOut,
+    ItemBasic,
+    ItemPolicy,
+    ItemReadQuery,
+    PmsExportBarcode,
+    PmsExportSkuCode,
+    PmsExportSkuCodeResolution,
+    PmsExportUom,
+)
+from app.pms.export.barcodes.services.barcode_read_service import (
+    PmsExportBarcodeReadService,
+)
+from app.pms.export.items.services.barcode_probe_service import BarcodeProbeService
+from app.pms.export.items.services.item_read_service import ItemReadService
+from app.pms.export.sku_codes.services.sku_code_read_service import (
+    PmsExportSkuCodeReadService,
+)
+from app.pms.export.uoms.services.uom_read_service import PmsExportUomReadService
+
+
+class InProcessPmsReadClient:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def list_item_basics(
+        self,
+        *,
+        query: ItemReadQuery | None = None,
+    ) -> list[ItemBasic]:
+        return await ItemReadService(self.session).alist_basic(query=query)
+
+    async def get_item_basic(self, *, item_id: int) -> ItemBasic | None:
+        return await ItemReadService(self.session).aget_basic_by_id(item_id=int(item_id))
+
+    async def get_item_basics(
+        self,
+        *,
+        item_ids: Iterable[int],
+    ) -> dict[int, ItemBasic]:
+        return await ItemReadService(self.session).aget_basics_by_item_ids(item_ids=item_ids)
+
+    async def get_item_policy(self, *, item_id: int) -> ItemPolicy | None:
+        return await ItemReadService(self.session).aget_policy_by_id(item_id=int(item_id))
+
+    async def get_item_policies(
+        self,
+        *,
+        item_ids: Iterable[int],
+    ) -> dict[int, ItemPolicy]:
+        return await ItemReadService(self.session).aget_policies_by_item_ids(item_ids=item_ids)
+
+    async def get_item_policy_by_sku(self, *, sku: str) -> ItemPolicy | None:
+        return await ItemReadService(self.session).aget_policy_by_sku(sku=str(sku))
+
+    async def search_report_item_ids_by_keyword(
+        self,
+        *,
+        keyword: str,
+        limit: int | None = None,
+    ) -> list[int]:
+        return await ItemReadService(self.session).asearch_report_item_ids_by_keyword(
+            keyword=str(keyword),
+            limit=limit,
+        )
+
+    async def get_report_meta_by_item_ids(
+        self,
+        *,
+        item_ids: Iterable[int],
+    ) -> dict[int, object]:
+        return await ItemReadService(self.session).aget_report_meta_by_item_ids(
+            item_ids=item_ids,
+        )
+
+    async def get_uom(self, *, item_uom_id: int) -> PmsExportUom | None:
+        return await PmsExportUomReadService(self.session).aget_by_id(
+            item_uom_id=int(item_uom_id),
+        )
+
+    async def list_uoms(
+        self,
+        *,
+        item_ids: Sequence[int] | None = None,
+        item_uom_ids: Sequence[int] | None = None,
+    ) -> list[PmsExportUom]:
+        return await PmsExportUomReadService(self.session).alist_uoms(
+            item_ids=item_ids,
+            item_uom_ids=item_uom_ids,
+        )
+
+    async def list_uoms_by_item_id(self, *, item_id: int) -> list[PmsExportUom]:
+        return await PmsExportUomReadService(self.session).alist_by_item_id(
+            item_id=int(item_id),
+        )
+
+    async def get_purchase_default_or_base_uom(
+        self,
+        *,
+        item_id: int,
+    ) -> PmsExportUom | None:
+        return await PmsExportUomReadService(self.session).aget_purchase_default_or_base(
+            item_id=int(item_id),
+        )
+
+    async def get_inbound_default_or_base_uom(
+        self,
+        *,
+        item_id: int,
+    ) -> PmsExportUom | None:
+        return await PmsExportUomReadService(self.session).aget_inbound_default_or_base(
+            item_id=int(item_id),
+        )
+
+    async def get_outbound_default_or_base_uom(
+        self,
+        *,
+        item_id: int,
+    ) -> PmsExportUom | None:
+        return await PmsExportUomReadService(self.session).aget_outbound_default_or_base(
+            item_id=int(item_id),
+        )
+
+    async def get_barcode(self, *, barcode_id: int) -> PmsExportBarcode | None:
+        return await PmsExportBarcodeReadService(self.session).aget_by_id(
+            barcode_id=int(barcode_id),
+        )
+
+    async def list_barcodes(
+        self,
+        *,
+        item_ids: Sequence[int] | None = None,
+        item_uom_ids: Sequence[int] | None = None,
+        barcode: str | None = None,
+        active: bool | None = None,
+        primary_only: bool = False,
+    ) -> list[PmsExportBarcode]:
+        return await PmsExportBarcodeReadService(self.session).alist_barcodes(
+            item_ids=item_ids,
+            item_uom_ids=item_uom_ids,
+            barcode=barcode,
+            active=active,
+            primary_only=primary_only,
+        )
+
+    async def list_barcodes_by_item_id(
+        self,
+        *,
+        item_id: int,
+        active: bool | None = True,
+        primary_only: bool = False,
+    ) -> list[PmsExportBarcode]:
+        return await PmsExportBarcodeReadService(self.session).alist_by_item_id(
+            item_id=int(item_id),
+            active=active,
+            primary_only=primary_only,
+        )
+
+    async def probe_barcode(self, *, barcode: str) -> BarcodeProbeOut:
+        return await BarcodeProbeService(self.session).aprobe(barcode=str(barcode))
+
+    async def get_sku_code(self, *, sku_code_id: int) -> PmsExportSkuCode | None:
+        return await PmsExportSkuCodeReadService(self.session).aget_by_id(
+            sku_code_id=int(sku_code_id),
+        )
+
+    async def list_sku_codes(
+        self,
+        *,
+        item_ids: Sequence[int] | None = None,
+        sku_code_ids: Sequence[int] | None = None,
+        code: str | None = None,
+        active: bool | None = None,
+        primary_only: bool = False,
+    ) -> list[PmsExportSkuCode]:
+        return await PmsExportSkuCodeReadService(self.session).alist_sku_codes(
+            item_ids=item_ids,
+            sku_code_ids=sku_code_ids,
+            code=code,
+            active=active,
+            primary_only=primary_only,
+        )
+
+    async def list_sku_codes_by_item_id(
+        self,
+        *,
+        item_id: int,
+        active: bool | None = True,
+        primary_only: bool = False,
+    ) -> list[PmsExportSkuCode]:
+        return await PmsExportSkuCodeReadService(self.session).alist_by_item_id(
+            item_id=int(item_id),
+            active=active,
+            primary_only=primary_only,
+        )
+
+    async def resolve_active_code_for_outbound_default(
+        self,
+        *,
+        code: str,
+        enabled_only: bool = True,
+    ) -> PmsExportSkuCodeResolution | None:
+        return await PmsExportSkuCodeReadService(
+            self.session
+        ).aresolve_active_code_for_outbound_default(
+            code=str(code),
+            enabled_only=bool(enabled_only),
+        )
+
+
+__all__ = ["InProcessPmsReadClient"]

--- a/app/wms/scan/services/scan_orchestrator_item_resolver.py
+++ b/app/wms/scan/services/scan_orchestrator_item_resolver.py
@@ -6,10 +6,7 @@ from typing import Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.services.barcode_probe_service import BarcodeProbeService
-from app.pms.export.sku_codes.services.sku_code_read_service import (
-    PmsExportSkuCodeReadService,
-)
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 
 
 @dataclass(frozen=True)
@@ -26,10 +23,11 @@ async def probe_item_from_barcode(
     barcode: str,
 ) -> Optional[ScanBarcodeResolved]:
     """
-    WMS scan 读取链复用 PMS export barcode probe：
+    WMS scan 读取链通过 PMS integration client 解析 barcode：
 
-    - 不再直接查询 item_barcodes
-    - 从 PMS BarcodeProbeService 获取主数据解析结果
+    - 不直接查询 item_barcodes
+    - 不直接 import PMS export service
+    - 当前实现仍为 InProcessPmsReadClient，未来可切 HTTP PMS client
     - 当前返回 richer 结构，供 parse_scan 后续阶段继续透传
     """
     code = (barcode or "").strip()
@@ -37,7 +35,7 @@ async def probe_item_from_barcode(
         return None
 
     try:
-        probe = await BarcodeProbeService(session).aprobe(barcode=code)
+        probe = await InProcessPmsReadClient(session).probe_barcode(barcode=code)
         if probe.status != "BOUND":
             return None
         if probe.item_id is None:
@@ -75,7 +73,7 @@ async def resolve_item_id_from_barcode(
 
 async def resolve_item_id_from_sku(session: AsyncSession, sku: str) -> Optional[int]:
     """
-    WMS scan SKU 文本解析复用 PMS export SKU code read service。
+    WMS scan SKU 文本解析通过 PMS integration client 读取 SKU code。
 
     保持原语义：
     - 只要求命中 active SKU code；
@@ -87,7 +85,7 @@ async def resolve_item_id_from_sku(session: AsyncSession, sku: str) -> Optional[
         return None
 
     try:
-        rows = await PmsExportSkuCodeReadService(session).alist_sku_codes(
+        rows = await InProcessPmsReadClient(session).list_sku_codes(
             code=s,
             active=True,
         )

--- a/tests/ci/test_pms_integration_client_boundary_contract.py
+++ b/tests/ci/test_pms_integration_client_boundary_contract.py
@@ -1,0 +1,61 @@
+# tests/ci/test_pms_integration_client_boundary_contract.py
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+PMS_EXPORT_IMPORT_RE = re.compile(
+    r"^\\s*from\\s+app\\.pms\\.export\\b"
+    r"|^\\s*import\\s+app\\.pms\\.export\\b"
+)
+
+
+def _rel(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def _import_violations(path: Path) -> list[str]:
+    violations: list[str] = []
+    for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        stripped = line.strip()
+        if PMS_EXPORT_IMPORT_RE.search(stripped):
+            violations.append(f"{_rel(path)}:{line_no}: {stripped}")
+    return violations
+
+
+def test_pms_integration_client_boundary_files_exist() -> None:
+    expected = {
+        "app/integrations/__init__.py",
+        "app/integrations/pms/__init__.py",
+        "app/integrations/pms/contracts.py",
+        "app/integrations/pms/client.py",
+        "app/integrations/pms/inprocess_client.py",
+    }
+
+    for rel in expected:
+        assert (ROOT / rel).is_file(), rel
+
+
+def test_wms_scan_resolver_no_longer_imports_pms_export_directly() -> None:
+    path = ROOT / "app/wms/scan/services/scan_orchestrator_item_resolver.py"
+
+    assert _import_violations(path) == []
+    assert "InProcessPmsReadClient" in path.read_text(encoding="utf-8")
+
+
+def test_only_pms_integration_bridge_imports_pms_export_inside_integrations() -> None:
+    allowed = {
+        "app/integrations/pms/contracts.py",
+        "app/integrations/pms/inprocess_client.py",
+    }
+
+    violations: list[str] = []
+    for path in sorted((ROOT / "app/integrations").rglob("*.py")):
+        rel = _rel(path)
+        if rel in allowed:
+            continue
+        violations.extend(_import_violations(path))
+
+    assert violations == []

--- a/tests/services/test_pms_integration_inprocess_client.py
+++ b/tests/services/test_pms_integration_inprocess_client.py
@@ -1,0 +1,86 @@
+# tests/services/test_pms_integration_inprocess_client.py
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.integrations.pms.contracts import BarcodeProbeStatus
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _pick_export_capable_row(session: AsyncSession) -> dict:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  i.id AS item_id,
+                  i.sku AS item_sku,
+                  i.name AS item_name,
+                  u.id AS item_uom_id,
+                  b.id AS barcode_id,
+                  b.barcode,
+                  sc.id AS sku_code_id,
+                  sc.code AS sku_code
+                FROM items i
+                JOIN item_uoms u
+                  ON u.item_id = i.id
+                 AND (u.is_outbound_default IS TRUE OR u.is_base IS TRUE)
+                JOIN item_barcodes b
+                  ON b.item_id = i.id
+                 AND b.item_uom_id = u.id
+                 AND b.active IS TRUE
+                JOIN item_sku_codes sc
+                  ON sc.item_id = i.id
+                 AND sc.is_active IS TRUE
+                WHERE i.enabled IS TRUE
+                ORDER BY
+                  i.id ASC,
+                  u.is_outbound_default DESC,
+                  u.is_base DESC,
+                  u.id ASC,
+                  b.is_primary DESC,
+                  b.id ASC,
+                  sc.is_primary DESC,
+                  sc.id ASC
+                LIMIT 1
+                """
+            )
+        )
+    ).mappings().first()
+
+    assert row is not None, "test baseline must contain PMS item/uom/barcode/sku-code seed row"
+    return dict(row)
+
+
+async def test_inprocess_pms_read_client_reads_basic_uom_barcode_and_sku(
+    session: AsyncSession,
+) -> None:
+    seed = await _pick_export_capable_row(session)
+    client = InProcessPmsReadClient(session)
+
+    item = await client.get_item_basic(item_id=int(seed["item_id"]))
+    assert item is not None
+    assert item.id == int(seed["item_id"])
+    assert item.sku == str(seed["item_sku"])
+    assert item.name == str(seed["item_name"])
+
+    uom = await client.get_uom(item_uom_id=int(seed["item_uom_id"]))
+    assert uom is not None
+    assert uom.id == int(seed["item_uom_id"])
+    assert uom.item_id == int(seed["item_id"])
+
+    probe = await client.probe_barcode(barcode=f"  {seed['barcode']}  ")
+    assert probe.status is BarcodeProbeStatus.BOUND
+    assert probe.item_id == int(seed["item_id"])
+    assert probe.item_uom_id == int(seed["item_uom_id"])
+
+    sku_rows = await client.list_sku_codes(
+        code=str(seed["sku_code"]).lower(),
+        active=True,
+    )
+    assert any(row.id == int(seed["sku_code_id"]) for row in sku_rows)
+    assert any(row.item_id == int(seed["item_id"]) for row in sku_rows)


### PR DESCRIPTION
## Summary
- add app.integrations.pms read client boundary
- add InProcessPmsReadClient as the current same-process PMS read implementation
- centralize PMS integration contracts behind app.integrations.pms.contracts
- migrate WMS scan item resolver away from direct app.pms.export service imports
- add CI guard for the first migrated WMS scan slice
- add service test for InProcessPmsReadClient basic/uom/barcode/sku-code reads

## Scope
- no database schema change
- no FK change
- no PMS physical split
- no pms-api process yet
- no full migration of all existing app.pms.export consumers in this PR

## Validation
- python3 -m compileall app/integrations and changed files
- targeted PMS integration/export/boundary tests: 29 passed
- WMS scan resolver no longer imports app.pms.export services directly