### PR TITLE
chore(pms): add http mode smoke command

### DIFF
--- a/scripts/make/test.mk
+++ b/scripts/make/test.mk
@@ -229,3 +229,13 @@ test-pricing-smoke: dev-reset-test-db audit-all
 	  tests/api/test_zone_brackets_constraints_and_copy.py \
 	  tests/api/test_zone_brackets_matrix_unbound_contract.py \
 	  tests/api/test_zone_brackets_matrix_grouped_contract.py
+
+
+# ---------------------------------
+# PMS HTTP mode smoke
+# Requires pms-api running locally on PMS_API_BASE_URL.
+# This target is intentionally local-only and not part of default CI.
+# ---------------------------------
+.PHONY: pms-http-smoke
+pms-http-smoke: venv
+	@PMS_CLIENT_MODE=http PMS_API_BASE_URL="$${PMS_API_BASE_URL:-http://127.0.0.1:8002}" PYTHONPATH=. $(PY) scripts/pms/http_smoke.py

--- a/scripts/pms/http_smoke.py
+++ b/scripts/pms/http_smoke.py
@@ -1,0 +1,103 @@
+# scripts/pms/http_smoke.py
+from __future__ import annotations
+
+import asyncio
+import os
+
+from app.integrations.pms.factory import (
+    create_pms_read_client,
+    create_sync_pms_read_client,
+)
+
+
+async def main() -> None:
+    base_url = (os.getenv("PMS_API_BASE_URL") or "").strip()
+    mode = (os.getenv("PMS_CLIENT_MODE") or "").strip()
+
+    if mode != "http":
+        raise RuntimeError("PMS_CLIENT_MODE=http is required")
+
+    if not base_url:
+        raise RuntimeError("PMS_API_BASE_URL is required")
+
+    client = create_pms_read_client(mode="http")
+
+    item = await client.get_item_basic(item_id=1)
+    assert item is not None
+    print("item:", item.id, item.sku, item.name)
+
+    basics = await client.get_item_basics(item_ids=[1, 4002, 999999])
+    assert 1 in basics
+    print("basic ids:", sorted(basics))
+
+    policy = await client.get_item_policy(item_id=1)
+    assert policy is not None
+    print("policy:", policy.item_id, policy.expiry_policy, policy.lot_source_policy)
+
+    policy_by_sku = await client.get_item_policy_by_sku(sku=item.sku)
+    assert policy_by_sku is not None
+    print("policy_by_sku:", policy_by_sku.item_id)
+
+    report_ids = await client.search_report_item_ids_by_keyword(keyword=item.sku, limit=10)
+    assert 1 in report_ids
+    print("report search ids:", report_ids)
+
+    report_meta = await client.get_report_meta_by_item_ids(item_ids=[1, 4002])
+    assert 1 in report_meta
+    print(
+        "report meta item 1:",
+        getattr(report_meta[1], "sku"),
+        getattr(report_meta[1], "barcode"),
+    )
+
+    uoms = await client.list_uoms_by_item_id(item_id=1)
+    assert uoms
+    print("uoms:", [(u.id, u.uom, u.ratio_to_base) for u in uoms])
+
+    outbound_uom = await client.get_outbound_default_or_base_uom(item_id=1)
+    assert outbound_uom is not None
+    print("outbound uom:", outbound_uom.id, outbound_uom.uom)
+
+    uom_by_id = await client.get_uom(item_uom_id=outbound_uom.id)
+    assert uom_by_id is not None
+    print("uom by id:", uom_by_id.id)
+
+    barcodes = await client.list_barcodes_by_item_id(item_id=1)
+    assert barcodes
+    print("barcodes:", [(b.id, b.barcode) for b in barcodes])
+
+    barcode = await client.get_barcode(barcode_id=barcodes[0].id)
+    assert barcode is not None
+    print("barcode by id:", barcode.id, barcode.barcode)
+
+    probe = await client.probe_barcode(barcode=barcodes[0].barcode)
+    assert probe.item_id == 1
+    print("probe:", probe.status, probe.item_id, probe.item_uom_id)
+
+    sku_codes = await client.list_sku_codes_by_item_id(item_id=1)
+    assert sku_codes
+    print("sku codes:", [(s.id, s.code) for s in sku_codes])
+
+    sku_code = await client.get_sku_code(sku_code_id=sku_codes[0].id)
+    assert sku_code is not None
+    print("sku code by id:", sku_code.id, sku_code.code)
+
+    resolved = await client.resolve_active_code_for_outbound_default(code=sku_code.code)
+    assert resolved is not None
+    print("resolved:", resolved.sku_code, resolved.item_id, resolved.item_uom_id)
+
+    sync_client = create_sync_pms_read_client(mode="http")
+    sync_resolved = sync_client.resolve_active_code_for_outbound_default(code=sku_code.code)
+    assert sync_resolved is not None
+    print(
+        "sync resolved:",
+        sync_resolved.sku_code,
+        sync_resolved.item_id,
+        sync_resolved.item_uom_id,
+    )
+
+    print("HTTP PMS smoke: OK")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add local PMS HTTP mode smoke script
- add make pms-http-smoke target
- verify wms-api can read PMS data through pms-api with PMS_CLIENT_MODE=http
- keep smoke local-only, not part of default CI

## Validation
- python3 -m compileall scripts/pms/http_smoke.py scripts/make/test.mk
- PMS_CLIENT_MODE=http PMS_API_BASE_URL=http://127.0.0.1:8002 PYTHONPATH=. python3 scripts/pms/http_smoke.py
- make pms-http-smoke
- make test TESTS="tests/ci/test_pms_integration_client_boundary_contract.py tests/ci/test_pms_read_client_factory_usage.py tests/services/test_pms_integration_http_client.py tests/services/test_pms_integration_factory.py"
- make alembic-check