### PR TITLE
refactor(pms): route wms inventory reads through integration client

### DIFF
--- a/app/wms/stock/repos/inventory_explain_repo.py
+++ b/app/wms/stock/repos/inventory_explain_repo.py
@@ -6,8 +6,7 @@ from typing import Any
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.services.item_read_service import ItemReadService
-from app.pms.export.uoms.services.uom_read_service import PmsExportUomReadService
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 
 
 def _norm_text(v: str | None) -> str | None:
@@ -36,7 +35,7 @@ async def _load_item_display_maps(
     item_ids: Iterable[int],
 ) -> tuple[dict[int, str], dict[int, dict[str, object | None]]]:
     """
-    通过 PMS export read service 批量读取库存解释页展示所需商品信息。
+    通过 PMS integration client 批量读取库存解释页展示所需商品信息。
 
     注意：
     - 这里只补当前查询展示信息；
@@ -47,7 +46,8 @@ async def _load_item_display_maps(
     if not ids:
         return {}, {}
 
-    basics = await ItemReadService(session).aget_basics_by_item_ids(item_ids=ids)
+    pms_client = InProcessPmsReadClient(session)
+    basics = await pms_client.get_item_basics(item_ids=ids)
     item_name_map = {
         int(item_id): str(item.name).strip()
         for item_id, item in basics.items()
@@ -58,7 +58,7 @@ async def _load_item_display_maps(
         item_id: {"base_item_uom_id": None, "base_uom_name": None}
         for item_id in ids
     }
-    uoms = await PmsExportUomReadService(session).alist_uoms(item_ids=ids)
+    uoms = await pms_client.list_uoms(item_ids=ids)
     for uom in uoms:
         if not bool(getattr(uom, "is_base", False)):
             continue

--- a/app/wms/stock/repos/inventory_options_repo.py
+++ b/app/wms/stock/repos/inventory_options_repo.py
@@ -5,8 +5,8 @@ from typing import Any
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.contracts.item_query import ItemReadQuery
-from app.pms.export.items.services.item_read_service import ItemReadService
+from app.integrations.pms.contracts import ItemReadQuery
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 
 
 async def list_active_warehouses(
@@ -37,7 +37,7 @@ async def list_public_items(
     q: str | None,
     limit: int,
 ) -> list[dict[str, Any]]:
-    items = await ItemReadService(session).alist_basic(
+    items = await InProcessPmsReadClient(session).list_item_basics(
         query=ItemReadQuery(
             enabled=True,
             q=q,

--- a/app/wms/stock/repos/inventory_read_repo.py
+++ b/app/wms/stock/repos/inventory_read_repo.py
@@ -6,10 +6,8 @@ from typing import Any
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.barcodes.services.barcode_read_service import PmsExportBarcodeReadService
-from app.pms.export.items.contracts.item_query import ItemReadQuery
-from app.pms.export.items.services.item_read_service import ItemReadService
-from app.pms.export.uoms.services.uom_read_service import PmsExportUomReadService
+from app.integrations.pms.contracts import ItemReadQuery
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 
 
 def _norm_text(v: str | None) -> str | None:
@@ -38,7 +36,7 @@ async def _resolve_inventory_q_item_ids(
     q: str | None,
 ) -> list[int] | None:
     """
-    将库存页 q 搜索交给 PMS export item read service。
+    将库存页 q 搜索交给 PMS integration item read client。
 
     返回语义：
     - None：未传 q，不加商品过滤；
@@ -49,7 +47,7 @@ async def _resolve_inventory_q_item_ids(
     if q_norm is None:
         return None
 
-    items = await ItemReadService(session).alist_basic(
+    items = await InProcessPmsReadClient(session).list_item_basics(
         query=ItemReadQuery(
             q=q_norm,
             limit=None,
@@ -68,13 +66,14 @@ async def _load_inventory_display_maps(
     if not ids:
         return {}, {}, {}
 
-    item_map = await ItemReadService(session).aget_basics_by_item_ids(item_ids=ids)
+    pms_client = InProcessPmsReadClient(session)
+    item_map = await pms_client.get_item_basics(item_ids=ids)
 
     base_uom_map: dict[int, dict[str, object | None]] = {
         item_id: {"base_item_uom_id": None, "base_uom_name": None}
         for item_id in ids
     }
-    uoms = await PmsExportUomReadService(session).alist_uoms(item_ids=ids)
+    uoms = await pms_client.list_uoms(item_ids=ids)
     for uom in uoms:
         if not bool(getattr(uom, "is_base", False)):
             continue
@@ -91,7 +90,7 @@ async def _load_inventory_display_maps(
 
     main_barcode_map: dict[int, str | None] = {}
     if include_main_barcode:
-        barcodes = await PmsExportBarcodeReadService(session).alist_barcodes(
+        barcodes = await pms_client.list_barcodes(
             item_ids=ids,
             active=True,
         )

--- a/tests/ci/test_pms_integration_client_boundary_contract.py
+++ b/tests/ci/test_pms_integration_client_boundary_contract.py
@@ -22,6 +22,9 @@ MIGRATED_NON_PMS_CONSUMERS = {
     "app/procurement/services/purchase_order_update.py",
     "app/procurement/helpers/purchase_reports.py",
     "app/procurement/routers/purchase_reports_routes_items.py",
+    "app/wms/stock/repos/inventory_options_repo.py",
+    "app/wms/stock/repos/inventory_read_repo.py",
+    "app/wms/stock/repos/inventory_explain_repo.py",
 }
 
 


### PR DESCRIPTION
## Summary
- route WMS inventory options item reads through InProcessPmsReadClient
- route WMS inventory list/detail item, UOM, and barcode enrichment through InProcessPmsReadClient
- route WMS inventory explain item and base UOM enrichment through InProcessPmsReadClient
- extend PMS integration boundary guard to cover migrated WMS inventory read consumers

## Scope
- WMS inventory read/query/explain chain only
- no lot write/policy chain migration in this PR
- no database schema change
- no FK change
- no PMS physical split
- no behavior change

## Validation
- python3 -m compileall changed files
- targeted PMS integration/export/boundary tests: 15 passed
- stock inventory read API tests: 5 passed
- migrated inventory direct PMS export import scan is empty