### PR TITLE
refactor(pms): inline integration contracts

### DIFF
--- a/app/integrations/pms/contracts.py
+++ b/app/integrations/pms/contracts.py
@@ -2,33 +2,192 @@
 """
 PMS integration contracts.
 
-Temporary in-repo bridge:
-- The source of truth is still app.pms.export contracts.
-- Non-PMS domains should import these contracts from app.integrations.pms.
-- When PMS becomes an independent service/repo, this file is the cutover point
-  to generated SDK/OpenAPI contracts.
+These contracts belong to the WMS-side consumer boundary.
+
+Important:
+- Non-PMS domains should import PMS read models from app.integrations.pms.
+- This file must not depend on legacy PMS owner/export modules.
+- pms-api is now the PMS owner runtime; WMS keeps these local contract models
+  so the integration client remains independent from the legacy in-process
+  PMS owner package.
 """
 
-from app.pms.export.barcodes.contracts.barcode import PmsExportBarcode
-from app.pms.export.items.contracts.barcode_probe import (
-    BarcodeProbeError,
-    BarcodeProbeIn,
-    BarcodeProbeOut,
-    BarcodeProbeStatus,
-)
-from app.pms.export.items.contracts.item_basic import ItemBasic
-from app.pms.export.items.contracts.item_policy import (
-    ExpiryPolicy,
-    ItemPolicy,
-    LotSourcePolicy,
-    ShelfLifeUnit,
-)
-from app.pms.export.items.contracts.item_query import ItemReadQuery
-from app.pms.export.sku_codes.contracts.sku_code import (
-    PmsExportSkuCode,
-    PmsExportSkuCodeResolution,
-)
-from app.pms.export.uoms.contracts.uom import PmsExportUom
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(from_attributes=True, extra="forbid", populate_by_name=True)
+
+
+ShelfLifeUnit = Literal["DAY", "WEEK", "MONTH", "YEAR"]
+ExpiryPolicy = Literal["NONE", "REQUIRED"]
+LotSourcePolicy = Literal["INTERNAL_ONLY", "SUPPLIER_ONLY"]
+PmsExportSkuCodeType = Literal["PRIMARY", "ALIAS", "LEGACY", "MANUAL"]
+
+
+def _norm_text(v: object) -> object:
+    if isinstance(v, str):
+        return v.strip()
+    return v
+
+
+class ItemReadQuery(_Base):
+    """
+    PMS item read query used by WMS-side consumers.
+
+    Keep this intentionally small. The HTTP client maps q to pms-api keyword.
+    """
+
+    q: str | None = Field(default=None, max_length=128)
+    limit: int | None = Field(default=None, ge=1, le=500)
+    enabled: bool | None = None
+
+    @field_validator("q", mode="before")
+    @classmethod
+    def _trim_q(cls, v: object) -> object:
+        v = _norm_text(v)
+        if v == "":
+            return None
+        return v
+
+
+class ItemBasic(_Base):
+    id: int = Field(gt=0)
+    sku: str = Field(min_length=1, max_length=128)
+    name: str = Field(min_length=1, max_length=128)
+    spec: str | None = Field(default=None, max_length=128)
+
+    enabled: bool = True
+    supplier_id: int | None = None
+
+    brand: str | None = Field(default=None, max_length=64)
+    category: str | None = Field(default=None, max_length=64)
+
+
+class ItemPolicy(_Base):
+    item_id: int = Field(gt=0)
+
+    expiry_policy: ExpiryPolicy
+    shelf_life_value: int | None = Field(default=None, gt=0)
+    shelf_life_unit: ShelfLifeUnit | None = None
+
+    lot_source_policy: LotSourcePolicy
+    derivation_allowed: bool
+    uom_governance_enabled: bool
+
+
+class PmsExportUom(_Base):
+    id: int = Field(gt=0)
+    item_id: int = Field(gt=0)
+
+    uom: str = Field(min_length=1, max_length=16)
+    display_name: str | None = Field(default=None, max_length=32)
+    uom_name: str = Field(min_length=1, max_length=32)
+
+    ratio_to_base: int = Field(ge=1)
+    net_weight_kg: float | None = Field(default=None, ge=0)
+
+    is_base: bool
+    is_purchase_default: bool
+    is_inbound_default: bool
+    is_outbound_default: bool
+
+
+class PmsExportBarcode(_Base):
+    id: int = Field(gt=0)
+    item_id: int = Field(gt=0)
+    item_uom_id: int = Field(gt=0)
+
+    barcode: str = Field(min_length=1, max_length=128)
+    symbology: str = Field(min_length=1, max_length=32)
+
+    active: bool
+    is_primary: bool
+
+    uom: str = Field(min_length=1, max_length=16)
+    display_name: str | None = Field(default=None, max_length=32)
+    uom_name: str = Field(min_length=1, max_length=32)
+    ratio_to_base: int = Field(ge=1)
+
+
+class BarcodeProbeStatus(str, Enum):
+    BOUND = "BOUND"
+    UNBOUND = "UNBOUND"
+    ERROR = "ERROR"
+
+
+class BarcodeProbeIn(_Base):
+    barcode: str = Field(min_length=1, max_length=128)
+
+    @field_validator("barcode", mode="before")
+    @classmethod
+    def _trim_barcode(cls, v: object) -> object:
+        return _norm_text(v)
+
+
+class BarcodeProbeError(_Base):
+    stage: str
+    error: str
+
+
+class BarcodeProbeOut(_Base):
+    ok: bool
+    status: BarcodeProbeStatus
+    barcode: str
+
+    item_id: int | None = None
+    item_uom_id: int | None = None
+    ratio_to_base: int | None = None
+
+    symbology: str | None = None
+    active: bool | None = None
+
+    item_basic: ItemBasic | None = None
+
+    errors: list[BarcodeProbeError] = Field(default_factory=list)
+
+
+class PmsExportSkuCode(_Base):
+    id: int = Field(gt=0)
+    item_id: int = Field(gt=0)
+
+    code: str = Field(min_length=1, max_length=128)
+    code_type: PmsExportSkuCodeType
+    is_primary: bool
+    is_active: bool
+
+    effective_from: datetime | None = None
+    effective_to: datetime | None = None
+    remark: str | None = Field(default=None, max_length=255)
+
+    item_sku: str = Field(min_length=1, max_length=128)
+    item_name: str = Field(min_length=1, max_length=128)
+    item_enabled: bool
+
+
+class PmsExportSkuCodeResolution(_Base):
+    sku_code_id: int = Field(gt=0)
+    item_id: int = Field(gt=0)
+
+    sku_code: str = Field(min_length=1, max_length=128)
+    code_type: PmsExportSkuCodeType
+    is_primary: bool
+
+    item_sku: str = Field(min_length=1, max_length=128)
+    item_name: str = Field(min_length=1, max_length=128)
+
+    item_uom_id: int = Field(gt=0)
+    uom: str = Field(min_length=1, max_length=16)
+    display_name: str | None = Field(default=None, max_length=32)
+    uom_name: str = Field(min_length=1, max_length=32)
+    ratio_to_base: int = Field(ge=1)
+
 
 __all__ = [
     "BarcodeProbeError",
@@ -43,6 +202,7 @@ __all__ = [
     "PmsExportBarcode",
     "PmsExportSkuCode",
     "PmsExportSkuCodeResolution",
+    "PmsExportSkuCodeType",
     "PmsExportUom",
     "ShelfLifeUnit",
 ]

--- a/app/integrations/pms/inprocess_client.py
+++ b/app/integrations/pms/inprocess_client.py
@@ -40,6 +40,24 @@ from app.pms.export.sku_codes.services.sku_code_read_service import (
 from app.pms.export.uoms.services.uom_read_service import PmsExportUomReadService
 
 
+
+def _contract_data(value):
+    if value is None:
+        return None
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="python")
+    return value
+
+
+def _contract_model(model_type, value):
+    if value is None:
+        return None
+    validator = getattr(model_type, "model_validate", None)
+    if callable(validator):
+        return validator(_contract_data(value))
+    return model_type(**_contract_data(value))
+
+
 class InProcessPmsReadClient:
     def __init__(self, session: AsyncSession) -> None:
         self.session = session
@@ -178,7 +196,8 @@ class InProcessPmsReadClient:
         )
 
     async def probe_barcode(self, *, barcode: str) -> BarcodeProbeOut:
-        return await BarcodeProbeService(self.session).aprobe(barcode=str(barcode))
+        probe = await BarcodeProbeService(self.session).aprobe(barcode=barcode)
+        return _contract_model(BarcodeProbeOut, probe)
 
     async def get_sku_code(self, *, sku_code_id: int) -> PmsExportSkuCode | None:
         return await PmsExportSkuCodeReadService(self.session).aget_by_id(

--- a/tests/ci/test_pms_integration_contracts_no_owner_import.py
+++ b/tests/ci/test_pms_integration_contracts_no_owner_import.py
@@ -1,0 +1,51 @@
+# tests/ci/test_pms_integration_contracts_no_owner_import.py
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_pms_integration_contracts_do_not_import_pms_owner_runtime() -> None:
+    text = (ROOT / "app" / "integrations" / "pms" / "contracts.py").read_text(
+        encoding="utf-8"
+    )
+
+    forbidden_lines = [
+        line
+        for line in text.splitlines()
+        if line.lstrip().startswith(("from app.pms", "import app.pms"))
+    ]
+
+    assert forbidden_lines == []
+
+
+def test_pms_integration_contracts_export_expected_names() -> None:
+    namespace: dict[str, object] = {}
+    exec(
+        (ROOT / "app" / "integrations" / "pms" / "contracts.py").read_text(
+            encoding="utf-8"
+        ),
+        namespace,
+    )
+
+    exported = set(namespace["__all__"])
+    expected = {
+        "BarcodeProbeError",
+        "BarcodeProbeIn",
+        "BarcodeProbeOut",
+        "BarcodeProbeStatus",
+        "ExpiryPolicy",
+        "ItemBasic",
+        "ItemPolicy",
+        "ItemReadQuery",
+        "LotSourcePolicy",
+        "PmsExportBarcode",
+        "PmsExportSkuCode",
+        "PmsExportSkuCodeResolution",
+        "PmsExportSkuCodeType",
+        "PmsExportUom",
+        "ShelfLifeUnit",
+    }
+
+    assert expected <= exported


### PR DESCRIPTION
## Summary
- inline PMS integration contract models in wms-api
- remove app.pms.export imports from app.integrations.pms.contracts
- normalize inprocess barcode probe output to integration contracts
- add CI guard preventing integration contracts from importing PMS owner runtime
- keep inprocess client otherwise unchanged for current default mode

## Validation
- python3 -m compileall app/integrations/pms tests/ci/test_pms_integration_contracts_no_owner_import.py
- make test TESTS="tests/ci/test_pms_integration_contracts_no_owner_import.py tests/ci/test_pms_owner_routes_not_mounted.py tests/ci/test_pms_integration_client_boundary_contract.py tests/ci/test_pms_read_client_factory_usage.py tests/services/test_pms_integration_http_client.py tests/services/test_pms_integration_factory.py tests/services/test_pms_integration_inprocess_client.py"
- make pms-http-smoke
- make pms-http-business-smoke
- make alembic-check