### PR TITLE
refactor(pms): route wms shared inbound reads through integration client

### DIFF
--- a/app/wms/inbound/repos/item_lookup_repo.py
+++ b/app/wms/inbound/repos/item_lookup_repo.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.contracts.item_policy import ItemPolicy
-from app.pms.export.items.services.item_read_service import ItemReadService
+from app.integrations.pms.contracts import ItemPolicy
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 
 
 async def get_item_policy_by_id(
@@ -11,8 +11,7 @@ async def get_item_policy_by_id(
     *,
     item_id: int,
 ) -> ItemPolicy | None:
-    svc = ItemReadService(session)
-    return await svc.aget_policy_by_id(item_id=int(item_id))
+    return await InProcessPmsReadClient(session).get_item_policy(item_id=int(item_id))
 
 
 __all__ = ["get_item_policy_by_id"]

--- a/app/wms/inbound/repos/lot_resolve_repo.py
+++ b/app/wms/inbound/repos/lot_resolve_repo.py
@@ -4,7 +4,7 @@ from datetime import date
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.contracts.item_policy import ItemPolicy
+from app.integrations.pms.contracts import ItemPolicy
 from app.wms.stock.services.lot_service import resolve_or_create_lot
 
 

--- a/app/wms/inbound/services/inbound_commit_service.py
+++ b/app/wms/inbound/services/inbound_commit_service.py
@@ -8,8 +8,7 @@ from uuid import uuid4
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.services.item_read_service import ItemReadService
-from app.pms.export.uoms.services.uom_read_service import PmsExportUomReadService
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 from app.procurement.services.purchase_order_completion_sync import (
     sync_purchase_completion_for_inbound_event,
 )
@@ -76,7 +75,7 @@ async def _require_ratio_to_base(
     item_id: int,
     uom_id: int,
 ) -> int:
-    uom = await PmsExportUomReadService(session).aget_by_id(item_uom_id=int(uom_id))
+    uom = await InProcessPmsReadClient(session).get_uom(item_uom_id=int(uom_id))
     if uom is None or int(uom.item_id) != int(item_id):
         raise HTTPException(
             status_code=400,
@@ -95,8 +94,9 @@ async def _load_item_display_snapshot(
     item_id: int,
     uom_id: int,
 ) -> tuple[str | None, str | None, str | None]:
-    item = await ItemReadService(session).aget_basic_by_id(item_id=int(item_id))
-    uom = await PmsExportUomReadService(session).aget_by_id(item_uom_id=int(uom_id))
+    pms_client = InProcessPmsReadClient(session)
+    item = await pms_client.get_item_basic(item_id=int(item_id))
+    uom = await pms_client.get_uom(item_uom_id=int(uom_id))
 
     if item is None or uom is None or int(uom.item_id) != int(item_id):
         raise HTTPException(

--- a/app/wms/shared/services/expiry_resolver.py
+++ b/app/wms/shared/services/expiry_resolver.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.services.item_read_service import ItemReadService
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 from app.wms.shared.services.expiry_rules import (
     ShelfLife,
     ShelfLifeUnit,
@@ -117,8 +117,7 @@ async def normalize_batch_dates_for_item(
     if production_date is None and expiry_date is None:
         return None, None, None
 
-    svc = ItemReadService(session)
-    policy = await svc.aget_policy_by_id(item_id=int(item_id))
+    policy = await InProcessPmsReadClient(session).get_item_policy(item_id=int(item_id))
     if policy is None:
         # 未找到 item：保守返回原值，不在共享层擅自抛错
         if production_date is not None and expiry_date is not None:

--- a/app/wms/shared/services/lot_code_contract.py
+++ b/app/wms/shared/services/lot_code_contract.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional, Set, Tuple
 from fastapi import HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.services.item_read_service import ItemReadService
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 
 # 非批次商品禁止的历史假码（严格 422）
 _FORBIDDEN_FAKE_CODES: Set[str] = {"NOEXP", "NEAR", "FAR", "IDEM"}
@@ -116,14 +116,14 @@ def _requires_batch_from_expiry_policy(expiry_policy: Optional[str]) -> bool:
 
 async def fetch_item_expiry_policy_map(session: AsyncSession, item_ids: Set[int]) -> Dict[int, str]:
     """
-    真相源：PMS export item policy read service。
+    真相源：PMS integration item policy read client。
 
     返回：{item_id: 'NONE' | 'REQUIRED'}
     """
     if not item_ids:
         return {}
 
-    policies = await ItemReadService(session).aget_policies_by_item_ids(item_ids=item_ids)
+    policies = await InProcessPmsReadClient(session).get_item_policies(item_ids=item_ids)
     return {
         int(item_id): str(policy.expiry_policy)
         for item_id, policy in policies.items()
@@ -133,13 +133,13 @@ async def fetch_item_expiry_policy_map(session: AsyncSession, item_ids: Set[int]
 async def fetch_item_by_sku(session: AsyncSession, sku: str) -> Optional[Tuple[int, bool]]:
     """
     返回 (item_id, requires_batch)
-    requires_batch 由 PMS export item policy 投影得出。
+    requires_batch 由 PMS integration item policy 投影得出。
     """
     s = (sku or "").strip()
     if not s:
         return None
 
-    policy = await ItemReadService(session).aget_policy_by_sku(sku=s)
+    policy = await InProcessPmsReadClient(session).get_item_policy_by_sku(sku=s)
     if policy is None:
         return None
 

--- a/tests/ci/test_pms_integration_client_boundary_contract.py
+++ b/tests/ci/test_pms_integration_client_boundary_contract.py
@@ -29,6 +29,11 @@ MIGRATED_NON_PMS_CONSUMERS = {
     "app/wms/stock/services/lot_resolver.py",
     "app/wms/stock/services/lots.py",
     "app/wms/stock/services/stock_adjust/db_items.py",
+    "app/wms/shared/services/expiry_resolver.py",
+    "app/wms/shared/services/lot_code_contract.py",
+    "app/wms/inbound/repos/item_lookup_repo.py",
+    "app/wms/inbound/repos/lot_resolve_repo.py",
+    "app/wms/inbound/services/inbound_commit_service.py",
 }
 
 


### PR DESCRIPTION
## Summary
- route WMS shared expiry resolver item policy reads through InProcessPmsReadClient
- route WMS shared lot code contract policy reads through InProcessPmsReadClient
- route WMS inbound item policy lookup through InProcessPmsReadClient
- route WMS inbound commit item/UOM display reads through InProcessPmsReadClient
- route inbound lot resolve policy contract type through app.integrations.pms.contracts
- extend PMS integration boundary guard to cover migrated shared/inbound consumers

## Scope
- WMS shared + inbound read/policy chain only
- no database schema change
- no FK change
- no PMS physical split
- no behavior change
- known clean-main outbound_reversal metadata issue is not addressed in this PR

## Validation
- python3 -m compileall changed files
- targeted PMS integration/export/boundary tests: 15 passed
- inbound/shared tests excluding known clean-main outbound_reversal failure: 32 passed
- migrated files direct PMS export import scan is empty