### PR TITLE
refactor(pms): remove remaining owner test deps

### DIFF
--- a/app/db/base.py
+++ b/app/db/base.py
@@ -19,6 +19,21 @@ class Base(DeclarativeBase):
 
 _INITIALIZED: bool = False  # 防重复初始化
 
+
+def _load_external_pms_orm_anchors() -> None:
+    """
+    Register minimal external PMS ORM anchors eagerly.
+
+    FastAPI runtime can trigger SQLAlchemy mapper configuration before
+    init_models() is called, for example during /users/login. WMS models still
+    contain transitional relationship("Item") / FK references, so Item / ItemUOM
+    / ItemSkuCode anchors must be registered as soon as app.db.base is imported.
+    """
+    importlib.import_module("app.db.external_pms_models")
+
+
+_load_external_pms_orm_anchors()
+
 # 显式排除清单：
 # 仅用于临时屏蔽“文件仍存在、但不得进入主线 metadata”的模型。
 # 当前旧 batch / 旧 inbound_receipt 模型已物理删除；PMS owner ORM 已迁入 pms-api。

--- a/tests/api/test_finance_purchase_sku_ledger_api.py
+++ b/tests/api/test_finance_purchase_sku_ledger_api.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 from decimal import Decimal
+from typing import Any
 
 import httpx
 import pytest
+from pytest import MonkeyPatch
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.integrations.pms.contracts import ItemBasic, PmsExportUom
 
 
 async def _headers(client: httpx.AsyncClient) -> dict[str, str]:
@@ -17,12 +21,26 @@ async def _headers(client: httpx.AsyncClient) -> dict[str, str]:
     return {"Authorization": f"Bearer {login.json()['access_token']}"}
 
 
-async def _pick_supplier_item(client: httpx.AsyncClient, headers: dict[str, str]) -> int:
-    resp = await client.get("/items?supplier_id=1&enabled=true", headers=headers)
-    assert resp.status_code == 200, resp.text
-    items = resp.json()
-    assert items, items
-    return int(items[0]["id"])
+async def _pick_supplier_item(session: AsyncSession) -> int:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT i.id
+                  FROM items i
+                  JOIN item_uoms u
+                    ON u.item_id = i.id
+                   AND (u.is_purchase_default IS TRUE OR u.is_base IS TRUE)
+                 WHERE i.supplier_id = 1
+                   AND i.enabled IS TRUE
+                 ORDER BY i.id ASC
+                 LIMIT 1
+                """
+            )
+        )
+    ).first()
+    assert row is not None, "expected seeded enabled supplier item with purchase/base uom"
+    return int(row[0])
 
 
 async def _pick_purchase_uom(session: AsyncSession, *, item_id: int) -> tuple[int, int]:
@@ -44,6 +62,157 @@ async def _pick_purchase_uom(session: AsyncSession, *, item_id: int) -> tuple[in
     return int(row["id"]), int(row["ratio_to_base"])
 
 
+async def _load_item_basic(session: AsyncSession, *, item_id: int) -> ItemBasic:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                    i.id,
+                    i.sku,
+                    i.name,
+                    i.spec,
+                    i.enabled,
+                    i.supplier_id,
+                    b.name_cn AS brand,
+                    c.category_name AS category
+                  FROM items i
+             LEFT JOIN pms_brands b
+                    ON b.id = i.brand_id
+             LEFT JOIN pms_business_categories c
+                    ON c.id = i.category_id
+                 WHERE i.id = :item_id
+                 LIMIT 1
+                """
+            ),
+            {"item_id": int(item_id)},
+        )
+    ).mappings().first()
+    assert row is not None
+
+    return ItemBasic(
+        id=int(row["id"]),
+        sku=str(row["sku"]),
+        name=str(row["name"]),
+        spec=(str(row["spec"]) if row["spec"] is not None else None),
+        enabled=bool(row["enabled"]),
+        supplier_id=(int(row["supplier_id"]) if row["supplier_id"] is not None else None),
+        brand=(str(row["brand"]) if row["brand"] is not None else None),
+        category=(str(row["category"]) if row["category"] is not None else None),
+    )
+
+
+async def _load_uom(session: AsyncSession, *, item_uom_id: int) -> PmsExportUom:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                    id,
+                    item_id,
+                    uom,
+                    display_name,
+                    COALESCE(NULLIF(display_name, ''), uom) AS uom_name,
+                    ratio_to_base,
+                    net_weight_kg,
+                    is_base,
+                    is_purchase_default,
+                    is_inbound_default,
+                    is_outbound_default
+                  FROM item_uoms
+                 WHERE id = :item_uom_id
+                 LIMIT 1
+                """
+            ),
+            {"item_uom_id": int(item_uom_id)},
+        )
+    ).mappings().first()
+    assert row is not None
+
+    return PmsExportUom(
+        id=int(row["id"]),
+        item_id=int(row["item_id"]),
+        uom=str(row["uom"]),
+        display_name=(str(row["display_name"]) if row["display_name"] is not None else None),
+        uom_name=str(row["uom_name"]),
+        ratio_to_base=int(row["ratio_to_base"]),
+        net_weight_kg=(
+            float(row["net_weight_kg"]) if row["net_weight_kg"] is not None else None
+        ),
+        is_base=bool(row["is_base"]),
+        is_purchase_default=bool(row["is_purchase_default"]),
+        is_inbound_default=bool(row["is_inbound_default"]),
+        is_outbound_default=bool(row["is_outbound_default"]),
+    )
+
+
+class _FakePmsReadClient:
+    def __init__(
+        self,
+        *,
+        items_by_id: dict[int, ItemBasic],
+        uoms_by_id: dict[int, PmsExportUom],
+    ) -> None:
+        self._items_by_id = items_by_id
+        self._uoms_by_id = uoms_by_id
+
+    async def get_item_basics(self, *, item_ids: list[int]) -> dict[int, ItemBasic]:
+        return {
+            int(item_id): self._items_by_id[int(item_id)]
+            for item_id in item_ids
+            if int(item_id) in self._items_by_id
+        }
+
+    async def get_item_basic(self, *, item_id: int) -> ItemBasic | None:
+        return self._items_by_id.get(int(item_id))
+
+    async def get_uom(self, *, item_uom_id: int) -> PmsExportUom | None:
+        return self._uoms_by_id.get(int(item_uom_id))
+
+
+def _patch_pms_read_client(
+    monkeypatch: MonkeyPatch,
+    *,
+    items_by_id: dict[int, ItemBasic],
+    uoms_by_id: dict[int, PmsExportUom],
+) -> None:
+    fake = _FakePmsReadClient(items_by_id=items_by_id, uoms_by_id=uoms_by_id)
+
+    def _factory(*args: Any, **kwargs: Any) -> _FakePmsReadClient:
+        _ = args
+        _ = kwargs
+        return fake
+
+    modules = (
+        "app.procurement.services.purchase_order_create",
+        "app.procurement.repos.purchase_order_create_repo",
+        "app.procurement.repos.receive_po_line_repo",
+        "app.finance.sources.purchase_cost_source",
+    )
+
+    for module_name in modules:
+        module = __import__(module_name, fromlist=["dummy"])
+        if hasattr(module, "create_pms_read_client"):
+            monkeypatch.setattr(module, "create_pms_read_client", _factory)
+
+
+async def _patch_pms_for_purchase_item(
+    monkeypatch: MonkeyPatch,
+    session: AsyncSession,
+    *,
+    item_id: int,
+    uom_id: int,
+) -> None:
+    item = await _load_item_basic(session, item_id=item_id)
+    uom = await _load_uom(session, item_uom_id=uom_id)
+
+    _patch_pms_read_client(
+        monkeypatch,
+        items_by_id={int(item_id): item},
+        uoms_by_id={int(uom_id): uom},
+    )
+
+
 def _decimal(value: object) -> Decimal:
     return Decimal(str(value))
 
@@ -52,10 +221,12 @@ def _decimal(value: object) -> Decimal:
 async def test_finance_purchase_sku_ledger_returns_po_line_level_prices_and_accounting_unit_price(
     client: httpx.AsyncClient,
     session: AsyncSession,
+    monkeypatch: MonkeyPatch,
 ) -> None:
     headers = await _headers(client)
-    item_id = await _pick_supplier_item(client, headers)
+    item_id = await _pick_supplier_item(session)
     uom_id, ratio_to_base = await _pick_purchase_uom(session, item_id=item_id)
+    await _patch_pms_for_purchase_item(monkeypatch, session, item_id=item_id, uom_id=uom_id)
 
     payload_1 = {
         "warehouse_id": 1,
@@ -190,10 +361,12 @@ async def test_finance_purchase_sku_ledger_returns_po_line_level_prices_and_acco
 async def test_finance_purchase_sku_ledger_filters_by_item_keyword_and_supplier(
     client: httpx.AsyncClient,
     session: AsyncSession,
+    monkeypatch: MonkeyPatch,
 ) -> None:
     headers = await _headers(client)
-    item_id = await _pick_supplier_item(client, headers)
+    item_id = await _pick_supplier_item(session)
     uom_id, _ratio_to_base = await _pick_purchase_uom(session, item_id=item_id)
+    await _patch_pms_for_purchase_item(monkeypatch, session, item_id=item_id, uom_id=uom_id)
 
     payload = {
         "warehouse_id": 1,
@@ -234,10 +407,12 @@ async def test_finance_purchase_sku_ledger_filters_by_item_keyword_and_supplier(
 async def test_finance_purchase_sku_ledger_options_include_items_suppliers_and_warehouses(
     client: httpx.AsyncClient,
     session: AsyncSession,
+    monkeypatch: MonkeyPatch,
 ) -> None:
     headers = await _headers(client)
-    item_id = await _pick_supplier_item(client, headers)
+    item_id = await _pick_supplier_item(session)
     uom_id, _ratio_to_base = await _pick_purchase_uom(session, item_id=item_id)
+    await _patch_pms_for_purchase_item(monkeypatch, session, item_id=item_id, uom_id=uom_id)
 
     payload = {
         "warehouse_id": 1,
@@ -275,10 +450,12 @@ async def test_finance_purchase_sku_ledger_options_include_items_suppliers_and_w
 async def test_finance_purchase_sku_ledger_options_are_cascading(
     client: httpx.AsyncClient,
     session: AsyncSession,
+    monkeypatch: MonkeyPatch,
 ) -> None:
     headers = await _headers(client)
-    item_id = await _pick_supplier_item(client, headers)
+    item_id = await _pick_supplier_item(session)
     uom_id, _ratio_to_base = await _pick_purchase_uom(session, item_id=item_id)
+    await _patch_pms_for_purchase_item(monkeypatch, session, item_id=item_id, uom_id=uom_id)
 
     payload = {
         "warehouse_id": 1,

--- a/tests/api/test_fskus_contract.py
+++ b/tests/api/test_fskus_contract.py
@@ -1,9 +1,15 @@
 # tests/api/test_fskus_contract.py
 from __future__ import annotations
 
-from uuid import uuid4
 from typing import Any, Dict, List
+from uuid import uuid4
+
 import pytest
+from pytest import MonkeyPatch
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.integrations.pms.contracts import PmsExportSkuCodeResolution
 
 
 def _assert_problem_shape(obj: Dict[str, Any]) -> None:
@@ -24,37 +30,153 @@ async def _auth_headers(client) -> Dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
-async def _pick_any_item_id(client, headers: Dict[str, str]) -> int:
-    r = await client.get("/items", params={"limit": 1}, headers=headers)
-    assert r.status_code == 200, r.text
-    data = r.json()
-    assert isinstance(data, list) and data
-    return int(data[0]["id"])
+async def _pick_any_item_id(session: AsyncSession) -> int:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT i.id
+                  FROM items i
+                  JOIN item_sku_codes c
+                    ON c.item_id = i.id
+                   AND c.code = i.sku
+                   AND c.is_active IS TRUE
+                  JOIN item_uoms u
+                    ON u.item_id = i.id
+                   AND (u.is_outbound_default IS TRUE OR u.is_base IS TRUE)
+                 WHERE i.enabled IS TRUE
+                 ORDER BY i.id ASC
+                 LIMIT 1
+                """
+            )
+        )
+    ).first()
+    assert row is not None, "expected seeded enabled item with active sku code and outbound/base uom"
+    return int(row[0])
 
 
-async def _pick_item_sku_by_id(client, headers: Dict[str, str], *, item_id: int) -> str:
-    r = await client.get("/items?limit=200", headers=headers)
-    assert r.status_code == 200, r.text
-    data = r.json()
-    for item in data:
-        if int(item["id"]) == int(item_id):
-            sku = str(item["sku"]).strip()
-            assert sku, item
-            return sku
-    raise AssertionError(f"item_id not found in /items list: {item_id}")
+async def _pick_item_sku_by_id(session: AsyncSession, *, item_id: int) -> str:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT sku
+                  FROM items
+                 WHERE id = :item_id
+                 LIMIT 1
+                """
+            ),
+            {"item_id": int(item_id)},
+        )
+    ).first()
+    assert row is not None, f"item_id not found in seeded items: {item_id}"
+    sku = str(row[0]).strip()
+    assert sku
+    return sku
+
+
+async def _load_resolution_by_sku(
+    session: AsyncSession,
+    *,
+    sku: str,
+) -> PmsExportSkuCodeResolution:
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                    c.id AS sku_code_id,
+                    i.id AS item_id,
+                    c.code AS sku_code,
+                    c.code_type::text AS code_type,
+                    c.is_primary AS is_primary,
+                    i.sku AS item_sku,
+                    i.name AS item_name,
+                    u.id AS item_uom_id,
+                    u.uom AS uom,
+                    u.display_name AS display_name,
+                    COALESCE(NULLIF(u.display_name, ''), u.uom) AS uom_name,
+                    u.ratio_to_base AS ratio_to_base
+                  FROM item_sku_codes c
+                  JOIN items i
+                    ON i.id = c.item_id
+                  JOIN item_uoms u
+                    ON u.item_id = i.id
+                   AND (u.is_outbound_default IS TRUE OR u.is_base IS TRUE)
+                 WHERE c.code = :sku
+                   AND c.is_active IS TRUE
+                   AND i.enabled IS TRUE
+                 ORDER BY u.is_outbound_default DESC, u.is_base DESC, u.id ASC
+                 LIMIT 1
+                """
+            ),
+            {"sku": str(sku).strip()},
+        )
+    ).mappings().first()
+
+    assert row is not None, f"expected PMS resolution seed for sku={sku!r}"
+
+    return PmsExportSkuCodeResolution(
+        sku_code_id=int(row["sku_code_id"]),
+        item_id=int(row["item_id"]),
+        sku_code=str(row["sku_code"]),
+        code_type=str(row["code_type"]),
+        is_primary=bool(row["is_primary"]),
+        item_sku=str(row["item_sku"]),
+        item_name=str(row["item_name"]),
+        item_uom_id=int(row["item_uom_id"]),
+        uom=str(row["uom"]),
+        display_name=(str(row["display_name"]) if row["display_name"] is not None else None),
+        uom_name=str(row["uom_name"]),
+        ratio_to_base=int(row["ratio_to_base"]),
+    )
+
+
+class _FakeSyncPmsReadClient:
+    def __init__(self, resolution_by_code: dict[str, PmsExportSkuCodeResolution]) -> None:
+        self._resolution_by_code = {
+            str(code).strip(): row for code, row in resolution_by_code.items()
+        }
+
+    def resolve_active_code_for_outbound_default(
+        self,
+        *,
+        code: str,
+        enabled_only: bool = True,
+    ) -> PmsExportSkuCodeResolution | None:
+        _ = enabled_only
+        return self._resolution_by_code.get(str(code).strip())
+
+
+def _patch_fsku_pms_resolver(
+    monkeypatch: MonkeyPatch,
+    resolution_by_code: dict[str, PmsExportSkuCodeResolution],
+) -> None:
+    import app.oms.fsku.services.fsku_service_write as fsku_write
+
+    def _factory(*args, **kwargs) -> _FakeSyncPmsReadClient:
+        _ = args
+        _ = kwargs
+        return _FakeSyncPmsReadClient(resolution_by_code)
+
+    monkeypatch.setattr(fsku_write, "create_sync_pms_read_client", _factory)
 
 
 async def _create_draft_fsku(
     client,
     headers: Dict[str, str],
     *,
+    session: AsyncSession,
+    monkeypatch: MonkeyPatch,
     name: str = "FSKU-TEST",
     shape: str = "bundle",
     fsku_expr: str | None = None,
 ) -> Dict[str, Any]:
     if fsku_expr is None:
-        item_id = await _pick_any_item_id(client, headers)
-        sku = await _pick_item_sku_by_id(client, headers, item_id=item_id)
+        item_id = await _pick_any_item_id(session)
+        sku = await _pick_item_sku_by_id(session, item_id=item_id)
+        resolution = await _load_resolution_by_sku(session, sku=sku)
+        _patch_fsku_pms_resolver(monkeypatch, {sku: resolution})
         alloc_unit_price = 1 + (uuid4().int % 100000)
         fsku_expr = f"{sku}*1*{alloc_unit_price}"
 
@@ -67,12 +189,25 @@ async def _create_draft_fsku(
     return r.json()
 
 
-async def _replace_components(client, headers: Dict[str, str], fsku_id: int, components: List[dict]):
+async def _replace_components(
+    client,
+    headers: Dict[str, str],
+    fsku_id: int,
+    components: List[dict],
+    *,
+    session: AsyncSession,
+    monkeypatch: MonkeyPatch,
+):
     parts: list[str] = []
+    resolution_by_code: dict[str, PmsExportSkuCodeResolution] = {}
+
     for c in components:
-        sku = await _pick_item_sku_by_id(client, headers, item_id=int(c["resolved_item_id"]))
+        sku = await _pick_item_sku_by_id(session, item_id=int(c["resolved_item_id"]))
+        resolution_by_code[sku] = await _load_resolution_by_sku(session, sku=sku)
         qty = int(c.get("qty") or 1)
         parts.append(f"{sku}*{qty}*1")
+
+    _patch_fsku_pms_resolver(monkeypatch, resolution_by_code)
 
     expr = "+".join(parts)
     r = await client.post(
@@ -107,7 +242,6 @@ async def test_fsku_list_contract_with_archive_fields(client):
 
     one = items[0]
 
-    # —— 主键 / 展示字段
     for k in (
         "id",
         "code",
@@ -128,7 +262,6 @@ async def test_fsku_list_contract_with_archive_fields(client):
     assert one["status"] in ("draft", "published", "retired")
     assert isinstance(one["components_summary"], str)
 
-    # 归档语义必须来自 status/retired_at
     if one["status"] == "retired":
         assert one["retired_at"] is not None
     else:
@@ -136,20 +269,32 @@ async def test_fsku_list_contract_with_archive_fields(client):
 
 
 @pytest.mark.asyncio
-async def test_fsku_archive_lifecycle(client):
+async def test_fsku_archive_lifecycle(
+    client,
+    session: AsyncSession,
+    monkeypatch: MonkeyPatch,
+):
     """
     归档（retire）行为必须在列表中可见
     """
     headers = await _auth_headers(client)
-    item_id = await _pick_any_item_id(client, headers)
+    item_id = await _pick_any_item_id(session)
 
-    f = await _create_draft_fsku(client, headers, name="FSKU-ARCHIVE-TEST")
+    f = await _create_draft_fsku(
+        client,
+        headers,
+        session=session,
+        monkeypatch=monkeypatch,
+        name="FSKU-ARCHIVE-TEST",
+    )
 
     await _replace_components(
         client,
         headers,
         fsku_id=f["id"],
         components=[{"resolved_item_id": item_id, "qty": 1, "role": "primary"}],
+        session=session,
+        monkeypatch=monkeypatch,
     )
 
     r_pub = await client.post(f"/oms/fskus/{f['id']}/publish", headers=headers)
@@ -162,7 +307,6 @@ async def test_fsku_archive_lifecycle(client):
     assert body["status"] == "retired"
     assert body["retired_at"] is not None
 
-    # 列表中必须能看到
     r_list = await client.get("/oms/fskus", headers=headers)
     items = r_list.json()["items"]
     hit = next(x for x in items if x["id"] == f["id"])
@@ -171,21 +315,33 @@ async def test_fsku_archive_lifecycle(client):
 
 
 @pytest.mark.asyncio
-async def test_fsku_unretire_lifecycle(client):
+async def test_fsku_unretire_lifecycle(
+    client,
+    session: AsyncSession,
+    monkeypatch: MonkeyPatch,
+):
     """
     契约封板：FSKU 生命周期单向（draft → published → retired），发布事实不可逆。
     因此 unretire endpoint 仅兼容保留，但必须永远返回 409（state_conflict）+ Problem shape。
     """
     headers = await _auth_headers(client)
-    item_id = await _pick_any_item_id(client, headers)
+    item_id = await _pick_any_item_id(session)
 
-    f = await _create_draft_fsku(client, headers, name="FSKU-UNRETIRE-TEST")
+    f = await _create_draft_fsku(
+        client,
+        headers,
+        session=session,
+        monkeypatch=monkeypatch,
+        name="FSKU-UNRETIRE-TEST",
+    )
 
     await _replace_components(
         client,
         headers,
         fsku_id=f["id"],
         components=[{"resolved_item_id": item_id, "qty": 1, "role": "primary"}],
+        session=session,
+        monkeypatch=monkeypatch,
     )
 
     r_pub = await client.post(f"/oms/fskus/{f['id']}/publish", headers=headers)
@@ -211,7 +367,11 @@ async def test_fsku_unretire_lifecycle(client):
 
 
 @pytest.mark.asyncio
-async def test_fsku_unretire_guard_requires_retired(client):
+async def test_fsku_unretire_guard_requires_retired(
+    client,
+    session: AsyncSession,
+    monkeypatch: MonkeyPatch,
+):
     """
     契约封板：unretire 永远不允许（兼容保留但必须 409 + Problem）
     - draft -> 409 + Problem
@@ -219,9 +379,15 @@ async def test_fsku_unretire_guard_requires_retired(client):
     - retired -> 409 + Problem
     """
     headers = await _auth_headers(client)
-    item_id = await _pick_any_item_id(client, headers)
+    item_id = await _pick_any_item_id(session)
 
-    f = await _create_draft_fsku(client, headers, name="FSKU-UNRETIRE-GUARD")
+    f = await _create_draft_fsku(
+        client,
+        headers,
+        session=session,
+        monkeypatch=monkeypatch,
+        name="FSKU-UNRETIRE-GUARD",
+    )
 
     r_un_draft = await client.post(f"/oms/fskus/{f['id']}/unretire", headers=headers)
     assert r_un_draft.status_code == 409, r_un_draft.text
@@ -232,6 +398,8 @@ async def test_fsku_unretire_guard_requires_retired(client):
         headers,
         fsku_id=f["id"],
         components=[{"resolved_item_id": item_id, "qty": 1, "role": "primary"}],
+        session=session,
+        monkeypatch=monkeypatch,
     )
 
     r_pub = await client.post(f"/oms/fskus/{f['id']}/publish", headers=headers)

--- a/tests/ci/test_no_legacy_pms_owner_tests.py
+++ b/tests/ci/test_no_legacy_pms_owner_tests.py
@@ -5,9 +5,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 
-ALLOWED_TEST_IMPORTS = {
-    "tests/fixtures/po_batch_semantics_fixtures.py",
-}
+ALLOWED_TEST_IMPORTS: set[str] = set()
 
 
 def test_tests_do_not_import_legacy_pms_owner_runtime() -> None:

--- a/tests/ci/test_no_pms_owner_route_requests.py
+++ b/tests/ci/test_no_pms_owner_route_requests.py
@@ -11,14 +11,7 @@ OWNER_ROUTE_RE = re.compile(
     r"""(/items\b|/items/|/item-uoms\b|/item-uoms/|/item-barcodes\b|/item-barcodes/|/pms/brands\b|/pms/brands/|/pms/categories\b|/pms/categories/|/pms/item-attribute|/pms/sku-coding)"""
 )
 
-# Transitional exceptions:
-# These are not PMS owner tests, but still use retired PMS owner routes to
-# prepare/read data. They must be refactored in the next PR to use seed data
-# or PMS HTTP read surface instead.
-TEMP_ALLOWED = {
-    "tests/api/test_fskus_contract.py",
-    "tests/api/test_finance_purchase_sku_ledger_api.py",
-}
+TEMP_ALLOWED: set[str] = set()
 
 
 def test_tests_do_not_call_retired_pms_owner_routes() -> None:

--- a/tests/ci/test_pms_metadata_boundary.py
+++ b/tests/ci/test_pms_metadata_boundary.py
@@ -89,3 +89,11 @@ def test_alembic_env_keeps_external_anchors_for_fk_resolution() -> None:
 
     assert "PMS_EXTERNAL_ANCHOR_TABLES" in text
     assert "t.name in PMS_OWNED_TABLES and t.name not in PMS_EXTERNAL_ANCHOR_TABLES" in text
+
+
+
+def test_db_base_eagerly_loads_external_pms_orm_anchors() -> None:
+    text = (ROOT / "app" / "db" / "base.py").read_text(encoding="utf-8")
+
+    assert "_load_external_pms_orm_anchors()" in text
+    assert 'importlib.import_module("app.db.external_pms_models")' in text

--- a/tests/fixtures/po_batch_semantics_fixtures.py
+++ b/tests/fixtures/po_batch_semantics_fixtures.py
@@ -2,13 +2,12 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from uuid import uuid4
 
 import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.pms.items.models.item import Item
-from app.pms.items.models.item_uom import ItemUOM
 from app.procurement.models.purchase_order import PurchaseOrder
 from app.procurement.models.purchase_order_line import PurchaseOrderLine
 
@@ -35,9 +34,101 @@ async def _get_any_warehouse_id(session: AsyncSession) -> int:
     return int(r[0])
 
 
-# ---------------------------------------------------------
-# 内部辅助：创建一个最小可运行 PO + 一行（按 Phase M-5 新合同）
-# ---------------------------------------------------------
+async def _create_test_item(
+    session: AsyncSession,
+    *,
+    supplier_id: int,
+    expiry_policy: str,
+) -> tuple[int, str, str]:
+    exp = str(expiry_policy or "").strip().upper() or "NONE"
+    sku = f"UT-SKU-{uuid4().hex[:16]}"
+    name = "UT-Item"
+
+    row = (
+        await session.execute(
+            text(
+                """
+                INSERT INTO items (
+                    name,
+                    sku,
+                    enabled,
+                    supplier_id,
+                    lot_source_policy,
+                    expiry_policy,
+                    derivation_allowed,
+                    uom_governance_enabled,
+                    shelf_life_value,
+                    shelf_life_unit
+                )
+                VALUES (
+                    :name,
+                    :sku,
+                    TRUE,
+                    :supplier_id,
+                    CAST('SUPPLIER_ONLY' AS lot_source_policy),
+                    CAST(:expiry_policy AS expiry_policy),
+                    TRUE,
+                    TRUE,
+                    :shelf_life_value,
+                    CASE
+                        WHEN :shelf_life_unit IS NULL THEN NULL
+                        ELSE CAST(:shelf_life_unit AS shelf_life_unit)
+                    END
+                )
+                RETURNING id, sku, name
+                """
+            ),
+            {
+                "name": name,
+                "sku": sku,
+                "supplier_id": int(supplier_id),
+                "expiry_policy": exp,
+                "shelf_life_value": 30 if _is_required_expiry_policy(exp) else None,
+                "shelf_life_unit": "DAY" if _is_required_expiry_policy(exp) else None,
+            },
+        )
+    ).first()
+
+    assert row is not None
+    return int(row[0]), str(row[1]), str(row[2])
+
+
+async def _create_base_item_uom(session: AsyncSession, *, item_id: int) -> int:
+    row = (
+        await session.execute(
+            text(
+                """
+                INSERT INTO item_uoms (
+                    item_id,
+                    uom,
+                    ratio_to_base,
+                    display_name,
+                    is_base,
+                    is_purchase_default,
+                    is_inbound_default,
+                    is_outbound_default
+                )
+                VALUES (
+                    :item_id,
+                    'EA',
+                    1,
+                    NULL,
+                    TRUE,
+                    TRUE,
+                    TRUE,
+                    TRUE
+                )
+                RETURNING id
+                """
+            ),
+            {"item_id": int(item_id)},
+        )
+    ).first()
+
+    assert row is not None
+    return int(row[0])
+
+
 async def _create_po_with_one_line(
     session: AsyncSession,
     *,
@@ -45,44 +136,16 @@ async def _create_po_with_one_line(
 ):
     exp = str(expiry_policy or "").strip().upper() or "NONE"
 
-    # 1️⃣ 复用 seed 的 supplier/warehouse（不猜表必填字段）
     wid = await _get_any_warehouse_id(session)
     sid, sname = await _get_any_supplier(session)
 
-    # 2️⃣ 创建商品（按当前 items schema）
-    # 注意：sku 唯一；fixture 用时间戳避免冲突
-    ts = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
-    item = Item(
-        name="UT-Item",
-        sku=f"UT-SKU-{ts}",
-        uom="EA",
-        enabled=True,
+    item_id, item_sku, item_name = await _create_test_item(
+        session,
         supplier_id=sid,
-        lot_source_policy="SUPPLIER_ONLY",
         expiry_policy=exp,
-        derivation_allowed=True,
-        uom_governance_enabled=True,
-        shelf_life_value=(30 if _is_required_expiry_policy(exp) else None),
-        shelf_life_unit=("DAY" if _is_required_expiry_policy(exp) else None),
     )
-    session.add(item)
-    await session.flush()
+    item_uom_id = await _create_base_item_uom(session, item_id=item_id)
 
-    # 3️⃣ 创建 base item_uom（ratio=1）
-    uom = ItemUOM(
-        item_id=int(item.id),
-        uom="EA",
-        ratio_to_base=1,
-        display_name=None,
-        is_base=True,
-        is_purchase_default=True,
-        is_inbound_default=True,
-        is_outbound_default=True,
-    )
-    session.add(uom)
-    await session.flush()
-
-    # 4️⃣ 创建采购单（按 purchase_orders NOT NULL）
     now = datetime.now(tz=timezone.utc)
     po = PurchaseOrder(
         warehouse_id=wid,
@@ -99,16 +162,15 @@ async def _create_po_with_one_line(
     session.add(po)
     await session.flush()
 
-    # 5️⃣ 创建采购行（按 Phase M-5 新合同）
     qty_base = 10
     line = PurchaseOrderLine(
         po_id=int(po.id),
         line_no=1,
-        item_id=int(item.id),
-        item_name=item.name,
-        item_sku=item.sku,
+        item_id=int(item_id),
+        item_name=item_name,
+        item_sku=item_sku,
         spec_text=None,
-        purchase_uom_id_snapshot=int(uom.id),
+        purchase_uom_id_snapshot=int(item_uom_id),
         purchase_ratio_to_base_snapshot=1,
         qty_ordered_input=qty_base,
         qty_ordered_base=qty_base,


### PR DESCRIPTION
## Summary
- remove remaining WMS test dependencies on retired PMS owner routes
- replace /items test lookups with SQL seed lookups
- replace app.pms ORM fixture usage with SQL seed
- clear temporary guard allowlists for PMS owner route calls and app.pms imports
- eagerly register external PMS ORM anchors so runtime mapper configuration can resolve relationship("Item")

## Validation
- python3 -m compileall tests/api/test_fskus_contract.py tests/api/test_finance_purchase_sku_ledger_api.py tests/fixtures/po_batch_semantics_fixtures.py tests/ci/test_no_pms_owner_route_requests.py tests/ci/test_no_legacy_pms_owner_tests.py app/db/base.py tests/ci/test_pms_metadata_boundary.py
- make test TESTS="tests/ci/test_no_pms_owner_route_requests.py tests/ci/test_no_legacy_pms_owner_tests.py tests/api/test_fskus_contract.py tests/api/test_finance_purchase_sku_ledger_api.py"
- make test TESTS="tests/ci/test_pms_metadata_boundary.py tests/ci/test_pms_integration_client_boundary_contract.py tests/ci/test_pms_integration_contracts_no_owner_import.py tests/ci/test_pms_owner_routes_not_mounted.py tests/ci/test_pms_read_client_factory_usage.py tests/services/test_pms_integration_http_client.py tests/services/test_pms_integration_factory.py"
- make pms-http-smoke
- make pms-http-business-smoke
- make alembic-check