### PR TITLE
test(pms): harden integration boundary guard

### DIFF
--- a/tests/ci/test_pms_integration_client_boundary_contract.py
+++ b/tests/ci/test_pms_integration_client_boundary_contract.py
@@ -11,45 +11,38 @@ PMS_EXPORT_IMPORT_RE = re.compile(
     r"|^\s*import\s+app\.pms\.export\b"
 )
 
-MIGRATED_NON_PMS_CONSUMERS = {
-    "app/wms/scan/services/scan_orchestrator_item_resolver.py",
-    "app/wms/inbound/repos/barcode_resolve_repo.py",
-    "app/wms/inventory_adjustment/return_inbound/services/inbound_task_probe_service.py",
-    "app/wms/inventory_adjustment/return_inbound/repos/inbound_operation_write_repo.py",
-    "app/procurement/repos/purchase_order_create_repo.py",
-    "app/procurement/repos/receive_po_line_repo.py",
-    "app/procurement/services/purchase_order_create.py",
-    "app/procurement/services/purchase_order_update.py",
-    "app/procurement/helpers/purchase_reports.py",
-    "app/procurement/routers/purchase_reports_routes_items.py",
-    "app/wms/stock/repos/inventory_options_repo.py",
-    "app/wms/stock/repos/inventory_read_repo.py",
-    "app/wms/stock/repos/inventory_explain_repo.py",
-    "app/wms/stock/services/lot_service.py",
-    "app/wms/stock/services/lot_resolver.py",
-    "app/wms/stock/services/lots.py",
-    "app/wms/stock/services/stock_adjust/db_items.py",
-    "app/wms/shared/services/expiry_resolver.py",
-    "app/wms/shared/services/lot_code_contract.py",
-    "app/wms/inbound/repos/item_lookup_repo.py",
-    "app/wms/inbound/repos/lot_resolve_repo.py",
-    "app/wms/inbound/services/inbound_commit_service.py",
-    "app/wms/inventory_adjustment/count/repos/count_doc_repo.py",
-    "app/wms/inventory_adjustment/summary/repos/summary_repo.py",
-    "app/wms/inventory_adjustment/return_inbound/contracts/inbound_task_read.py",
-    "app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_read_repo.py",
-    "app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_write_repo.py",
-    "app/wms/inventory_adjustment/return_inbound/routers/order_refs.py",
-    "app/wms/ledger/helpers/stock_ledger.py",
-    "app/oms/services/platform_order_resolve_loaders.py",
-    "app/oms/fsku/services/fsku_service_write.py",
-    "app/oms/orders/repos/order_outbound_view_repo.py",
-    "app/finance/sources/order_sales_source.py",
+NON_PMS_BUSINESS_APP_DIRS = {
+    "app/wms",
+    "app/oms",
+    "app/procurement",
+    "app/finance",
+}
+
+PMS_INTEGRATION_BOUNDARY_FILES = {
+    "app/integrations/__init__.py",
+    "app/integrations/pms/__init__.py",
+    "app/integrations/pms/contracts.py",
+    "app/integrations/pms/client.py",
+    "app/integrations/pms/inprocess_client.py",
+    "app/integrations/pms/sync_client.py",
+}
+
+PMS_EXPORT_BRIDGE_ALLOWLIST = {
+    "app/integrations/pms/contracts.py",
+    "app/integrations/pms/inprocess_client.py",
+    "app/integrations/pms/sync_client.py",
 }
 
 
 def _rel(path: Path) -> str:
     return path.relative_to(ROOT).as_posix()
+
+
+def _python_files_under(rel_dir: str) -> list[Path]:
+    base = ROOT / rel_dir
+    if not base.exists():
+        return []
+    return sorted(path for path in base.rglob("*.py") if path.is_file())
 
 
 def _import_violations(path: Path) -> list[str]:
@@ -62,44 +55,37 @@ def _import_violations(path: Path) -> list[str]:
 
 
 def test_pms_integration_client_boundary_files_exist() -> None:
-    expected = {
-        "app/integrations/__init__.py",
-        "app/integrations/pms/__init__.py",
-        "app/integrations/pms/contracts.py",
-        "app/integrations/pms/client.py",
-        "app/integrations/pms/inprocess_client.py",
-        "app/integrations/pms/sync_client.py",
-    }
-
-    for rel in expected:
+    for rel in sorted(PMS_INTEGRATION_BOUNDARY_FILES):
         assert (ROOT / rel).is_file(), rel
 
 
-def test_migrated_non_pms_consumers_no_longer_import_pms_export_directly() -> None:
-    for rel in sorted(MIGRATED_NON_PMS_CONSUMERS):
-        path = ROOT / rel
-        assert path.is_file(), rel
-        assert _import_violations(path) == []
+def test_non_pms_business_domains_do_not_import_pms_export_directly() -> None:
+    """
+    PMS 独立化准备合同：
 
+    WMS / OMS / Procurement / Finance 不允许直接 import app.pms.export。
+    这些业务域只能通过 app.integrations.pms 读取 PMS export 能力。
 
-def test_migrated_non_pms_consumers_use_integration_boundary() -> None:
-    for rel in sorted(MIGRATED_NON_PMS_CONSUMERS):
-        path = ROOT / rel
-        text = path.read_text(encoding="utf-8")
-        assert "app.integrations.pms" in text
+    允许 direct import app.pms.export 的位置：
+    - PMS 自己的 export 实现；
+    - app.integrations.pms 桥接实现；
+    - PMS export 自身合同/服务测试。
+    """
+    violations: list[str] = []
+
+    for rel_dir in sorted(NON_PMS_BUSINESS_APP_DIRS):
+        for path in _python_files_under(rel_dir):
+            violations.extend(_import_violations(path))
+
+    assert violations == []
 
 
 def test_only_pms_integration_bridge_imports_pms_export_inside_integrations() -> None:
-    allowed = {
-        "app/integrations/pms/contracts.py",
-        "app/integrations/pms/inprocess_client.py",
-        "app/integrations/pms/sync_client.py",
-    }
-
     violations: list[str] = []
+
     for path in sorted((ROOT / "app/integrations").rglob("*.py")):
         rel = _rel(path)
-        if rel in allowed:
+        if rel in PMS_EXPORT_BRIDGE_ALLOWLIST:
             continue
         violations.extend(_import_violations(path))
 


### PR DESCRIPTION
## Summary
- replace migrated-file allowlist with full non-PMS business domain guard
- forbid direct app.pms.export imports from app/wms, app/oms, app/procurement, and app/finance
- keep app.integrations.pms as the only allowed non-PMS bridge to PMS export
- preserve PMS export bridge allowlist for contracts, async in-process client, and sync in-process client

## Scope
- CI boundary test only
- no runtime code change
- no database schema change
- no FK change
- no PMS physical split

## Validation
- python3 -m compileall tests/ci/test_pms_integration_client_boundary_contract.py
- targeted PMS integration/export/boundary tests: 14 passed
- non-PMS business domains direct PMS export import scan is empty