### PR TITLE
refactor(pms): stop mounting PMS routes

### DIFF
--- a/app/router_mount.py
+++ b/app/router_mount.py
@@ -16,19 +16,6 @@ def mount_routers(app: FastAPI) -> None:
         router as inventory_adjustment_summary_router,
     )
     from app.finance.routers.router import router as finance_router
-    from app.pms.items.routers.item_aggregate import router as item_aggregate_router
-    from app.pms.items.routers.item_barcodes import router as item_barcodes_router
-    from app.pms.items.routers.item_list import router as item_list_router
-    from app.pms.items.routers.item_master import router as item_master_router
-    from app.pms.items.routers.item_sku_codes import router as item_sku_codes_router
-    from app.pms.items.routers.item_uoms import router as item_uoms_router
-    from app.pms.items.routers.items import router as items_router
-    from app.pms.sku_coding.routers.sku_coding import router as sku_coding_router
-    from app.pms.export.items.routers.barcode_probe import router as pms_export_barcode_probe_router
-    from app.pms.export.items.routers.items_read import router as pms_export_items_read_router
-    from app.pms.export.uoms.routers.uoms_read import router as pms_export_uoms_read_router
-    from app.pms.export.sku_codes.routers.sku_codes_read import router as pms_export_sku_codes_read_router
-    from app.pms.export.barcodes.routers.barcodes_read import router as pms_export_barcodes_read_router
     from app.partners.export.suppliers.routers.suppliers_read import (
         router as partners_export_suppliers_read_router,
     )
@@ -129,21 +116,7 @@ def mount_routers(app: FastAPI) -> None:
     # - /pms/export/items/barcode-probe 先于 /items/{id}
     # - /items/aggregate 先于 /items/{id}
     # - /pms/export/items、/pms/export/uoms、/pms/export/sku-codes、/pms/export/barcodes、/partners/export/suppliers 独立前缀，不与 owner 冲突
-    app.include_router(pms_export_items_read_router)
-    app.include_router(pms_export_uoms_read_router)
-    app.include_router(pms_export_sku_codes_read_router)
-    app.include_router(pms_export_barcodes_read_router)
-    app.include_router(pms_export_barcode_probe_router)
     app.include_router(partners_export_suppliers_read_router)
-    app.include_router(item_aggregate_router)
-    app.include_router(item_list_router)
-    app.include_router(items_router)
-    app.include_router(item_master_router)
-    app.include_router(item_sku_codes_router)
-    app.include_router(sku_coding_router)
-    app.include_router(item_barcodes_router)
-    app.include_router(item_uoms_router)
-
     app.include_router(suppliers_router)
     app.include_router(supplier_contacts_router)
 

--- a/tests/ci/test_pms_owner_routes_not_mounted.py
+++ b/tests/ci/test_pms_owner_routes_not_mounted.py
@@ -1,0 +1,37 @@
+# tests/ci/test_pms_owner_routes_not_mounted.py
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.main import app
+
+ROOT = Path(__file__).resolve().parents[2]
+
+FORBIDDEN_ROUTE_PREFIXES = (
+    "/pms",
+    "/items",
+    "/item-uoms",
+    "/item-barcodes",
+)
+
+
+def test_wms_api_does_not_mount_pms_routes() -> None:
+    mounted = sorted(
+        {
+            getattr(route, "path", "")
+            for route in app.routes
+            if any(
+                getattr(route, "path", "") == prefix
+                or getattr(route, "path", "").startswith(prefix + "/")
+                for prefix in FORBIDDEN_ROUTE_PREFIXES
+            )
+        }
+    )
+
+    assert mounted == []
+
+
+def test_router_mount_does_not_import_pms_routers() -> None:
+    text = (ROOT / "app" / "router_mount.py").read_text(encoding="utf-8")
+
+    assert "from app.pms." not in text


### PR DESCRIPTION
## Summary
- stop mounting PMS owner/export routes in wms-api
- add CI guard ensuring wms-api does not expose PMS routes
- keep app/pms code in place for current inprocess PMS integration mode
- do not drop tables, FKs, or app/pms runtime code yet

## Validation
- python3 -m compileall app tests/ci/test_pms_owner_routes_not_mounted.py
- python route scan for /pms, /items, /item-uoms, /item-barcodes
- make test TESTS="tests/ci/test_pms_owner_routes_not_mounted.py tests/ci/test_pms_integration_client_boundary_contract.py tests/ci/test_pms_read_client_factory_usage.py tests/services/test_pms_integration_http_client.py tests/services/test_pms_integration_factory.py"
- make pms-http-smoke
- make pms-http-business-smoke
- make alembic-check