### PR TITLE
feat(pms): sync PMS read projection from pms-api

### DIFF
--- a/app/integrations/pms/projection_sync.py
+++ b/app/integrations/pms/projection_sync.py
@@ -1,0 +1,583 @@
+# app/integrations/pms/projection_sync.py
+"""
+Sync WMS-owned PMS read projection tables from pms-api read-v1 HTTP feed.
+
+Boundary:
+- Source must be pms-api /pms/read/v1/projection-feed/*.
+- This module must not read PMS owner tables directly.
+- This module only writes WMS-owned projection tables.
+- Projection is a current-state read index, not snapshot and not write validation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Literal
+
+import httpx
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+ProjectionResource = Literal["items", "uoms", "sku-codes", "barcodes"]
+
+SYNC_VERSION = "pms-read-v1-projection-feed"
+DEFAULT_LIMIT = 500
+MAX_LIMIT = 500
+
+RESOURCE_ORDER: tuple[ProjectionResource, ...] = (
+    "items",
+    "uoms",
+    "sku-codes",
+    "barcodes",
+)
+
+RESOURCE_PATHS: dict[ProjectionResource, str] = {
+    "items": "/pms/read/v1/projection-feed/items",
+    "uoms": "/pms/read/v1/projection-feed/uoms",
+    "sku-codes": "/pms/read/v1/projection-feed/sku-codes",
+    "barcodes": "/pms/read/v1/projection-feed/barcodes",
+}
+
+
+class PmsProjectionSyncError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class PmsProjectionResourceSyncResult:
+    resource: ProjectionResource
+    fetched: int
+    upserted: int
+    pages: int
+    last_offset: int
+    has_more: bool
+
+
+@dataclass(frozen=True)
+class PmsProjectionSyncResult:
+    resources: dict[ProjectionResource, PmsProjectionResourceSyncResult]
+
+    @property
+    def fetched(self) -> int:
+        return sum(row.fetched for row in self.resources.values())
+
+    @property
+    def upserted(self) -> int:
+        return sum(row.upserted for row in self.resources.values())
+
+
+def _base_url(value: str | None = None) -> str:
+    raw = (value or os.getenv("PMS_API_BASE_URL") or "").strip()
+    if not raw:
+        raise RuntimeError("PMS_API_BASE_URL is required for PMS projection sync")
+    return raw.rstrip("/")
+
+
+def _safe_limit(value: int) -> int:
+    return max(1, min(int(value), MAX_LIMIT))
+
+
+def _as_mapping(value: object, *, context: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise PmsProjectionSyncError(f"{context} must be an object")
+    return value
+
+
+def _required_int(row: Mapping[str, Any], key: str) -> int:
+    value = row.get(key)
+    if value is None:
+        raise PmsProjectionSyncError(f"PMS projection feed row missing required field: {key}")
+    return int(value)
+
+
+def _required_str(row: Mapping[str, Any], key: str) -> str:
+    value = row.get(key)
+    if value is None:
+        raise PmsProjectionSyncError(f"PMS projection feed row missing required field: {key}")
+    text_value = str(value).strip()
+    if not text_value:
+        raise PmsProjectionSyncError(f"PMS projection feed row has blank required field: {key}")
+    return text_value
+
+
+def _optional_str(row: Mapping[str, Any], key: str) -> str | None:
+    value = row.get(key)
+    if value is None:
+        return None
+    text_value = str(value).strip()
+    return text_value or None
+
+
+def _required_bool(row: Mapping[str, Any], key: str) -> bool:
+    value = row.get(key)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "t", "1", "yes", "y"}:
+            return True
+        if lowered in {"false", "f", "0", "no", "n"}:
+            return False
+    raise PmsProjectionSyncError(f"PMS projection feed row has invalid boolean field: {key}")
+
+
+def _optional_int(row: Mapping[str, Any], key: str) -> int | None:
+    value = row.get(key)
+    return int(value) if value is not None else None
+
+
+def _optional_decimal(row: Mapping[str, Any], key: str) -> Decimal | None:
+    value = row.get(key)
+    return Decimal(str(value)) if value is not None else None
+
+
+def _optional_datetime(row: Mapping[str, Any], key: str) -> datetime | None:
+    value = row.get(key)
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+
+
+def _required_datetime(row: Mapping[str, Any], key: str) -> datetime:
+    value = _optional_datetime(row, key)
+    if value is None:
+        raise PmsProjectionSyncError(f"PMS projection feed row missing required field: {key}")
+    return value
+
+
+def _source_hash(row: Mapping[str, Any]) -> str:
+    payload = json.dumps(
+        dict(row),
+        ensure_ascii=False,
+        sort_keys=True,
+        default=str,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _item_params(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "item_id": _required_int(row, "item_id"),
+        "sku": _required_str(row, "sku"),
+        "name": _required_str(row, "name"),
+        "spec": _optional_str(row, "spec"),
+        "enabled": _required_bool(row, "enabled"),
+        "supplier_id": _optional_int(row, "supplier_id"),
+        "brand": _optional_str(row, "brand"),
+        "category": _optional_str(row, "category"),
+        "expiry_policy": _required_str(row, "expiry_policy"),
+        "shelf_life_value": _optional_int(row, "shelf_life_value"),
+        "shelf_life_unit": _optional_str(row, "shelf_life_unit"),
+        "lot_source_policy": _required_str(row, "lot_source_policy"),
+        "derivation_allowed": _required_bool(row, "derivation_allowed"),
+        "uom_governance_enabled": _required_bool(row, "uom_governance_enabled"),
+        "pms_updated_at": _required_datetime(row, "pms_updated_at"),
+        "source_hash": _source_hash(row),
+        "sync_version": SYNC_VERSION,
+    }
+
+
+def _uom_params(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "item_uom_id": _required_int(row, "item_uom_id"),
+        "item_id": _required_int(row, "item_id"),
+        "uom": _required_str(row, "uom"),
+        "display_name": _optional_str(row, "display_name"),
+        "uom_name": _required_str(row, "uom_name"),
+        "ratio_to_base": _required_int(row, "ratio_to_base"),
+        "net_weight_kg": _optional_decimal(row, "net_weight_kg"),
+        "is_base": _required_bool(row, "is_base"),
+        "is_purchase_default": _required_bool(row, "is_purchase_default"),
+        "is_inbound_default": _required_bool(row, "is_inbound_default"),
+        "is_outbound_default": _required_bool(row, "is_outbound_default"),
+        "pms_updated_at": _required_datetime(row, "pms_updated_at"),
+        "source_hash": _source_hash(row),
+        "sync_version": SYNC_VERSION,
+    }
+
+
+def _sku_code_params(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "sku_code_id": _required_int(row, "sku_code_id"),
+        "item_id": _required_int(row, "item_id"),
+        "sku_code": _required_str(row, "sku_code"),
+        "code_type": _required_str(row, "code_type"),
+        "is_primary": _required_bool(row, "is_primary"),
+        "is_active": _required_bool(row, "is_active"),
+        "effective_from": _optional_datetime(row, "effective_from"),
+        "effective_to": _optional_datetime(row, "effective_to"),
+        "pms_updated_at": _required_datetime(row, "pms_updated_at"),
+        "source_hash": _source_hash(row),
+        "sync_version": SYNC_VERSION,
+    }
+
+
+def _barcode_params(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "barcode_id": _required_int(row, "barcode_id"),
+        "item_id": _required_int(row, "item_id"),
+        "item_uom_id": _required_int(row, "item_uom_id"),
+        "barcode": _required_str(row, "barcode"),
+        "symbology": _required_str(row, "symbology"),
+        "active": _required_bool(row, "active"),
+        "is_primary": _required_bool(row, "is_primary"),
+        "pms_updated_at": _required_datetime(row, "pms_updated_at"),
+        "source_hash": _source_hash(row),
+        "sync_version": SYNC_VERSION,
+    }
+
+
+UPSERT_SQL: dict[ProjectionResource, str] = {
+    "items": """
+        INSERT INTO wms_pms_item_projection (
+            item_id,
+            sku,
+            name,
+            spec,
+            enabled,
+            supplier_id,
+            brand,
+            category,
+            expiry_policy,
+            shelf_life_value,
+            shelf_life_unit,
+            lot_source_policy,
+            derivation_allowed,
+            uom_governance_enabled,
+            pms_updated_at,
+            source_hash,
+            sync_version,
+            synced_at
+        )
+        VALUES (
+            :item_id,
+            :sku,
+            :name,
+            :spec,
+            :enabled,
+            :supplier_id,
+            :brand,
+            :category,
+            :expiry_policy,
+            :shelf_life_value,
+            :shelf_life_unit,
+            :lot_source_policy,
+            :derivation_allowed,
+            :uom_governance_enabled,
+            :pms_updated_at,
+            :source_hash,
+            :sync_version,
+            now()
+        )
+        ON CONFLICT (item_id) DO UPDATE SET
+            sku = EXCLUDED.sku,
+            name = EXCLUDED.name,
+            spec = EXCLUDED.spec,
+            enabled = EXCLUDED.enabled,
+            supplier_id = EXCLUDED.supplier_id,
+            brand = EXCLUDED.brand,
+            category = EXCLUDED.category,
+            expiry_policy = EXCLUDED.expiry_policy,
+            shelf_life_value = EXCLUDED.shelf_life_value,
+            shelf_life_unit = EXCLUDED.shelf_life_unit,
+            lot_source_policy = EXCLUDED.lot_source_policy,
+            derivation_allowed = EXCLUDED.derivation_allowed,
+            uom_governance_enabled = EXCLUDED.uom_governance_enabled,
+            pms_updated_at = EXCLUDED.pms_updated_at,
+            source_hash = EXCLUDED.source_hash,
+            sync_version = EXCLUDED.sync_version,
+            synced_at = now()
+    """,
+    "uoms": """
+        INSERT INTO wms_pms_uom_projection (
+            item_uom_id,
+            item_id,
+            uom,
+            display_name,
+            uom_name,
+            ratio_to_base,
+            net_weight_kg,
+            is_base,
+            is_purchase_default,
+            is_inbound_default,
+            is_outbound_default,
+            pms_updated_at,
+            source_hash,
+            sync_version,
+            synced_at
+        )
+        VALUES (
+            :item_uom_id,
+            :item_id,
+            :uom,
+            :display_name,
+            :uom_name,
+            :ratio_to_base,
+            :net_weight_kg,
+            :is_base,
+            :is_purchase_default,
+            :is_inbound_default,
+            :is_outbound_default,
+            :pms_updated_at,
+            :source_hash,
+            :sync_version,
+            now()
+        )
+        ON CONFLICT (item_uom_id) DO UPDATE SET
+            item_id = EXCLUDED.item_id,
+            uom = EXCLUDED.uom,
+            display_name = EXCLUDED.display_name,
+            uom_name = EXCLUDED.uom_name,
+            ratio_to_base = EXCLUDED.ratio_to_base,
+            net_weight_kg = EXCLUDED.net_weight_kg,
+            is_base = EXCLUDED.is_base,
+            is_purchase_default = EXCLUDED.is_purchase_default,
+            is_inbound_default = EXCLUDED.is_inbound_default,
+            is_outbound_default = EXCLUDED.is_outbound_default,
+            pms_updated_at = EXCLUDED.pms_updated_at,
+            source_hash = EXCLUDED.source_hash,
+            sync_version = EXCLUDED.sync_version,
+            synced_at = now()
+    """,
+    "sku-codes": """
+        INSERT INTO wms_pms_sku_code_projection (
+            sku_code_id,
+            item_id,
+            sku_code,
+            code_type,
+            is_primary,
+            is_active,
+            effective_from,
+            effective_to,
+            pms_updated_at,
+            source_hash,
+            sync_version,
+            synced_at
+        )
+        VALUES (
+            :sku_code_id,
+            :item_id,
+            :sku_code,
+            :code_type,
+            :is_primary,
+            :is_active,
+            :effective_from,
+            :effective_to,
+            :pms_updated_at,
+            :source_hash,
+            :sync_version,
+            now()
+        )
+        ON CONFLICT (sku_code_id) DO UPDATE SET
+            item_id = EXCLUDED.item_id,
+            sku_code = EXCLUDED.sku_code,
+            code_type = EXCLUDED.code_type,
+            is_primary = EXCLUDED.is_primary,
+            is_active = EXCLUDED.is_active,
+            effective_from = EXCLUDED.effective_from,
+            effective_to = EXCLUDED.effective_to,
+            pms_updated_at = EXCLUDED.pms_updated_at,
+            source_hash = EXCLUDED.source_hash,
+            sync_version = EXCLUDED.sync_version,
+            synced_at = now()
+    """,
+    "barcodes": """
+        INSERT INTO wms_pms_barcode_projection (
+            barcode_id,
+            item_id,
+            item_uom_id,
+            barcode,
+            symbology,
+            active,
+            is_primary,
+            pms_updated_at,
+            source_hash,
+            sync_version,
+            synced_at
+        )
+        VALUES (
+            :barcode_id,
+            :item_id,
+            :item_uom_id,
+            :barcode,
+            :symbology,
+            :active,
+            :is_primary,
+            :pms_updated_at,
+            :source_hash,
+            :sync_version,
+            now()
+        )
+        ON CONFLICT (barcode_id) DO UPDATE SET
+            item_id = EXCLUDED.item_id,
+            item_uom_id = EXCLUDED.item_uom_id,
+            barcode = EXCLUDED.barcode,
+            symbology = EXCLUDED.symbology,
+            active = EXCLUDED.active,
+            is_primary = EXCLUDED.is_primary,
+            pms_updated_at = EXCLUDED.pms_updated_at,
+            source_hash = EXCLUDED.source_hash,
+            sync_version = EXCLUDED.sync_version,
+            synced_at = now()
+    """,
+}
+
+
+def _params_for_resource(
+    resource: ProjectionResource,
+    row: Mapping[str, Any],
+) -> dict[str, Any]:
+    if resource == "items":
+        return _item_params(row)
+    if resource == "uoms":
+        return _uom_params(row)
+    if resource == "sku-codes":
+        return _sku_code_params(row)
+    if resource == "barcodes":
+        return _barcode_params(row)
+    raise PmsProjectionSyncError(f"unsupported projection resource: {resource}")
+
+
+async def _fetch_page(
+    client: httpx.AsyncClient,
+    *,
+    resource: ProjectionResource,
+    limit: int,
+    offset: int,
+) -> Mapping[str, Any]:
+    response = await client.get(
+        RESOURCE_PATHS[resource],
+        params={"limit": int(limit), "offset": int(offset)},
+    )
+    response.raise_for_status()
+    return _as_mapping(response.json(), context=f"PMS projection feed {resource} response")
+
+
+async def _upsert_rows(
+    session: AsyncSession,
+    *,
+    resource: ProjectionResource,
+    rows: Sequence[Mapping[str, Any]],
+) -> int:
+    if not rows:
+        return 0
+
+    params = [_params_for_resource(resource, row) for row in rows]
+    await session.execute(text(UPSERT_SQL[resource]), params)
+    return len(params)
+
+
+async def _sync_resource(
+    session: AsyncSession,
+    client: httpx.AsyncClient,
+    *,
+    resource: ProjectionResource,
+    limit: int,
+) -> PmsProjectionResourceSyncResult:
+    safe_limit = _safe_limit(limit)
+    offset = 0
+    pages = 0
+    fetched = 0
+    upserted = 0
+    has_more = False
+    last_offset = 0
+
+    while True:
+        payload = await _fetch_page(
+            client,
+            resource=resource,
+            limit=safe_limit,
+            offset=offset,
+        )
+        rows_value = payload.get("rows")
+        if not isinstance(rows_value, list):
+            raise PmsProjectionSyncError(f"PMS projection feed {resource} rows must be an array")
+
+        rows = [_as_mapping(row, context=f"PMS projection feed {resource} row") for row in rows_value]
+        pages += 1
+        fetched += len(rows)
+        upserted += await _upsert_rows(session, resource=resource, rows=rows)
+
+        has_more = bool(payload.get("has_more"))
+        last_offset = offset
+        if not has_more:
+            break
+
+        next_offset_raw = payload.get("next_offset")
+        if next_offset_raw is None:
+            raise PmsProjectionSyncError(
+                f"PMS projection feed {resource} has_more=true but next_offset is null"
+            )
+
+        next_offset = int(next_offset_raw)
+        if next_offset <= offset:
+            raise PmsProjectionSyncError(
+                f"PMS projection feed {resource} next_offset must advance"
+            )
+
+        offset = next_offset
+
+    return PmsProjectionResourceSyncResult(
+        resource=resource,
+        fetched=fetched,
+        upserted=upserted,
+        pages=pages,
+        last_offset=last_offset,
+        has_more=has_more,
+    )
+
+
+async def sync_pms_read_projection_once(
+    session: AsyncSession,
+    *,
+    pms_api_base_url: str | None = None,
+    limit: int = DEFAULT_LIMIT,
+    resources: Sequence[ProjectionResource] | None = None,
+    timeout_seconds: float = 30.0,
+    transport: httpx.AsyncBaseTransport | None = None,
+) -> PmsProjectionSyncResult:
+    selected = tuple(resources or RESOURCE_ORDER)
+    unknown = [resource for resource in selected if resource not in RESOURCE_ORDER]
+    if unknown:
+        raise PmsProjectionSyncError(f"unsupported projection resources: {unknown}")
+
+    async with httpx.AsyncClient(
+        base_url=_base_url(pms_api_base_url),
+        timeout=httpx.Timeout(timeout_seconds),
+        transport=transport,
+    ) as client:
+        results: dict[ProjectionResource, PmsProjectionResourceSyncResult] = {}
+        for resource in RESOURCE_ORDER:
+            if resource not in selected:
+                continue
+            results[resource] = await _sync_resource(
+                session,
+                client,
+                resource=resource,
+                limit=limit,
+            )
+
+    return PmsProjectionSyncResult(resources=results)
+
+
+__all__ = [
+    "DEFAULT_LIMIT",
+    "MAX_LIMIT",
+    "PmsProjectionResourceSyncResult",
+    "PmsProjectionSyncError",
+    "PmsProjectionSyncResult",
+    "ProjectionResource",
+    "RESOURCE_ORDER",
+    "sync_pms_read_projection_once",
+]

--- a/scripts/make/test.mk
+++ b/scripts/make/test.mk
@@ -250,3 +250,12 @@ pms-http-smoke: venv
 .PHONY: pms-http-business-smoke
 pms-http-business-smoke: venv
 	@PMS_CLIENT_MODE=http PMS_API_BASE_URL="$${PMS_API_BASE_URL:-http://127.0.0.1:8002}" PYTHONPATH=. $(PY) scripts/pms/http_business_smoke.py
+
+# ---------------------------------
+# PMS projection sync
+# Requires pms-api running locally on PMS_API_BASE_URL.
+# This target is intentionally local/manual and is not part of default CI.
+# ---------------------------------
+.PHONY: pms-projection-sync
+pms-projection-sync: venv
+	@PMS_API_BASE_URL="$${PMS_API_BASE_URL:-http://127.0.0.1:8002}" PYTHONPATH=. $(PY) scripts/pms/sync_projection.py --limit "$${PMS_PROJECTION_SYNC_LIMIT:-500}"

--- a/scripts/pms/sync_projection.py
+++ b/scripts/pms/sync_projection.py
@@ -1,0 +1,65 @@
+# scripts/pms/sync_projection.py
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+from app.db.session import async_session_maker
+from app.integrations.pms.projection_sync import (
+    DEFAULT_LIMIT,
+    RESOURCE_ORDER,
+    ProjectionResource,
+    sync_pms_read_projection_once,
+)
+
+
+def _resources(values: list[str] | None) -> tuple[ProjectionResource, ...] | None:
+    if not values:
+        return None
+
+    allowed = set(RESOURCE_ORDER)
+    out: list[ProjectionResource] = []
+    for value in values:
+        resource = value.strip()
+        if resource not in allowed:
+            raise SystemExit(f"unsupported resource={resource}; expected one of {sorted(allowed)}")
+        out.append(resource)  # type: ignore[arg-type]
+    return tuple(out)
+
+
+async def _main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Sync PMS read projection tables from pms-api read-v1 projection feed"
+    )
+    parser.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
+    parser.add_argument("--pms-api-base-url", default=None)
+    parser.add_argument(
+        "--resource",
+        action="append",
+        choices=list(RESOURCE_ORDER),
+        help="Resource to sync. Can be repeated. Defaults to all resources.",
+    )
+    args = parser.parse_args()
+
+    async with async_session_maker() as session:
+        result = await sync_pms_read_projection_once(
+            session,
+            pms_api_base_url=args.pms_api_base_url,
+            limit=args.limit,
+            resources=_resources(args.resource),
+        )
+        await session.commit()
+
+    print(
+        "synced PMS read projection: "
+        f"fetched={result.fetched} upserted={result.upserted}"
+    )
+    for resource, row in result.resources.items():
+        print(
+            f"- {resource}: fetched={row.fetched} upserted={row.upserted} "
+            f"pages={row.pages} last_offset={row.last_offset} has_more={row.has_more}"
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/tests/ci/test_wms_pms_projection_sync_boundary.py
+++ b/tests/ci/test_wms_pms_projection_sync_boundary.py
@@ -1,0 +1,41 @@
+# tests/ci/test_wms_pms_projection_sync_boundary.py
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+FORBIDDEN_OWNER_SQL_RE = re.compile(
+    r"\bFROM\s+(items|item_uoms|item_sku_codes|item_barcodes)\b"
+    r"|\bJOIN\s+(items|item_uoms|item_sku_codes|item_barcodes)\b",
+    re.IGNORECASE,
+)
+
+
+def test_pms_projection_sync_uses_read_v1_feed_endpoints_only() -> None:
+    text = (ROOT / "app/integrations/pms/projection_sync.py").read_text(encoding="utf-8")
+
+    assert "/pms/read/v1/projection-feed/items" in text
+    assert "/pms/read/v1/projection-feed/uoms" in text
+    assert "/pms/read/v1/projection-feed/sku-codes" in text
+    assert "/pms/read/v1/projection-feed/barcodes" in text
+
+    assert "/pms/export/" not in text
+    assert "/items/basic" not in text
+
+
+def test_pms_projection_sync_does_not_read_owner_tables_directly() -> None:
+    text = (ROOT / "app/integrations/pms/projection_sync.py").read_text(encoding="utf-8")
+
+    assert FORBIDDEN_OWNER_SQL_RE.search(text) is None
+    assert "app.pms" not in text
+
+
+def test_pms_projection_sync_writes_projection_tables_only() -> None:
+    text = (ROOT / "app/integrations/pms/projection_sync.py").read_text(encoding="utf-8")
+
+    assert "INSERT INTO wms_pms_item_projection" in text
+    assert "INSERT INTO wms_pms_uom_projection" in text
+    assert "INSERT INTO wms_pms_sku_code_projection" in text
+    assert "INSERT INTO wms_pms_barcode_projection" in text

--- a/tests/services/test_pms_projection_sync.py
+++ b/tests/services/test_pms_projection_sync.py
@@ -1,0 +1,287 @@
+# tests/services/test_pms_projection_sync.py
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.integrations.pms.projection_sync import (
+    SYNC_VERSION,
+    sync_pms_read_projection_once,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _clear_projection_tables(session: AsyncSession) -> None:
+    for table_name in (
+        "wms_pms_barcode_projection",
+        "wms_pms_sku_code_projection",
+        "wms_pms_uom_projection",
+        "wms_pms_item_projection",
+    ):
+        await session.execute(text(f"DELETE FROM {table_name}"))
+
+
+def _transport(calls: list[tuple[str, str]]) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        offset = int(request.url.params.get("offset", 0))
+        limit = int(request.url.params.get("limit", 500))
+        calls.append((path, str(request.url.query.decode("utf-8"))))
+
+        if path == "/pms/read/v1/projection-feed/items":
+            rows: list[dict[str, Any]] = [
+                {
+                    "item_id": 9001,
+                    "sku": "SYNC-ITEM-1",
+                    "name": "同步商品1",
+                    "spec": None,
+                    "enabled": True,
+                    "supplier_id": None,
+                    "brand": None,
+                    "category": None,
+                    "expiry_policy": "NONE",
+                    "shelf_life_value": None,
+                    "shelf_life_unit": None,
+                    "lot_source_policy": "INTERNAL_ONLY",
+                    "derivation_allowed": True,
+                    "uom_governance_enabled": False,
+                    "pms_updated_at": "2026-01-01T00:00:00Z",
+                },
+                {
+                    "item_id": 9002,
+                    "sku": "SYNC-ITEM-2",
+                    "name": "同步商品2",
+                    "spec": "规格2",
+                    "enabled": False,
+                    "supplier_id": 12,
+                    "brand": "品牌2",
+                    "category": "分类2",
+                    "expiry_policy": "REQUIRED",
+                    "shelf_life_value": 12,
+                    "shelf_life_unit": "MONTH",
+                    "lot_source_policy": "SUPPLIER_ONLY",
+                    "derivation_allowed": False,
+                    "uom_governance_enabled": True,
+                    "pms_updated_at": "2026-01-02T00:00:00Z",
+                },
+            ]
+            page = rows[offset : offset + limit]
+            has_more = offset + limit < len(rows)
+            return httpx.Response(
+                200,
+                json={
+                    "rows": page,
+                    "limit": limit,
+                    "offset": offset,
+                    "next_offset": offset + limit if has_more else None,
+                    "has_more": has_more,
+                },
+            )
+
+        if path == "/pms/read/v1/projection-feed/uoms":
+            return httpx.Response(
+                200,
+                json={
+                    "rows": [
+                        {
+                            "item_uom_id": 9101,
+                            "item_id": 9001,
+                            "uom": "PCS",
+                            "display_name": "件",
+                            "uom_name": "件",
+                            "ratio_to_base": 1,
+                            "net_weight_kg": 0.5,
+                            "is_base": True,
+                            "is_purchase_default": True,
+                            "is_inbound_default": True,
+                            "is_outbound_default": True,
+                            "pms_updated_at": "2026-01-03T00:00:00Z",
+                        }
+                    ],
+                    "limit": limit,
+                    "offset": offset,
+                    "next_offset": None,
+                    "has_more": False,
+                },
+            )
+
+        if path == "/pms/read/v1/projection-feed/sku-codes":
+            return httpx.Response(
+                200,
+                json={
+                    "rows": [
+                        {
+                            "sku_code_id": 9201,
+                            "item_id": 9001,
+                            "sku_code": "SYNC-ITEM-1",
+                            "code_type": "PRIMARY",
+                            "is_primary": True,
+                            "is_active": True,
+                            "effective_from": None,
+                            "effective_to": None,
+                            "pms_updated_at": "2026-01-04T00:00:00Z",
+                        }
+                    ],
+                    "limit": limit,
+                    "offset": offset,
+                    "next_offset": None,
+                    "has_more": False,
+                },
+            )
+
+        if path == "/pms/read/v1/projection-feed/barcodes":
+            return httpx.Response(
+                200,
+                json={
+                    "rows": [
+                        {
+                            "barcode_id": 9301,
+                            "item_id": 9001,
+                            "item_uom_id": 9101,
+                            "barcode": "SYNC-BARCODE-1",
+                            "symbology": "CUSTOM",
+                            "active": True,
+                            "is_primary": True,
+                            "pms_updated_at": "2026-01-05T00:00:00Z",
+                        }
+                    ],
+                    "limit": limit,
+                    "offset": offset,
+                    "next_offset": None,
+                    "has_more": False,
+                },
+            )
+
+        return httpx.Response(404, json={"detail": f"unexpected path: {path}"})
+
+    return httpx.MockTransport(handler)
+
+
+async def test_sync_pms_read_projection_upserts_feed_rows(session: AsyncSession) -> None:
+    await _clear_projection_tables(session)
+
+    calls: list[tuple[str, str]] = []
+    result = await sync_pms_read_projection_once(
+        session,
+        pms_api_base_url="http://pms-api.test",
+        limit=1,
+        transport=_transport(calls),
+    )
+    await session.flush()
+
+    assert result.fetched == 5
+    assert result.upserted == 5
+    assert result.resources["items"].pages == 2
+    assert result.resources["items"].fetched == 2
+
+    item = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                    item_id,
+                    sku,
+                    name,
+                    enabled,
+                    expiry_policy,
+                    shelf_life_value,
+                    shelf_life_unit,
+                    lot_source_policy,
+                    source_hash,
+                    sync_version
+                FROM wms_pms_item_projection
+                WHERE item_id = 9002
+                """
+            )
+        )
+    ).mappings().one()
+    assert item["sku"] == "SYNC-ITEM-2"
+    assert item["enabled"] is False
+    assert item["expiry_policy"] == "REQUIRED"
+    assert item["shelf_life_value"] == 12
+    assert item["shelf_life_unit"] == "MONTH"
+    assert item["lot_source_policy"] == "SUPPLIER_ONLY"
+    assert item["source_hash"]
+    assert item["sync_version"] == SYNC_VERSION
+
+    uom = (
+        await session.execute(
+            text(
+                """
+                SELECT item_uom_id, item_id, uom, uom_name, ratio_to_base, net_weight_kg
+                FROM wms_pms_uom_projection
+                WHERE item_uom_id = 9101
+                """
+            )
+        )
+    ).mappings().one()
+    assert uom["item_id"] == 9001
+    assert uom["uom"] == "PCS"
+    assert uom["uom_name"] == "件"
+    assert uom["ratio_to_base"] == 1
+
+    sku_code = (
+        await session.execute(
+            text(
+                """
+                SELECT sku_code_id, item_id, sku_code, code_type, is_primary, is_active
+                FROM wms_pms_sku_code_projection
+                WHERE sku_code_id = 9201
+                """
+            )
+        )
+    ).mappings().one()
+    assert sku_code["sku_code"] == "SYNC-ITEM-1"
+    assert sku_code["code_type"] == "PRIMARY"
+    assert sku_code["is_primary"] is True
+    assert sku_code["is_active"] is True
+
+    barcode = (
+        await session.execute(
+            text(
+                """
+                SELECT barcode_id, item_id, item_uom_id, barcode, symbology, active, is_primary
+                FROM wms_pms_barcode_projection
+                WHERE barcode_id = 9301
+                """
+            )
+        )
+    ).mappings().one()
+    assert barcode["barcode"] == "SYNC-BARCODE-1"
+    assert barcode["symbology"] == "CUSTOM"
+    assert barcode["active"] is True
+    assert barcode["is_primary"] is True
+
+    called_paths = [path for path, _ in calls]
+    assert called_paths == [
+        "/pms/read/v1/projection-feed/items",
+        "/pms/read/v1/projection-feed/items",
+        "/pms/read/v1/projection-feed/uoms",
+        "/pms/read/v1/projection-feed/sku-codes",
+        "/pms/read/v1/projection-feed/barcodes",
+    ]
+
+
+async def test_sync_pms_read_projection_can_limit_resources(session: AsyncSession) -> None:
+    await _clear_projection_tables(session)
+
+    calls: list[tuple[str, str]] = []
+    result = await sync_pms_read_projection_once(
+        session,
+        pms_api_base_url="http://pms-api.test",
+        limit=500,
+        resources=["barcodes"],
+        transport=_transport(calls),
+    )
+    await session.flush()
+
+    assert sorted(result.resources) == ["barcodes"]
+    assert result.fetched == 1
+
+    called_paths = [path for path, _ in calls]
+    assert called_paths == ["/pms/read/v1/projection-feed/barcodes"]


### PR DESCRIPTION
## Summary
- add PMS read projection sync service
- sync WMS PMS projection tables from pms-api read-v1 projection-feed endpoints
- add manual sync script scripts/pms/sync_projection.py
- add make pms-projection-sync target
- add sync service smoke tests
- add CI boundary guard for feed-only HTTP sync and projection-only writes

## Boundary
- source is pms-api /pms/read/v1/projection-feed/*
- no direct SQL reads of PMS owner tables in WMS
- no business read path is changed
- no delete sync in this PR
- no reconciliation in this PR
- projection remains a WMS local read index, not write validation and not snapshot

## Validation
- python3 -m compileall targeted files
- targeted pytest: tests/services/test_pms_projection_sync.py tests/ci/test_wms_pms_projection_sync_boundary.py tests/ci/test_wms_pms_read_projection_boundary.py tests/ci/test_pms_owner_boundary_contract.py
- make alembic-check
- real HTTP sync against pms-api projection feed
- DB row count after real sync: items=12, uoms=16, sku-codes=12, barcodes=15
- DB FK check confirms projection tables have no foreign keys
