### PR TITLE
chore(pms): add standalone api scaffold

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,4 @@ include scripts/make/audit.mk
 include scripts/make/test.mk
 include scripts/make/lint.mk
 include scripts/make/openapi.mk
+include scripts/make/pms_api.mk

--- a/app/pms_api/__init__.py
+++ b/app/pms_api/__init__.py
@@ -1,0 +1,8 @@
+# app/pms_api/__init__.py
+"""
+Standalone PMS API application package.
+
+This package is the process boundary for the future PMS service.
+It must mount PMS-owned routes only and must not mount WMS / OMS /
+Procurement / Finance / Shipping Assist runtime routes.
+"""

--- a/app/pms_api/main.py
+++ b/app/pms_api/main.py
@@ -1,0 +1,73 @@
+# app/pms_api/main.py
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from app.http_problem_handlers import register_exception_handlers
+from app.pms_api.router_mount import mount_pms_routers
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger("pms-api")
+
+PMS_API_VERSION = "0.1.0"
+PMS_ENV = os.getenv("PMS_ENV", os.getenv("WMS_ENV", "dev")).lower()
+
+app = FastAPI(
+    title="PMS API",
+    version=PMS_API_VERSION,
+    docs_url="/docs",
+    redoc_url="/redoc",
+    openapi_url="/openapi.json",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[
+        "http://127.0.0.1:5174",
+        "http://localhost:5174",
+        "http://127.0.0.1:8002",
+        "http://localhost:8002",
+    ],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+register_exception_handlers(app)
+mount_pms_routers(app)
+
+
+@app.get("/")
+async def root() -> dict[str, Any]:
+    return {
+        "name": "PMS API",
+        "version": PMS_API_VERSION,
+        "env": PMS_ENV,
+    }
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {
+        "status": "ok",
+        "service": "pms-api",
+        "version": PMS_API_VERSION,
+    }
+
+
+@app.get("/healthz")
+async def healthz() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/pms/read/v1/health")
+async def read_v1_health() -> dict[str, str]:
+    return {
+        "status": "ok",
+        "surface": "pms-read-v1",
+    }

--- a/app/pms_api/router_mount.py
+++ b/app/pms_api/router_mount.py
@@ -1,0 +1,87 @@
+# app/pms_api/router_mount.py
+"""
+Standalone PMS API router mount.
+
+Scope:
+- PMS owner routes
+- PMS export/read routes
+- SKU coding routes
+- supplier master-data routes currently required by PMS item ownership
+
+Out of scope:
+- WMS execution routes
+- OMS routes
+- Procurement routes
+- Finance routes
+- Shipping Assist routes
+- Admin/user navigation routes
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from app.partners.export.suppliers.routers.suppliers_read import (
+    router as partners_export_suppliers_read_router,
+)
+from app.partners.suppliers.routers.supplier_contacts import (
+    router as supplier_contacts_router,
+)
+from app.partners.suppliers.routers.suppliers import router as suppliers_router
+from app.pms.export.barcodes.routers.barcodes_read import (
+    router as pms_export_barcodes_read_router,
+)
+from app.pms.export.items.routers.barcode_probe import (
+    router as pms_export_barcode_probe_router,
+)
+from app.pms.export.items.routers.items_read import (
+    router as pms_export_items_read_router,
+)
+from app.pms.export.sku_codes.routers.sku_codes_read import (
+    router as pms_export_sku_codes_read_router,
+)
+from app.pms.export.uoms.routers.uoms_read import (
+    router as pms_export_uoms_read_router,
+)
+from app.pms.items.routers.item_aggregate import router as item_aggregate_router
+from app.pms.items.routers.item_barcodes import router as item_barcodes_router
+from app.pms.items.routers.item_list import router as item_list_router
+from app.pms.items.routers.item_master import router as item_master_router
+from app.pms.items.routers.item_sku_codes import router as item_sku_codes_router
+from app.pms.items.routers.item_uoms import router as item_uoms_router
+from app.pms.items.routers.items import router as items_router
+from app.pms.sku_coding.routers.sku_coding import router as sku_coding_router
+
+
+def mount_pms_routers(app: FastAPI) -> None:
+    """
+    Mount PMS standalone process routes.
+
+    Keep export/read routes before owner /items routes to avoid path-order
+    surprises. Do not add WMS / OMS / Procurement / Finance / Shipping routes
+    here.
+    """
+
+    # Cross-domain read/export surface for WMS / OMS / Procurement / Finance.
+    app.include_router(pms_export_items_read_router)
+    app.include_router(pms_export_uoms_read_router)
+    app.include_router(pms_export_sku_codes_read_router)
+    app.include_router(pms_export_barcodes_read_router)
+    app.include_router(pms_export_barcode_probe_router)
+    app.include_router(partners_export_suppliers_read_router)
+
+    # PMS owner/master-data surface for pms-web.
+    app.include_router(item_aggregate_router)
+    app.include_router(item_list_router)
+    app.include_router(items_router)
+    app.include_router(item_master_router)
+    app.include_router(item_sku_codes_router)
+    app.include_router(sku_coding_router)
+    app.include_router(item_barcodes_router)
+    app.include_router(item_uoms_router)
+
+    # Supplier master data is currently still under app.partners but is required
+    # by PMS item ownership through supplier_id. This mount is intentional for
+    # the first standalone PMS process; later we can re-home the module.
+    app.include_router(suppliers_router)
+    app.include_router(supplier_contacts_router)

--- a/scripts/make/pms_api.mk
+++ b/scripts/make/pms_api.mk
@@ -1,0 +1,45 @@
+# scripts/make/pms_api.mk
+#
+# Standalone PMS API process commands.
+#
+# 说明：
+# - 使用 .RECIPEPREFIX 避免 Makefile tab / heredoc 缩进问题。
+# - pms-api 当前是独立进程、暂时同库。
+# - 不挂 WMS / OMS / Procurement / Finance / Shipping Assist runtime routes。
+
+.RECIPEPREFIX := >
+
+.PHONY: pms-api-dev pms-api-routes pms-api-smoke
+
+pms-api-dev:
+>PYTHONPATH=. \
+>PMS_ENV=dev \
+>WMS_ENV=dev \
+>WMS_DATABASE_URL="$(DEV_DB_DSN)" \
+>WMS_TEST_DATABASE_URL="$(DEV_DB_DSN)" \
+>$(PY) -m uvicorn app.pms_api.main:app --host 127.0.0.1 --port 8002 --reload
+
+pms-api-routes:
+>PYTHONPATH=. $(PY) scripts/print_pms_api_routes.py
+
+pms-api-smoke:
+>set -euo pipefail; \
+>PYTHONPATH=. \
+>PMS_ENV=dev \
+>WMS_ENV=dev \
+>WMS_DATABASE_URL="$(DEV_DB_DSN)" \
+>WMS_TEST_DATABASE_URL="$(DEV_DB_DSN)" \
+>$(PY) -m uvicorn app.pms_api.main:app --host 127.0.0.1 --port 8002 >/tmp/pms-api-smoke.log 2>&1 & \
+>pid=$$!; \
+>trap 'kill $$pid >/dev/null 2>&1 || true' EXIT; \
+>for i in $$(seq 1 30); do \
+>  if curl -fsS http://127.0.0.1:8002/health >/tmp/pms-api-health.json; then \
+>    cat /tmp/pms-api-health.json; \
+>    echo; \
+>    exit 0; \
+>  fi; \
+>  sleep 1; \
+>done; \
+>echo "pms-api smoke failed"; \
+>cat /tmp/pms-api-smoke.log; \
+>exit 1

--- a/scripts/print_pms_api_routes.py
+++ b/scripts/print_pms_api_routes.py
@@ -1,0 +1,21 @@
+# scripts/print_pms_api_routes.py
+from __future__ import annotations
+
+from app.pms_api.main import app
+
+
+def main() -> None:
+    rows: list[tuple[str, str]] = []
+
+    for route in app.routes:
+        path = getattr(route, "path", "")
+        methods = sorted(getattr(route, "methods", []) or [])
+        if isinstance(path, str):
+            rows.append((path, ",".join(methods)))
+
+    for path, methods in sorted(rows):
+        print(f"{methods:20s} {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/api/test_pms_api_standalone_app.py
+++ b/tests/api/test_pms_api_standalone_app.py
@@ -1,0 +1,74 @@
+# tests/api/test_pms_api_standalone_app.py
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.pms_api.main import app
+
+
+def _paths() -> set[str]:
+    return {
+        str(getattr(route, "path", ""))
+        for route in app.routes
+        if isinstance(getattr(route, "path", ""), str)
+    }
+
+
+def test_pms_api_health_endpoint() -> None:
+    client = TestClient(app)
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+    assert response.json()["service"] == "pms-api"
+
+
+def test_pms_api_mounts_pms_and_supplier_routes() -> None:
+    paths = _paths()
+
+    assert "/pms/export/items" in paths
+    assert "/pms/export/items/barcode-probe" in paths
+    assert "/pms/export/uoms" in paths
+    assert "/pms/export/sku-codes" in paths
+    assert "/pms/export/barcodes" in paths
+
+    assert "/items" in paths
+    assert "/items/list-rows" in paths
+    assert "/item-uoms" in paths
+    assert "/item-barcodes" in paths
+    assert "/pms/brands" in paths
+    assert "/pms/categories" in paths
+    assert "/pms/sku-coding/generate" in paths
+
+    assert "/partners/export/suppliers" in paths
+
+
+def test_pms_api_does_not_mount_non_pms_runtime_domains() -> None:
+    paths = _paths()
+
+    forbidden_prefixes = (
+        "/admin",
+        "/users",
+        "/oms",
+        "/finance",
+        "/purchase-orders",
+        "/purchase-reports",
+        "/shipping-assist",
+        "/stock",
+        "/wms/inbound",
+        "/wms/outbound",
+        "/return-tasks",
+        "/count",
+        "/count-docs",
+        "/print-jobs",
+    )
+
+    violations = [
+        path
+        for path in sorted(paths)
+        for prefix in forbidden_prefixes
+        if path == prefix or path.startswith(f"{prefix}/")
+    ]
+
+    assert violations == []


### PR DESCRIPTION
## Summary
- add standalone PMS API FastAPI entrypoint
- mount PMS owner/export/supplier master-data routes only
- add PMS API make commands
- add route boundary tests for standalone PMS API

## Validation
- python3 -m compileall app/pms_api tests/api/test_pms_api_standalone_app.py scripts/print_pms_api_routes.py
- make test TESTS="tests/api/test_pms_api_standalone_app.py"
- make pms-api-routes