### PR TITLE
feat(pms): use projection for inventory options

### DIFF
--- a/app/wms/stock/repos/inventory_options_repo.py
+++ b/app/wms/stock/repos/inventory_options_repo.py
@@ -5,8 +5,12 @@ from typing import Any
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.integrations.pms.contracts import ItemReadQuery
-from app.integrations.pms.factory import create_pms_read_client
+
+def _norm_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    text_value = str(value).strip()
+    return text_value or None
 
 
 async def list_active_warehouses(
@@ -37,21 +41,46 @@ async def list_public_items(
     q: str | None,
     limit: int,
 ) -> list[dict[str, Any]]:
-    items = await create_pms_read_client(session=session).list_item_basics(
-        query=ItemReadQuery(
-            enabled=True,
-            q=q,
-            limit=int(limit),
+    """
+    Inventory options read PMS current-state from WMS local projection.
+
+    Boundary:
+    - projection is a WMS read index synced from pms-api read-v1 HTTP;
+    - this read path must not call pms-api per request;
+    - write validation still belongs to pms-api HTTP integration;
+    - historical facts still belong to snapshot / ledger / lot rows.
+    """
+    q_norm = _norm_text(q)
+    safe_limit = max(1, min(int(limit), 500))
+
+    conditions = ["p.enabled IS TRUE"]
+    params: dict[str, Any] = {"limit": safe_limit}
+
+    if q_norm is not None:
+        conditions.append(
+            """
+            (
+                p.sku ILIKE :q
+                OR p.name ILIKE :q
+            )
+            """
         )
+        params["q"] = f"%{q_norm}%"
+
+    sql = text(
+        f"""
+        SELECT
+            p.item_id AS id,
+            p.sku,
+            p.name
+        FROM wms_pms_item_projection AS p
+        WHERE {" AND ".join(conditions)}
+        ORDER BY p.item_id ASC
+        LIMIT :limit
+        """
     )
-    return [
-        {
-            "id": int(item.id),
-            "sku": str(item.sku),
-            "name": str(item.name),
-        }
-        for item in items
-    ]
+    rows = (await session.execute(sql, params)).mappings().all()
+    return [dict(r) for r in rows]
 
 
 __all__ = [

--- a/tests/api/test_stock_inventory_read_api.py
+++ b/tests/api/test_stock_inventory_read_api.py
@@ -50,6 +50,92 @@ async def test_stock_options_returns_warehouses_and_items(client: AsyncClient) -
 
 
 @pytest.mark.asyncio
+async def test_stock_options_items_use_pms_projection(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+
+    item_id = 990101
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_pms_item_projection (
+                item_id,
+                sku,
+                name,
+                spec,
+                enabled,
+                supplier_id,
+                brand,
+                category,
+                expiry_policy,
+                shelf_life_value,
+                shelf_life_unit,
+                lot_source_policy,
+                derivation_allowed,
+                uom_governance_enabled,
+                pms_updated_at,
+                source_hash,
+                sync_version,
+                synced_at
+            )
+            VALUES (
+                :item_id,
+                :sku,
+                :name,
+                NULL,
+                TRUE,
+                NULL,
+                NULL,
+                NULL,
+                'NONE',
+                NULL,
+                NULL,
+                'INTERNAL_ONLY',
+                TRUE,
+                FALSE,
+                now(),
+                :source_hash,
+                'ut-stock-options-projection',
+                now()
+            )
+            ON CONFLICT (item_id) DO UPDATE SET
+                sku = EXCLUDED.sku,
+                name = EXCLUDED.name,
+                enabled = EXCLUDED.enabled,
+                pms_updated_at = EXCLUDED.pms_updated_at,
+                source_hash = EXCLUDED.source_hash,
+                sync_version = EXCLUDED.sync_version,
+                synced_at = now()
+            """
+        ),
+        {
+            "item_id": item_id,
+            "sku": "UT-PROJ-STOCK-OPT-990101",
+            "name": "库存选项Projection商品990101",
+            "source_hash": "ut-stock-options-projection-990101",
+        },
+    )
+    await session.commit()
+
+    r = await client.get(
+        "/stock/options",
+        headers=headers,
+        params={"item_q": "UT-PROJ-STOCK-OPT-990101", "item_limit": 20},
+    )
+    assert r.status_code == 200, r.text
+
+    items = r.json()["items"]
+    assert any(
+        int(item["id"]) == item_id
+        and item["sku"] == "UT-PROJ-STOCK-OPT-990101"
+        and item["name"] == "库存选项Projection商品990101"
+        for item in items
+    ), items
+
+
+@pytest.mark.asyncio
 async def test_stock_inventory_returns_inventory_rows_with_lot_code_only(client: AsyncClient) -> None:
     headers = await _login_admin_headers(client)
 

--- a/tests/ci/test_wms_pms_projection_read_usage.py
+++ b/tests/ci/test_wms_pms_projection_read_usage.py
@@ -1,0 +1,34 @@
+# tests/ci/test_wms_pms_projection_read_usage.py
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_inventory_options_items_read_from_projection_not_http() -> None:
+    text = (ROOT / "app/wms/stock/repos/inventory_options_repo.py").read_text(encoding="utf-8")
+
+    assert "wms_pms_item_projection" in text
+    assert "create_pms_read_client" not in text
+    assert "ItemReadQuery" not in text
+
+
+def test_inventory_options_items_do_not_read_pms_owner_tables() -> None:
+    text = (ROOT / "app/wms/stock/repos/inventory_options_repo.py").read_text(encoding="utf-8")
+
+    forbidden = re.compile(
+        r"\bFROM\s+(items|item_uoms|item_sku_codes|item_barcodes)\b"
+        r"|\bJOIN\s+(items|item_uoms|item_sku_codes|item_barcodes)\b",
+        re.IGNORECASE,
+    )
+    assert forbidden.search(text) is None
+
+
+def test_inventory_options_items_do_not_write_projection() -> None:
+    text = (ROOT / "app/wms/stock/repos/inventory_options_repo.py").read_text(encoding="utf-8")
+
+    assert "INSERT INTO wms_pms_" not in text
+    assert "UPDATE wms_pms_" not in text
+    assert "DELETE FROM wms_pms_" not in text


### PR DESCRIPTION
## Summary
- switch /stock/options item candidates from PMS HTTP read client to WMS local PMS item projection
- keep warehouse options unchanged
- add API coverage proving stock options can return projection-backed item rows
- add CI guard to prevent inventory options from calling PMS HTTP or reading PMS owner tables directly

## Boundary
- only /stock/options item candidate read path is changed
- no write validation is changed
- no inventory list/detail/explain read path is changed
- no snapshot / lot / ledger historical facts are changed
- projection is used only as a WMS local current-state read index
- PMS owner truth still belongs to pms-api

## Validation
- targeted pytest: tests/api/test_stock_inventory_read_api.py::test_stock_options_returns_warehouses_and_items
- targeted pytest: tests/api/test_stock_inventory_read_api.py::test_stock_options_items_use_pms_projection
- targeted pytest: tests/ci/test_wms_pms_projection_read_usage.py
- targeted projection/boundary CI guards
- make alembic-check
- HTTP smoke: /stock/options?item_q=SKU-0001 returns projection-backed SKU-0001
