### PR TITLE
refactor(pms): route procurement write reads through integration client

### DIFF
--- a/app/procurement/repos/purchase_order_create_repo.py
+++ b/app/procurement/repos/purchase_order_create_repo.py
@@ -8,8 +8,8 @@ from typing import Any, Sequence
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.uoms.contracts.uom import PmsExportUom
-from app.pms.export.uoms.services.uom_read_service import PmsExportUomReadService
+from app.integrations.pms.contracts import PmsExportUom
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 from app.procurement.models.purchase_order import PurchaseOrder
 from app.procurement.models.purchase_order_line import PurchaseOrderLine
 from app.procurement.repos.purchase_order_line_completion_repo import (
@@ -38,7 +38,7 @@ async def require_item_uom_ratio_to_base(
     item_id: int,
     uom_id: int,
 ) -> tuple[int, str]:
-    row = await PmsExportUomReadService(session).aget_by_id(item_uom_id=int(uom_id))
+    row = await InProcessPmsReadClient(session).get_uom(item_uom_id=int(uom_id))
     if row is None or int(row.item_id) != int(item_id):
         raise ValueError(
             f"uom_id 不存在或不属于该商品：item_id={int(item_id)} uom_id={int(uom_id)}"
@@ -57,7 +57,7 @@ async def pick_default_purchase_uom(
     item_id: int,
 ) -> tuple[int, int, str]:
     """
-    采购默认单位读取统一走 PMS export UOM service。
+    采购默认单位读取统一走 PMS integration client。
 
     优先级：
     1) is_purchase_default = true
@@ -65,11 +65,11 @@ async def pick_default_purchase_uom(
     3) 任意第一条 UOM
     返回：(uom_id, ratio_to_base, uom_name_snapshot)
     """
-    svc = PmsExportUomReadService(session)
-    row = await svc.aget_purchase_default_or_base(item_id=int(item_id))
+    client = InProcessPmsReadClient(session)
+    row = await client.get_purchase_default_or_base_uom(item_id=int(item_id))
 
     if row is None:
-        rows = await svc.alist_by_item_id(item_id=int(item_id))
+        rows = await client.list_uoms_by_item_id(item_id=int(item_id))
         row = rows[0] if rows else None
 
     if row is None:

--- a/app/procurement/repos/receive_po_line_repo.py
+++ b/app/procurement/repos/receive_po_line_repo.py
@@ -5,22 +5,19 @@ from typing import Optional, Tuple
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.services.item_read_service import ItemReadService
-from app.pms.export.uoms.contracts.uom import PmsExportUom
-from app.pms.export.uoms.services.uom_read_service import PmsExportUomReadService
+from app.integrations.pms.contracts import PmsExportUom
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 
 
 async def load_item_expiry_policy(session: AsyncSession, *, item_id: int) -> str:
-    svc = ItemReadService(session)
-    policy = await svc.aget_policy_by_id(item_id=int(item_id))
+    policy = await InProcessPmsReadClient(session).get_item_policy(item_id=int(item_id))
     if policy is None:
         return "NONE"
     return str(policy.expiry_policy or "NONE").upper()
 
 
 async def load_item_lot_source_policy(session: AsyncSession, *, item_id: int) -> str:
-    svc = ItemReadService(session)
-    policy = await svc.aget_policy_by_id(item_id=int(item_id))
+    policy = await InProcessPmsReadClient(session).get_item_policy(item_id=int(item_id))
     if policy is None:
         return "INTERNAL_ONLY"
     return str(policy.lot_source_policy or "INTERNAL_ONLY").upper()
@@ -40,7 +37,7 @@ async def require_item_uom_ratio_to_base(
     if uom_id <= 0:
         raise HTTPException(status_code=400, detail="uom_id 必须为正整数")
 
-    row = await PmsExportUomReadService(session).aget_by_id(item_uom_id=int(uom_id))
+    row = await InProcessPmsReadClient(session).get_uom(item_uom_id=int(uom_id))
     if row is None or int(row.item_id) != int(item_id):
         raise HTTPException(
             status_code=400,

--- a/app/procurement/services/purchase_order_create.py
+++ b/app/procurement/services/purchase_order_create.py
@@ -7,10 +7,10 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.procurement.models.purchase_order import PurchaseOrder
-from app.pms.export.items.contracts.item_basic import ItemBasic
-from app.pms.export.items.services.item_read_service import ItemReadService
+from app.integrations.pms.contracts import ItemBasic
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 from app.partners.export.suppliers.services.supplier_read_service import SupplierReadService
+from app.procurement.models.purchase_order import PurchaseOrder
 from app.procurement.repos.purchase_order_create_repo import (
     insert_purchase_order_head,
     insert_purchase_order_lines,
@@ -23,8 +23,7 @@ from app.procurement.repos.purchase_order_create_repo import (
 async def _load_items_map(session: AsyncSession, item_ids: List[int]) -> Dict[int, ItemBasic]:
     if not item_ids:
         return {}
-    svc = ItemReadService(session)
-    return await svc.aget_basics_by_item_ids(item_ids=item_ids)
+    return await InProcessPmsReadClient(session).get_item_basics(item_ids=item_ids)
 
 
 async def _require_supplier_snapshot_via_partners(

--- a/app/procurement/services/purchase_order_update.py
+++ b/app/procurement/services/purchase_order_update.py
@@ -8,8 +8,8 @@ from typing import Any, Dict, List, Tuple
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.integrations.pms.contracts import ItemBasic
 from app.procurement.models.purchase_order import PurchaseOrder
-from app.pms.export.items.contracts.item_basic import ItemBasic
 from app.procurement.repos.purchase_order_create_repo import (
     pick_default_purchase_uom,
     require_item_uom_ratio_to_base,

--- a/tests/ci/test_pms_integration_client_boundary_contract.py
+++ b/tests/ci/test_pms_integration_client_boundary_contract.py
@@ -16,6 +16,10 @@ MIGRATED_NON_PMS_CONSUMERS = {
     "app/wms/inbound/repos/barcode_resolve_repo.py",
     "app/wms/inventory_adjustment/return_inbound/services/inbound_task_probe_service.py",
     "app/wms/inventory_adjustment/return_inbound/repos/inbound_operation_write_repo.py",
+    "app/procurement/repos/purchase_order_create_repo.py",
+    "app/procurement/repos/receive_po_line_repo.py",
+    "app/procurement/services/purchase_order_create.py",
+    "app/procurement/services/purchase_order_update.py",
 }
 
 
@@ -52,11 +56,11 @@ def test_migrated_non_pms_consumers_no_longer_import_pms_export_directly() -> No
         assert _import_violations(path) == []
 
 
-def test_migrated_non_pms_consumers_use_integration_client() -> None:
+def test_migrated_non_pms_consumers_use_integration_boundary() -> None:
     for rel in sorted(MIGRATED_NON_PMS_CONSUMERS):
         path = ROOT / rel
         text = path.read_text(encoding="utf-8")
-        assert "InProcessPmsReadClient" in text
+        assert "app.integrations.pms" in text
 
 
 def test_only_pms_integration_bridge_imports_pms_export_inside_integrations() -> None:


### PR DESCRIPTION
## Summary
- route purchase order create/update item reads through InProcessPmsReadClient
- route purchase order UOM validation/default selection through InProcessPmsReadClient
- route receive PO line item policy and UOM reads through InProcessPmsReadClient
- extend PMS integration boundary guard to cover migrated procurement write consumers

## Scope
- procurement create/update/receive helper chain only
- no procurement report migration in this PR
- no database schema change
- no FK change
- no PMS physical split
- no behavior change

## Validation
- python3 -m compileall changed files
- targeted PMS integration/export/boundary tests: 15 passed
- procurement related tests: 21 passed
- migrated procurement direct PMS export import scan is empty