### PR TITLE
feat(pms): use projection for scan probes

### DIFF
--- a/app/integrations/pms/projection_read.py
+++ b/app/integrations/pms/projection_read.py
@@ -1,0 +1,119 @@
+# app/integrations/pms/projection_read.py
+"""
+Read helpers for WMS-owned PMS projection tables.
+
+Boundary:
+- These helpers read WMS local projection tables only.
+- They must not call pms-api HTTP.
+- They must not read PMS owner tables directly.
+- They are for read/probe/display paths only, not write validation authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@dataclass(frozen=True)
+class ProjectionBarcodeResolved:
+    item_id: int
+    item_uom_id: int | None
+    ratio_to_base: int | None
+    symbology: str | None
+    active: bool | None
+
+
+async def resolve_projection_barcode(
+    session: AsyncSession,
+    *,
+    barcode: str,
+) -> ProjectionBarcodeResolved | None:
+    code = str(barcode or "").strip()
+    if not code:
+        return None
+
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                    b.item_id,
+                    b.item_uom_id,
+                    u.ratio_to_base,
+                    b.symbology,
+                    b.active
+                FROM wms_pms_barcode_projection AS b
+                LEFT JOIN wms_pms_uom_projection AS u
+                  ON u.item_uom_id = b.item_uom_id
+                 AND u.item_id = b.item_id
+                WHERE b.barcode = :barcode
+                LIMIT 1
+                """
+            ),
+            {"barcode": code},
+        )
+    ).mappings().first()
+
+    if row is None:
+        return None
+    if bool(row["active"]) is not True:
+        return None
+
+    return ProjectionBarcodeResolved(
+        item_id=int(row["item_id"]),
+        item_uom_id=(
+            int(row["item_uom_id"]) if row["item_uom_id"] is not None else None
+        ),
+        ratio_to_base=(
+            int(row["ratio_to_base"]) if row["ratio_to_base"] is not None else None
+        ),
+        symbology=(str(row["symbology"]) if row["symbology"] is not None else None),
+        active=bool(row["active"]),
+    )
+
+
+async def resolve_projection_sku_code_item_id(
+    session: AsyncSession,
+    *,
+    sku_code: str,
+    active_only: bool = True,
+) -> int | None:
+    code = str(sku_code or "").strip().upper()
+    if not code:
+        return None
+
+    cond = ["UPPER(s.sku_code) = :sku_code"]
+    params: dict[str, object] = {"sku_code": code}
+
+    if active_only:
+        cond.append("s.is_active IS TRUE")
+
+    row = (
+        await session.execute(
+            text(
+                f"""
+                SELECT
+                    s.item_id
+                FROM wms_pms_sku_code_projection AS s
+                WHERE {" AND ".join(cond)}
+                ORDER BY s.is_primary DESC, s.sku_code_id ASC
+                LIMIT 1
+                """
+            ),
+            params,
+        )
+    ).first()
+
+    if row is None:
+        return None
+    return int(row[0])
+
+
+__all__ = [
+    "ProjectionBarcodeResolved",
+    "resolve_projection_barcode",
+    "resolve_projection_sku_code_item_id",
+]

--- a/app/wms/scan/services/scan_orchestrator_ingest.py
+++ b/app/wms/scan/services/scan_orchestrator_ingest.py
@@ -156,15 +156,6 @@ async def ingest(scan: Dict[str, Any], session: Optional[AsyncSession]) -> Dict[
             "qty_base": qty_base,
         }
 
-    base_kwargs: Dict[str, Any] = {
-        "item_id": item_id,
-        "warehouse_id": wh_id,
-        "lot_code": lot_code,
-        "ref": scan_ref_norm,
-        "production_date": production_date,
-        "expiry_date": expiry_date,
-    }
-
     try:
         if not probe:
             ev = await AUDIT.other(session, scan_ref_norm)
@@ -188,7 +179,6 @@ async def ingest(scan: Dict[str, Any], session: Optional[AsyncSession]) -> Dict[
             audit=AUDIT,
             scan_ref_norm=scan_ref_norm,
             parsed=parsed,
-            base_kwargs=base_kwargs,
             qty=exec_qty,
             item_id=item_id,
             wh_id=wh_id,

--- a/app/wms/scan/services/scan_orchestrator_item_resolver.py
+++ b/app/wms/scan/services/scan_orchestrator_item_resolver.py
@@ -6,7 +6,10 @@ from typing import Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.integrations.pms.factory import create_pms_read_client
+from app.integrations.pms.projection_read import (
+    resolve_projection_barcode,
+    resolve_projection_sku_code_item_id,
+)
 
 
 @dataclass(frozen=True)
@@ -23,34 +26,41 @@ async def probe_item_from_barcode(
     barcode: str,
 ) -> Optional[ScanBarcodeResolved]:
     """
-    WMS scan 读取链通过 PMS integration client 解析 barcode：
+    WMS /scan probe reads barcode current-state from WMS local PMS projection.
 
-    - 不直接查询 item_barcodes
-    - 不直接 import PMS export service
-    - 当前业务通过 PMS read client factory 获取客户端，默认 inprocess，未来可切 HTTP PMS client
-    - 当前返回 richer 结构，供 parse_scan 后续阶段继续透传
+    Boundary:
+    - /scan is probe-only and does not post inventory facts;
+    - this read path must not call pms-api per scan request;
+    - this read path must not read PMS owner tables directly;
+    - write validation remains in formal WMS submit flows and PMS HTTP integration.
     """
     code = (barcode or "").strip()
     if not code:
         return None
 
     try:
-        probe = await create_pms_read_client(session=session).probe_barcode(barcode=code)
-        if probe.status != "BOUND":
-            return None
-        if probe.item_id is None:
+        resolved = await resolve_projection_barcode(session, barcode=code)
+        if resolved is None:
             return None
 
         return ScanBarcodeResolved(
-            item_id=int(probe.item_id),
+            item_id=int(resolved.item_id),
             item_uom_id=(
-                int(probe.item_uom_id) if probe.item_uom_id is not None else None
+                int(resolved.item_uom_id)
+                if resolved.item_uom_id is not None
+                else None
             ),
             ratio_to_base=(
-                int(probe.ratio_to_base) if probe.ratio_to_base is not None else None
+                int(resolved.ratio_to_base)
+                if resolved.ratio_to_base is not None
+                else None
             ),
-            symbology=(str(probe.symbology) if probe.symbology is not None else None),
-            active=probe.active if probe.active is not None else None,
+            symbology=(
+                str(resolved.symbology)
+                if resolved.symbology is not None
+                else None
+            ),
+            active=resolved.active if resolved.active is not None else None,
         )
     except Exception:
         return None
@@ -62,8 +72,8 @@ async def resolve_item_id_from_barcode(
 ) -> Optional[int]:
     """
     兼容壳：
-    - 现阶段 parse_scan 仍只消费 item_id
-    - 后续阶段将逐步改为直接消费 probe_item_from_barcode 的 richer 结果
+    - parse_scan 仍可只消费 item_id；
+    - richer barcode projection result 仍由 probe_item_from_barcode 承载。
     """
     resolved = await probe_item_from_barcode(session, barcode)
     if resolved is None:
@@ -73,24 +83,23 @@ async def resolve_item_id_from_barcode(
 
 async def resolve_item_id_from_sku(session: AsyncSession, sku: str) -> Optional[int]:
     """
-    WMS scan SKU 文本解析通过 PMS integration client 读取 SKU code。
+    WMS /scan SKU text probe reads active sku_code current-state from projection.
 
-    保持原语义：
-    - 只要求命中 active SKU code；
-    - 不要求出库默认单位 / 基础单位；
-    - 不在 WMS scan 内直接读取 PMS item_sku_codes / items 表。
+    Boundary:
+    - only resolves active SKU code to item_id;
+    - does not require outbound default/base uom;
+    - does not call pms-api per scan request;
+    - does not read PMS owner tables directly.
     """
     s = (sku or "").strip().upper()
     if not s:
         return None
 
     try:
-        rows = await create_pms_read_client(session=session).list_sku_codes(
-            code=s,
-            active=True,
+        return await resolve_projection_sku_code_item_id(
+            session,
+            sku_code=s,
+            active_only=True,
         )
-        if not rows:
-            return None
-        return int(rows[0].item_id)
     except Exception:
         return None

--- a/app/wms/scan/services/scan_orchestrator_parse.py
+++ b/app/wms/scan/services/scan_orchestrator_parse.py
@@ -108,6 +108,11 @@ async def parse_scan(
             if getattr(r, "expiry", None) and not parsed.get("expiry_date"):
                 parsed["expiry_date"] = r.expiry  # type: ignore[assignment]
 
+    if raw and parsed.get("item_id") is None:
+        iid = await resolve_item_id_from_sku(session, raw)
+        if iid:
+            parsed["item_id"] = iid
+
     qty = int(parsed.get("qty") or scan.get("qty") or 1)
     item_id = int(parsed.get("item_id") or 0)
     lot_code = parsed.get("lot_code")

--- a/tests/ci/test_wms_pms_projection_read_usage.py
+++ b/tests/ci/test_wms_pms_projection_read_usage.py
@@ -32,3 +32,34 @@ def test_inventory_options_items_do_not_write_projection() -> None:
     assert "INSERT INTO wms_pms_" not in text
     assert "UPDATE wms_pms_" not in text
     assert "DELETE FROM wms_pms_" not in text
+
+def test_scan_probe_reads_barcode_and_sku_from_projection_not_http() -> None:
+    text = (ROOT / "app/wms/scan/services/scan_orchestrator_item_resolver.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "resolve_projection_barcode" in text
+    assert "resolve_projection_sku_code_item_id" in text
+    assert "create_pms_read_client" not in text
+    assert "probe_barcode" not in text
+    assert "list_sku_codes" not in text
+
+
+def test_projection_read_helper_reads_only_projection_tables() -> None:
+    text = (ROOT / "app/integrations/pms/projection_read.py").read_text(encoding="utf-8")
+
+    assert "wms_pms_barcode_projection" in text
+    assert "wms_pms_sku_code_projection" in text
+    assert "wms_pms_uom_projection" in text
+
+    forbidden = re.compile(
+        r"\bFROM\s+(items|item_uoms|item_sku_codes|item_barcodes)\b"
+        r"|\bJOIN\s+(items|item_uoms|item_sku_codes|item_barcodes)\b",
+        re.IGNORECASE,
+    )
+    assert forbidden.search(text) is None
+
+    assert "create_pms_read_client" not in text
+    assert "INSERT INTO wms_pms_" not in text
+    assert "UPDATE wms_pms_" not in text
+    assert "DELETE FROM wms_pms_" not in text

--- a/tests/services/test_scan_projection_item_resolver.py
+++ b/tests/services/test_scan_projection_item_resolver.py
@@ -1,0 +1,340 @@
+# tests/services/test_scan_projection_item_resolver.py
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.wms.scan.services.scan_orchestrator_ingest import ingest
+from app.wms.scan.services.scan_orchestrator_parse import parse_scan
+from app.wms.scan.services.scan_orchestrator_item_resolver import (
+    probe_item_from_barcode,
+    resolve_item_id_from_barcode,
+    resolve_item_id_from_sku,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_projection(session: AsyncSession) -> None:
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_pms_item_projection (
+                item_id,
+                sku,
+                name,
+                spec,
+                enabled,
+                supplier_id,
+                brand,
+                category,
+                expiry_policy,
+                shelf_life_value,
+                shelf_life_unit,
+                lot_source_policy,
+                derivation_allowed,
+                uom_governance_enabled,
+                pms_updated_at,
+                source_hash,
+                sync_version,
+                synced_at
+            )
+            VALUES (
+                991001,
+                'UT-SCAN-SKU-991001',
+                '扫码Projection商品991001',
+                NULL,
+                TRUE,
+                NULL,
+                NULL,
+                NULL,
+                'NONE',
+                NULL,
+                NULL,
+                'INTERNAL_ONLY',
+                TRUE,
+                FALSE,
+                now(),
+                'ut-scan-item-991001',
+                'ut-scan-projection',
+                now()
+            )
+            ON CONFLICT (item_id) DO UPDATE SET
+                sku = EXCLUDED.sku,
+                name = EXCLUDED.name,
+                enabled = EXCLUDED.enabled,
+                pms_updated_at = EXCLUDED.pms_updated_at,
+                source_hash = EXCLUDED.source_hash,
+                sync_version = EXCLUDED.sync_version,
+                synced_at = now()
+            """
+        )
+    )
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_pms_uom_projection (
+                item_uom_id,
+                item_id,
+                uom,
+                display_name,
+                uom_name,
+                ratio_to_base,
+                net_weight_kg,
+                is_base,
+                is_purchase_default,
+                is_inbound_default,
+                is_outbound_default,
+                pms_updated_at,
+                source_hash,
+                sync_version,
+                synced_at
+            )
+            VALUES (
+                991011,
+                991001,
+                'PCS',
+                '件',
+                '件',
+                1,
+                NULL,
+                TRUE,
+                TRUE,
+                TRUE,
+                TRUE,
+                now(),
+                'ut-scan-uom-991011',
+                'ut-scan-projection',
+                now()
+            )
+            ON CONFLICT (item_uom_id) DO UPDATE SET
+                item_id = EXCLUDED.item_id,
+                uom = EXCLUDED.uom,
+                display_name = EXCLUDED.display_name,
+                uom_name = EXCLUDED.uom_name,
+                ratio_to_base = EXCLUDED.ratio_to_base,
+                is_base = EXCLUDED.is_base,
+                is_purchase_default = EXCLUDED.is_purchase_default,
+                is_inbound_default = EXCLUDED.is_inbound_default,
+                is_outbound_default = EXCLUDED.is_outbound_default,
+                pms_updated_at = EXCLUDED.pms_updated_at,
+                source_hash = EXCLUDED.source_hash,
+                sync_version = EXCLUDED.sync_version,
+                synced_at = now()
+            """
+        )
+    )
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_pms_barcode_projection (
+                barcode_id,
+                item_id,
+                item_uom_id,
+                barcode,
+                symbology,
+                active,
+                is_primary,
+                pms_updated_at,
+                source_hash,
+                sync_version,
+                synced_at
+            )
+            VALUES (
+                991021,
+                991001,
+                991011,
+                'UT-SCAN-BARCODE-991001',
+                'CUSTOM',
+                TRUE,
+                TRUE,
+                now(),
+                'ut-scan-barcode-991021',
+                'ut-scan-projection',
+                now()
+            )
+            ON CONFLICT (barcode_id) DO UPDATE SET
+                item_id = EXCLUDED.item_id,
+                item_uom_id = EXCLUDED.item_uom_id,
+                barcode = EXCLUDED.barcode,
+                symbology = EXCLUDED.symbology,
+                active = EXCLUDED.active,
+                is_primary = EXCLUDED.is_primary,
+                pms_updated_at = EXCLUDED.pms_updated_at,
+                source_hash = EXCLUDED.source_hash,
+                sync_version = EXCLUDED.sync_version,
+                synced_at = now()
+            """
+        )
+    )
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_pms_sku_code_projection (
+                sku_code_id,
+                item_id,
+                sku_code,
+                code_type,
+                is_primary,
+                is_active,
+                effective_from,
+                effective_to,
+                pms_updated_at,
+                source_hash,
+                sync_version,
+                synced_at
+            )
+            VALUES (
+                991031,
+                991001,
+                'UT-SCAN-SKU-991001',
+                'PRIMARY',
+                TRUE,
+                TRUE,
+                now(),
+                NULL,
+                now(),
+                'ut-scan-sku-code-991031',
+                'ut-scan-projection',
+                now()
+            )
+            ON CONFLICT (sku_code_id) DO UPDATE SET
+                item_id = EXCLUDED.item_id,
+                sku_code = EXCLUDED.sku_code,
+                code_type = EXCLUDED.code_type,
+                is_primary = EXCLUDED.is_primary,
+                is_active = EXCLUDED.is_active,
+                effective_from = EXCLUDED.effective_from,
+                effective_to = EXCLUDED.effective_to,
+                pms_updated_at = EXCLUDED.pms_updated_at,
+                source_hash = EXCLUDED.source_hash,
+                sync_version = EXCLUDED.sync_version,
+                synced_at = now()
+            """
+        )
+    )
+
+
+async def test_scan_barcode_probe_reads_projection_without_http(
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PMS_API_BASE_URL", raising=False)
+    await _seed_projection(session)
+    await session.flush()
+
+    resolved = await probe_item_from_barcode(
+        session,
+        "UT-SCAN-BARCODE-991001",
+    )
+
+    assert resolved is not None
+    assert resolved.item_id == 991001
+    assert resolved.item_uom_id == 991011
+    assert resolved.ratio_to_base == 1
+    assert resolved.symbology == "CUSTOM"
+    assert resolved.active is True
+
+    item_id = await resolve_item_id_from_barcode(
+        session,
+        "UT-SCAN-BARCODE-991001",
+    )
+    assert item_id == 991001
+
+
+async def test_scan_sku_text_reads_projection_without_http(
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PMS_API_BASE_URL", raising=False)
+    await _seed_projection(session)
+    await session.flush()
+
+    item_id = await resolve_item_id_from_sku(
+        session,
+        "ut-scan-sku-991001",
+    )
+
+    assert item_id == 991001
+
+
+async def test_scan_projection_lookup_returns_none_for_missing(
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PMS_API_BASE_URL", raising=False)
+
+    assert await probe_item_from_barcode(session, "MISSING-SCAN-BARCODE") is None
+    assert await resolve_item_id_from_sku(session, "MISSING-SCAN-SKU") is None
+
+async def test_parse_scan_raw_sku_text_reads_projection(
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PMS_API_BASE_URL", raising=False)
+    await _seed_projection(session)
+    await session.flush()
+
+    (
+        parsed,
+        mode,
+        probe,
+        qty,
+        item_id,
+        lot_code,
+        warehouse_id,
+        production_date,
+        expiry_date,
+    ) = await parse_scan(
+        {
+            "mode": "pick",
+            "probe": True,
+            "barcode": "UT-SCAN-SKU-991001",
+            "qty": 1,
+            "warehouse_id": 1,
+        },
+        session,
+    )
+
+    assert parsed["item_id"] == 991001
+    assert mode == "pick"
+    assert probe is True
+    assert qty == 1
+    assert item_id == 991001
+    assert lot_code is None
+    assert warehouse_id == 1
+    assert production_date is None
+    assert expiry_date is None
+
+
+async def test_scan_ingest_pick_probe_uses_projection_without_base_kwargs_error(
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PMS_API_BASE_URL", raising=False)
+    await _seed_projection(session)
+    await session.flush()
+
+    result = await ingest(
+        {
+            "mode": "pick",
+            "probe": True,
+            "barcode": "UT-SCAN-BARCODE-991001",
+            "qty": 1,
+            "warehouse_id": 1,
+        },
+        session,
+    )
+
+    assert result["ok"] is True
+    assert result["committed"] is False
+    assert result["source"] == "scan_pick_probe_parse_only"
+    assert result["item_id"] == 991001
+    assert result["item_uom_id"] == 991011
+    assert result["ratio_to_base"] == 1
+    assert result["qty_base"] == 1
+    assert result["errors"] == []


### PR DESCRIPTION
## Summary
- add WMS PMS projection read helper for barcode and sku-code probe reads
- switch /scan probe barcode resolution from PMS HTTP to WMS local barcode projection
- switch /scan probe SKU text resolution from PMS HTTP to WMS local sku-code projection
- fix /scan pick probe call shape by removing retired base_kwargs argument
- add raw SKU fallback for /scan text probes
- add service tests and CI guards for projection-only scan probe reads

## Boundary
- only /scan probe read path is changed
- no formal inbound commit path is changed
- no return inbound operation submit path is changed
- no FSKU write/resolve_active_code_for_outbound_default path is changed
- no inventory facts are written by /scan
- no PMS owner table is read directly
- no pms-api HTTP call is made per /scan probe request
- projection remains a WMS local current-state read index, not write validation authority

## Validation
- targeted pytest: tests/services/test_scan_projection_item_resolver.py
- targeted pytest: tests/ci/test_wms_pms_projection_read_usage.py
- targeted projection/boundary CI guards
- make alembic-check
- HTTP smoke: /scan barcode probe resolves item_id=1 item_uom_id=7 ratio_to_base=1 from projection
- HTTP smoke: /scan sku-code probe resolves item_id=3001 from projection
