### PR TITLE
refactor(pms): route wms stock policy reads through integration client

### DIFF
--- a/app/wms/stock/services/lot_resolver.py
+++ b/app/wms/stock/services/lot_resolver.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.services.item_read_service import ItemReadService
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 from app.wms.stock.services.lots import ensure_internal_lot_singleton, ensure_lot_full
 
 
@@ -22,7 +22,7 @@ class LotResolver:
     """
 
     async def requires_batch(self, session: AsyncSession, *, item_id: int) -> bool:
-        policy = await ItemReadService(session).aget_policy_by_id(item_id=int(item_id))
+        policy = await InProcessPmsReadClient(session).get_item_policy(item_id=int(item_id))
         if policy is None:
             raise ValueError("item_not_found")
         return str(policy.expiry_policy or "").upper() == "REQUIRED"

--- a/app/wms/stock/services/lot_service.py
+++ b/app/wms/stock/services/lot_service.py
@@ -8,8 +8,8 @@ from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.integrations.pms.contracts import ItemPolicy
 from app.wms.stock.models.lot import Lot
-from app.pms.export.items.contracts.item_policy import ItemPolicy
 from app.wms.stock.services.lots import ensure_internal_lot_singleton, ensure_lot_full
 
 

--- a/app/wms/stock/services/lots.py
+++ b/app/wms/stock/services/lots.py
@@ -9,8 +9,8 @@ from typing import Optional
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.contracts.item_policy import ItemPolicy
-from app.pms.export.items.services.item_read_service import ItemReadService
+from app.integrations.pms.contracts import ItemPolicy
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 
 
 def normalize_lot_code(code: str | None) -> tuple[str, str]:
@@ -153,7 +153,7 @@ async def _load_item_policy(
     *,
     item_id: int,
 ) -> ItemPolicy:
-    policy = await ItemReadService(session).aget_policy_by_id(item_id=int(item_id))
+    policy = await InProcessPmsReadClient(session).get_item_policy(item_id=int(item_id))
     if policy is None:
         raise ValueError("item_not_found")
     return policy

--- a/app/wms/stock/services/stock_adjust/db_items.py
+++ b/app/wms/stock/services/stock_adjust/db_items.py
@@ -3,18 +3,18 @@ from __future__ import annotations
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.services.item_read_service import ItemReadService
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 
 
 async def item_requires_batch(session: AsyncSession, *, item_id: int) -> bool:
     """
-    通过 PMS export 商品策略读面判断是否批次受控。
+    通过 PMS integration 商品策略读面判断是否批次受控。
 
     - expiry_policy='REQUIRED' => requires_batch=True
     - expiry_policy='NONE'     => requires_batch=False
     - item 不存在时必须明确失败，unknown item 不能默认成 NONE。
     """
-    policy = await ItemReadService(session).aget_policy_by_id(item_id=int(item_id))
+    policy = await InProcessPmsReadClient(session).get_item_policy(item_id=int(item_id))
     if policy is None:
         raise ValueError("item_not_found")
 

--- a/tests/ci/test_pms_integration_client_boundary_contract.py
+++ b/tests/ci/test_pms_integration_client_boundary_contract.py
@@ -25,6 +25,10 @@ MIGRATED_NON_PMS_CONSUMERS = {
     "app/wms/stock/repos/inventory_options_repo.py",
     "app/wms/stock/repos/inventory_read_repo.py",
     "app/wms/stock/repos/inventory_explain_repo.py",
+    "app/wms/stock/services/lot_service.py",
+    "app/wms/stock/services/lot_resolver.py",
+    "app/wms/stock/services/lots.py",
+    "app/wms/stock/services/stock_adjust/db_items.py",
 }
 
 


### PR DESCRIPTION
## Summary
- route WMS lot policy reads through InProcessPmsReadClient
- route WMS lot resolver item policy reads through InProcessPmsReadClient
- route WMS stock adjust batch-policy read through InProcessPmsReadClient
- extend PMS integration boundary guard to cover migrated WMS stock policy consumers
- clear direct app.pms.export imports from app/wms/stock

## Scope
- WMS stock lot / policy / stock_adjust item policy chain only
- no database schema change
- no FK change
- no PMS physical split
- no behavior change

## Validation
- python3 -m compileall changed files
- targeted PMS integration/export/boundary tests: 15 passed
- app/wms/stock direct PMS export import scan is empty
- broader lot/stock-adjust candidate run has an unrelated pre-existing clean-main failure in tests/services/test_outbound_reversal_service.py: outbound_event_lines.order_line_id -> order_lines.id metadata issue