### PR TITLE
refactor(pms): retire ORM FK relationships

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -74,9 +74,8 @@ def build_scoped_metadata(scope: str) -> MetaData:
     按 scope 构建一个缩小版的 MetaData，减少 alembic check 的噪音。
 
     PMS owner tables live in pms-api. wms-api keeps minimal external ORM
-    anchors in Base.metadata only to let transitional WMS/OMS/Procurement
-    foreign keys and relationship("Item") references resolve. Alembic must
-    ignore PMS-owned tables from wms-api.
+    anchors in Base.metadata during the shared-database transition. Alembic
+    must ignore PMS-owned tables from wms-api.
     """
     md = MetaData()
     if scope == "all":

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -24,10 +24,9 @@ def _load_external_pms_orm_anchors() -> None:
     """
     Register minimal external PMS ORM anchors eagerly.
 
-    FastAPI runtime can trigger SQLAlchemy mapper configuration before
-    init_models() is called, for example during /users/login. WMS models still
-    contain transitional relationship("Item") / FK references, so Item / ItemUOM
-    / ItemSkuCode anchors must be registered as soon as app.db.base is imported.
+    PMS owner runtime has moved to pms-api. During the shared-database
+    transition, wms-api keeps minimal PMS anchor tables in metadata so Alembic
+    can consistently filter PMS-owned tables while DB physical FKs still exist.
     """
     importlib.import_module("app.db.external_pms_models")
 

--- a/app/db/external_pms_models.py
+++ b/app/db/external_pms_models.py
@@ -2,11 +2,10 @@
 """
 External PMS ORM anchors for the shared-database transition.
 
-PMS owner runtime has moved to pms-api. wms-api still has WMS/OMS/Procurement
-tables with database FKs and legacy SQLAlchemy relationship("Item") references
-to PMS-owned tables.
+PMS owner runtime has moved to pms-api. wms-api still shares a database with
+PMS owner tables until the final physical-FK retirement step.
 
-These ORM classes are FK / mapper anchors only:
+These ORM classes are metadata anchors only:
 - do not add PMS business fields here
 - do not use these classes for PMS reads/writes
 - do not let Alembic manage these tables from wms-api

--- a/app/oms/fsku/models/fsku.py
+++ b/app/oms/fsku/models/fsku.py
@@ -110,24 +110,6 @@ class FskuComponent(Base):
             name="fk_oms_fsku_components_fsku",
             ondelete="CASCADE",
         ),
-        sa.ForeignKeyConstraint(
-            ["resolved_item_id"],
-            ["items.id"],
-            name="fk_oms_fsku_components_resolved_item",
-            ondelete="RESTRICT",
-        ),
-        sa.ForeignKeyConstraint(
-            ["resolved_item_sku_code_id", "resolved_item_id"],
-            ["item_sku_codes.id", "item_sku_codes.item_id"],
-            name="fk_oms_fsku_components_resolved_sku_code",
-            ondelete="RESTRICT",
-        ),
-        sa.ForeignKeyConstraint(
-            ["resolved_item_uom_id", "resolved_item_id"],
-            ["item_uoms.id", "item_uoms.item_id"],
-            name="fk_oms_fsku_components_resolved_uom",
-            ondelete="RESTRICT",
-        ),
         sa.UniqueConstraint(
             "fsku_id",
             "component_sku_code",

--- a/app/oms/orders/models/order_item.py
+++ b/app/oms/orders/models/order_item.py
@@ -28,7 +28,6 @@ class OrderItem(Base):
     )
     item_id: Mapped[int] = mapped_column(
         Integer,
-        ForeignKey("items.id", ondelete="RESTRICT"),
         nullable=False,
     )
 

--- a/app/procurement/models/purchase_order_line.py
+++ b/app/procurement/models/purchase_order_line.py
@@ -42,7 +42,6 @@ class PurchaseOrderLine(Base):
 
     item_id: Mapped[int] = mapped_column(
         sa.Integer,
-        sa.ForeignKey("items.id", ondelete="RESTRICT"),
         nullable=False,
         index=True,
     )
@@ -53,7 +52,6 @@ class PurchaseOrderLine(Base):
 
     purchase_uom_id_snapshot: Mapped[int] = mapped_column(
         sa.Integer,
-        sa.ForeignKey("item_uoms.id", name="fk_po_line_purchase_uom"),
         nullable=False,
     )
     purchase_uom_name_snapshot: Mapped[str] = mapped_column(

--- a/app/wms/inbound/models/inbound_event.py
+++ b/app/wms/inbound/models/inbound_event.py
@@ -186,7 +186,6 @@ class InboundEventLine(Base):
 
     item_id: Mapped[int] = mapped_column(
         Integer,
-        ForeignKey("items.id", name="fk_inbound_event_lines_item", ondelete="RESTRICT"),
         nullable=False,
     )
 
@@ -195,7 +194,6 @@ class InboundEventLine(Base):
 
     actual_uom_id: Mapped[int] = mapped_column(
         Integer,
-        ForeignKey("item_uoms.id", name="fk_inbound_event_lines_actual_uom", ondelete="RESTRICT"),
         nullable=False,
     )
     actual_uom_name_snapshot: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)

--- a/app/wms/inventory_adjustment/count/models/count_doc.py
+++ b/app/wms/inventory_adjustment/count/models/count_doc.py
@@ -140,7 +140,6 @@ class CountDocLine(Base):
 
     item_id: Mapped[int] = mapped_column(
         sa.Integer,
-        sa.ForeignKey("items.id", name="fk_count_doc_lines_item", ondelete="RESTRICT"),
         nullable=False,
         index=True,
     )
@@ -189,12 +188,6 @@ class CountDocLine(Base):
     )
 
     __table_args__ = (
-        sa.ForeignKeyConstraint(
-            ["counted_item_uom_id", "item_id"],
-            ["item_uoms.id", "item_uoms.item_id"],
-            name="fk_count_doc_lines_counted_item_uom_pair",
-            ondelete="RESTRICT",
-        ),
         sa.UniqueConstraint("doc_id", "line_no", name="uq_count_doc_lines_doc_line"),
         sa.UniqueConstraint("doc_id", "item_id", name="uq_count_doc_lines_doc_item"),
         sa.CheckConstraint(

--- a/app/wms/inventory_adjustment/return_inbound/models/inbound_operation.py
+++ b/app/wms/inventory_adjustment/return_inbound/models/inbound_operation.py
@@ -95,7 +95,6 @@ class WmsInboundOperationLine(Base):
 
     item_id: Mapped[int] = mapped_column(
         Integer,
-        ForeignKey("items.id", name="fk_wms_inbound_operation_lines_item", ondelete="RESTRICT"),
         nullable=False,
     )
     item_name_snapshot: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
@@ -103,7 +102,6 @@ class WmsInboundOperationLine(Base):
 
     actual_item_uom_id: Mapped[int] = mapped_column(
         Integer,
-        ForeignKey("item_uoms.id", name="fk_wms_inbound_operation_lines_actual_item_uom", ondelete="RESTRICT"),
         nullable=False,
     )
     actual_uom_name_snapshot: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)

--- a/app/wms/inventory_adjustment/return_inbound/models/inbound_receipt.py
+++ b/app/wms/inventory_adjustment/return_inbound/models/inbound_receipt.py
@@ -99,12 +99,10 @@ class InboundReceiptLine(Base):
 
     item_id: Mapped[int] = mapped_column(
         Integer,
-        ForeignKey("items.id", name="fk_inbound_receipt_lines_item", ondelete="RESTRICT"),
         nullable=False,
     )
     item_uom_id: Mapped[int] = mapped_column(
         Integer,
-        ForeignKey("item_uoms.id", name="fk_inbound_receipt_lines_item_uom", ondelete="RESTRICT"),
         nullable=False,
     )
 

--- a/app/wms/stock/models/lot.py
+++ b/app/wms/stock/models/lot.py
@@ -50,7 +50,6 @@ class Lot(Base):
 
     item_id: Mapped[int] = mapped_column(
         Integer,
-        ForeignKey("items.id", ondelete="RESTRICT"),
         nullable=False,
     )
 

--- a/app/wms/stock/models/stock_lot.py
+++ b/app/wms/stock/models/stock_lot.py
@@ -37,7 +37,6 @@ class StockLot(Base):
 
     item_id: Mapped[int] = mapped_column(
         sa.Integer,
-        sa.ForeignKey("items.id", ondelete="RESTRICT"),
         nullable=False,
         index=True,
     )
@@ -66,7 +65,6 @@ class StockLot(Base):
     )
 
     warehouse = relationship("Warehouse", lazy="selectin")
-    item = relationship("Item", lazy="selectin")
     lot = relationship(Lot, lazy="selectin", viewonly=True, overlaps="warehouse,item")
 
     def __repr__(self) -> str:

--- a/app/wms/stock/models/stock_snapshot.py
+++ b/app/wms/stock/models/stock_snapshot.py
@@ -18,7 +18,7 @@ class StockSnapshot(Base):
 
     snapshot_date: Mapped[date] = mapped_column(Date, nullable=False)
     warehouse_id: Mapped[int] = mapped_column(Integer, sa.ForeignKey("warehouses.id"), nullable=False)
-    item_id: Mapped[int] = mapped_column(Integer, sa.ForeignKey("items.id"), nullable=False)
+    item_id: Mapped[int] = mapped_column(Integer, nullable=False)
 
     # Phase 3: lot-world grain
     lot_id: Mapped[int] = mapped_column(Integer, nullable=False)

--- a/tests/ci/test_pms_orm_fk_relationship_retired.py
+++ b/tests/ci/test_pms_orm_fk_relationship_retired.py
@@ -1,0 +1,72 @@
+# tests/ci/test_pms_orm_fk_relationship_retired.py
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from app.db.base import Base, init_models
+from app.db.external_pms_models import PMS_OWNED_TABLES
+
+ROOT = Path(__file__).resolve().parents[2]
+
+PMS_OWNER_TABLES = {
+    "items",
+    "item_uoms",
+    "item_sku_codes",
+    "item_barcodes",
+}
+
+FORBIDDEN_TEXT_RE = re.compile(
+    r"ForeignKey\(\s*[\"'](?:items|item_uoms|item_sku_codes|item_barcodes)\."
+    r"|ForeignKeyConstraint\([\s\S]*?\[(?:[^\]]*[\"'](?:items|item_uoms|item_sku_codes|item_barcodes)\.)"
+    r"|relationship\(\s*[\"'](?:Item|ItemUOM|ItemSkuCode|ItemBarcode)[\"']",
+    re.MULTILINE,
+)
+
+
+def _runtime_model_files() -> list[Path]:
+    roots = [
+        ROOT / "app" / "wms",
+        ROOT / "app" / "oms",
+        ROOT / "app" / "procurement",
+        ROOT / "app" / "finance",
+    ]
+    files: list[Path] = []
+    for root in roots:
+        if root.exists():
+            files.extend(sorted(root.rglob("models/*.py")))
+    return files
+
+
+def _rel(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def test_runtime_models_do_not_declare_pms_owner_orm_foreign_keys_or_relationships() -> None:
+    violations: list[str] = []
+
+    for path in _runtime_model_files():
+        text = path.read_text(encoding="utf-8")
+        for match in FORBIDDEN_TEXT_RE.finditer(text):
+            snippet = " ".join(match.group(0).split())
+            violations.append(f"{_rel(path)}: {snippet}")
+
+    assert violations == []
+
+
+def test_runtime_metadata_has_no_foreign_keys_to_pms_owner_tables() -> None:
+    init_models(force=True)
+
+    violations: list[str] = []
+    for table in Base.metadata.tables.values():
+        if table.name in PMS_OWNED_TABLES:
+            continue
+
+        for fk in table.foreign_keys:
+            if fk.column.table.name in PMS_OWNER_TABLES:
+                violations.append(
+                    f"{table.name}.{fk.parent.name} -> "
+                    f"{fk.column.table.name}.{fk.column.name}"
+                )
+
+    assert violations == []


### PR DESCRIPTION
## Summary
- remove ORM-level ForeignKey references from WMS/OMS/Procurement models to PMS owner tables
- remove legacy relationship("Item") usage from stock lot ORM
- keep scalar PMS identity fields such as item_id, item_uom_id, resolved_item_id, resolved_item_sku_code_id, resolved_item_uom_id
- update comments around external PMS metadata anchors
- add CI guard to prevent runtime models from reintroducing ORM FK / relationship coupling to PMS owner anchors

## Boundary
- no DB migration is added
- no physical DB foreign key is dropped in this PR
- physical PMS FKs remain for the shared-database transition
- PMS owner runtime remains in pms-api
- WMS reads PMS current-state through projection / HTTP integration according to prior cuts
- final physical FK retirement is reserved for the seventh cut

## Validation
- targeted pytest: tests/ci/test_pms_orm_fk_relationship_retired.py
- targeted PMS metadata / owner / projection boundary tests
- make alembic-check
- DB check confirms PMS physical FK count remains 26
