### PR TITLE
refactor(pms): route wms count summary reads through integration client

### DIFF
--- a/app/wms/inventory_adjustment/count/repos/count_doc_repo.py
+++ b/app/wms/inventory_adjustment/count/repos/count_doc_repo.py
@@ -8,8 +8,7 @@ from sqlalchemy import case, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.pms.export.items.services.item_read_service import ItemReadService
-from app.pms.export.uoms.services.uom_read_service import PmsExportUomReadService
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 from app.wms.inventory_adjustment.count.models.count_doc import (
     CountDoc,
     CountDocLine,
@@ -293,7 +292,7 @@ class CountDocRepo:
         if not ids:
             return {}
 
-        uoms = await PmsExportUomReadService(session).alist_uoms(item_ids=ids)
+        uoms = await InProcessPmsReadClient(session).list_uoms(item_ids=ids)
 
         out: dict[int, dict[str, Any]] = {}
         for uom in uoms:
@@ -383,7 +382,7 @@ class CountDocRepo:
         ).mappings().all()
 
         item_ids = sorted({int(row["item_id"]) for row in line_rows})
-        item_map = await ItemReadService(session).aget_basics_by_item_ids(item_ids=item_ids)
+        item_map = await InProcessPmsReadClient(session).get_item_basics(item_ids=item_ids)
 
         for row in line_rows:
             item_id = int(row["item_id"])

--- a/app/wms/inventory_adjustment/summary/repos/summary_repo.py
+++ b/app/wms/inventory_adjustment/summary/repos/summary_repo.py
@@ -6,8 +6,7 @@ from typing import Any
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.services.item_read_service import ItemReadService
-from app.pms.export.uoms.services.uom_read_service import PmsExportUomReadService
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 
 
 SUMMARY_CTE = """
@@ -282,7 +281,7 @@ async def _enrich_summary_ledger_rows(
     为库存调节汇总详情的 ledger_rows 补齐商品展示字段。
 
     WMS 事实仍来自 stock_ledger / lots；
-    商品名和基础单位展示通过 PMS export read service 获取，
+    商品名和基础单位展示通过 PMS integration client 获取，
     不在 WMS summary repo 里直接读取 PMS owner items / item_uoms。
     """
     out = [dict(row) for row in rows]
@@ -291,13 +290,14 @@ async def _enrich_summary_ledger_rows(
     if not item_ids:
         return out
 
-    item_map = await ItemReadService(session).aget_basics_by_item_ids(item_ids=item_ids)
+    pms_client = InProcessPmsReadClient(session)
+    item_map = await pms_client.get_item_basics(item_ids=item_ids)
 
     base_uom_map: dict[int, dict[str, object | None]] = {
         item_id: {"base_item_uom_id": None, "base_uom_name": None}
         for item_id in item_ids
     }
-    uoms = await PmsExportUomReadService(session).alist_uoms(item_ids=item_ids)
+    uoms = await pms_client.list_uoms(item_ids=item_ids)
     for uom in uoms:
         if not bool(getattr(uom, "is_base", False)):
             continue

--- a/tests/ci/test_pms_integration_client_boundary_contract.py
+++ b/tests/ci/test_pms_integration_client_boundary_contract.py
@@ -34,6 +34,8 @@ MIGRATED_NON_PMS_CONSUMERS = {
     "app/wms/inbound/repos/item_lookup_repo.py",
     "app/wms/inbound/repos/lot_resolve_repo.py",
     "app/wms/inbound/services/inbound_commit_service.py",
+    "app/wms/inventory_adjustment/count/repos/count_doc_repo.py",
+    "app/wms/inventory_adjustment/summary/repos/summary_repo.py",
 }
 
 


### PR DESCRIPTION
## Summary
- route count doc base UOM reads through InProcessPmsReadClient
- route count doc item snapshot reads through InProcessPmsReadClient
- route inventory adjustment summary item/UOM enrichment through InProcessPmsReadClient
- extend PMS integration boundary guard to cover migrated count/summary consumers

## Scope
- WMS count doc and inventory adjustment summary read/enrichment chain only
- no database schema change
- no FK change
- no PMS physical split
- no behavior change
- known clean-main outbound_reversal metadata issue is not addressed in this PR

## Validation
- python3 -m compileall changed files
- targeted PMS integration/export/boundary tests: 15 passed
- count / summary related tests excluding known clean-main outbound_reversal failure: 26 passed
- migrated count / summary direct PMS export import scan is empty