### PR TITLE
refactor(pms): route inbound barcode resolve through integration client

### DIFF
--- a/app/wms/inbound/repos/barcode_resolve_repo.py
+++ b/app/wms/inbound/repos/barcode_resolve_repo.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.services.barcode_probe_service import BarcodeProbeService
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 
 
 @dataclass(frozen=True)
@@ -14,7 +14,7 @@ class InboundBarcodeResolved:
     入库条码解析结果。
 
     说明：
-    - 这是 WMS inbound 对 PMS export barcode probe 的轻包装
+    - 这是 WMS inbound 对 PMS integration barcode probe 的轻包装
     - 只承载入库提交链真正需要的最小字段
     - 不承载 qty / event_id / lot 等仓内执行语义
     """
@@ -32,7 +32,7 @@ async def resolve_inbound_barcode(
     barcode: str,
 ) -> InboundBarcodeResolved | None:
     """
-    通过 PMS export barcode probe 解析入库条码。
+    通过 PMS integration client 解析入库条码。
 
     规则：
     - 空条码 => None
@@ -43,7 +43,7 @@ async def resolve_inbound_barcode(
     if not code:
         return None
 
-    probe = await BarcodeProbeService(session).aprobe(barcode=code)
+    probe = await InProcessPmsReadClient(session).probe_barcode(barcode=code)
     if probe.status != "BOUND":
         return None
     if probe.item_id is None:

--- a/tests/ci/test_pms_integration_client_boundary_contract.py
+++ b/tests/ci/test_pms_integration_client_boundary_contract.py
@@ -7,9 +7,14 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 
 PMS_EXPORT_IMPORT_RE = re.compile(
-    r"^\\s*from\\s+app\\.pms\\.export\\b"
-    r"|^\\s*import\\s+app\\.pms\\.export\\b"
+    r"^\s*from\s+app\.pms\.export\b"
+    r"|^\s*import\s+app\.pms\.export\b"
 )
+
+MIGRATED_NON_PMS_CONSUMERS = {
+    "app/wms/scan/services/scan_orchestrator_item_resolver.py",
+    "app/wms/inbound/repos/barcode_resolve_repo.py",
+}
 
 
 def _rel(path: Path) -> str:
@@ -38,11 +43,18 @@ def test_pms_integration_client_boundary_files_exist() -> None:
         assert (ROOT / rel).is_file(), rel
 
 
-def test_wms_scan_resolver_no_longer_imports_pms_export_directly() -> None:
-    path = ROOT / "app/wms/scan/services/scan_orchestrator_item_resolver.py"
+def test_migrated_non_pms_consumers_no_longer_import_pms_export_directly() -> None:
+    for rel in sorted(MIGRATED_NON_PMS_CONSUMERS):
+        path = ROOT / rel
+        assert path.is_file(), rel
+        assert _import_violations(path) == []
 
-    assert _import_violations(path) == []
-    assert "InProcessPmsReadClient" in path.read_text(encoding="utf-8")
+
+def test_migrated_non_pms_consumers_use_integration_client() -> None:
+    for rel in sorted(MIGRATED_NON_PMS_CONSUMERS):
+        path = ROOT / rel
+        text = path.read_text(encoding="utf-8")
+        assert "InProcessPmsReadClient" in text
 
 
 def test_only_pms_integration_bridge_imports_pms_export_inside_integrations() -> None:


### PR DESCRIPTION
## Summary
- route WMS inbound barcode resolve through InProcessPmsReadClient
- remove direct BarcodeProbeService import from inbound barcode resolver
- extend PMS integration boundary guard to cover the migrated inbound resolver

## Scope
- no database schema change
- no FK change
- no PMS physical split
- no behavior change
- remaining PMS export consumers will be migrated incrementally

## Validation
- python3 -m compileall changed files
- targeted PMS integration/export/boundary tests: 15 passed
- migrated files direct PMS export import scan is empty