### PR TITLE
refactor(pms): route consumers through read client factory

### DIFF
--- a/app/finance/sources/order_sales_source.py
+++ b/app/finance/sources/order_sales_source.py
@@ -8,7 +8,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.finance.services.common import to_decimal
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 
 
 class OrderSalesSource:
@@ -94,7 +94,7 @@ class OrderSalesSource:
         ids = sorted({int(x) for x in item_ids if x is not None and int(x) > 0})
         if not ids:
             return {}
-        return await InProcessPmsReadClient(self.session).get_report_meta_by_item_ids(
+        return await create_pms_read_client(session=self.session).get_report_meta_by_item_ids(
             item_ids=ids,
         )
 

--- a/app/integrations/pms/__init__.py
+++ b/app/integrations/pms/__init__.py
@@ -8,14 +8,18 @@ PMS export services directly.
 
 from app.integrations.pms.factory import (
     create_pms_read_client,
+    create_sync_pms_read_client,
     get_pms_client_mode,
 )
 from app.integrations.pms.http_client import HttpPmsReadClient
+from app.integrations.pms.sync_http_client import SyncHttpPmsReadClient
 from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 
 __all__ = [
     "HttpPmsReadClient",
     "InProcessPmsReadClient",
+    "SyncHttpPmsReadClient",
     "create_pms_read_client",
+    "create_sync_pms_read_client",
     "get_pms_client_mode",
 ]

--- a/app/integrations/pms/factory.py
+++ b/app/integrations/pms/factory.py
@@ -21,6 +21,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.integrations.pms.client import PmsReadClient
 from app.integrations.pms.http_client import HttpPmsReadClient
+from app.integrations.pms.sync_client import SyncInProcessPmsReadClient
+from app.integrations.pms.sync_http_client import SyncHttpPmsReadClient
 from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 
 PmsClientMode = Literal["inprocess", "http"]
@@ -67,5 +69,33 @@ def create_pms_read_client(
 __all__ = [
     "PmsClientMode",
     "create_pms_read_client",
+    "create_sync_pms_read_client",
     "get_pms_client_mode",
 ]
+
+
+def create_sync_pms_read_client(
+    *,
+    session=None,
+    mode: str | None = None,
+    pms_api_base_url: str | None = None,
+    timeout_seconds: float = 10.0,
+    transport: httpx.BaseTransport | None = None,
+):
+    selected = get_pms_client_mode(mode)
+
+    if selected == "inprocess":
+        if session is None:
+            raise RuntimeError(
+                "PMS_CLIENT_MODE=inprocess requires a synchronous Session"
+            )
+        return SyncInProcessPmsReadClient(session)
+
+    if selected == "http":
+        return SyncHttpPmsReadClient(
+            base_url=pms_api_base_url,
+            timeout_seconds=timeout_seconds,
+            transport=transport,
+        )
+
+    raise RuntimeError(f"Unsupported PMS client mode: {selected}")

--- a/app/integrations/pms/sync_http_client.py
+++ b/app/integrations/pms/sync_http_client.py
@@ -1,0 +1,82 @@
+# app/integrations/pms/sync_http_client.py
+"""
+Synchronous HTTP PMS read client.
+
+Current use case:
+- synchronous service paths that currently use SyncInProcessPmsReadClient.
+- first supported method mirrors the sync boundary:
+  resolve_active_code_for_outbound_default.
+
+No fallback:
+- PMS_API_BASE_URL must be configured explicitly.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+import httpx
+
+from app.integrations.pms.contracts import PmsExportSkuCodeResolution
+
+ModelT = TypeVar("ModelT")
+
+
+def _base_url(value: str | None) -> str:
+    raw = (value or os.getenv("PMS_API_BASE_URL") or "").strip()
+    if not raw:
+        raise RuntimeError("PMS_API_BASE_URL is required for SyncHttpPmsReadClient")
+    return raw.rstrip("/")
+
+
+def _parse_model(model_type: type[ModelT], data: Mapping[str, Any]) -> ModelT:
+    validator = getattr(model_type, "model_validate", None)
+    if callable(validator):
+        return validator(data)
+    return model_type(**data)  # type: ignore[misc]
+
+
+class SyncHttpPmsReadClient:
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        timeout_seconds: float = 10.0,
+        transport: httpx.BaseTransport | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> None:
+        self.base_url = _base_url(base_url)
+        self.timeout = httpx.Timeout(timeout_seconds)
+        self.transport = transport
+        self.headers = dict(headers or {})
+
+    def resolve_active_code_for_outbound_default(
+        self,
+        *,
+        code: str,
+        enabled_only: bool = True,
+    ) -> PmsExportSkuCodeResolution | None:
+        with httpx.Client(
+            base_url=self.base_url,
+            timeout=self.timeout,
+            transport=self.transport,
+            headers=self.headers,
+        ) as client:
+            response = client.get(
+                "/pms/read/v1/sku-codes/resolve-outbound-default",
+                params={"code": str(code), "enabled_only": bool(enabled_only)},
+            )
+
+        if response.status_code in {404, 409, 422}:
+            return None
+
+        response.raise_for_status()
+        data = response.json()
+        if not isinstance(data, Mapping):
+            raise ValueError("pms-api resolve response must be object")
+        return _parse_model(PmsExportSkuCodeResolution, data)
+
+
+__all__ = ["SyncHttpPmsReadClient"]

--- a/app/oms/fsku/services/fsku_service_write.py
+++ b/app/oms/fsku/services/fsku_service_write.py
@@ -14,7 +14,7 @@ from app.oms.fsku.models.fsku import Fsku, FskuComponent
 from app.oms.fsku.services.fsku_service_errors import FskuBadInput, FskuConflict, FskuNotFound
 from app.oms.fsku.services.fsku_service_mapper import to_detail
 from app.oms.fsku.services.fsku_service_utils import normalize_code, normalize_shape, utc_now
-from app.integrations.pms.sync_client import SyncInProcessPmsReadClient
+from app.integrations.pms.factory import create_sync_pms_read_client
 
 
 _SKU_TOKEN = re.compile(r"^[A-Z0-9][A-Z0-9._-]{0,127}$")
@@ -146,8 +146,8 @@ def parse_fsku_expr(expr: object) -> ParsedExpression:
 
 
 def _resolve_component(db: Session, parsed: ParsedComponent) -> ResolvedComponent:
-    resolved = SyncInProcessPmsReadClient(
-        db
+    resolved = create_sync_pms_read_client(
+        session=db
     ).resolve_active_code_for_outbound_default(
         code=parsed.component_sku_code,
         enabled_only=True,

--- a/app/oms/orders/repos/order_outbound_view_repo.py
+++ b/app/oms/orders/repos/order_outbound_view_repo.py
@@ -7,7 +7,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.integrations.pms.contracts import PmsExportUom
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 
 
 def _pick_base_uom(rows: list[PmsExportUom]) -> PmsExportUom | None:
@@ -111,7 +111,7 @@ async def load_order_outbound_lines(
         }
     )
 
-    pms_client = InProcessPmsReadClient(session)
+    pms_client = create_pms_read_client(session=session)
     item_map = await pms_client.get_item_basics(item_ids=item_ids)
     uom_rows = await pms_client.list_uoms(item_ids=item_ids)
 

--- a/app/oms/services/platform_order_resolve_loaders.py
+++ b/app/oms/services/platform_order_resolve_loaders.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 
 
 async def load_fsku_components(
@@ -51,7 +51,7 @@ async def load_items_brief(
     if not item_ids:
         return {}
 
-    rows = await InProcessPmsReadClient(session).get_item_basics(
+    rows = await create_pms_read_client(session=session).get_item_basics(
         item_ids=[int(x) for x in item_ids],
     )
 

--- a/app/procurement/helpers/purchase_reports.py
+++ b/app/procurement/helpers/purchase_reports.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 
 
 async def resolve_report_item_ids(
@@ -27,4 +27,4 @@ async def resolve_report_item_ids(
     if not kw:
         return None
 
-    return await InProcessPmsReadClient(session).search_report_item_ids_by_keyword(keyword=kw)
+    return await create_pms_read_client(session=session).search_report_item_ids_by_keyword(keyword=kw)

--- a/app/procurement/repos/purchase_order_create_repo.py
+++ b/app/procurement/repos/purchase_order_create_repo.py
@@ -9,7 +9,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.integrations.pms.contracts import PmsExportUom
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 from app.procurement.models.purchase_order import PurchaseOrder
 from app.procurement.models.purchase_order_line import PurchaseOrderLine
 from app.procurement.repos.purchase_order_line_completion_repo import (
@@ -38,7 +38,7 @@ async def require_item_uom_ratio_to_base(
     item_id: int,
     uom_id: int,
 ) -> tuple[int, str]:
-    row = await InProcessPmsReadClient(session).get_uom(item_uom_id=int(uom_id))
+    row = await create_pms_read_client(session=session).get_uom(item_uom_id=int(uom_id))
     if row is None or int(row.item_id) != int(item_id):
         raise ValueError(
             f"uom_id 不存在或不属于该商品：item_id={int(item_id)} uom_id={int(uom_id)}"
@@ -65,7 +65,7 @@ async def pick_default_purchase_uom(
     3) 任意第一条 UOM
     返回：(uom_id, ratio_to_base, uom_name_snapshot)
     """
-    client = InProcessPmsReadClient(session)
+    client = create_pms_read_client(session=session)
     row = await client.get_purchase_default_or_base_uom(item_id=int(item_id))
 
     if row is None:

--- a/app/procurement/repos/receive_po_line_repo.py
+++ b/app/procurement/repos/receive_po_line_repo.py
@@ -6,18 +6,18 @@ from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.integrations.pms.contracts import PmsExportUom
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 
 
 async def load_item_expiry_policy(session: AsyncSession, *, item_id: int) -> str:
-    policy = await InProcessPmsReadClient(session).get_item_policy(item_id=int(item_id))
+    policy = await create_pms_read_client(session=session).get_item_policy(item_id=int(item_id))
     if policy is None:
         return "NONE"
     return str(policy.expiry_policy or "NONE").upper()
 
 
 async def load_item_lot_source_policy(session: AsyncSession, *, item_id: int) -> str:
-    policy = await InProcessPmsReadClient(session).get_item_policy(item_id=int(item_id))
+    policy = await create_pms_read_client(session=session).get_item_policy(item_id=int(item_id))
     if policy is None:
         return "INTERNAL_ONLY"
     return str(policy.lot_source_policy or "INTERNAL_ONLY").upper()
@@ -37,7 +37,7 @@ async def require_item_uom_ratio_to_base(
     if uom_id <= 0:
         raise HTTPException(status_code=400, detail="uom_id 必须为正整数")
 
-    row = await InProcessPmsReadClient(session).get_uom(item_uom_id=int(uom_id))
+    row = await create_pms_read_client(session=session).get_uom(item_uom_id=int(uom_id))
     if row is None or int(row.item_id) != int(item_id):
         raise HTTPException(
             status_code=400,

--- a/app/procurement/routers/purchase_reports_routes_items.py
+++ b/app/procurement/routers/purchase_reports_routes_items.py
@@ -10,7 +10,7 @@ from sqlalchemy import distinct, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_session
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 from app.procurement.contracts.purchase_report import ItemPurchaseReportItem
 from app.procurement.helpers.purchase_reports import resolve_report_item_ids
 from app.procurement.models.purchase_order import PurchaseOrder
@@ -72,7 +72,7 @@ def register(router: APIRouter) -> None:
         if report_item_ids is not None and not report_item_ids:
             return []
 
-        pms_client = InProcessPmsReadClient(session)
+        pms_client = create_pms_read_client(session=session)
         planned_line_amount_expr = (
             func.coalesce(PurchaseOrderLine.supply_price, 0)
             * PurchaseOrderLine.qty_ordered_base

--- a/app/procurement/services/purchase_order_create.py
+++ b/app/procurement/services/purchase_order_create.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.integrations.pms.contracts import ItemBasic
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 from app.partners.export.suppliers.services.supplier_read_service import SupplierReadService
 from app.procurement.models.purchase_order import PurchaseOrder
 from app.procurement.repos.purchase_order_create_repo import (
@@ -23,7 +23,7 @@ from app.procurement.repos.purchase_order_create_repo import (
 async def _load_items_map(session: AsyncSession, item_ids: List[int]) -> Dict[int, ItemBasic]:
     if not item_ids:
         return {}
-    return await InProcessPmsReadClient(session).get_item_basics(item_ids=item_ids)
+    return await create_pms_read_client(session=session).get_item_basics(item_ids=item_ids)
 
 
 async def _require_supplier_snapshot_via_partners(

--- a/app/wms/inbound/repos/barcode_resolve_repo.py
+++ b/app/wms/inbound/repos/barcode_resolve_repo.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 
 
 @dataclass(frozen=True)
@@ -43,7 +43,7 @@ async def resolve_inbound_barcode(
     if not code:
         return None
 
-    probe = await InProcessPmsReadClient(session).probe_barcode(barcode=code)
+    probe = await create_pms_read_client(session=session).probe_barcode(barcode=code)
     if probe.status != "BOUND":
         return None
     if probe.item_id is None:

--- a/app/wms/inbound/repos/item_lookup_repo.py
+++ b/app/wms/inbound/repos/item_lookup_repo.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.integrations.pms.contracts import ItemPolicy
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 
 
 async def get_item_policy_by_id(
@@ -11,7 +11,7 @@ async def get_item_policy_by_id(
     *,
     item_id: int,
 ) -> ItemPolicy | None:
-    return await InProcessPmsReadClient(session).get_item_policy(item_id=int(item_id))
+    return await create_pms_read_client(session=session).get_item_policy(item_id=int(item_id))
 
 
 __all__ = ["get_item_policy_by_id"]

--- a/app/wms/inbound/services/inbound_commit_service.py
+++ b/app/wms/inbound/services/inbound_commit_service.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 from app.procurement.services.purchase_order_completion_sync import (
     sync_purchase_completion_for_inbound_event,
 )
@@ -75,7 +75,7 @@ async def _require_ratio_to_base(
     item_id: int,
     uom_id: int,
 ) -> int:
-    uom = await InProcessPmsReadClient(session).get_uom(item_uom_id=int(uom_id))
+    uom = await create_pms_read_client(session=session).get_uom(item_uom_id=int(uom_id))
     if uom is None or int(uom.item_id) != int(item_id):
         raise HTTPException(
             status_code=400,
@@ -94,7 +94,7 @@ async def _load_item_display_snapshot(
     item_id: int,
     uom_id: int,
 ) -> tuple[str | None, str | None, str | None]:
-    pms_client = InProcessPmsReadClient(session)
+    pms_client = create_pms_read_client(session=session)
     item = await pms_client.get_item_basic(item_id=int(item_id))
     uom = await pms_client.get_uom(item_uom_id=int(uom_id))
 

--- a/app/wms/inventory_adjustment/count/repos/count_doc_repo.py
+++ b/app/wms/inventory_adjustment/count/repos/count_doc_repo.py
@@ -8,7 +8,7 @@ from sqlalchemy import case, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 from app.wms.inventory_adjustment.count.models.count_doc import (
     CountDoc,
     CountDocLine,
@@ -292,7 +292,7 @@ class CountDocRepo:
         if not ids:
             return {}
 
-        uoms = await InProcessPmsReadClient(session).list_uoms(item_ids=ids)
+        uoms = await create_pms_read_client(session=session).list_uoms(item_ids=ids)
 
         out: dict[int, dict[str, Any]] = {}
         for uom in uoms:
@@ -382,7 +382,7 @@ class CountDocRepo:
         ).mappings().all()
 
         item_ids = sorted({int(row["item_id"]) for row in line_rows})
-        item_map = await InProcessPmsReadClient(session).get_item_basics(item_ids=item_ids)
+        item_map = await create_pms_read_client(session=session).get_item_basics(item_ids=item_ids)
 
         for row in line_rows:
             item_id = int(row["item_id"])

--- a/app/wms/inventory_adjustment/return_inbound/repos/inbound_operation_write_repo.py
+++ b/app/wms/inventory_adjustment/return_inbound/repos/inbound_operation_write_repo.py
@@ -8,7 +8,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.integrations.pms.contracts import BarcodeProbeStatus
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 from app.wms.inbound.repos.item_lookup_repo import get_item_policy_by_id
 from app.wms.inbound.repos.lot_resolve_repo import resolve_inbound_lot
 from app.wms.inventory_adjustment.count.services.count_freeze_guard_service import (
@@ -53,7 +53,7 @@ async def _load_item_uom_snapshot(
     item_id: int,
     item_uom_id: int,
 ) -> tuple[int, str | None, int]:
-    uom = await InProcessPmsReadClient(session).get_uom(
+    uom = await create_pms_read_client(session=session).get_uom(
         item_uom_id=int(item_uom_id),
     )
     if uom is None or int(uom.item_id) != int(item_id):
@@ -76,7 +76,7 @@ async def _resolve_barcode_uom_snapshot(
     barcode: str,
 ) -> tuple[int, str | None, int]:
     code = (barcode or "").strip()
-    client = InProcessPmsReadClient(session)
+    client = create_pms_read_client(session=session)
     probe = await client.probe_barcode(barcode=code)
 
     if (

--- a/app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_read_repo.py
+++ b/app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_read_repo.py
@@ -6,7 +6,7 @@ from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 
 from app.wms.inventory_adjustment.return_inbound.contracts.receipt_read import (
     InboundReceiptLineReadOut,
@@ -49,7 +49,7 @@ async def _load_inbound_default_uoms_by_item_id(
     if not ids:
         return {}
 
-    uoms = await InProcessPmsReadClient(session).list_uoms(item_ids=ids)
+    uoms = await create_pms_read_client(session=session).list_uoms(item_ids=ids)
 
     selected = {}
     for uom in sorted(
@@ -180,7 +180,7 @@ async def get_inbound_return_source_repo(
         raise HTTPException(status_code=409, detail="return_order_has_no_refundable_lines")
 
     item_ids = _clean_item_ids(row["item_id"] for row in line_rows)
-    item_map = await InProcessPmsReadClient(session).get_item_basics(item_ids=item_ids)
+    item_map = await create_pms_read_client(session=session).get_item_basics(item_ids=item_ids)
     inbound_uom_map = await _load_inbound_default_uoms_by_item_id(
         session,
         item_ids=item_ids,

--- a/app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_write_repo.py
+++ b/app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_write_repo.py
@@ -7,7 +7,7 @@ from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 from app.wms.inventory_adjustment.return_inbound.contracts.receipt_create_from_purchase import (
     InboundReceiptCreateFromPurchaseIn,
     InboundReceiptCreateFromPurchaseOut,
@@ -129,7 +129,7 @@ async def _load_manual_line_snapshot(
     item_id: int,
     item_uom_id: int,
 ) -> dict[str, object]:
-    pms_client = InProcessPmsReadClient(session)
+    pms_client = create_pms_read_client(session=session)
     item = await pms_client.get_item_basic(item_id=int(item_id))
     if item is None:
         raise HTTPException(status_code=404, detail="item_not_found")

--- a/app/wms/inventory_adjustment/return_inbound/routers/order_refs.py
+++ b/app/wms/inventory_adjustment/return_inbound/routers/order_refs.py
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_session
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 from app.wms.inventory_adjustment.return_inbound.contracts.return_task import (
     ReturnOrderRefDetailOut,
     ReturnOrderRefItem,
@@ -53,7 +53,7 @@ async def _enrich_order_ref_summary_lines(
     if not item_ids:
         return out
 
-    item_map = await InProcessPmsReadClient(session).get_item_basics(item_ids=item_ids)
+    item_map = await create_pms_read_client(session=session).get_item_basics(item_ids=item_ids)
 
     for row in out:
         item_id = int(row["item_id"])

--- a/app/wms/inventory_adjustment/return_inbound/services/inbound_task_probe_service.py
+++ b/app/wms/inventory_adjustment/return_inbound/services/inbound_task_probe_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 from app.wms.inventory_adjustment.return_inbound.contracts.probe import (
     InboundTaskProbeOut,
     InboundTaskProbeStatus,
@@ -22,7 +22,7 @@ async def _load_actual_uom_name(
     if item_uom_id is None:
         return None
 
-    uom = await InProcessPmsReadClient(session).get_uom(
+    uom = await create_pms_read_client(session=session).get_uom(
         item_uom_id=int(item_uom_id),
     )
     if uom is None:
@@ -80,7 +80,7 @@ async def probe_inbound_task_barcode(
     code = (barcode or "").strip()
     lines = await get_inbound_task_probe_lines(session, receipt_no=receipt_no)
 
-    probe = await InProcessPmsReadClient(session).probe_barcode(barcode=code)
+    probe = await create_pms_read_client(session=session).probe_barcode(barcode=code)
     if probe.status != "BOUND" or probe.item_id is None:
         return InboundTaskProbeOut(
             ok=True,

--- a/app/wms/inventory_adjustment/summary/repos/summary_repo.py
+++ b/app/wms/inventory_adjustment/summary/repos/summary_repo.py
@@ -6,7 +6,7 @@ from typing import Any
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 
 
 SUMMARY_CTE = """
@@ -290,7 +290,7 @@ async def _enrich_summary_ledger_rows(
     if not item_ids:
         return out
 
-    pms_client = InProcessPmsReadClient(session)
+    pms_client = create_pms_read_client(session=session)
     item_map = await pms_client.get_item_basics(item_ids=item_ids)
 
     base_uom_map: dict[int, dict[str, object | None]] = {

--- a/app/wms/ledger/helpers/stock_ledger.py
+++ b/app/wms/ledger/helpers/stock_ledger.py
@@ -12,7 +12,7 @@ from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 from app.wms.shared.services.lot_code_contract import normalize_optional_lot_code
 from app.wms.stock.models.lot import Lot
 from app.wms.ledger.models.stock_ledger import StockLedger
@@ -132,7 +132,7 @@ async def resolve_ledger_item_keyword_item_ids(
     keyword = str(getattr(payload, "item_keyword", None) or "").strip()
     if not keyword:
         return None
-    return await InProcessPmsReadClient(session).search_report_item_ids_by_keyword(keyword=keyword)
+    return await create_pms_read_client(session=session).search_report_item_ids_by_keyword(keyword=keyword)
 
 
 async def load_ledger_item_display_maps(
@@ -152,7 +152,7 @@ async def load_ledger_item_display_maps(
     if not ids:
         return {}, {}
 
-    pms_client = InProcessPmsReadClient(session)
+    pms_client = create_pms_read_client(session=session)
     item_meta_map = await pms_client.get_report_meta_by_item_ids(item_ids=ids)
     item_name_map = {
         int(item_id): str(meta.name).strip()

--- a/app/wms/scan/services/scan_orchestrator_item_resolver.py
+++ b/app/wms/scan/services/scan_orchestrator_item_resolver.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 
 
 @dataclass(frozen=True)
@@ -27,7 +27,7 @@ async def probe_item_from_barcode(
 
     - 不直接查询 item_barcodes
     - 不直接 import PMS export service
-    - 当前实现仍为 InProcessPmsReadClient，未来可切 HTTP PMS client
+    - 当前业务通过 PMS read client factory 获取客户端，默认 inprocess，未来可切 HTTP PMS client
     - 当前返回 richer 结构，供 parse_scan 后续阶段继续透传
     """
     code = (barcode or "").strip()
@@ -35,7 +35,7 @@ async def probe_item_from_barcode(
         return None
 
     try:
-        probe = await InProcessPmsReadClient(session).probe_barcode(barcode=code)
+        probe = await create_pms_read_client(session=session).probe_barcode(barcode=code)
         if probe.status != "BOUND":
             return None
         if probe.item_id is None:
@@ -85,7 +85,7 @@ async def resolve_item_id_from_sku(session: AsyncSession, sku: str) -> Optional[
         return None
 
     try:
-        rows = await InProcessPmsReadClient(session).list_sku_codes(
+        rows = await create_pms_read_client(session=session).list_sku_codes(
             code=s,
             active=True,
         )

--- a/app/wms/shared/services/expiry_resolver.py
+++ b/app/wms/shared/services/expiry_resolver.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 from app.wms.shared.services.expiry_rules import (
     ShelfLife,
     ShelfLifeUnit,
@@ -117,7 +117,7 @@ async def normalize_batch_dates_for_item(
     if production_date is None and expiry_date is None:
         return None, None, None
 
-    policy = await InProcessPmsReadClient(session).get_item_policy(item_id=int(item_id))
+    policy = await create_pms_read_client(session=session).get_item_policy(item_id=int(item_id))
     if policy is None:
         # 未找到 item：保守返回原值，不在共享层擅自抛错
         if production_date is not None and expiry_date is not None:

--- a/app/wms/shared/services/lot_code_contract.py
+++ b/app/wms/shared/services/lot_code_contract.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional, Set, Tuple
 from fastapi import HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 
 # 非批次商品禁止的历史假码（严格 422）
 _FORBIDDEN_FAKE_CODES: Set[str] = {"NOEXP", "NEAR", "FAR", "IDEM"}
@@ -123,7 +123,7 @@ async def fetch_item_expiry_policy_map(session: AsyncSession, item_ids: Set[int]
     if not item_ids:
         return {}
 
-    policies = await InProcessPmsReadClient(session).get_item_policies(item_ids=item_ids)
+    policies = await create_pms_read_client(session=session).get_item_policies(item_ids=item_ids)
     return {
         int(item_id): str(policy.expiry_policy)
         for item_id, policy in policies.items()
@@ -139,7 +139,7 @@ async def fetch_item_by_sku(session: AsyncSession, sku: str) -> Optional[Tuple[i
     if not s:
         return None
 
-    policy = await InProcessPmsReadClient(session).get_item_policy_by_sku(sku=s)
+    policy = await create_pms_read_client(session=session).get_item_policy_by_sku(sku=s)
     if policy is None:
         return None
 

--- a/app/wms/stock/repos/inventory_explain_repo.py
+++ b/app/wms/stock/repos/inventory_explain_repo.py
@@ -6,7 +6,7 @@ from typing import Any
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 
 
 def _norm_text(v: str | None) -> str | None:
@@ -46,7 +46,7 @@ async def _load_item_display_maps(
     if not ids:
         return {}, {}
 
-    pms_client = InProcessPmsReadClient(session)
+    pms_client = create_pms_read_client(session=session)
     basics = await pms_client.get_item_basics(item_ids=ids)
     item_name_map = {
         int(item_id): str(item.name).strip()

--- a/app/wms/stock/repos/inventory_options_repo.py
+++ b/app/wms/stock/repos/inventory_options_repo.py
@@ -6,7 +6,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.integrations.pms.contracts import ItemReadQuery
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 
 
 async def list_active_warehouses(
@@ -37,7 +37,7 @@ async def list_public_items(
     q: str | None,
     limit: int,
 ) -> list[dict[str, Any]]:
-    items = await InProcessPmsReadClient(session).list_item_basics(
+    items = await create_pms_read_client(session=session).list_item_basics(
         query=ItemReadQuery(
             enabled=True,
             q=q,

--- a/app/wms/stock/repos/inventory_read_repo.py
+++ b/app/wms/stock/repos/inventory_read_repo.py
@@ -7,7 +7,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.integrations.pms.contracts import ItemReadQuery
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 
 
 def _norm_text(v: str | None) -> str | None:
@@ -47,7 +47,7 @@ async def _resolve_inventory_q_item_ids(
     if q_norm is None:
         return None
 
-    items = await InProcessPmsReadClient(session).list_item_basics(
+    items = await create_pms_read_client(session=session).list_item_basics(
         query=ItemReadQuery(
             q=q_norm,
             limit=None,
@@ -66,7 +66,7 @@ async def _load_inventory_display_maps(
     if not ids:
         return {}, {}, {}
 
-    pms_client = InProcessPmsReadClient(session)
+    pms_client = create_pms_read_client(session=session)
     item_map = await pms_client.get_item_basics(item_ids=ids)
 
     base_uom_map: dict[int, dict[str, object | None]] = {

--- a/app/wms/stock/services/lot_resolver.py
+++ b/app/wms/stock/services/lot_resolver.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 from app.wms.stock.services.lots import ensure_internal_lot_singleton, ensure_lot_full
 
 
@@ -22,7 +22,7 @@ class LotResolver:
     """
 
     async def requires_batch(self, session: AsyncSession, *, item_id: int) -> bool:
-        policy = await InProcessPmsReadClient(session).get_item_policy(item_id=int(item_id))
+        policy = await create_pms_read_client(session=session).get_item_policy(item_id=int(item_id))
         if policy is None:
             raise ValueError("item_not_found")
         return str(policy.expiry_policy or "").upper() == "REQUIRED"

--- a/app/wms/stock/services/lots.py
+++ b/app/wms/stock/services/lots.py
@@ -10,7 +10,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.integrations.pms.contracts import ItemPolicy
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 
 
 def normalize_lot_code(code: str | None) -> tuple[str, str]:
@@ -153,7 +153,7 @@ async def _load_item_policy(
     *,
     item_id: int,
 ) -> ItemPolicy:
-    policy = await InProcessPmsReadClient(session).get_item_policy(item_id=int(item_id))
+    policy = await create_pms_read_client(session=session).get_item_policy(item_id=int(item_id))
     if policy is None:
         raise ValueError("item_not_found")
     return policy

--- a/app/wms/stock/services/stock_adjust/db_items.py
+++ b/app/wms/stock/services/stock_adjust/db_items.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.integrations.pms.inprocess_client import InProcessPmsReadClient
+from app.integrations.pms.factory import create_pms_read_client
 
 
 async def item_requires_batch(session: AsyncSession, *, item_id: int) -> bool:
@@ -14,7 +14,7 @@ async def item_requires_batch(session: AsyncSession, *, item_id: int) -> bool:
     - expiry_policy='NONE'     => requires_batch=False
     - item 不存在时必须明确失败，unknown item 不能默认成 NONE。
     """
-    policy = await InProcessPmsReadClient(session).get_item_policy(item_id=int(item_id))
+    policy = await create_pms_read_client(session=session).get_item_policy(item_id=int(item_id))
     if policy is None:
         raise ValueError("item_not_found")
 

--- a/tests/ci/test_pms_integration_client_boundary_contract.py
+++ b/tests/ci/test_pms_integration_client_boundary_contract.py
@@ -27,6 +27,7 @@ PMS_INTEGRATION_BOUNDARY_FILES = {
     "app/integrations/pms/client.py",
     "app/integrations/pms/inprocess_client.py",
     "app/integrations/pms/sync_client.py",
+    "app/integrations/pms/sync_http_client.py",
 }
 
 PMS_EXPORT_BRIDGE_ALLOWLIST = {
@@ -35,6 +36,7 @@ PMS_EXPORT_BRIDGE_ALLOWLIST = {
     "app/integrations/pms/http_client.py",
     "app/integrations/pms/inprocess_client.py",
     "app/integrations/pms/sync_client.py",
+    "app/integrations/pms/sync_http_client.py",
 }
 
 

--- a/tests/ci/test_pms_read_client_factory_usage.py
+++ b/tests/ci/test_pms_read_client_factory_usage.py
@@ -1,0 +1,43 @@
+# tests/ci/test_pms_read_client_factory_usage.py
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+BUSINESS_DIRS = (
+    "app/wms",
+    "app/oms",
+    "app/procurement",
+    "app/finance",
+)
+
+FORBIDDEN_PATTERNS = (
+    re.compile(r"^\s*from\s+app\.integrations\.pms\.inprocess_client\s+import\b"),
+    re.compile(r"^\s*from\s+app\.integrations\.pms\.sync_client\s+import\b"),
+    re.compile(r"\bInProcessPmsReadClient\s*\("),
+    re.compile(r"\bSyncInProcessPmsReadClient\s*\("),
+)
+
+
+def _rel(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def test_business_domains_use_pms_read_client_factory() -> None:
+    violations: list[str] = []
+
+    for rel_dir in BUSINESS_DIRS:
+        base = ROOT / rel_dir
+        if not base.exists():
+            continue
+
+        for path in sorted(base.rglob("*.py")):
+            text = path.read_text(encoding="utf-8")
+            for line_no, line in enumerate(text.splitlines(), start=1):
+                for pattern in FORBIDDEN_PATTERNS:
+                    if pattern.search(line):
+                        violations.append(f"{_rel(path)}:{line_no}: {line.strip()}")
+
+    assert violations == []

--- a/tests/services/test_pms_integration_factory.py
+++ b/tests/services/test_pms_integration_factory.py
@@ -9,9 +9,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.integrations.pms.factory import (
     create_pms_read_client,
+    create_sync_pms_read_client,
     get_pms_client_mode,
 )
 from app.integrations.pms.http_client import HttpPmsReadClient
+from app.integrations.pms.sync_http_client import SyncHttpPmsReadClient
 from app.integrations.pms.inprocess_client import InProcessPmsReadClient
 
 
@@ -79,3 +81,42 @@ def test_create_http_pms_read_client() -> None:
 
     assert isinstance(client, HttpPmsReadClient)
     assert client.base_url == "http://pms-api.test"
+
+
+
+def test_create_sync_inprocess_pms_read_client_requires_session() -> None:
+    with pytest.raises(RuntimeError, match="requires a synchronous Session"):
+        create_sync_pms_read_client(mode="inprocess")
+
+
+def test_create_sync_http_pms_read_client() -> None:
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(
+            200,
+            json={
+                "sku_code_id": 10,
+                "item_id": 1,
+                "sku_code": "SKU-0001",
+                "code_type": "PRIMARY",
+                "is_primary": True,
+                "item_sku": "SKU-0001",
+                "item_name": "笔记本",
+                "item_uom_id": 7,
+                "uom": "本",
+                "display_name": None,
+                "uom_name": "本",
+                "ratio_to_base": 1,
+            },
+        )
+    )
+
+    client = create_sync_pms_read_client(
+        mode="http",
+        pms_api_base_url="http://pms-api.test",
+        transport=transport,
+    )
+
+    assert isinstance(client, SyncHttpPmsReadClient)
+    resolved = client.resolve_active_code_for_outbound_default(code="SKU-0001")
+    assert resolved is not None
+    assert resolved.item_id == 1


### PR DESCRIPTION
## Summary
- route WMS / OMS / Procurement / Finance PMS reads through create_pms_read_client
- add sync HTTP PMS read client and sync factory
- keep default PMS_CLIENT_MODE=inprocess
- add CI guard preventing business domains from direct InProcessPmsReadClient usage
- do not switch runtime mode to HTTP yet

## Validation
- python3 -m compileall app tests/ci/test_pms_read_client_factory_usage.py tests/services/test_pms_integration_factory.py
- make test TESTS="tests/ci/test_pms_integration_client_boundary_contract.py tests/ci/test_pms_read_client_factory_usage.py tests/services/test_pms_integration_http_client.py tests/services/test_pms_integration_factory.py"
- make alembic-check