### PR TITLE
refactor(pms): use external ORM anchors

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -38,6 +38,10 @@ if config.config_file_name is not None:
 
 # 延迟加载模型（避免导入时机引发的问题）
 from app.db.base import Base, init_models  # noqa: E402
+from app.db.external_pms_models import (  # noqa: E402
+    PMS_EXTERNAL_ANCHOR_TABLES,
+    PMS_OWNED_TABLES,
+)
 
 # ---------------------------------------------------------------------------
 # 范围控制：按 scope 限定参与 compare 的表集合
@@ -68,10 +72,17 @@ PHASE3_DEPS = {"items", "warehouses"}
 def build_scoped_metadata(scope: str) -> MetaData:
     """
     按 scope 构建一个缩小版的 MetaData，减少 alembic check 的噪音。
+
+    PMS owner tables live in pms-api. wms-api keeps minimal external ORM
+    anchors in Base.metadata only to let transitional WMS/OMS/Procurement
+    foreign keys and relationship("Item") references resolve. Alembic must
+    ignore PMS-owned tables from wms-api.
     """
     md = MetaData()
     if scope == "all":
         for t in Base.metadata.tables.values():
+            if t.name in PMS_OWNED_TABLES and t.name not in PMS_EXTERNAL_ANCHOR_TABLES:
+                continue
             t.to_metadata(md)
         return md
 
@@ -83,10 +94,18 @@ def build_scoped_metadata(scope: str) -> MetaData:
     else:
         # 未知 scope 时退回全量，宁可多查，不搞黑盒
         for t in Base.metadata.tables.values():
+            if t.name in PMS_OWNED_TABLES and t.name not in PMS_EXTERNAL_ANCHOR_TABLES:
+                continue
             t.to_metadata(md)
         return md
 
     for name, tbl in Base.metadata.tables.items():
+        if name in PMS_EXTERNAL_ANCHOR_TABLES:
+            tbl.to_metadata(md)
+
+    for name, tbl in Base.metadata.tables.items():
+        if name in PMS_OWNED_TABLES:
+            continue
         if name in wanted:
             tbl.to_metadata(md)
 
@@ -101,6 +120,17 @@ BACKUP_SUFFIX = os.getenv("WMS_BACKUP_SUFFIX", "20251109")
 _BACKUP_RE = re.compile(rf".*_{re.escape('backup_' + BACKUP_SUFFIX)}$", re.IGNORECASE)
 
 
+def _object_table_name(obj: Any, name: str | None, type_: str) -> str:
+    if type_ == "table":
+        return name or getattr(obj, "name", "") or ""
+
+    table = getattr(obj, "table", None)
+    if table is not None:
+        return getattr(table, "name", "") or ""
+
+    return ""
+
+
 def include_object(
     obj: Any, name: str | None, type_: str, reflected: bool, compare_to: Any
 ) -> bool:
@@ -113,6 +143,12 @@ def include_object(
       3) 定点静音 batches.expire_at（避免 comment 差异反复骚扰）。
     """
     n = name or ""
+
+    # 0) PMS-owned tables are managed by pms-api, not wms-api.
+    #    wms-api may keep minimal ORM anchors in target metadata only to
+    #    resolve transitional cross-domain FKs.
+    if _object_table_name(obj, name, type_) in PMS_OWNED_TABLES:
+        return False
 
     # 1) 忽略备份表/索引/序列
     if type_ in {"table", "index", "sequence"} and _BACKUP_RE.match(n):

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -21,7 +21,7 @@ _INITIALIZED: bool = False  # 防重复初始化
 
 # 显式排除清单：
 # 仅用于临时屏蔽“文件仍存在、但不得进入主线 metadata”的模型。
-# 当前旧 batch / 旧 inbound_receipt 模型已物理删除，清单保持为空。
+# 当前旧 batch / 旧 inbound_receipt 模型已物理删除；PMS owner ORM 已迁入 pms-api。
 _DEFAULT_EXCLUDE: Set[str] = set()
 
 # Phase M-5：表名级别的 legacy 黑名单（防止未来模块改名/移动导致 ex 失效）
@@ -100,14 +100,11 @@ def init_models(
 
     loaded: List[str] = []
 
-    # ✅ 显式加载链：只放“主线真相表”的模型（避免把 legacy 表带进 metadata）
+    # ✅ 显式加载链：只放 wms-api owner 模型；PMS owner ORM 不再进入 wms-api metadata。
     explicit_chain = [
         "app.partners.suppliers.models.supplier",
         "app.partners.suppliers.models.supplier_contact",
-        "app.pms.sku_coding.models.sku_coding",
-        "app.pms.items.models.item",
-        "app.pms.items.models.item_uom",
-        "app.pms.items.models.item_barcode",
+        "app.db.external_pms_models",
         "app.procurement.models.purchase_order",
         "app.procurement.models.purchase_order_line",
         "app.wms.inventory_adjustment.return_inbound.models.inbound_receipt",
@@ -135,8 +132,6 @@ def init_models(
     for pkg_name in (
         "app.procurement.models",
         "app.finance.models",
-        "app.pms.items.models",
-        "app.pms.sku_coding.models",
         "app.partners.suppliers.models",
         "app.wms.inventory_adjustment.return_inbound.models",
         "app.wms.inventory_adjustment.count.models",

--- a/app/db/external_pms_models.py
+++ b/app/db/external_pms_models.py
@@ -1,0 +1,83 @@
+# app/db/external_pms_models.py
+"""
+External PMS ORM anchors for the shared-database transition.
+
+PMS owner runtime has moved to pms-api. wms-api still has WMS/OMS/Procurement
+tables with database FKs and legacy SQLAlchemy relationship("Item") references
+to PMS-owned tables.
+
+These ORM classes are FK / mapper anchors only:
+- do not add PMS business fields here
+- do not use these classes for PMS reads/writes
+- do not let Alembic manage these tables from wms-api
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+PMS_OWNED_TABLES: frozenset[str] = frozenset(
+    {
+        "items",
+        "item_uoms",
+        "item_barcodes",
+        "item_sku_codes",
+        "pms_brands",
+        "pms_business_categories",
+        "item_attribute_defs",
+        "item_attribute_options",
+        "item_attribute_values",
+        "sku_code_templates",
+        "sku_code_template_segments",
+    }
+)
+
+PMS_EXTERNAL_ANCHOR_TABLES: frozenset[str] = frozenset(
+    {
+        "items",
+        "item_uoms",
+        "item_sku_codes",
+    }
+)
+
+
+class Item(Base):
+    __tablename__ = "items"
+    __table_args__ = {"info": {"external_owner": "pms-api", "anchor_only": True}}
+
+    id: Mapped[int] = mapped_column(sa.Integer, primary_key=True)
+
+
+class ItemUOM(Base):
+    __tablename__ = "item_uoms"
+    __table_args__ = (
+        sa.UniqueConstraint("id", "item_id", name="uq_item_uoms_id_item_id"),
+        {"info": {"external_owner": "pms-api", "anchor_only": True}},
+    )
+
+    id: Mapped[int] = mapped_column(sa.Integer, primary_key=True)
+    item_id: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+
+
+class ItemSkuCode(Base):
+    __tablename__ = "item_sku_codes"
+    __table_args__ = (
+        sa.UniqueConstraint("id", "item_id", name="uq_item_sku_codes_id_item_id"),
+        {"info": {"external_owner": "pms-api", "anchor_only": True}},
+    )
+
+    id: Mapped[int] = mapped_column(sa.Integer, primary_key=True)
+    item_id: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+
+
+__all__ = [
+    "Item",
+    "ItemSkuCode",
+    "ItemUOM",
+    "PMS_EXTERNAL_ANCHOR_TABLES",
+    "PMS_OWNED_TABLES",
+]

--- a/tests/ci/test_pms_metadata_boundary.py
+++ b/tests/ci/test_pms_metadata_boundary.py
@@ -1,0 +1,91 @@
+# tests/ci/test_pms_metadata_boundary.py
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from app.db.external_pms_models import PMS_EXTERNAL_ANCHOR_TABLES, PMS_OWNED_TABLES
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_db_base_does_not_load_pms_owner_orm_modules() -> None:
+    text = (ROOT / "app" / "db" / "base.py").read_text(encoding="utf-8")
+
+    assert "app.pms.items.models" not in text
+    assert "app.pms.sku_coding.models" not in text
+    assert "app.db.external_pms_models" in text
+
+
+def test_fresh_init_models_registers_only_external_pms_anchors() -> None:
+    code = """
+import json
+from app.db.base import Base, init_models
+from app.db.external_pms_models import PMS_OWNED_TABLES
+
+init_models(force=True)
+print("PMS_TABLES=" + json.dumps(sorted(set(Base.metadata.tables) & set(PMS_OWNED_TABLES))))
+"""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = "."
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    marker = "PMS_TABLES="
+    lines = [line for line in result.stdout.splitlines() if line.startswith(marker)]
+    assert lines, result.stdout + result.stderr
+
+    assert set(json.loads(lines[-1][len(marker) :])) == set(PMS_EXTERNAL_ANCHOR_TABLES)
+
+
+def test_external_pms_anchor_tables_are_minimal() -> None:
+    from app.db.base import Base, init_models
+
+    init_models(force=True)
+
+    items = Base.metadata.tables["items"]
+    item_uoms = Base.metadata.tables["item_uoms"]
+    item_sku_codes = Base.metadata.tables["item_sku_codes"]
+
+    assert items.info["external_owner"] == "pms-api"
+    assert item_uoms.info["external_owner"] == "pms-api"
+    assert item_sku_codes.info["external_owner"] == "pms-api"
+
+    assert set(items.c.keys()) == {"id"}
+    assert set(item_uoms.c.keys()) == {"id", "item_id"}
+    assert set(item_sku_codes.c.keys()) == {"id", "item_id"}
+
+
+def test_non_anchor_pms_owner_tables_are_not_registered() -> None:
+    from app.db.base import Base, init_models
+
+    init_models(force=True)
+
+    forbidden = set(PMS_OWNED_TABLES) - set(PMS_EXTERNAL_ANCHOR_TABLES)
+    assert sorted(set(Base.metadata.tables) & forbidden) == []
+
+
+def test_alembic_env_excludes_pms_owned_tables() -> None:
+    text = (ROOT / "alembic" / "env.py").read_text(encoding="utf-8")
+
+    assert "PMS_OWNED_TABLES" in text
+    assert "PMS-owned tables are managed by pms-api" in text
+    assert "_object_table_name(obj, name, type_) in PMS_OWNED_TABLES" in text
+
+
+
+def test_alembic_env_keeps_external_anchors_for_fk_resolution() -> None:
+    text = (ROOT / "alembic" / "env.py").read_text(encoding="utf-8")
+
+    assert "PMS_EXTERNAL_ANCHOR_TABLES" in text
+    assert "t.name in PMS_OWNED_TABLES and t.name not in PMS_EXTERNAL_ANCHOR_TABLES" in text


### PR DESCRIPTION
## Summary
- stop loading PMS owner ORM modules into wms-api metadata
- add minimal external PMS ORM anchors for Item / ItemUOM / ItemSkuCode
- keep anchors only for transitional FK and relationship resolution
- exclude PMS-owned tables from wms-api Alembic object comparison
- keep app/pms package temporarily until remaining fixture/schema cleanup

## Validation
- python3 -m compileall app/db alembic/env.py tests/ci/test_pms_metadata_boundary.py
- make test TESTS="tests/ci/test_pms_metadata_boundary.py tests/ci/test_no_legacy_pms_owner_tests.py tests/ci/test_pms_integration_client_boundary_contract.py tests/ci/test_pms_integration_contracts_no_owner_import.py tests/ci/test_pms_owner_routes_not_mounted.py tests/ci/test_pms_read_client_factory_usage.py tests/services/test_pms_integration_http_client.py tests/services/test_pms_integration_factory.py"
- make pms-http-smoke
- make pms-http-business-smoke
- make alembic-check