### PR TITLE
refactor(pms): route oms reads through integration client

### DIFF
--- a/app/integrations/pms/sync_client.py
+++ b/app/integrations/pms/sync_client.py
@@ -1,0 +1,42 @@
+# app/integrations/pms/sync_client.py
+"""
+Synchronous in-process PMS read client.
+
+Current use case:
+- legacy synchronous service paths that still use sqlalchemy.orm.Session
+- keeps non-PMS domains from importing app.pms.export services directly
+
+Future deployment mode:
+- replace this implementation with a synchronous HTTP PMS client behind the
+  same consumer-side boundary.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.integrations.pms.contracts import PmsExportSkuCodeResolution
+from app.pms.export.sku_codes.services.sku_code_read_service import (
+    PmsExportSkuCodeReadService,
+)
+
+
+class SyncInProcessPmsReadClient:
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def resolve_active_code_for_outbound_default(
+        self,
+        *,
+        code: str,
+        enabled_only: bool = True,
+    ) -> PmsExportSkuCodeResolution | None:
+        return PmsExportSkuCodeReadService(
+            self.session
+        ).resolve_active_code_for_outbound_default(
+            code=str(code),
+            enabled_only=bool(enabled_only),
+        )
+
+
+__all__ = ["SyncInProcessPmsReadClient"]

--- a/app/oms/fsku/services/fsku_service_write.py
+++ b/app/oms/fsku/services/fsku_service_write.py
@@ -14,9 +14,7 @@ from app.oms.fsku.models.fsku import Fsku, FskuComponent
 from app.oms.fsku.services.fsku_service_errors import FskuBadInput, FskuConflict, FskuNotFound
 from app.oms.fsku.services.fsku_service_mapper import to_detail
 from app.oms.fsku.services.fsku_service_utils import normalize_code, normalize_shape, utc_now
-from app.pms.export.sku_codes.services.sku_code_read_service import (
-    PmsExportSkuCodeReadService,
-)
+from app.integrations.pms.sync_client import SyncInProcessPmsReadClient
 
 
 _SKU_TOKEN = re.compile(r"^[A-Z0-9][A-Z0-9._-]{0,127}$")
@@ -148,7 +146,7 @@ def parse_fsku_expr(expr: object) -> ParsedExpression:
 
 
 def _resolve_component(db: Session, parsed: ParsedComponent) -> ResolvedComponent:
-    resolved = PmsExportSkuCodeReadService(
+    resolved = SyncInProcessPmsReadClient(
         db
     ).resolve_active_code_for_outbound_default(
         code=parsed.component_sku_code,

--- a/app/oms/orders/repos/order_outbound_view_repo.py
+++ b/app/oms/orders/repos/order_outbound_view_repo.py
@@ -6,9 +6,8 @@ from typing import Any, Dict, List, Mapping
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.services.item_read_service import ItemReadService
-from app.pms.export.uoms.contracts.uom import PmsExportUom
-from app.pms.export.uoms.services.uom_read_service import PmsExportUomReadService
+from app.integrations.pms.contracts import PmsExportUom
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 
 
 def _pick_base_uom(rows: list[PmsExportUom]) -> PmsExportUom | None:
@@ -73,12 +72,12 @@ async def load_order_outbound_lines(
     order_id: int,
 ) -> List[Dict[str, Any]]:
     """
-    订单出库页：读取订单行（来源真相 = order_lines + PMS export display）
+    订单出库页：读取订单行（来源真相 = order_lines + PMS integration display）
 
     说明：
     - 核心真相是 order_lines；
-    - 商品展示字段 sku / name / spec 通过 PMS export ItemReadService 读取；
-    - base_uom 展示通过 PMS export UOM read service 读取；
+    - 商品展示字段 sku / name / spec 通过 PMS integration client 读取；
+    - base_uom 展示通过 PMS integration client 读取；
     - 不直接 JOIN PMS 内部 items / item_uoms 表。
     """
     line_rows = (
@@ -112,8 +111,9 @@ async def load_order_outbound_lines(
         }
     )
 
-    item_map = await ItemReadService(session).aget_basics_by_item_ids(item_ids=item_ids)
-    uom_rows = await PmsExportUomReadService(session).alist_uoms(item_ids=item_ids)
+    pms_client = InProcessPmsReadClient(session)
+    item_map = await pms_client.get_item_basics(item_ids=item_ids)
+    uom_rows = await pms_client.list_uoms(item_ids=item_ids)
 
     uoms_by_item_id: Dict[int, List[PmsExportUom]] = {}
     for row in uom_rows:

--- a/app/oms/services/platform_order_resolve_loaders.py
+++ b/app/oms/services/platform_order_resolve_loaders.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.export.items.services.item_read_service import ItemReadService
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 
 
 async def load_fsku_components(
@@ -51,8 +51,9 @@ async def load_items_brief(
     if not item_ids:
         return {}
 
-    svc = ItemReadService(session)
-    rows = await svc.aget_basics_by_item_ids(item_ids=[int(x) for x in item_ids])
+    rows = await InProcessPmsReadClient(session).get_item_basics(
+        item_ids=[int(x) for x in item_ids],
+    )
 
     out: Dict[int, Dict[str, Any]] = {}
     for item_id, item in rows.items():

--- a/tests/ci/test_pms_integration_client_boundary_contract.py
+++ b/tests/ci/test_pms_integration_client_boundary_contract.py
@@ -41,6 +41,9 @@ MIGRATED_NON_PMS_CONSUMERS = {
     "app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_write_repo.py",
     "app/wms/inventory_adjustment/return_inbound/routers/order_refs.py",
     "app/wms/ledger/helpers/stock_ledger.py",
+    "app/oms/services/platform_order_resolve_loaders.py",
+    "app/oms/fsku/services/fsku_service_write.py",
+    "app/oms/orders/repos/order_outbound_view_repo.py",
 }
 
 
@@ -64,6 +67,7 @@ def test_pms_integration_client_boundary_files_exist() -> None:
         "app/integrations/pms/contracts.py",
         "app/integrations/pms/client.py",
         "app/integrations/pms/inprocess_client.py",
+        "app/integrations/pms/sync_client.py",
     }
 
     for rel in expected:
@@ -88,6 +92,7 @@ def test_only_pms_integration_bridge_imports_pms_export_inside_integrations() ->
     allowed = {
         "app/integrations/pms/contracts.py",
         "app/integrations/pms/inprocess_client.py",
+        "app/integrations/pms/sync_client.py",
     }
 
     violations: list[str] = []


### PR DESCRIPTION
## Summary
- add SyncInProcessPmsReadClient for synchronous OMS FSKU write path
- route OMS platform order resolve item reads through InProcessPmsReadClient
- route OMS FSKU component SKU-code resolution through SyncInProcessPmsReadClient
- route OMS order outbound view item/UOM enrichment through InProcessPmsReadClient
- extend PMS integration boundary guard to cover migrated OMS consumers
- clear direct app.pms.export imports from app/oms

## Scope
- OMS read/enrichment and FSKU component resolution chain only
- no database schema change
- no FK change
- no PMS physical split
- no behavior change

## Validation
- python3 -m compileall changed files
- targeted PMS integration/export/boundary tests: 15 passed
- OMS tests: 34 passed
- app/oms direct PMS export import scan is empty
- all non-PMS app direct PMS export import scan now only reports app/finance/sources/order_sales_source.py