### PR TITLE
feat(pms): add WMS PMS read projection tables

### DIFF
--- a/alembic/versions/a8c1f4e2d9b0_add_wms_pms_read_projection_tables.py
+++ b/alembic/versions/a8c1f4e2d9b0_add_wms_pms_read_projection_tables.py
@@ -1,0 +1,236 @@
+"""add_wms_pms_read_projection_tables
+
+Revision ID: a8c1f4e2d9b0
+Revises: 9f3d2c8a7b41
+Create Date: 2026-05-11 13:00:00.000000
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a8c1f4e2d9b0"
+down_revision: Union[str, Sequence[str], None] = "9f3d2c8a7b41"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+
+    op.create_table(
+        "wms_pms_item_projection",
+        sa.Column("item_id", sa.Integer(), autoincrement=False, nullable=False),
+        sa.Column("sku", sa.String(length=128), nullable=False),
+        sa.Column("name", sa.String(length=128), nullable=False),
+        sa.Column("spec", sa.String(length=128), nullable=True),
+        sa.Column("enabled", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.Column("supplier_id", sa.Integer(), nullable=True),
+        sa.Column("brand", sa.String(length=64), nullable=True),
+        sa.Column("category", sa.String(length=64), nullable=True),
+        sa.Column("expiry_policy", sa.String(length=32), nullable=True),
+        sa.Column("shelf_life_value", sa.Integer(), nullable=True),
+        sa.Column("shelf_life_unit", sa.String(length=16), nullable=True),
+        sa.Column("lot_source_policy", sa.String(length=32), nullable=True),
+        sa.Column("derivation_allowed", sa.Boolean(), nullable=True),
+        sa.Column("uom_governance_enabled", sa.Boolean(), nullable=True),
+        sa.Column("pms_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("source_hash", sa.String(length=128), nullable=True),
+        sa.Column("sync_version", sa.String(length=64), nullable=True),
+        sa.Column("synced_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("item_id", name="pk_wms_pms_item_projection"),
+        sa.UniqueConstraint("sku", name="uq_wms_pms_item_projection_sku"),
+        sa.CheckConstraint(
+            "expiry_policy IS NULL OR expiry_policy IN ('NONE', 'REQUIRED')",
+            name="ck_wms_pms_item_projection_expiry_policy",
+        ),
+        sa.CheckConstraint(
+            "shelf_life_unit IS NULL OR shelf_life_unit IN ('DAY', 'WEEK', 'MONTH', 'YEAR')",
+            name="ck_wms_pms_item_projection_shelf_life_unit",
+        ),
+        sa.CheckConstraint(
+            "(shelf_life_value IS NULL) = (shelf_life_unit IS NULL)",
+            name="ck_wms_pms_item_projection_shelf_life_pair",
+        ),
+        sa.CheckConstraint(
+            "shelf_life_value IS NULL OR shelf_life_value > 0",
+            name="ck_wms_pms_item_projection_shelf_life_value_pos",
+        ),
+        sa.CheckConstraint(
+            "lot_source_policy IS NULL OR lot_source_policy IN ('INTERNAL_ONLY', 'SUPPLIER_ONLY')",
+            name="ck_wms_pms_item_projection_lot_source_policy",
+        ),
+    )
+    op.create_index(
+        "ix_wms_pms_item_projection_enabled",
+        "wms_pms_item_projection",
+        ["enabled"],
+    )
+    op.create_index(
+        "ix_wms_pms_item_projection_name",
+        "wms_pms_item_projection",
+        ["name"],
+    )
+    op.create_index(
+        "ix_wms_pms_item_projection_synced_at",
+        "wms_pms_item_projection",
+        ["synced_at"],
+    )
+
+    op.create_table(
+        "wms_pms_uom_projection",
+        sa.Column("item_uom_id", sa.Integer(), autoincrement=False, nullable=False),
+        sa.Column("item_id", sa.Integer(), nullable=False),
+        sa.Column("uom", sa.String(length=16), nullable=False),
+        sa.Column("display_name", sa.String(length=32), nullable=True),
+        sa.Column("uom_name", sa.String(length=32), nullable=False),
+        sa.Column("ratio_to_base", sa.Integer(), nullable=False),
+        sa.Column("net_weight_kg", sa.Numeric(10, 3), nullable=True),
+        sa.Column("is_base", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.Column("is_purchase_default", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.Column("is_inbound_default", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.Column("is_outbound_default", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.Column("pms_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("source_hash", sa.String(length=128), nullable=True),
+        sa.Column("sync_version", sa.String(length=64), nullable=True),
+        sa.Column("synced_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("item_uom_id", name="pk_wms_pms_uom_projection"),
+        sa.UniqueConstraint("item_id", "uom", name="uq_wms_pms_uom_projection_item_uom"),
+        sa.CheckConstraint(
+            "ratio_to_base >= 1",
+            name="ck_wms_pms_uom_projection_ratio_ge_1",
+        ),
+    )
+    op.create_index(
+        "ix_wms_pms_uom_projection_item_id",
+        "wms_pms_uom_projection",
+        ["item_id"],
+    )
+    op.create_index(
+        "ix_wms_pms_uom_projection_synced_at",
+        "wms_pms_uom_projection",
+        ["synced_at"],
+    )
+
+    op.create_table(
+        "wms_pms_sku_code_projection",
+        sa.Column("sku_code_id", sa.Integer(), autoincrement=False, nullable=False),
+        sa.Column("item_id", sa.Integer(), nullable=False),
+        sa.Column("sku_code", sa.String(length=128), nullable=False),
+        sa.Column("code_type", sa.String(length=16), nullable=False),
+        sa.Column("is_primary", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.Column("is_active", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.Column("effective_from", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("effective_to", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("pms_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("source_hash", sa.String(length=128), nullable=True),
+        sa.Column("sync_version", sa.String(length=64), nullable=True),
+        sa.Column("synced_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("sku_code_id", name="pk_wms_pms_sku_code_projection"),
+        sa.UniqueConstraint("sku_code", name="uq_wms_pms_sku_code_projection_sku_code"),
+        sa.CheckConstraint(
+            "length(trim(sku_code)) > 0",
+            name="ck_wms_pms_sku_code_projection_sku_code_non_empty",
+        ),
+        sa.CheckConstraint(
+            "code_type IN ('PRIMARY', 'ALIAS', 'LEGACY', 'MANUAL')",
+            name="ck_wms_pms_sku_code_projection_code_type",
+        ),
+        sa.CheckConstraint(
+            "is_primary = false OR is_active = true",
+            name="ck_wms_pms_sku_code_projection_primary_active",
+        ),
+        sa.CheckConstraint(
+            "is_primary = false OR effective_to IS NULL",
+            name="ck_wms_pms_sku_code_projection_primary_no_effective_to",
+        ),
+    )
+    op.create_index(
+        "ix_wms_pms_sku_code_projection_item_id",
+        "wms_pms_sku_code_projection",
+        ["item_id"],
+    )
+    op.create_index(
+        "ix_wms_pms_sku_code_projection_is_active",
+        "wms_pms_sku_code_projection",
+        ["is_active"],
+    )
+    op.create_index(
+        "ix_wms_pms_sku_code_projection_synced_at",
+        "wms_pms_sku_code_projection",
+        ["synced_at"],
+    )
+
+    op.create_table(
+        "wms_pms_barcode_projection",
+        sa.Column("barcode_id", sa.BigInteger(), autoincrement=False, nullable=False),
+        sa.Column("item_id", sa.Integer(), nullable=False),
+        sa.Column("item_uom_id", sa.Integer(), autoincrement=False, nullable=False),
+        sa.Column("barcode", sa.String(length=128), nullable=False),
+        sa.Column("symbology", sa.String(length=32), nullable=False),
+        sa.Column("active", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.Column("is_primary", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.Column("pms_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("source_hash", sa.String(length=128), nullable=True),
+        sa.Column("sync_version", sa.String(length=64), nullable=True),
+        sa.Column("synced_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("barcode_id", name="pk_wms_pms_barcode_projection"),
+        sa.UniqueConstraint("barcode", name="uq_wms_pms_barcode_projection_barcode"),
+        sa.CheckConstraint(
+            "length(trim(barcode)) > 0",
+            name="ck_wms_pms_barcode_projection_barcode_non_empty",
+        ),
+        sa.CheckConstraint(
+            "is_primary = false OR active = true",
+            name="ck_wms_pms_barcode_projection_primary_active",
+        ),
+    )
+    op.create_index(
+        "ix_wms_pms_barcode_projection_item_id",
+        "wms_pms_barcode_projection",
+        ["item_id"],
+    )
+    op.create_index(
+        "ix_wms_pms_barcode_projection_item_uom_id",
+        "wms_pms_barcode_projection",
+        ["item_uom_id"],
+    )
+    op.create_index(
+        "ix_wms_pms_barcode_projection_active",
+        "wms_pms_barcode_projection",
+        ["active"],
+    )
+    op.create_index(
+        "ix_wms_pms_barcode_projection_synced_at",
+        "wms_pms_barcode_projection",
+        ["synced_at"],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+
+    op.drop_index("ix_wms_pms_barcode_projection_synced_at", table_name="wms_pms_barcode_projection")
+    op.drop_index("ix_wms_pms_barcode_projection_active", table_name="wms_pms_barcode_projection")
+    op.drop_index("ix_wms_pms_barcode_projection_item_uom_id", table_name="wms_pms_barcode_projection")
+    op.drop_index("ix_wms_pms_barcode_projection_item_id", table_name="wms_pms_barcode_projection")
+    op.drop_table("wms_pms_barcode_projection")
+
+    op.drop_index("ix_wms_pms_sku_code_projection_synced_at", table_name="wms_pms_sku_code_projection")
+    op.drop_index("ix_wms_pms_sku_code_projection_is_active", table_name="wms_pms_sku_code_projection")
+    op.drop_index("ix_wms_pms_sku_code_projection_item_id", table_name="wms_pms_sku_code_projection")
+    op.drop_table("wms_pms_sku_code_projection")
+
+    op.drop_index("ix_wms_pms_uom_projection_synced_at", table_name="wms_pms_uom_projection")
+    op.drop_index("ix_wms_pms_uom_projection_item_id", table_name="wms_pms_uom_projection")
+    op.drop_table("wms_pms_uom_projection")
+
+    op.drop_index("ix_wms_pms_item_projection_synced_at", table_name="wms_pms_item_projection")
+    op.drop_index("ix_wms_pms_item_projection_name", table_name="wms_pms_item_projection")
+    op.drop_index("ix_wms_pms_item_projection_enabled", table_name="wms_pms_item_projection")
+    op.drop_table("wms_pms_item_projection")

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -120,6 +120,7 @@ def init_models(
         "app.partners.suppliers.models.supplier",
         "app.partners.suppliers.models.supplier_contact",
         "app.db.external_pms_models",
+        "app.integrations.pms.projection_models",
         "app.procurement.models.purchase_order",
         "app.procurement.models.purchase_order_line",
         "app.wms.inventory_adjustment.return_inbound.models.inbound_receipt",

--- a/app/integrations/pms/projection_contracts.py
+++ b/app/integrations/pms/projection_contracts.py
@@ -1,0 +1,118 @@
+# app/integrations/pms/projection_contracts.py
+"""
+WMS PMS projection contracts.
+
+These contracts describe WMS-owned read projection rows. They are not PMS owner
+contracts and must not depend on the legacy PMS owner package.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(from_attributes=True, extra="forbid", populate_by_name=True)
+
+
+ExpiryPolicy = Literal["NONE", "REQUIRED"]
+ShelfLifeUnit = Literal["DAY", "WEEK", "MONTH", "YEAR"]
+LotSourcePolicy = Literal["INTERNAL_ONLY", "SUPPLIER_ONLY"]
+SkuCodeType = Literal["PRIMARY", "ALIAS", "LEGACY", "MANUAL"]
+
+
+class WmsPmsItemProjectionRow(_Base):
+    item_id: int = Field(gt=0)
+
+    sku: str = Field(min_length=1, max_length=128)
+    name: str = Field(min_length=1, max_length=128)
+    spec: str | None = Field(default=None, max_length=128)
+    enabled: bool = True
+
+    supplier_id: int | None = None
+    brand: str | None = Field(default=None, max_length=64)
+    category: str | None = Field(default=None, max_length=64)
+
+    expiry_policy: ExpiryPolicy | None = None
+    shelf_life_value: int | None = Field(default=None, gt=0)
+    shelf_life_unit: ShelfLifeUnit | None = None
+    lot_source_policy: LotSourcePolicy | None = None
+    derivation_allowed: bool | None = None
+    uom_governance_enabled: bool | None = None
+
+    pms_updated_at: datetime | None = None
+    source_hash: str | None = Field(default=None, max_length=128)
+    sync_version: str | None = Field(default=None, max_length=64)
+    synced_at: datetime
+
+
+class WmsPmsUomProjectionRow(_Base):
+    item_uom_id: int = Field(gt=0)
+    item_id: int = Field(gt=0)
+
+    uom: str = Field(min_length=1, max_length=16)
+    display_name: str | None = Field(default=None, max_length=32)
+    uom_name: str = Field(min_length=1, max_length=32)
+
+    ratio_to_base: int = Field(ge=1)
+    net_weight_kg: Decimal | None = Field(default=None, ge=0)
+
+    is_base: bool
+    is_purchase_default: bool
+    is_inbound_default: bool
+    is_outbound_default: bool
+
+    pms_updated_at: datetime | None = None
+    source_hash: str | None = Field(default=None, max_length=128)
+    sync_version: str | None = Field(default=None, max_length=64)
+    synced_at: datetime
+
+
+class WmsPmsSkuCodeProjectionRow(_Base):
+    sku_code_id: int = Field(gt=0)
+    item_id: int = Field(gt=0)
+
+    sku_code: str = Field(min_length=1, max_length=128)
+    code_type: SkuCodeType
+    is_primary: bool
+    is_active: bool
+
+    effective_from: datetime | None = None
+    effective_to: datetime | None = None
+
+    pms_updated_at: datetime | None = None
+    source_hash: str | None = Field(default=None, max_length=128)
+    sync_version: str | None = Field(default=None, max_length=64)
+    synced_at: datetime
+
+
+class WmsPmsBarcodeProjectionRow(_Base):
+    barcode_id: int = Field(gt=0)
+    item_id: int = Field(gt=0)
+    item_uom_id: int = Field(gt=0)
+
+    barcode: str = Field(min_length=1, max_length=128)
+    symbology: str = Field(min_length=1, max_length=32)
+    active: bool
+    is_primary: bool
+
+    pms_updated_at: datetime | None = None
+    source_hash: str | None = Field(default=None, max_length=128)
+    sync_version: str | None = Field(default=None, max_length=64)
+    synced_at: datetime
+
+
+__all__ = [
+    "ExpiryPolicy",
+    "LotSourcePolicy",
+    "ShelfLifeUnit",
+    "SkuCodeType",
+    "WmsPmsBarcodeProjectionRow",
+    "WmsPmsItemProjectionRow",
+    "WmsPmsSkuCodeProjectionRow",
+    "WmsPmsUomProjectionRow",
+]

--- a/app/integrations/pms/projection_models.py
+++ b/app/integrations/pms/projection_models.py
@@ -1,0 +1,275 @@
+# app/integrations/pms/projection_models.py
+"""
+WMS-owned PMS read projection ORM models.
+
+These tables are WMS local read indexes for PMS current state.
+
+Boundary:
+- PMS owner runtime remains in pms-api.
+- These tables are not PMS owner tables.
+- These tables must be populated by a sync job that reads pms-api read-v1 HTTP.
+- Business writes must not write these tables directly.
+- These tables do not replace snapshot facts.
+- These tables do not replace HTTP validation.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+PROJECTION_TABLE_INFO = {
+    "owner": "wms-api",
+    "source_owner": "pms-api",
+    "projection": True,
+    "read_only_index": True,
+}
+
+
+class WmsPmsItemProjection(Base):
+    __tablename__ = "wms_pms_item_projection"
+    __table_args__ = (
+        sa.UniqueConstraint("sku", name="uq_wms_pms_item_projection_sku"),
+        sa.CheckConstraint(
+            "expiry_policy IS NULL OR expiry_policy IN ('NONE', 'REQUIRED')",
+            name="ck_wms_pms_item_projection_expiry_policy",
+        ),
+        sa.CheckConstraint(
+            "shelf_life_unit IS NULL OR shelf_life_unit IN ('DAY', 'WEEK', 'MONTH', 'YEAR')",
+            name="ck_wms_pms_item_projection_shelf_life_unit",
+        ),
+        sa.CheckConstraint(
+            "(shelf_life_value IS NULL) = (shelf_life_unit IS NULL)",
+            name="ck_wms_pms_item_projection_shelf_life_pair",
+        ),
+        sa.CheckConstraint(
+            "shelf_life_value IS NULL OR shelf_life_value > 0",
+            name="ck_wms_pms_item_projection_shelf_life_value_pos",
+        ),
+        sa.CheckConstraint(
+            "lot_source_policy IS NULL OR lot_source_policy IN ('INTERNAL_ONLY', 'SUPPLIER_ONLY')",
+            name="ck_wms_pms_item_projection_lot_source_policy",
+        ),
+        sa.Index("ix_wms_pms_item_projection_enabled", "enabled"),
+        sa.Index("ix_wms_pms_item_projection_name", "name"),
+        sa.Index("ix_wms_pms_item_projection_synced_at", "synced_at"),
+        {"info": PROJECTION_TABLE_INFO},
+    )
+
+    item_id: Mapped[int] = mapped_column(sa.Integer, primary_key=True, autoincrement=False)
+
+    sku: Mapped[str] = mapped_column(sa.String(128), nullable=False)
+    name: Mapped[str] = mapped_column(sa.String(128), nullable=False)
+    spec: Mapped[str | None] = mapped_column(sa.String(128), nullable=True)
+    enabled: Mapped[bool] = mapped_column(
+        sa.Boolean(),
+        nullable=False,
+        server_default=sa.text("true"),
+    )
+
+    supplier_id: Mapped[int | None] = mapped_column(sa.Integer, nullable=True)
+    brand: Mapped[str | None] = mapped_column(sa.String(64), nullable=True)
+    category: Mapped[str | None] = mapped_column(sa.String(64), nullable=True)
+
+    expiry_policy: Mapped[str | None] = mapped_column(sa.String(32), nullable=True)
+    shelf_life_value: Mapped[int | None] = mapped_column(sa.Integer, nullable=True)
+    shelf_life_unit: Mapped[str | None] = mapped_column(sa.String(16), nullable=True)
+    lot_source_policy: Mapped[str | None] = mapped_column(sa.String(32), nullable=True)
+    derivation_allowed: Mapped[bool | None] = mapped_column(sa.Boolean(), nullable=True)
+    uom_governance_enabled: Mapped[bool | None] = mapped_column(sa.Boolean(), nullable=True)
+
+    pms_updated_at: Mapped[datetime | None] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=True,
+    )
+    source_hash: Mapped[str | None] = mapped_column(sa.String(128), nullable=True)
+    sync_version: Mapped[str | None] = mapped_column(sa.String(64), nullable=True)
+    synced_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+
+
+class WmsPmsUomProjection(Base):
+    __tablename__ = "wms_pms_uom_projection"
+    __table_args__ = (
+        sa.UniqueConstraint("item_id", "uom", name="uq_wms_pms_uom_projection_item_uom"),
+        sa.CheckConstraint(
+            "ratio_to_base >= 1",
+            name="ck_wms_pms_uom_projection_ratio_ge_1",
+        ),
+        sa.Index("ix_wms_pms_uom_projection_item_id", "item_id"),
+        sa.Index("ix_wms_pms_uom_projection_synced_at", "synced_at"),
+        {"info": PROJECTION_TABLE_INFO},
+    )
+
+    item_uom_id: Mapped[int] = mapped_column(sa.Integer, primary_key=True, autoincrement=False)
+    item_id: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+
+    uom: Mapped[str] = mapped_column(sa.String(16), nullable=False)
+    display_name: Mapped[str | None] = mapped_column(sa.String(32), nullable=True)
+    uom_name: Mapped[str] = mapped_column(sa.String(32), nullable=False)
+
+    ratio_to_base: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    net_weight_kg: Mapped[Decimal | None] = mapped_column(sa.Numeric(10, 3), nullable=True)
+
+    is_base: Mapped[bool] = mapped_column(
+        sa.Boolean(),
+        nullable=False,
+        server_default=sa.text("false"),
+    )
+    is_purchase_default: Mapped[bool] = mapped_column(
+        sa.Boolean(),
+        nullable=False,
+        server_default=sa.text("false"),
+    )
+    is_inbound_default: Mapped[bool] = mapped_column(
+        sa.Boolean(),
+        nullable=False,
+        server_default=sa.text("false"),
+    )
+    is_outbound_default: Mapped[bool] = mapped_column(
+        sa.Boolean(),
+        nullable=False,
+        server_default=sa.text("false"),
+    )
+
+    pms_updated_at: Mapped[datetime | None] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=True,
+    )
+    source_hash: Mapped[str | None] = mapped_column(sa.String(128), nullable=True)
+    sync_version: Mapped[str | None] = mapped_column(sa.String(64), nullable=True)
+    synced_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+
+
+class WmsPmsSkuCodeProjection(Base):
+    __tablename__ = "wms_pms_sku_code_projection"
+    __table_args__ = (
+        sa.UniqueConstraint("sku_code", name="uq_wms_pms_sku_code_projection_sku_code"),
+        sa.CheckConstraint(
+            "length(trim(sku_code)) > 0",
+            name="ck_wms_pms_sku_code_projection_sku_code_non_empty",
+        ),
+        sa.CheckConstraint(
+            "code_type IN ('PRIMARY', 'ALIAS', 'LEGACY', 'MANUAL')",
+            name="ck_wms_pms_sku_code_projection_code_type",
+        ),
+        sa.CheckConstraint(
+            "is_primary = false OR is_active = true",
+            name="ck_wms_pms_sku_code_projection_primary_active",
+        ),
+        sa.CheckConstraint(
+            "is_primary = false OR effective_to IS NULL",
+            name="ck_wms_pms_sku_code_projection_primary_no_effective_to",
+        ),
+        sa.Index("ix_wms_pms_sku_code_projection_item_id", "item_id"),
+        sa.Index("ix_wms_pms_sku_code_projection_is_active", "is_active"),
+        sa.Index("ix_wms_pms_sku_code_projection_synced_at", "synced_at"),
+        {"info": PROJECTION_TABLE_INFO},
+    )
+
+    sku_code_id: Mapped[int] = mapped_column(sa.Integer, primary_key=True, autoincrement=False)
+    item_id: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+
+    sku_code: Mapped[str] = mapped_column(sa.String(128), nullable=False)
+    code_type: Mapped[str] = mapped_column(sa.String(16), nullable=False)
+    is_primary: Mapped[bool] = mapped_column(
+        sa.Boolean(),
+        nullable=False,
+        server_default=sa.text("false"),
+    )
+    is_active: Mapped[bool] = mapped_column(
+        sa.Boolean(),
+        nullable=False,
+        server_default=sa.text("true"),
+    )
+
+    effective_from: Mapped[datetime | None] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=True,
+    )
+    effective_to: Mapped[datetime | None] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=True,
+    )
+
+    pms_updated_at: Mapped[datetime | None] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=True,
+    )
+    source_hash: Mapped[str | None] = mapped_column(sa.String(128), nullable=True)
+    sync_version: Mapped[str | None] = mapped_column(sa.String(64), nullable=True)
+    synced_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+
+
+class WmsPmsBarcodeProjection(Base):
+    __tablename__ = "wms_pms_barcode_projection"
+    __table_args__ = (
+        sa.UniqueConstraint("barcode", name="uq_wms_pms_barcode_projection_barcode"),
+        sa.CheckConstraint(
+            "length(trim(barcode)) > 0",
+            name="ck_wms_pms_barcode_projection_barcode_non_empty",
+        ),
+        sa.CheckConstraint(
+            "is_primary = false OR active = true",
+            name="ck_wms_pms_barcode_projection_primary_active",
+        ),
+        sa.Index("ix_wms_pms_barcode_projection_item_id", "item_id"),
+        sa.Index("ix_wms_pms_barcode_projection_item_uom_id", "item_uom_id"),
+        sa.Index("ix_wms_pms_barcode_projection_active", "active"),
+        sa.Index("ix_wms_pms_barcode_projection_synced_at", "synced_at"),
+        {"info": PROJECTION_TABLE_INFO},
+    )
+
+    barcode_id: Mapped[int] = mapped_column(sa.BigInteger, primary_key=True, autoincrement=False)
+    item_id: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    item_uom_id: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+
+    barcode: Mapped[str] = mapped_column(sa.String(128), nullable=False)
+    symbology: Mapped[str] = mapped_column(sa.String(32), nullable=False)
+    active: Mapped[bool] = mapped_column(
+        sa.Boolean(),
+        nullable=False,
+        server_default=sa.text("true"),
+    )
+    is_primary: Mapped[bool] = mapped_column(
+        sa.Boolean(),
+        nullable=False,
+        server_default=sa.text("false"),
+    )
+
+    pms_updated_at: Mapped[datetime | None] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=True,
+    )
+    source_hash: Mapped[str | None] = mapped_column(sa.String(128), nullable=True)
+    sync_version: Mapped[str | None] = mapped_column(sa.String(64), nullable=True)
+    synced_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+
+
+__all__ = [
+    "WmsPmsBarcodeProjection",
+    "WmsPmsItemProjection",
+    "WmsPmsSkuCodeProjection",
+    "WmsPmsUomProjection",
+]

--- a/tests/ci/test_wms_pms_projection_retired_schema.py
+++ b/tests/ci/test_wms_pms_projection_retired_schema.py
@@ -8,7 +8,18 @@ from sqlalchemy.ext.asyncio import AsyncSession
 pytestmark = pytest.mark.asyncio
 
 
-async def test_wms_pms_projection_tables_are_retired(session: AsyncSession) -> None:
+async def test_legacy_wms_pms_projection_tables_are_retired(session: AsyncSession) -> None:
+    """
+    Historical WMS PMS projection schema was retired by migration 9f3d2c8a7b41.
+
+    The new v2 read projection uses final table names:
+    - wms_pms_item_projection
+    - wms_pms_uom_projection
+    - wms_pms_sku_code_projection
+    - wms_pms_barcode_projection
+
+    This guard only blocks the legacy table names and the retired sync cursor.
+    """
     rows = await session.execute(
         text(
             """
@@ -16,7 +27,6 @@ async def test_wms_pms_projection_tables_are_retired(session: AsyncSession) -> N
             FROM information_schema.tables
             WHERE table_schema = 'public'
               AND table_name IN (
-                'wms_pms_item_projection',
                 'wms_pms_item_uom_projection',
                 'wms_pms_item_policy_projection',
                 'wms_pms_item_sku_code_projection',

--- a/tests/ci/test_wms_pms_read_projection_boundary.py
+++ b/tests/ci/test_wms_pms_read_projection_boundary.py
@@ -1,0 +1,189 @@
+# tests/ci/test_wms_pms_read_projection_boundary.py
+from __future__ import annotations
+
+import re
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from pathlib import Path
+
+from app.db.base import Base, init_models
+
+ROOT = Path(__file__).resolve().parents[2]
+
+PROJECTION_COLUMNS: dict[str, set[str]] = {
+    "wms_pms_item_projection": {
+        "item_id",
+        "sku",
+        "name",
+        "spec",
+        "enabled",
+        "supplier_id",
+        "brand",
+        "category",
+        "expiry_policy",
+        "shelf_life_value",
+        "shelf_life_unit",
+        "lot_source_policy",
+        "derivation_allowed",
+        "uom_governance_enabled",
+        "pms_updated_at",
+        "source_hash",
+        "sync_version",
+        "synced_at",
+    },
+    "wms_pms_uom_projection": {
+        "item_uom_id",
+        "item_id",
+        "uom",
+        "display_name",
+        "uom_name",
+        "ratio_to_base",
+        "net_weight_kg",
+        "is_base",
+        "is_purchase_default",
+        "is_inbound_default",
+        "is_outbound_default",
+        "pms_updated_at",
+        "source_hash",
+        "sync_version",
+        "synced_at",
+    },
+    "wms_pms_sku_code_projection": {
+        "sku_code_id",
+        "item_id",
+        "sku_code",
+        "code_type",
+        "is_primary",
+        "is_active",
+        "effective_from",
+        "effective_to",
+        "pms_updated_at",
+        "source_hash",
+        "sync_version",
+        "synced_at",
+    },
+    "wms_pms_barcode_projection": {
+        "barcode_id",
+        "item_id",
+        "item_uom_id",
+        "barcode",
+        "symbology",
+        "active",
+        "is_primary",
+        "pms_updated_at",
+        "source_hash",
+        "sync_version",
+        "synced_at",
+    },
+}
+
+BUSINESS_DIRS = (
+    "app/wms",
+    "app/oms",
+    "app/procurement",
+    "app/finance",
+)
+
+BUSINESS_PROJECTION_WRITE_RE = re.compile(
+    r"\b(INSERT\s+INTO|UPDATE|DELETE\s+FROM)\s+wms_pms_",
+    re.IGNORECASE,
+)
+
+
+def _rel(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def test_db_base_loads_wms_pms_projection_models() -> None:
+    text = (ROOT / "app" / "db" / "base.py").read_text(encoding="utf-8")
+
+    assert '"app.integrations.pms.projection_models"' in text
+
+
+def test_wms_pms_projection_tables_are_registered_in_metadata() -> None:
+    init_models(force=True)
+
+    for table_name, expected_columns in PROJECTION_COLUMNS.items():
+        assert table_name in Base.metadata.tables
+
+        table = Base.metadata.tables[table_name]
+        assert table.info["owner"] == "wms-api"
+        assert table.info["source_owner"] == "pms-api"
+        assert table.info["projection"] is True
+        assert table.info["read_only_index"] is True
+        assert set(table.c.keys()) == expected_columns
+
+
+def test_wms_pms_projection_tables_do_not_point_to_pms_owner_tables() -> None:
+    init_models(force=True)
+
+    for table_name in PROJECTION_COLUMNS:
+        table = Base.metadata.tables[table_name]
+        assert list(table.foreign_keys) == []
+
+
+def test_wms_pms_projection_models_have_no_relationships_or_foreign_keys() -> None:
+    text = (ROOT / "app/integrations/pms/projection_models.py").read_text(encoding="utf-8")
+
+    assert "ForeignKey(" not in text
+    assert "relationship(" not in text
+
+
+def test_wms_pms_projection_contracts_do_not_import_owner_or_db_runtime() -> None:
+    text = (ROOT / "app/integrations/pms/projection_contracts.py").read_text(encoding="utf-8")
+
+    assert "app.pms" not in text
+    assert "sqlalchemy" not in text
+
+
+def test_business_domains_do_not_write_wms_pms_projection_tables() -> None:
+    violations: list[str] = []
+
+    for directory in BUSINESS_DIRS:
+        root = ROOT / directory
+        if not root.exists():
+            continue
+
+        for path in sorted(root.rglob("*.py")):
+            rel = _rel(path)
+            for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+                if BUSINESS_PROJECTION_WRITE_RE.search(line):
+                    violations.append(f"{rel}:{line_no}: {line.strip()}")
+
+    assert violations == []
+
+
+@pytest.mark.asyncio
+async def test_wms_pms_projection_primary_keys_have_no_db_defaults(
+    session: AsyncSession,
+) -> None:
+    rows = await session.execute(
+        text(
+            """
+            SELECT table_name, column_name, column_default
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND (table_name, column_name) IN (
+                ('wms_pms_item_projection', 'item_id'),
+                ('wms_pms_uom_projection', 'item_uom_id'),
+                ('wms_pms_sku_code_projection', 'sku_code_id'),
+                ('wms_pms_barcode_projection', 'barcode_id')
+              )
+            ORDER BY table_name, column_name
+            """
+        )
+    )
+
+    got = {
+        (str(row["table_name"]), str(row["column_name"])): row["column_default"]
+        for row in rows.mappings().all()
+    }
+
+    assert got == {
+        ("wms_pms_barcode_projection", "barcode_id"): None,
+        ("wms_pms_item_projection", "item_id"): None,
+        ("wms_pms_sku_code_projection", "sku_code_id"): None,
+        ("wms_pms_uom_projection", "item_uom_id"): None,
+    }


### PR DESCRIPTION
## Summary
- add WMS-owned PMS read projection tables for item/uom/sku-code/barcode current-state indexes
- add ORM and Pydantic projection row contracts
- keep projection tables free of FK/relationship coupling to PMS owner tables
- update retired projection guard to block legacy projection schema only
- add CI boundary guard for projection metadata, contracts, no direct FK, no business writes, and no local serial PK defaults

## Boundary
- no business read path is changed
- no sync job is added in this PR
- no PMS owner runtime is reintroduced into WMS
- projection remains WMS local read index only
- write validation still belongs to pms-api HTTP integration
- snapshot facts remain the historical source of truth

## Validation
- python3 -m compileall targeted files
- make upgrade-dev
- make alembic-check
- make upgrade-dev-test-db
- targeted pytest for PMS projection/boundary guards
- DB check confirms projection PK defaults are null
- DB check confirms pg_get_serial_sequence is null for projection PKs
- DB check confirms projection tables have no foreign keys