### PR TITLE
feat(pms): add read client factory

### DIFF
--- a/app/integrations/pms/__init__.py
+++ b/app/integrations/pms/__init__.py
@@ -6,7 +6,16 @@ Consumers outside PMS should depend on this package instead of importing
 PMS export services directly.
 """
 
+from app.integrations.pms.factory import (
+    create_pms_read_client,
+    get_pms_client_mode,
+)
 from app.integrations.pms.http_client import HttpPmsReadClient
 from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 
-__all__ = ["HttpPmsReadClient", "InProcessPmsReadClient"]
+__all__ = [
+    "HttpPmsReadClient",
+    "InProcessPmsReadClient",
+    "create_pms_read_client",
+    "get_pms_client_mode",
+]

--- a/app/integrations/pms/factory.py
+++ b/app/integrations/pms/factory.py
@@ -1,0 +1,71 @@
+# app/integrations/pms/factory.py
+"""
+PMS read client factory.
+
+This is the explicit cutover point between:
+- in-process PMS reads inside wms-api
+- HTTP PMS reads through the independent pms-api process
+
+No fallback:
+- PMS_CLIENT_MODE=inprocess requires an AsyncSession
+- PMS_CLIENT_MODE=http requires PMS_API_BASE_URL or explicit pms_api_base_url
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Literal
+
+import httpx
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.integrations.pms.client import PmsReadClient
+from app.integrations.pms.http_client import HttpPmsReadClient
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+
+PmsClientMode = Literal["inprocess", "http"]
+
+
+def get_pms_client_mode(value: str | None = None) -> PmsClientMode:
+    raw = (value or os.getenv("PMS_CLIENT_MODE") or "inprocess").strip().lower()
+
+    if raw in {"inprocess", "http"}:
+        return raw  # type: ignore[return-value]
+
+    raise RuntimeError(
+        "Invalid PMS_CLIENT_MODE. Expected one of: inprocess, http"
+    )
+
+
+def create_pms_read_client(
+    *,
+    session: AsyncSession | None = None,
+    mode: str | None = None,
+    pms_api_base_url: str | None = None,
+    timeout_seconds: float = 10.0,
+    transport: httpx.AsyncBaseTransport | None = None,
+) -> PmsReadClient:
+    selected = get_pms_client_mode(mode)
+
+    if selected == "inprocess":
+        if session is None:
+            raise RuntimeError(
+                "PMS_CLIENT_MODE=inprocess requires an AsyncSession"
+            )
+        return InProcessPmsReadClient(session)
+
+    if selected == "http":
+        return HttpPmsReadClient(
+            base_url=pms_api_base_url,
+            timeout_seconds=timeout_seconds,
+            transport=transport,
+        )
+
+    raise RuntimeError(f"Unsupported PMS client mode: {selected}")
+
+
+__all__ = [
+    "PmsClientMode",
+    "create_pms_read_client",
+    "get_pms_client_mode",
+]

--- a/tests/ci/test_pms_integration_client_boundary_contract.py
+++ b/tests/ci/test_pms_integration_client_boundary_contract.py
@@ -22,6 +22,7 @@ PMS_INTEGRATION_BOUNDARY_FILES = {
     "app/integrations/__init__.py",
     "app/integrations/pms/__init__.py",
     "app/integrations/pms/contracts.py",
+    "app/integrations/pms/factory.py",
     "app/integrations/pms/http_client.py",
     "app/integrations/pms/client.py",
     "app/integrations/pms/inprocess_client.py",
@@ -30,6 +31,7 @@ PMS_INTEGRATION_BOUNDARY_FILES = {
 
 PMS_EXPORT_BRIDGE_ALLOWLIST = {
     "app/integrations/pms/contracts.py",
+    "app/integrations/pms/factory.py",
     "app/integrations/pms/http_client.py",
     "app/integrations/pms/inprocess_client.py",
     "app/integrations/pms/sync_client.py",

--- a/tests/services/test_pms_integration_factory.py
+++ b/tests/services/test_pms_integration_factory.py
@@ -1,0 +1,81 @@
+# tests/services/test_pms_integration_factory.py
+from __future__ import annotations
+
+from typing import cast
+
+import httpx
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.integrations.pms.factory import (
+    create_pms_read_client,
+    get_pms_client_mode,
+)
+from app.integrations.pms.http_client import HttpPmsReadClient
+from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+
+
+def test_get_pms_client_mode_defaults_to_inprocess(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PMS_CLIENT_MODE", raising=False)
+
+    assert get_pms_client_mode() == "inprocess"
+
+
+def test_get_pms_client_mode_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PMS_CLIENT_MODE", "http")
+
+    assert get_pms_client_mode() == "http"
+
+
+def test_get_pms_client_mode_rejects_invalid_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PMS_CLIENT_MODE", "mixed")
+
+    with pytest.raises(RuntimeError, match="Invalid PMS_CLIENT_MODE"):
+        get_pms_client_mode()
+
+
+def test_create_inprocess_pms_read_client_requires_session() -> None:
+    with pytest.raises(RuntimeError, match="requires an AsyncSession"):
+        create_pms_read_client(mode="inprocess")
+
+
+def test_create_inprocess_pms_read_client() -> None:
+    fake_session = cast(AsyncSession, object())
+
+    client = create_pms_read_client(
+        mode="inprocess",
+        session=fake_session,
+    )
+
+    assert isinstance(client, InProcessPmsReadClient)
+    assert client.session is fake_session
+
+
+def test_create_http_pms_read_client_requires_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PMS_API_BASE_URL", raising=False)
+
+    with pytest.raises(RuntimeError, match="PMS_API_BASE_URL"):
+        create_pms_read_client(mode="http")
+
+
+def test_create_http_pms_read_client() -> None:
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(
+            200,
+            json={
+                "items_by_id": {},
+                "missing_item_ids": [],
+                "inactive_item_ids": [],
+                "errors": [],
+            },
+        )
+    )
+
+    client = create_pms_read_client(
+        mode="http",
+        pms_api_base_url="http://pms-api.test",
+        transport=transport,
+    )
+
+    assert isinstance(client, HttpPmsReadClient)
+    assert client.base_url == "http://pms-api.test"


### PR DESCRIPTION
## Summary
- add explicit PMS read client factory
- support PMS_CLIENT_MODE=inprocess/http
- keep InProcessPmsReadClient as the default mode
- require PMS_API_BASE_URL only in http mode
- update PMS integration boundary guard

## Validation
- python3 -m compileall app/integrations/pms tests/services/test_pms_integration_factory.py tests/ci/test_pms_integration_client_boundary_contract.py
- make test TESTS="tests/ci/test_pms_integration_client_boundary_contract.py tests/services/test_pms_integration_http_client.py tests/services/test_pms_integration_factory.py"
- make alembic-check