### PR TITLE
refactor(pms): route return inbound remaining reads through integration client

### DIFF
--- a/app/wms/inventory_adjustment/return_inbound/contracts/inbound_task_read.py
+++ b/app/wms/inventory_adjustment/return_inbound/contracts/inbound_task_read.py
@@ -10,7 +10,7 @@ from app.wms.inventory_adjustment.return_inbound.contracts.enums import (
     InboundReceiptSourceType,
     InboundReceiptStatus,
 )
-from app.pms.export.items.contracts.item_policy import (
+from app.integrations.pms.contracts import (
     ExpiryPolicy,
     LotSourcePolicy,
     ShelfLifeUnit,

--- a/app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_read_repo.py
+++ b/app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_read_repo.py
@@ -6,8 +6,7 @@ from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.services.item_read_service import ItemReadService
-from app.pms.export.uoms.services.uom_read_service import PmsExportUomReadService
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 
 from app.wms.inventory_adjustment.return_inbound.contracts.receipt_read import (
     InboundReceiptLineReadOut,
@@ -50,7 +49,7 @@ async def _load_inbound_default_uoms_by_item_id(
     if not ids:
         return {}
 
-    uoms = await PmsExportUomReadService(session).alist_uoms(item_ids=ids)
+    uoms = await InProcessPmsReadClient(session).list_uoms(item_ids=ids)
 
     selected = {}
     for uom in sorted(
@@ -181,7 +180,7 @@ async def get_inbound_return_source_repo(
         raise HTTPException(status_code=409, detail="return_order_has_no_refundable_lines")
 
     item_ids = _clean_item_ids(row["item_id"] for row in line_rows)
-    item_map = await ItemReadService(session).aget_basics_by_item_ids(item_ids=item_ids)
+    item_map = await InProcessPmsReadClient(session).get_item_basics(item_ids=item_ids)
     inbound_uom_map = await _load_inbound_default_uoms_by_item_id(
         session,
         item_ids=item_ids,

--- a/app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_write_repo.py
+++ b/app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_write_repo.py
@@ -7,8 +7,7 @@ from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.services.item_read_service import ItemReadService
-from app.pms.export.uoms.services.uom_read_service import PmsExportUomReadService
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 from app.wms.inventory_adjustment.return_inbound.contracts.receipt_create_from_purchase import (
     InboundReceiptCreateFromPurchaseIn,
     InboundReceiptCreateFromPurchaseOut,
@@ -130,11 +129,12 @@ async def _load_manual_line_snapshot(
     item_id: int,
     item_uom_id: int,
 ) -> dict[str, object]:
-    item = await ItemReadService(session).aget_basic_by_id(item_id=int(item_id))
+    pms_client = InProcessPmsReadClient(session)
+    item = await pms_client.get_item_basic(item_id=int(item_id))
     if item is None:
         raise HTTPException(status_code=404, detail="item_not_found")
 
-    uom = await PmsExportUomReadService(session).aget_by_id(
+    uom = await pms_client.get_uom(
         item_uom_id=int(item_uom_id),
     )
     if uom is None:

--- a/app/wms/inventory_adjustment/return_inbound/routers/order_refs.py
+++ b/app/wms/inventory_adjustment/return_inbound/routers/order_refs.py
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_session
-from app.pms.export.items.services.item_read_service import ItemReadService
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 from app.wms.inventory_adjustment.return_inbound.contracts.return_task import (
     ReturnOrderRefDetailOut,
     ReturnOrderRefItem,
@@ -45,7 +45,7 @@ async def _enrich_order_ref_summary_lines(
     退货 order_ref 摘要行商品展示补齐。
 
     WMS 事实仍来自 stock_ledger / lots；
-    商品名通过 PMS export read service 获取，
+    商品名通过 PMS integration client 获取，
     不在 return inbound order_refs 里直接读取 PMS owner items。
     """
     out = [dict(row) for row in rows]
@@ -53,7 +53,7 @@ async def _enrich_order_ref_summary_lines(
     if not item_ids:
         return out
 
-    item_map = await ItemReadService(session).aget_basics_by_item_ids(item_ids=item_ids)
+    item_map = await InProcessPmsReadClient(session).get_item_basics(item_ids=item_ids)
 
     for row in out:
         item_id = int(row["item_id"])

--- a/tests/ci/test_pms_integration_client_boundary_contract.py
+++ b/tests/ci/test_pms_integration_client_boundary_contract.py
@@ -36,6 +36,10 @@ MIGRATED_NON_PMS_CONSUMERS = {
     "app/wms/inbound/services/inbound_commit_service.py",
     "app/wms/inventory_adjustment/count/repos/count_doc_repo.py",
     "app/wms/inventory_adjustment/summary/repos/summary_repo.py",
+    "app/wms/inventory_adjustment/return_inbound/contracts/inbound_task_read.py",
+    "app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_read_repo.py",
+    "app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_write_repo.py",
+    "app/wms/inventory_adjustment/return_inbound/routers/order_refs.py",
 }
 
 


### PR DESCRIPTION
## Summary
- route return inbound task read policy contract types through app.integrations.pms.contracts
- route return inbound receipt read item/UOM enrichment through InProcessPmsReadClient
- route return inbound receipt manual line snapshot reads through InProcessPmsReadClient
- route return order refs item enrichment through InProcessPmsReadClient
- extend PMS integration boundary guard to cover migrated return inbound remaining consumers

## Scope
- WMS return inbound remaining read/write helper chain only
- no database schema change
- no FK change
- no PMS physical split
- no behavior change

## Validation
- python3 -m compileall changed files
- targeted PMS integration/export/boundary tests: 15 passed
- return_inbound tests: 11 passed
- migrated return_inbound direct PMS export import scan is empty