### PR TITLE
refactor(pms): route return inbound reads through integration client

### DIFF
--- a/app/wms/inventory_adjustment/return_inbound/repos/inbound_operation_write_repo.py
+++ b/app/wms/inventory_adjustment/return_inbound/repos/inbound_operation_write_repo.py
@@ -7,9 +7,8 @@ from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.contracts.barcode_probe import BarcodeProbeStatus
-from app.pms.export.items.services.barcode_probe_service import BarcodeProbeService
-from app.pms.export.uoms.services.uom_read_service import PmsExportUomReadService
+from app.integrations.pms.contracts import BarcodeProbeStatus
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 from app.wms.inbound.repos.item_lookup_repo import get_item_policy_by_id
 from app.wms.inbound.repos.lot_resolve_repo import resolve_inbound_lot
 from app.wms.inventory_adjustment.count.services.count_freeze_guard_service import (
@@ -54,7 +53,7 @@ async def _load_item_uom_snapshot(
     item_id: int,
     item_uom_id: int,
 ) -> tuple[int, str | None, int]:
-    uom = await PmsExportUomReadService(session).aget_by_id(
+    uom = await InProcessPmsReadClient(session).get_uom(
         item_uom_id=int(item_uom_id),
     )
     if uom is None or int(uom.item_id) != int(item_id):
@@ -77,7 +76,8 @@ async def _resolve_barcode_uom_snapshot(
     barcode: str,
 ) -> tuple[int, str | None, int]:
     code = (barcode or "").strip()
-    probe = await BarcodeProbeService(session).aprobe(barcode=code)
+    client = InProcessPmsReadClient(session)
+    probe = await client.probe_barcode(barcode=code)
 
     if (
         probe.status != BarcodeProbeStatus.BOUND
@@ -91,7 +91,7 @@ async def _resolve_barcode_uom_snapshot(
             detail=f"barcode_unbound_or_item_mismatch:{code}",
         )
 
-    uom = await PmsExportUomReadService(session).aget_by_id(
+    uom = await client.get_uom(
         item_uom_id=int(probe.item_uom_id),
     )
     if uom is None or int(uom.item_id) != int(item_id):

--- a/app/wms/inventory_adjustment/return_inbound/services/inbound_task_probe_service.py
+++ b/app/wms/inventory_adjustment/return_inbound/services/inbound_task_probe_service.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.services.barcode_probe_service import BarcodeProbeService
-from app.pms.export.uoms.services.uom_read_service import PmsExportUomReadService
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 from app.wms.inventory_adjustment.return_inbound.contracts.probe import (
     InboundTaskProbeOut,
     InboundTaskProbeStatus,
@@ -23,7 +22,7 @@ async def _load_actual_uom_name(
     if item_uom_id is None:
         return None
 
-    uom = await PmsExportUomReadService(session).aget_by_id(
+    uom = await InProcessPmsReadClient(session).get_uom(
         item_uom_id=int(item_uom_id),
     )
     if uom is None:
@@ -81,7 +80,7 @@ async def probe_inbound_task_barcode(
     code = (barcode or "").strip()
     lines = await get_inbound_task_probe_lines(session, receipt_no=receipt_no)
 
-    probe = await BarcodeProbeService(session).aprobe(barcode=code)
+    probe = await InProcessPmsReadClient(session).probe_barcode(barcode=code)
     if probe.status != "BOUND" or probe.item_id is None:
         return InboundTaskProbeOut(
             ok=True,

--- a/tests/ci/test_pms_integration_client_boundary_contract.py
+++ b/tests/ci/test_pms_integration_client_boundary_contract.py
@@ -14,6 +14,8 @@ PMS_EXPORT_IMPORT_RE = re.compile(
 MIGRATED_NON_PMS_CONSUMERS = {
     "app/wms/scan/services/scan_orchestrator_item_resolver.py",
     "app/wms/inbound/repos/barcode_resolve_repo.py",
+    "app/wms/inventory_adjustment/return_inbound/services/inbound_task_probe_service.py",
+    "app/wms/inventory_adjustment/return_inbound/repos/inbound_operation_write_repo.py",
 }
 
 


### PR DESCRIPTION
## Summary
- route return inbound task barcode probe through InProcessPmsReadClient
- route return inbound operation UOM lookup through InProcessPmsReadClient
- route return inbound operation barcode probe through InProcessPmsReadClient
- extend PMS integration boundary guard to cover the migrated return inbound consumers

## Scope
- no database schema change
- no FK change
- no PMS physical split
- no behavior change
- remaining PMS export consumers will be migrated incrementally

## Validation
- python3 -m compileall changed files
- targeted PMS integration/export/boundary tests: 15 passed
- return inbound related tests: 15 passed
- migrated files direct PMS export import scan is empty