### PR TITLE
feat(pms): add http read client

### DIFF
--- a/app/integrations/pms/__init__.py
+++ b/app/integrations/pms/__init__.py
@@ -6,6 +6,7 @@ Consumers outside PMS should depend on this package instead of importing
 PMS export services directly.
 """
 
+from app.integrations.pms.http_client import HttpPmsReadClient
 from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 
-__all__ = ["InProcessPmsReadClient"]
+__all__ = ["HttpPmsReadClient", "InProcessPmsReadClient"]

--- a/app/integrations/pms/http_client.py
+++ b/app/integrations/pms/http_client.py
@@ -1,0 +1,404 @@
+# app/integrations/pms/http_client.py
+"""
+HTTP PMS read client.
+
+This client is the future PMS integration implementation for the
+independent pms-api process.
+
+Important:
+- It is not wired into WMS / OMS / Procurement / Finance yet.
+- It does not fallback to InProcessPmsReadClient.
+- A deployment must explicitly choose this implementation.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable, Mapping, Sequence
+from types import SimpleNamespace
+from typing import Any, NoReturn, TypeVar
+
+import httpx
+
+from app.integrations.pms.contracts import (
+    BarcodeProbeOut,
+    ItemBasic,
+    ItemPolicy,
+    ItemReadQuery,
+    PmsExportBarcode,
+    PmsExportSkuCode,
+    PmsExportSkuCodeResolution,
+    PmsExportUom,
+)
+
+ModelT = TypeVar("ModelT")
+
+
+def _clean_ids(values: Iterable[int]) -> list[int]:
+    return sorted({int(value) for value in values if int(value) > 0})
+
+
+def _base_url(value: str | None) -> str:
+    raw = (value or os.getenv("PMS_API_BASE_URL") or "").strip()
+    if not raw:
+        raise RuntimeError("PMS_API_BASE_URL is required for HttpPmsReadClient")
+    return raw.rstrip("/")
+
+
+def _parse_model(model_type: type[ModelT], data: Mapping[str, Any]) -> ModelT:
+    validator = getattr(model_type, "model_validate", None)
+    if callable(validator):
+        return validator(data)
+    return model_type(**data)  # type: ignore[misc]
+
+
+def _parse_model_list(model_type: type[ModelT], rows: object) -> list[ModelT]:
+    if not isinstance(rows, list):
+        return []
+    return [_parse_model(model_type, row) for row in rows if isinstance(row, Mapping)]
+
+
+def _parse_model_map(
+    model_type: type[ModelT],
+    body: Mapping[str, Any],
+    field: str,
+) -> dict[int, ModelT]:
+    raw = body.get(field)
+    if not isinstance(raw, Mapping):
+        return {}
+
+    out: dict[int, ModelT] = {}
+    for key, value in raw.items():
+        if not isinstance(value, Mapping):
+            continue
+        out[int(key)] = _parse_model(model_type, value)
+    return out
+
+
+def _parse_object_map(body: Mapping[str, Any], field: str) -> dict[int, object]:
+    raw = body.get(field)
+    if not isinstance(raw, Mapping):
+        return {}
+
+    out: dict[int, object] = {}
+    for key, value in raw.items():
+        if isinstance(value, Mapping):
+            out[int(key)] = SimpleNamespace(**dict(value))
+    return out
+
+
+class HttpPmsReadClient:
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        timeout_seconds: float = 10.0,
+        transport: httpx.AsyncBaseTransport | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> None:
+        self.base_url = _base_url(base_url)
+        self.timeout = httpx.Timeout(timeout_seconds)
+        self.transport = transport
+        self.headers = dict(headers or {})
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: Mapping[str, Any] | None = None,
+        params: Mapping[str, Any] | None = None,
+        none_status_codes: set[int] | None = None,
+    ) -> Mapping[str, Any] | None:
+        async with httpx.AsyncClient(
+            base_url=self.base_url,
+            timeout=self.timeout,
+            transport=self.transport,
+            headers=self.headers,
+        ) as client:
+            response = await client.request(
+                method,
+                path,
+                json=json_body,
+                params=params,
+            )
+
+        if none_status_codes and response.status_code in none_status_codes:
+            return None
+
+        response.raise_for_status()
+        data = response.json()
+        if not isinstance(data, Mapping):
+            raise ValueError(f"pms-api response must be object: path={path}")
+        return data
+
+    @staticmethod
+    def _unsupported(method: str) -> NoReturn:
+        raise NotImplementedError(
+            f"HttpPmsReadClient.{method} is not supported by current pms-api HTTP surface"
+        )
+
+    async def list_item_basics(
+        self,
+        *,
+        query: ItemReadQuery | None = None,
+    ) -> list[ItemBasic]:
+        _ = query
+        self._unsupported("list_item_basics")
+
+    async def get_item_basic(self, *, item_id: int) -> ItemBasic | None:
+        rows = await self.get_item_basics(item_ids=[int(item_id)])
+        return rows.get(int(item_id))
+
+    async def get_item_basics(
+        self,
+        *,
+        item_ids: Iterable[int],
+    ) -> dict[int, ItemBasic]:
+        ids = _clean_ids(item_ids)
+        if not ids:
+            return {}
+
+        body = await self._request(
+            "POST",
+            "/pms/read/v1/items/basic/batch",
+            json_body={"item_ids": ids, "enabled_only": False},
+        )
+        assert body is not None
+        return _parse_model_map(ItemBasic, body, "items_by_id")
+
+    async def get_item_policy(self, *, item_id: int) -> ItemPolicy | None:
+        rows = await self.get_item_policies(item_ids=[int(item_id)])
+        return rows.get(int(item_id))
+
+    async def get_item_policies(
+        self,
+        *,
+        item_ids: Iterable[int],
+    ) -> dict[int, ItemPolicy]:
+        ids = _clean_ids(item_ids)
+        if not ids:
+            return {}
+
+        body = await self._request(
+            "POST",
+            "/pms/read/v1/items/policies/batch",
+            json_body={"item_ids": ids, "enabled_only": False},
+        )
+        assert body is not None
+        return _parse_model_map(ItemPolicy, body, "policies_by_item_id")
+
+    async def get_item_policy_by_sku(self, *, sku: str) -> ItemPolicy | None:
+        _ = sku
+        self._unsupported("get_item_policy_by_sku")
+
+    async def search_report_item_ids_by_keyword(
+        self,
+        *,
+        keyword: str,
+        limit: int | None = None,
+    ) -> list[int]:
+        params: dict[str, Any] = {"keyword": str(keyword)}
+        if limit is not None:
+            params["limit"] = int(limit)
+
+        body = await self._request(
+            "GET",
+            "/pms/read/v1/items/report-search",
+            params=params,
+        )
+        assert body is not None
+        item_ids = body.get("item_ids")
+        if not isinstance(item_ids, list):
+            return []
+        return [int(value) for value in item_ids]
+
+    async def get_report_meta_by_item_ids(
+        self,
+        *,
+        item_ids: Iterable[int],
+    ) -> dict[int, object]:
+        ids = _clean_ids(item_ids)
+        if not ids:
+            return {}
+
+        body = await self._request(
+            "POST",
+            "/pms/read/v1/items/report-meta/batch",
+            json_body={"item_ids": ids, "enabled_only": False},
+        )
+        assert body is not None
+        return _parse_object_map(body, "meta_by_item_id")
+
+    async def get_uom(self, *, item_uom_id: int) -> PmsExportUom | None:
+        rows = await self.list_uoms(item_uom_ids=[int(item_uom_id)])
+        return rows[0] if rows else None
+
+    async def list_uoms(
+        self,
+        *,
+        item_ids: Sequence[int] | None = None,
+        item_uom_ids: Sequence[int] | None = None,
+    ) -> list[PmsExportUom]:
+        body = await self._request(
+            "POST",
+            "/pms/read/v1/uoms/query",
+            json_body={
+                "item_ids": _clean_ids(item_ids or []),
+                "item_uom_ids": _clean_ids(item_uom_ids or []),
+            },
+        )
+        assert body is not None
+        return _parse_model_list(PmsExportUom, body.get("uoms"))
+
+    async def list_uoms_by_item_id(self, *, item_id: int) -> list[PmsExportUom]:
+        return await self.list_uoms(item_ids=[int(item_id)])
+
+    async def _get_default_or_base_uom(
+        self,
+        *,
+        item_id: int,
+        usage: str,
+    ) -> PmsExportUom | None:
+        body = await self._request(
+            "POST",
+            "/pms/read/v1/items/uom-defaults/batch",
+            json_body={"item_ids": [int(item_id)], "usage": usage},
+        )
+        assert body is not None
+        raw = body.get("uoms_by_item_id")
+        if not isinstance(raw, Mapping):
+            return None
+        value = raw.get(str(int(item_id))) or raw.get(int(item_id))
+        if not isinstance(value, Mapping):
+            return None
+        return _parse_model(PmsExportUom, value)
+
+    async def get_purchase_default_or_base_uom(
+        self,
+        *,
+        item_id: int,
+    ) -> PmsExportUom | None:
+        return await self._get_default_or_base_uom(item_id=int(item_id), usage="PURCHASE")
+
+    async def get_inbound_default_or_base_uom(
+        self,
+        *,
+        item_id: int,
+    ) -> PmsExportUom | None:
+        return await self._get_default_or_base_uom(item_id=int(item_id), usage="INBOUND")
+
+    async def get_outbound_default_or_base_uom(
+        self,
+        *,
+        item_id: int,
+    ) -> PmsExportUom | None:
+        return await self._get_default_or_base_uom(item_id=int(item_id), usage="OUTBOUND")
+
+    async def get_barcode(self, *, barcode_id: int) -> PmsExportBarcode | None:
+        _ = barcode_id
+        self._unsupported("get_barcode")
+
+    async def list_barcodes(
+        self,
+        *,
+        item_ids: Sequence[int] | None = None,
+        item_uom_ids: Sequence[int] | None = None,
+        barcode: str | None = None,
+        active: bool | None = None,
+        primary_only: bool = False,
+    ) -> list[PmsExportBarcode]:
+        body = await self._request(
+            "POST",
+            "/pms/read/v1/barcodes/query",
+            json_body={
+                "item_ids": _clean_ids(item_ids or []),
+                "item_uom_ids": _clean_ids(item_uom_ids or []),
+                "barcode": barcode,
+                "active": active,
+                "primary_only": bool(primary_only),
+            },
+        )
+        assert body is not None
+        return _parse_model_list(PmsExportBarcode, body.get("barcodes"))
+
+    async def list_barcodes_by_item_id(
+        self,
+        *,
+        item_id: int,
+        active: bool | None = True,
+        primary_only: bool = False,
+    ) -> list[PmsExportBarcode]:
+        return await self.list_barcodes(
+            item_ids=[int(item_id)],
+            active=active,
+            primary_only=primary_only,
+        )
+
+    async def probe_barcode(self, *, barcode: str) -> BarcodeProbeOut:
+        body = await self._request(
+            "POST",
+            "/pms/read/v1/barcodes/probe",
+            json_body={"barcode": str(barcode)},
+        )
+        assert body is not None
+        return _parse_model(BarcodeProbeOut, body)
+
+    async def get_sku_code(self, *, sku_code_id: int) -> PmsExportSkuCode | None:
+        rows = await self.list_sku_codes(sku_code_ids=[int(sku_code_id)])
+        return rows[0] if rows else None
+
+    async def list_sku_codes(
+        self,
+        *,
+        item_ids: Sequence[int] | None = None,
+        sku_code_ids: Sequence[int] | None = None,
+        code: str | None = None,
+        active: bool | None = None,
+        primary_only: bool = False,
+    ) -> list[PmsExportSkuCode]:
+        body = await self._request(
+            "POST",
+            "/pms/read/v1/sku-codes/query",
+            json_body={
+                "item_ids": _clean_ids(item_ids or []),
+                "sku_code_ids": _clean_ids(sku_code_ids or []),
+                "code": code,
+                "active": active,
+                "primary_only": bool(primary_only),
+            },
+        )
+        assert body is not None
+        return _parse_model_list(PmsExportSkuCode, body.get("sku_codes"))
+
+    async def list_sku_codes_by_item_id(
+        self,
+        *,
+        item_id: int,
+        active: bool | None = True,
+        primary_only: bool = False,
+    ) -> list[PmsExportSkuCode]:
+        return await self.list_sku_codes(
+            item_ids=[int(item_id)],
+            active=active,
+            primary_only=primary_only,
+        )
+
+    async def resolve_active_code_for_outbound_default(
+        self,
+        *,
+        code: str,
+        enabled_only: bool = True,
+    ) -> PmsExportSkuCodeResolution | None:
+        body = await self._request(
+            "GET",
+            "/pms/read/v1/sku-codes/resolve-outbound-default",
+            params={"code": str(code), "enabled_only": bool(enabled_only)},
+            none_status_codes={404, 409, 422},
+        )
+        if body is None:
+            return None
+        return _parse_model(PmsExportSkuCodeResolution, body)
+
+
+__all__ = ["HttpPmsReadClient"]

--- a/tests/ci/test_pms_integration_client_boundary_contract.py
+++ b/tests/ci/test_pms_integration_client_boundary_contract.py
@@ -22,6 +22,7 @@ PMS_INTEGRATION_BOUNDARY_FILES = {
     "app/integrations/__init__.py",
     "app/integrations/pms/__init__.py",
     "app/integrations/pms/contracts.py",
+    "app/integrations/pms/http_client.py",
     "app/integrations/pms/client.py",
     "app/integrations/pms/inprocess_client.py",
     "app/integrations/pms/sync_client.py",
@@ -29,6 +30,7 @@ PMS_INTEGRATION_BOUNDARY_FILES = {
 
 PMS_EXPORT_BRIDGE_ALLOWLIST = {
     "app/integrations/pms/contracts.py",
+    "app/integrations/pms/http_client.py",
     "app/integrations/pms/inprocess_client.py",
     "app/integrations/pms/sync_client.py",
 }

--- a/tests/services/test_pms_integration_http_client.py
+++ b/tests/services/test_pms_integration_http_client.py
@@ -1,0 +1,330 @@
+# tests/services/test_pms_integration_http_client.py
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from app.integrations.pms.contracts import BarcodeProbeStatus
+from app.integrations.pms.http_client import HttpPmsReadClient
+
+pytestmark = pytest.mark.asyncio
+
+
+def _json(request: httpx.Request) -> dict[str, Any]:
+    if not request.content:
+        return {}
+    return json.loads(request.content.decode("utf-8"))
+
+
+def _transport() -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+
+        if path == "/pms/read/v1/items/basic/batch":
+            payload = _json(request)
+            assert payload["item_ids"] in ([1, 2], [1])
+            return httpx.Response(
+                200,
+                json={
+                    "items_by_id": {
+                        "1": {
+                            "id": 1,
+                            "sku": "SKU-0001",
+                            "name": "笔记本",
+                            "spec": None,
+                            "enabled": True,
+                            "supplier_id": 3,
+                            "brand": "得力",
+                            "category": "办公用品",
+                        }
+                    },
+                    "missing_item_ids": [2],
+                    "inactive_item_ids": [],
+                    "errors": [],
+                },
+            )
+
+        if path == "/pms/read/v1/items/policies/batch":
+            return httpx.Response(
+                200,
+                json={
+                    "policies_by_item_id": {
+                        "1": {
+                            "item_id": 1,
+                            "expiry_policy": "NONE",
+                            "shelf_life_value": None,
+                            "shelf_life_unit": None,
+                            "lot_source_policy": "INTERNAL_ONLY",
+                            "derivation_allowed": True,
+                            "uom_governance_enabled": False,
+                        }
+                    },
+                    "missing_item_ids": [],
+                    "inactive_item_ids": [],
+                    "errors": [],
+                },
+            )
+
+        if path == "/pms/read/v1/items/report-search":
+            assert request.url.params["keyword"] == "笔"
+            return httpx.Response(200, json={"item_ids": [1, 2]})
+
+        if path == "/pms/read/v1/items/report-meta/batch":
+            return httpx.Response(
+                200,
+                json={
+                    "meta_by_item_id": {
+                        "1": {
+                            "item_id": 1,
+                            "sku": "SKU-0001",
+                            "name": "笔记本",
+                            "brand": "得力",
+                            "category": "办公用品",
+                            "barcode": "6921734948311",
+                        }
+                    },
+                    "missing_item_ids": [],
+                    "errors": [],
+                },
+            )
+
+        if path == "/pms/read/v1/uoms/query":
+            return httpx.Response(
+                200,
+                json={
+                    "uoms": [
+                        {
+                            "id": 7,
+                            "item_id": 1,
+                            "uom": "本",
+                            "display_name": None,
+                            "uom_name": "本",
+                            "ratio_to_base": 1,
+                            "net_weight_kg": 0.2,
+                            "is_base": True,
+                            "is_purchase_default": False,
+                            "is_inbound_default": True,
+                            "is_outbound_default": True,
+                        }
+                    ],
+                    "missing_item_uom_ids": [],
+                    "errors": [],
+                },
+            )
+
+        if path == "/pms/read/v1/items/uom-defaults/batch":
+            return httpx.Response(
+                200,
+                json={
+                    "uoms_by_item_id": {
+                        "1": {
+                            "id": 7,
+                            "item_id": 1,
+                            "uom": "本",
+                            "display_name": None,
+                            "uom_name": "本",
+                            "ratio_to_base": 1,
+                            "net_weight_kg": 0.2,
+                            "is_base": True,
+                            "is_purchase_default": False,
+                            "is_inbound_default": True,
+                            "is_outbound_default": True,
+                        }
+                    },
+                    "missing_item_ids": [],
+                    "missing_default_uom_item_ids": [],
+                    "errors": [],
+                },
+            )
+
+        if path == "/pms/read/v1/barcodes/query":
+            return httpx.Response(
+                200,
+                json={
+                    "barcodes": [
+                        {
+                            "id": 2,
+                            "item_id": 1,
+                            "item_uom_id": 7,
+                            "barcode": "6921734948311",
+                            "symbology": "CUSTOM",
+                            "active": True,
+                            "is_primary": True,
+                            "uom": "本",
+                            "display_name": None,
+                            "uom_name": "本",
+                            "ratio_to_base": 1,
+                        }
+                    ],
+                    "errors": [],
+                },
+            )
+
+        if path == "/pms/read/v1/barcodes/probe":
+            return httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "status": "BOUND",
+                    "barcode": "6921734948311",
+                    "item_id": 1,
+                    "item_uom_id": 7,
+                    "ratio_to_base": 1,
+                    "symbology": "CUSTOM",
+                    "active": True,
+                    "item_basic": {
+                        "id": 1,
+                        "sku": "SKU-0001",
+                        "name": "笔记本",
+                        "spec": None,
+                        "enabled": True,
+                        "supplier_id": 3,
+                        "brand": "得力",
+                        "category": "办公用品",
+                    },
+                    "errors": [],
+                },
+            )
+
+        if path == "/pms/read/v1/sku-codes/query":
+            return httpx.Response(
+                200,
+                json={
+                    "sku_codes": [
+                        {
+                            "id": 10,
+                            "item_id": 1,
+                            "code": "SKU-0001",
+                            "code_type": "PRIMARY",
+                            "is_primary": True,
+                            "is_active": True,
+                            "effective_from": None,
+                            "effective_to": None,
+                            "remark": None,
+                            "item_sku": "SKU-0001",
+                            "item_name": "笔记本",
+                            "item_enabled": True,
+                        }
+                    ],
+                    "errors": [],
+                },
+            )
+
+        if path == "/pms/read/v1/sku-codes/resolve-outbound-default":
+            if request.url.params["code"] == "MISSING":
+                return httpx.Response(404, json={"detail": "pms_sku_code_not_found"})
+
+            return httpx.Response(
+                200,
+                json={
+                    "sku_code_id": 10,
+                    "item_id": 1,
+                    "sku_code": "SKU-0001",
+                    "code_type": "PRIMARY",
+                    "is_primary": True,
+                    "item_sku": "SKU-0001",
+                    "item_name": "笔记本",
+                    "item_uom_id": 7,
+                    "uom": "本",
+                    "display_name": None,
+                    "uom_name": "本",
+                    "ratio_to_base": 1,
+                },
+            )
+
+        return httpx.Response(404, json={"detail": f"unexpected path: {path}"})
+
+    return httpx.MockTransport(handler)
+
+
+def _client() -> HttpPmsReadClient:
+    return HttpPmsReadClient(
+        base_url="http://pms-api.test",
+        transport=_transport(),
+    )
+
+
+async def test_http_pms_read_client_reads_item_basic_policy_and_report_meta() -> None:
+    client = _client()
+
+    basics = await client.get_item_basics(item_ids=[2, 1, 1, 0])
+    assert sorted(basics) == [1]
+    assert basics[1].sku == "SKU-0001"
+
+    item = await client.get_item_basic(item_id=1)
+    assert item is not None
+    assert item.name == "笔记本"
+
+    policies = await client.get_item_policies(item_ids=[1])
+    assert policies[1].expiry_policy == "NONE"
+
+    policy = await client.get_item_policy(item_id=1)
+    assert policy is not None
+    assert policy.lot_source_policy == "INTERNAL_ONLY"
+
+    ids = await client.search_report_item_ids_by_keyword(keyword="笔", limit=10)
+    assert ids == [1, 2]
+
+    meta = await client.get_report_meta_by_item_ids(item_ids=[1])
+    assert getattr(meta[1], "barcode") == "6921734948311"
+
+
+async def test_http_pms_read_client_reads_uom_barcode_and_sku_code() -> None:
+    client = _client()
+
+    uom = await client.get_uom(item_uom_id=7)
+    assert uom is not None
+    assert uom.uom == "本"
+
+    uoms = await client.list_uoms_by_item_id(item_id=1)
+    assert uoms[0].id == 7
+
+    outbound_uom = await client.get_outbound_default_or_base_uom(item_id=1)
+    assert outbound_uom is not None
+    assert outbound_uom.id == 7
+
+    barcodes = await client.list_barcodes_by_item_id(item_id=1)
+    assert barcodes[0].barcode == "6921734948311"
+
+    probe = await client.probe_barcode(barcode="6921734948311")
+    assert probe.status is BarcodeProbeStatus.BOUND
+    assert probe.item_id == 1
+    assert probe.item_basic is not None
+    assert probe.item_basic.sku == "SKU-0001"
+
+    sku_codes = await client.list_sku_codes(item_ids=[1], active=True)
+    assert sku_codes[0].code == "SKU-0001"
+
+    sku_code = await client.get_sku_code(sku_code_id=10)
+    assert sku_code is not None
+    assert sku_code.item_id == 1
+
+    resolved = await client.resolve_active_code_for_outbound_default(code="SKU-0001")
+    assert resolved is not None
+    assert resolved.item_uom_id == 7
+
+    missing = await client.resolve_active_code_for_outbound_default(code="MISSING")
+    assert missing is None
+
+
+async def test_http_pms_read_client_requires_explicit_base_url(monkeypatch) -> None:
+    monkeypatch.delenv("PMS_API_BASE_URL", raising=False)
+
+    with pytest.raises(RuntimeError, match="PMS_API_BASE_URL"):
+        HttpPmsReadClient()
+
+
+async def test_http_pms_read_client_unsupported_methods_are_explicit() -> None:
+    client = _client()
+
+    with pytest.raises(NotImplementedError):
+        await client.list_item_basics()
+
+    with pytest.raises(NotImplementedError):
+        await client.get_item_policy_by_sku(sku="SKU-0001")
+
+    with pytest.raises(NotImplementedError):
+        await client.get_barcode(barcode_id=1)


### PR DESCRIPTION
## Summary
- add HttpPmsReadClient for pms-api read-only HTTP surface
- keep InProcessPmsReadClient as current business implementation
- add MockTransport-based HTTP client tests
- update PMS integration boundary guard

## Validation
- python3 -m compileall app/integrations/pms tests/services/test_pms_integration_http_client.py tests/ci/test_pms_integration_client_boundary_contract.py
- make test TESTS="tests/ci/test_pms_integration_client_boundary_contract.py tests/services/test_pms_integration_http_client.py"
- make alembic-check