### PR TITLE
refactor(pms): route finance sales reads through integration client

### DIFF
--- a/app/finance/sources/order_sales_source.py
+++ b/app/finance/sources/order_sales_source.py
@@ -8,7 +8,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.finance.services.common import to_decimal
-from app.pms.export.items.services.item_read_service import ItemReadService
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 
 
 class OrderSalesSource:
@@ -21,7 +21,7 @@ class OrderSalesSource:
     - 不读取采购；
     - 不读取发货辅助；
     - 不计算利润。
-    - 商品展示维度通过 PMS export ItemReadService 后置补充，不直接 JOIN PMS 内部 items 表。
+    - 商品展示维度通过 PMS integration client 后置补充，不直接 JOIN PMS 内部 items 表。
     """
 
     def __init__(self, session: AsyncSession) -> None:
@@ -94,7 +94,9 @@ class OrderSalesSource:
         ids = sorted({int(x) for x in item_ids if x is not None and int(x) > 0})
         if not ids:
             return {}
-        return await ItemReadService(self.session).aget_report_meta_by_item_ids(item_ids=ids)
+        return await InProcessPmsReadClient(self.session).get_report_meta_by_item_ids(
+            item_ids=ids,
+        )
 
     async def _summary(self, params: dict[str, object]) -> dict[str, object]:
         sql = text(

--- a/tests/ci/test_pms_integration_client_boundary_contract.py
+++ b/tests/ci/test_pms_integration_client_boundary_contract.py
@@ -44,6 +44,7 @@ MIGRATED_NON_PMS_CONSUMERS = {
     "app/oms/services/platform_order_resolve_loaders.py",
     "app/oms/fsku/services/fsku_service_write.py",
     "app/oms/orders/repos/order_outbound_view_repo.py",
+    "app/finance/sources/order_sales_source.py",
 }
 
 


### PR DESCRIPTION
## Summary
- route finance order sales item metadata enrichment through InProcessPmsReadClient
- extend PMS integration boundary guard to cover migrated finance sales source
- clear direct app.pms.export imports from app/wms, app/oms, app/procurement, and app/finance

## Scope
- Finance order sales read/enrichment chain only
- no database schema change
- no FK change
- no PMS physical split
- no behavior change

## Validation
- python3 -m compileall changed files
- targeted PMS integration/export/boundary tests: 15 passed
- finance tests: 8 passed
- all non-PMS app direct PMS export import scan is empty