### PR TITLE
feat(pms): complete http read client compatibility methods

### DIFF
--- a/app/integrations/pms/http_client.py
+++ b/app/integrations/pms/http_client.py
@@ -143,8 +143,39 @@ class HttpPmsReadClient:
         *,
         query: ItemReadQuery | None = None,
     ) -> list[ItemBasic]:
-        _ = query
-        self._unsupported("list_item_basics")
+        params: dict[str, Any] = {"limit": 500}
+
+        if query is not None:
+            data = query.model_dump(exclude_none=True) if hasattr(query, "model_dump") else {}
+            keyword = (
+                data.get("keyword")
+                or data.get("q")
+                or data.get("search")
+                or data.get("sku")
+                or data.get("name")
+            )
+            if keyword:
+                params["keyword"] = str(keyword)
+
+            if data.get("enabled") is not None:
+                params["enabled"] = bool(data["enabled"])
+
+            if data.get("limit") is not None:
+                params["limit"] = int(data["limit"])
+
+        async with httpx.AsyncClient(
+            base_url=self.base_url,
+            timeout=self.timeout,
+            transport=self.transport,
+            headers=self.headers,
+        ) as client:
+            response = await client.get("/pms/read/v1/items/basic", params=params)
+
+        response.raise_for_status()
+        data = response.json()
+        if not isinstance(data, list):
+            raise ValueError("pms-api item basic list response must be array")
+        return _parse_model_list(ItemBasic, data)
 
     async def get_item_basic(self, *, item_id: int) -> ItemBasic | None:
         rows = await self.get_item_basics(item_ids=[int(item_id)])
@@ -189,8 +220,19 @@ class HttpPmsReadClient:
         return _parse_model_map(ItemPolicy, body, "policies_by_item_id")
 
     async def get_item_policy_by_sku(self, *, sku: str) -> ItemPolicy | None:
-        _ = sku
-        self._unsupported("get_item_policy_by_sku")
+        clean_sku = str(sku or "").strip()
+        if not clean_sku:
+            return None
+
+        body = await self._request(
+            "GET",
+            "/pms/read/v1/items/policy-by-sku",
+            params={"sku": clean_sku},
+            none_status_codes={404},
+        )
+        if body is None:
+            return None
+        return _parse_model(ItemPolicy, body)
 
     async def search_report_item_ids_by_keyword(
         self,
@@ -296,8 +338,14 @@ class HttpPmsReadClient:
         return await self._get_default_or_base_uom(item_id=int(item_id), usage="OUTBOUND")
 
     async def get_barcode(self, *, barcode_id: int) -> PmsExportBarcode | None:
-        _ = barcode_id
-        self._unsupported("get_barcode")
+        body = await self._request(
+            "GET",
+            f"/pms/read/v1/barcodes/{int(barcode_id)}",
+            none_status_codes={404},
+        )
+        if body is None:
+            return None
+        return _parse_model(PmsExportBarcode, body)
 
     async def list_barcodes(
         self,

--- a/tests/services/test_pms_integration_http_client.py
+++ b/tests/services/test_pms_integration_http_client.py
@@ -23,6 +23,23 @@ def _transport() -> httpx.MockTransport:
     def handler(request: httpx.Request) -> httpx.Response:
         path = request.url.path
 
+        if path == "/pms/read/v1/items/basic":
+            return httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": 1,
+                        "sku": "SKU-0001",
+                        "name": "笔记本",
+                        "spec": None,
+                        "enabled": True,
+                        "supplier_id": 3,
+                        "brand": "得力",
+                        "category": "办公用品",
+                    }
+                ],
+            )
+
         if path == "/pms/read/v1/items/basic/batch":
             payload = _json(request)
             assert payload["item_ids"] in ([1, 2], [1])
@@ -44,6 +61,22 @@ def _transport() -> httpx.MockTransport:
                     "missing_item_ids": [2],
                     "inactive_item_ids": [],
                     "errors": [],
+                },
+            )
+
+        if path == "/pms/read/v1/items/policy-by-sku":
+            if request.url.params["sku"] == "MISSING":
+                return httpx.Response(404, json={"detail": "pms_item_policy_not_found"})
+            return httpx.Response(
+                200,
+                json={
+                    "item_id": 1,
+                    "expiry_policy": "NONE",
+                    "shelf_life_value": None,
+                    "shelf_life_unit": None,
+                    "lot_source_policy": "INTERNAL_ONLY",
+                    "derivation_allowed": True,
+                    "uom_governance_enabled": False,
                 },
             )
 
@@ -137,6 +170,24 @@ def _transport() -> httpx.MockTransport:
                     "missing_item_ids": [],
                     "missing_default_uom_item_ids": [],
                     "errors": [],
+                },
+            )
+
+        if path == "/pms/read/v1/barcodes/2":
+            return httpx.Response(
+                200,
+                json={
+                    "id": 2,
+                    "item_id": 1,
+                    "item_uom_id": 7,
+                    "barcode": "6921734948311",
+                    "symbology": "CUSTOM",
+                    "active": True,
+                    "is_primary": True,
+                    "uom": "本",
+                    "display_name": None,
+                    "uom_name": "本",
+                    "ratio_to_base": 1,
                 },
             )
 
@@ -317,14 +368,21 @@ async def test_http_pms_read_client_requires_explicit_base_url(monkeypatch) -> N
         HttpPmsReadClient()
 
 
-async def test_http_pms_read_client_unsupported_methods_are_explicit() -> None:
+async def test_http_pms_read_client_compat_methods_are_backed_by_http() -> None:
     client = _client()
 
-    with pytest.raises(NotImplementedError):
-        await client.list_item_basics()
+    rows = await client.list_item_basics()
+    assert len(rows) == 1
+    assert rows[0].sku == "SKU-0001"
 
-    with pytest.raises(NotImplementedError):
-        await client.get_item_policy_by_sku(sku="SKU-0001")
+    policy = await client.get_item_policy_by_sku(sku="SKU-0001")
+    assert policy is not None
+    assert policy.item_id == 1
+    assert policy.expiry_policy == "NONE"
 
-    with pytest.raises(NotImplementedError):
-        await client.get_barcode(barcode_id=1)
+    missing_policy = await client.get_item_policy_by_sku(sku="MISSING")
+    assert missing_policy is None
+
+    barcode = await client.get_barcode(barcode_id=2)
+    assert barcode is not None
+    assert barcode.barcode == "6921734948311"


### PR DESCRIPTION
## Summary
- implement remaining HttpPmsReadClient compatibility methods
- route list_item_basics through pms-api item basic list endpoint
- route get_item_policy_by_sku through pms-api policy-by-sku endpoint
- route get_barcode through pms-api barcode single-read endpoint
- remove NotImplemented expectations from HTTP client tests

## Validation
- python3 -m compileall app/integrations/pms tests/services/test_pms_integration_http_client.py tests/services/test_pms_integration_factory.py tests/ci/test_pms_integration_client_boundary_contract.py tests/ci/test_pms_read_client_factory_usage.py
- make test TESTS="tests/ci/test_pms_integration_client_boundary_contract.py tests/ci/test_pms_read_client_factory_usage.py tests/services/test_pms_integration_http_client.py tests/services/test_pms_integration_factory.py"
- make alembic-check