### PR TITLE
refactor(pms): route procurement reports through integration client

### DIFF
--- a/app/procurement/helpers/purchase_reports.py
+++ b/app/procurement/helpers/purchase_reports.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.services.item_read_service import ItemReadService
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 
 
 async def resolve_report_item_ids(
@@ -17,7 +17,7 @@ async def resolve_report_item_ids(
     """
     返回：
     - [item_id]：显式 item_id 过滤
-    - [ids...]：按 PMS export item 搜索出的 item_id 集合
+    - [ids...]：按 PMS integration item 搜索出的 item_id 集合
     - None：不加 item 过滤
     """
     if item_id is not None:
@@ -27,5 +27,4 @@ async def resolve_report_item_ids(
     if not kw:
         return None
 
-    svc = ItemReadService(session)
-    return await svc.asearch_report_item_ids_by_keyword(keyword=kw)
+    return await InProcessPmsReadClient(session).search_report_item_ids_by_keyword(keyword=kw)

--- a/app/procurement/routers/purchase_reports_routes_items.py
+++ b/app/procurement/routers/purchase_reports_routes_items.py
@@ -10,7 +10,7 @@ from sqlalchemy import distinct, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_session
-from app.pms.export.items.services.item_read_service import ItemReadService
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 from app.procurement.contracts.purchase_report import ItemPurchaseReportItem
 from app.procurement.helpers.purchase_reports import resolve_report_item_ids
 from app.procurement.models.purchase_order import PurchaseOrder
@@ -72,7 +72,7 @@ def register(router: APIRouter) -> None:
         if report_item_ids is not None and not report_item_ids:
             return []
 
-        item_read_svc = ItemReadService(session)
+        pms_client = InProcessPmsReadClient(session)
         planned_line_amount_expr = (
             func.coalesce(PurchaseOrderLine.supply_price, 0)
             * PurchaseOrderLine.qty_ordered_base
@@ -130,7 +130,7 @@ def register(router: APIRouter) -> None:
         if not rows:
             return []
 
-        meta_map = await item_read_svc.aget_report_meta_by_item_ids(
+        meta_map = await pms_client.get_report_meta_by_item_ids(
             item_ids=[int(r["item_id"]) for r in rows]
         )
 

--- a/tests/ci/test_pms_integration_client_boundary_contract.py
+++ b/tests/ci/test_pms_integration_client_boundary_contract.py
@@ -20,6 +20,8 @@ MIGRATED_NON_PMS_CONSUMERS = {
     "app/procurement/repos/receive_po_line_repo.py",
     "app/procurement/services/purchase_order_create.py",
     "app/procurement/services/purchase_order_update.py",
+    "app/procurement/helpers/purchase_reports.py",
+    "app/procurement/routers/purchase_reports_routes_items.py",
 }
 
 


### PR DESCRIPTION
## Summary
- route procurement report item keyword resolution through InProcessPmsReadClient
- route procurement report item metadata enrichment through InProcessPmsReadClient
- extend PMS integration boundary guard to cover migrated procurement report consumers
- clear direct app.pms.export imports from app/procurement

## Scope
- procurement report read chain only
- no database schema change
- no FK change
- no PMS physical split
- no behavior change

## Validation
- python3 -m compileall changed files
- targeted PMS integration/export/boundary tests: 15 passed
- procurement related tests: 21 passed
- app/procurement direct PMS export import scan is empty