### PR TITLE
feat(pms): add projection reconciliation

### DIFF
--- a/app/integrations/pms/projection_reconciliation.py
+++ b/app/integrations/pms/projection_reconciliation.py
@@ -1,0 +1,353 @@
+# app/integrations/pms/projection_reconciliation.py
+"""
+Read-only reconciliation for WMS PMS projection references.
+
+Boundary:
+- This module compares WMS scalar PMS references against WMS local projection tables.
+- It must not read PMS owner tables directly.
+- It must not write or repair data.
+- It must not replace HTTP write validation.
+- It exists to support the shared-DB transition before physical FK retirement.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Literal
+import re
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+IdentifierKind = Literal["table", "column"]
+IssueType = Literal[
+    "ITEM_MISSING_IN_PROJECTION",
+    "UOM_MISSING_IN_PROJECTION",
+    "UOM_ITEM_MISMATCH",
+    "SKU_CODE_MISSING_IN_PROJECTION",
+    "SKU_CODE_ITEM_MISMATCH",
+]
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+@dataclass(frozen=True)
+class ItemReference:
+    source_table: str
+    source_id_column: str | None
+    item_id_column: str
+
+
+@dataclass(frozen=True)
+class UomReference:
+    source_table: str
+    source_id_column: str | None
+    item_id_column: str
+    item_uom_id_column: str
+
+
+@dataclass(frozen=True)
+class SkuCodeReference:
+    source_table: str
+    source_id_column: str | None
+    item_id_column: str
+    sku_code_id_column: str
+
+
+@dataclass(frozen=True)
+class PmsProjectionReconciliationIssue:
+    issue_type: IssueType
+    source_table: str
+    source_column: str
+    source_id: str
+    item_id: int | None = None
+    item_uom_id: int | None = None
+    sku_code_id: int | None = None
+    projection_item_id: int | None = None
+
+
+@dataclass(frozen=True)
+class PmsProjectionReconciliationResult:
+    issues: list[PmsProjectionReconciliationIssue]
+
+    @property
+    def issue_count(self) -> int:
+        return len(self.issues)
+
+    @property
+    def ok(self) -> bool:
+        return self.issue_count == 0
+
+    def summary_by_type(self) -> dict[str, int]:
+        out: dict[str, int] = {}
+        for issue in self.issues:
+            out[issue.issue_type] = out.get(issue.issue_type, 0) + 1
+        return dict(sorted(out.items()))
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "ok": self.ok,
+            "issue_count": self.issue_count,
+            "summary_by_type": self.summary_by_type(),
+            "issues": [asdict(issue) for issue in self.issues],
+        }
+
+
+DEFAULT_ITEM_REFERENCES: tuple[ItemReference, ...] = (
+    ItemReference("stocks_lot", "id", "item_id"),
+    ItemReference("stock_ledger", "id", "item_id"),
+    ItemReference("stock_snapshots", "id", "item_id"),
+    ItemReference("lots", "id", "item_id"),
+    ItemReference("inbound_event_lines", "id", "item_id"),
+    ItemReference("wms_inbound_operation_lines", "id", "item_id"),
+    ItemReference("inbound_receipt_lines", "id", "item_id"),
+    ItemReference("count_doc_lines", "id", "item_id"),
+    ItemReference("purchase_order_lines", "id", "item_id"),
+    ItemReference("purchase_order_line_completion", None, "item_id"),
+    ItemReference("order_items", "id", "item_id"),
+    ItemReference("order_lines", "id", "item_id"),
+    ItemReference("oms_fsku_components", "id", "resolved_item_id"),
+    ItemReference("manual_outbound_lines", "id", "item_id"),
+    ItemReference("outbound_commits", "id", "item_id"),
+    ItemReference("outbound_event_lines", "id", "item_id"),
+    ItemReference("outbound_ship_ops", "id", "item_id"),
+    ItemReference("pick_task_lines", "id", "item_id"),
+    ItemReference("platform_order_manual_decisions", "id", "item_id"),
+    ItemReference("receive_task_scan_events", "id", "item_id"),
+    ItemReference("return_task_lines", "id", "item_id"),
+    ItemReference("store_items", "id", "item_id"),
+    ItemReference("finance_purchase_price_ledger_lines", "id", "item_id"),
+    ItemReference("finance_order_sales_lines", "id", "item_id"),
+)
+
+DEFAULT_UOM_REFERENCES: tuple[UomReference, ...] = (
+    UomReference("inbound_event_lines", "id", "item_id", "actual_uom_id"),
+    UomReference("wms_inbound_operation_lines", "id", "item_id", "actual_item_uom_id"),
+    UomReference("inbound_receipt_lines", "id", "item_id", "item_uom_id"),
+    UomReference("count_doc_lines", "id", "item_id", "counted_item_uom_id"),
+    UomReference("purchase_order_lines", "id", "item_id", "purchase_uom_id_snapshot"),
+    UomReference("purchase_order_line_completion", None, "item_id", "purchase_uom_id_snapshot"),
+    UomReference("oms_fsku_components", "id", "resolved_item_id", "resolved_item_uom_id"),
+    UomReference("manual_outbound_lines", "id", "item_id", "item_uom_id"),
+)
+
+DEFAULT_SKU_CODE_REFERENCES: tuple[SkuCodeReference, ...] = (
+    SkuCodeReference("oms_fsku_components", "id", "resolved_item_id", "resolved_item_sku_code_id"),
+)
+
+
+def _quote_identifier(name: str, *, kind: IdentifierKind) -> str:
+    parts = str(name).split(".")
+    if not parts or any(not _IDENTIFIER_RE.fullmatch(part) for part in parts):
+        raise ValueError(f"invalid SQL {kind} identifier: {name!r}")
+    return ".".join(f'"{part}"' for part in parts)
+
+
+def _source_id_select_and_order(source_id_column: str | None) -> tuple[str, str]:
+    if source_id_column is None:
+        return "CAST(t.ctid AS TEXT)", "t.ctid"
+
+    quoted = _quote_identifier(source_id_column, kind="column")
+    return f"CAST(t.{quoted} AS TEXT)", f"t.{quoted}"
+
+
+async def _collect_item_issues(
+    session: AsyncSession,
+    *,
+    ref: ItemReference,
+    limit: int,
+) -> list[PmsProjectionReconciliationIssue]:
+    source_table_sql = _quote_identifier(ref.source_table, kind="table")
+    source_id_select_sql, source_id_order_sql = _source_id_select_and_order(
+        ref.source_id_column
+    )
+    item_id_sql = _quote_identifier(ref.item_id_column, kind="column")
+
+    rows = (
+        await session.execute(
+            text(
+                f"""
+                SELECT
+                    {source_id_select_sql} AS source_id,
+                    t.{item_id_sql} AS item_id
+                FROM {source_table_sql} AS t
+                LEFT JOIN wms_pms_item_projection AS p
+                  ON p.item_id = t.{item_id_sql}
+                WHERE t.{item_id_sql} IS NOT NULL
+                  AND p.item_id IS NULL
+                ORDER BY {source_id_order_sql}
+                LIMIT :limit
+                """
+            ),
+            {"limit": int(limit)},
+        )
+    ).mappings().all()
+
+    return [
+        PmsProjectionReconciliationIssue(
+            issue_type="ITEM_MISSING_IN_PROJECTION",
+            source_table=ref.source_table,
+            source_column=ref.item_id_column,
+            source_id=str(row["source_id"]),
+            item_id=int(row["item_id"]),
+        )
+        for row in rows
+    ]
+
+
+async def _collect_uom_issues(
+    session: AsyncSession,
+    *,
+    ref: UomReference,
+    limit: int,
+) -> list[PmsProjectionReconciliationIssue]:
+    source_table_sql = _quote_identifier(ref.source_table, kind="table")
+    source_id_select_sql, source_id_order_sql = _source_id_select_and_order(
+        ref.source_id_column
+    )
+    item_id_sql = _quote_identifier(ref.item_id_column, kind="column")
+    item_uom_id_sql = _quote_identifier(ref.item_uom_id_column, kind="column")
+
+    rows = (
+        await session.execute(
+            text(
+                f"""
+                SELECT
+                    {source_id_select_sql} AS source_id,
+                    t.{item_id_sql} AS item_id,
+                    t.{item_uom_id_sql} AS item_uom_id,
+                    u.item_id AS projection_item_id,
+                    CASE
+                      WHEN u.item_uom_id IS NULL THEN 'UOM_MISSING_IN_PROJECTION'
+                      WHEN u.item_id <> t.{item_id_sql} THEN 'UOM_ITEM_MISMATCH'
+                      ELSE 'OK'
+                    END AS issue_type
+                FROM {source_table_sql} AS t
+                LEFT JOIN wms_pms_uom_projection AS u
+                  ON u.item_uom_id = t.{item_uom_id_sql}
+                WHERE t.{item_uom_id_sql} IS NOT NULL
+                  AND (
+                    u.item_uom_id IS NULL
+                    OR u.item_id <> t.{item_id_sql}
+                  )
+                ORDER BY {source_id_order_sql}
+                LIMIT :limit
+                """
+            ),
+            {"limit": int(limit)},
+        )
+    ).mappings().all()
+
+    return [
+        PmsProjectionReconciliationIssue(
+            issue_type=str(row["issue_type"]),  # type: ignore[arg-type]
+            source_table=ref.source_table,
+            source_column=ref.item_uom_id_column,
+            source_id=str(row["source_id"]),
+            item_id=int(row["item_id"]) if row["item_id"] is not None else None,
+            item_uom_id=int(row["item_uom_id"]) if row["item_uom_id"] is not None else None,
+            projection_item_id=(
+                int(row["projection_item_id"])
+                if row["projection_item_id"] is not None
+                else None
+            ),
+        )
+        for row in rows
+    ]
+
+
+async def _collect_sku_code_issues(
+    session: AsyncSession,
+    *,
+    ref: SkuCodeReference,
+    limit: int,
+) -> list[PmsProjectionReconciliationIssue]:
+    source_table_sql = _quote_identifier(ref.source_table, kind="table")
+    source_id_select_sql, source_id_order_sql = _source_id_select_and_order(
+        ref.source_id_column
+    )
+    item_id_sql = _quote_identifier(ref.item_id_column, kind="column")
+    sku_code_id_sql = _quote_identifier(ref.sku_code_id_column, kind="column")
+
+    rows = (
+        await session.execute(
+            text(
+                f"""
+                SELECT
+                    {source_id_select_sql} AS source_id,
+                    t.{item_id_sql} AS item_id,
+                    t.{sku_code_id_sql} AS sku_code_id,
+                    s.item_id AS projection_item_id,
+                    CASE
+                      WHEN s.sku_code_id IS NULL THEN 'SKU_CODE_MISSING_IN_PROJECTION'
+                      WHEN s.item_id <> t.{item_id_sql} THEN 'SKU_CODE_ITEM_MISMATCH'
+                      ELSE 'OK'
+                    END AS issue_type
+                FROM {source_table_sql} AS t
+                LEFT JOIN wms_pms_sku_code_projection AS s
+                  ON s.sku_code_id = t.{sku_code_id_sql}
+                WHERE t.{sku_code_id_sql} IS NOT NULL
+                  AND (
+                    s.sku_code_id IS NULL
+                    OR s.item_id <> t.{item_id_sql}
+                  )
+                ORDER BY {source_id_order_sql}
+                LIMIT :limit
+                """
+            ),
+            {"limit": int(limit)},
+        )
+    ).mappings().all()
+
+    return [
+        PmsProjectionReconciliationIssue(
+            issue_type=str(row["issue_type"]),  # type: ignore[arg-type]
+            source_table=ref.source_table,
+            source_column=ref.sku_code_id_column,
+            source_id=str(row["source_id"]),
+            item_id=int(row["item_id"]) if row["item_id"] is not None else None,
+            sku_code_id=int(row["sku_code_id"]) if row["sku_code_id"] is not None else None,
+            projection_item_id=(
+                int(row["projection_item_id"])
+                if row["projection_item_id"] is not None
+                else None
+            ),
+        )
+        for row in rows
+    ]
+
+
+async def reconcile_pms_projection_references(
+    session: AsyncSession,
+    *,
+    item_references: tuple[ItemReference, ...] = DEFAULT_ITEM_REFERENCES,
+    uom_references: tuple[UomReference, ...] = DEFAULT_UOM_REFERENCES,
+    sku_code_references: tuple[SkuCodeReference, ...] = DEFAULT_SKU_CODE_REFERENCES,
+    per_reference_limit: int = 200,
+) -> PmsProjectionReconciliationResult:
+    safe_limit = max(1, min(int(per_reference_limit), 1000))
+    issues: list[PmsProjectionReconciliationIssue] = []
+
+    for ref in item_references:
+        issues.extend(await _collect_item_issues(session, ref=ref, limit=safe_limit))
+
+    for ref in uom_references:
+        issues.extend(await _collect_uom_issues(session, ref=ref, limit=safe_limit))
+
+    for ref in sku_code_references:
+        issues.extend(await _collect_sku_code_issues(session, ref=ref, limit=safe_limit))
+
+    return PmsProjectionReconciliationResult(issues=issues)
+
+
+__all__ = [
+    "DEFAULT_ITEM_REFERENCES",
+    "DEFAULT_SKU_CODE_REFERENCES",
+    "DEFAULT_UOM_REFERENCES",
+    "ItemReference",
+    "PmsProjectionReconciliationIssue",
+    "PmsProjectionReconciliationResult",
+    "SkuCodeReference",
+    "UomReference",
+    "reconcile_pms_projection_references",
+]

--- a/scripts/make/test.mk
+++ b/scripts/make/test.mk
@@ -259,3 +259,12 @@ pms-http-business-smoke: venv
 .PHONY: pms-projection-sync
 pms-projection-sync: venv
 	@PMS_API_BASE_URL="$${PMS_API_BASE_URL:-http://127.0.0.1:8002}" PYTHONPATH=. $(PY) scripts/pms/sync_projection.py --limit "$${PMS_PROJECTION_SYNC_LIMIT:-500}"
+
+# ---------------------------------
+# PMS projection reconciliation
+# Verifies WMS scalar PMS references against WMS local projection tables.
+# This target is local/manual and may fail when projection is stale.
+# ---------------------------------
+.PHONY: pms-projection-reconcile
+pms-projection-reconcile: venv
+	@PYTHONPATH=. $(PY) scripts/pms/reconcile_projection.py --fail-on-issues --per-reference-limit "$${PMS_PROJECTION_RECONCILE_LIMIT:-200}"

--- a/scripts/pms/reconcile_projection.py
+++ b/scripts/pms/reconcile_projection.py
@@ -1,0 +1,40 @@
+# scripts/pms/reconcile_projection.py
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+
+from app.db.session import async_session_maker
+from app.integrations.pms.projection_reconciliation import (
+    reconcile_pms_projection_references,
+)
+
+
+async def _main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Reconcile WMS PMS scalar references against local PMS projection tables"
+    )
+    parser.add_argument("--per-reference-limit", type=int, default=200)
+    parser.add_argument(
+        "--fail-on-issues",
+        action="store_true",
+        help="Exit with code 2 when reconciliation issues are found.",
+    )
+    args = parser.parse_args()
+
+    async with async_session_maker() as session:
+        result = await reconcile_pms_projection_references(
+            session,
+            per_reference_limit=int(args.per_reference_limit),
+        )
+
+    print(json.dumps(result.to_dict(), ensure_ascii=False, indent=2, default=str))
+    if args.fail_on_issues and not result.ok:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(_main()))

--- a/tests/ci/test_wms_pms_projection_reconciliation_boundary.py
+++ b/tests/ci/test_wms_pms_projection_reconciliation_boundary.py
@@ -1,0 +1,44 @@
+# tests/ci/test_wms_pms_projection_reconciliation_boundary.py
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+FORBIDDEN_OWNER_SQL_RE = re.compile(
+    r"\bFROM\s+(items|item_uoms|item_sku_codes|item_barcodes)\b"
+    r"|\bJOIN\s+(items|item_uoms|item_sku_codes|item_barcodes)\b",
+    re.IGNORECASE,
+)
+
+
+def test_pms_projection_reconciliation_reads_projection_not_owner_tables() -> None:
+    text = (ROOT / "app/integrations/pms/projection_reconciliation.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "wms_pms_item_projection" in text
+    assert "wms_pms_uom_projection" in text
+    assert "wms_pms_sku_code_projection" in text
+    assert "wms_pms_barcode_projection" not in text
+    assert FORBIDDEN_OWNER_SQL_RE.search(text) is None
+
+
+def test_pms_projection_reconciliation_is_read_only() -> None:
+    text = (ROOT / "app/integrations/pms/projection_reconciliation.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "INSERT INTO" not in text
+    assert "UPDATE " not in text
+    assert "DELETE FROM" not in text
+    assert "DROP " not in text
+    assert "ALTER " not in text
+
+
+def test_pms_projection_reconciliation_cli_uses_service() -> None:
+    text = (ROOT / "scripts/pms/reconcile_projection.py").read_text(encoding="utf-8")
+
+    assert "reconcile_pms_projection_references" in text
+    assert "fail-on-issues" in text

--- a/tests/services/test_pms_projection_reconciliation.py
+++ b/tests/services/test_pms_projection_reconciliation.py
@@ -1,0 +1,412 @@
+# tests/services/test_pms_projection_reconciliation.py
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.integrations.pms.projection_reconciliation import (
+    ItemReference,
+    SkuCodeReference,
+    UomReference,
+    reconcile_pms_projection_references,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_projection(session: AsyncSession) -> None:
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_pms_item_projection (
+                item_id,
+                sku,
+                name,
+                spec,
+                enabled,
+                supplier_id,
+                brand,
+                category,
+                expiry_policy,
+                shelf_life_value,
+                shelf_life_unit,
+                lot_source_policy,
+                derivation_allowed,
+                uom_governance_enabled,
+                pms_updated_at,
+                source_hash,
+                sync_version,
+                synced_at
+            )
+            VALUES (
+                980001,
+                'UT-RECON-ITEM-980001',
+                '对账商品980001',
+                NULL,
+                TRUE,
+                NULL,
+                NULL,
+                NULL,
+                'NONE',
+                NULL,
+                NULL,
+                'INTERNAL_ONLY',
+                TRUE,
+                FALSE,
+                now(),
+                'ut-recon-item-980001',
+                'ut-recon-projection',
+                now()
+            )
+            ON CONFLICT (item_id) DO UPDATE SET
+                sku = EXCLUDED.sku,
+                name = EXCLUDED.name,
+                enabled = EXCLUDED.enabled,
+                pms_updated_at = EXCLUDED.pms_updated_at,
+                source_hash = EXCLUDED.source_hash,
+                sync_version = EXCLUDED.sync_version,
+                synced_at = now()
+            """
+        )
+    )
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_pms_uom_projection (
+                item_uom_id,
+                item_id,
+                uom,
+                display_name,
+                uom_name,
+                ratio_to_base,
+                net_weight_kg,
+                is_base,
+                is_purchase_default,
+                is_inbound_default,
+                is_outbound_default,
+                pms_updated_at,
+                source_hash,
+                sync_version,
+                synced_at
+            )
+            VALUES
+              (
+                980011,
+                980001,
+                'PCS',
+                '件',
+                '件',
+                1,
+                NULL,
+                TRUE,
+                TRUE,
+                TRUE,
+                TRUE,
+                now(),
+                'ut-recon-uom-980011',
+                'ut-recon-projection',
+                now()
+              ),
+              (
+                980012,
+                980002,
+                'BOX',
+                '箱',
+                '箱',
+                10,
+                NULL,
+                FALSE,
+                FALSE,
+                FALSE,
+                FALSE,
+                now(),
+                'ut-recon-uom-980012',
+                'ut-recon-projection',
+                now()
+              )
+            ON CONFLICT (item_uom_id) DO UPDATE SET
+                item_id = EXCLUDED.item_id,
+                uom = EXCLUDED.uom,
+                display_name = EXCLUDED.display_name,
+                uom_name = EXCLUDED.uom_name,
+                ratio_to_base = EXCLUDED.ratio_to_base,
+                is_base = EXCLUDED.is_base,
+                pms_updated_at = EXCLUDED.pms_updated_at,
+                source_hash = EXCLUDED.source_hash,
+                sync_version = EXCLUDED.sync_version,
+                synced_at = now()
+            """
+        )
+    )
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_pms_sku_code_projection (
+                sku_code_id,
+                item_id,
+                sku_code,
+                code_type,
+                is_primary,
+                is_active,
+                effective_from,
+                effective_to,
+                pms_updated_at,
+                source_hash,
+                sync_version,
+                synced_at
+            )
+            VALUES
+              (
+                980021,
+                980001,
+                'UT-RECON-ITEM-980001',
+                'PRIMARY',
+                TRUE,
+                TRUE,
+                now(),
+                NULL,
+                now(),
+                'ut-recon-sku-980021',
+                'ut-recon-projection',
+                now()
+              ),
+              (
+                980022,
+                980002,
+                'UT-RECON-ITEM-980002',
+                'PRIMARY',
+                TRUE,
+                TRUE,
+                now(),
+                NULL,
+                now(),
+                'ut-recon-sku-980022',
+                'ut-recon-projection',
+                now()
+              )
+            ON CONFLICT (sku_code_id) DO UPDATE SET
+                item_id = EXCLUDED.item_id,
+                sku_code = EXCLUDED.sku_code,
+                code_type = EXCLUDED.code_type,
+                is_primary = EXCLUDED.is_primary,
+                is_active = EXCLUDED.is_active,
+                pms_updated_at = EXCLUDED.pms_updated_at,
+                source_hash = EXCLUDED.source_hash,
+                sync_version = EXCLUDED.sync_version,
+                synced_at = now()
+            """
+        )
+    )
+
+
+async def _seed_temp_refs(session: AsyncSession) -> None:
+    await session.execute(
+        text(
+            """
+            CREATE TEMP TABLE tmp_pms_reconcile_item_refs (
+                id INTEGER NOT NULL,
+                item_id INTEGER
+            ) ON COMMIT DROP
+            """
+        )
+    )
+    await session.execute(
+        text(
+            """
+            CREATE TEMP TABLE tmp_pms_reconcile_uom_refs (
+                id INTEGER NOT NULL,
+                item_id INTEGER,
+                item_uom_id INTEGER
+            ) ON COMMIT DROP
+            """
+        )
+    )
+    await session.execute(
+        text(
+            """
+            CREATE TEMP TABLE tmp_pms_reconcile_sku_refs (
+                id INTEGER NOT NULL,
+                item_id INTEGER,
+                sku_code_id INTEGER
+            ) ON COMMIT DROP
+            """
+        )
+    )
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO tmp_pms_reconcile_item_refs (id, item_id)
+            VALUES
+              (1, 980001),
+              (2, 980099)
+            """
+        )
+    )
+    await session.execute(
+        text(
+            """
+            INSERT INTO tmp_pms_reconcile_uom_refs (id, item_id, item_uom_id)
+            VALUES
+              (1, 980001, 980011),
+              (2, 980001, 980099),
+              (3, 980001, 980012)
+            """
+        )
+    )
+    await session.execute(
+        text(
+            """
+            INSERT INTO tmp_pms_reconcile_sku_refs (id, item_id, sku_code_id)
+            VALUES
+              (1, 980001, 980021),
+              (2, 980001, 980099),
+              (3, 980001, 980022)
+            """
+        )
+    )
+
+
+async def test_pms_projection_reconciliation_reports_missing_and_mismatch(
+    session: AsyncSession,
+) -> None:
+    await _seed_projection(session)
+    await _seed_temp_refs(session)
+
+    result = await reconcile_pms_projection_references(
+        session,
+        item_references=(
+            ItemReference("pg_temp.tmp_pms_reconcile_item_refs", "id", "item_id"),
+        ),
+        uom_references=(
+            UomReference(
+                "pg_temp.tmp_pms_reconcile_uom_refs",
+                "id",
+                "item_id",
+                "item_uom_id",
+            ),
+        ),
+        sku_code_references=(
+            SkuCodeReference(
+                "pg_temp.tmp_pms_reconcile_sku_refs",
+                "id",
+                "item_id",
+                "sku_code_id",
+            ),
+        ),
+    )
+
+    assert result.ok is False
+    assert result.issue_count == 5
+    assert result.summary_by_type() == {
+        "ITEM_MISSING_IN_PROJECTION": 1,
+        "SKU_CODE_ITEM_MISMATCH": 1,
+        "SKU_CODE_MISSING_IN_PROJECTION": 1,
+        "UOM_ITEM_MISMATCH": 1,
+        "UOM_MISSING_IN_PROJECTION": 1,
+    }
+
+    payload = result.to_dict()
+    assert payload["ok"] is False
+    assert payload["issue_count"] == 5
+
+
+async def test_pms_projection_reconciliation_returns_ok_for_clean_refs(
+    session: AsyncSession,
+) -> None:
+    await _seed_projection(session)
+
+    await session.execute(
+        text(
+            """
+            CREATE TEMP TABLE tmp_pms_reconcile_clean_refs (
+                id INTEGER NOT NULL,
+                item_id INTEGER,
+                item_uom_id INTEGER,
+                sku_code_id INTEGER
+            ) ON COMMIT DROP
+            """
+        )
+    )
+    await session.execute(
+        text(
+            """
+            INSERT INTO tmp_pms_reconcile_clean_refs (
+                id,
+                item_id,
+                item_uom_id,
+                sku_code_id
+            )
+            VALUES (1, 980001, 980011, 980021)
+            """
+        )
+    )
+
+    result = await reconcile_pms_projection_references(
+        session,
+        item_references=(
+            ItemReference("pg_temp.tmp_pms_reconcile_clean_refs", "id", "item_id"),
+        ),
+        uom_references=(
+            UomReference(
+                "pg_temp.tmp_pms_reconcile_clean_refs",
+                "id",
+                "item_id",
+                "item_uom_id",
+            ),
+        ),
+        sku_code_references=(
+            SkuCodeReference(
+                "pg_temp.tmp_pms_reconcile_clean_refs",
+                "id",
+                "item_id",
+                "sku_code_id",
+            ),
+        ),
+    )
+
+    assert result.ok is True
+    assert result.issue_count == 0
+    assert result.summary_by_type() == {}
+
+async def test_pms_projection_reconciliation_supports_reference_table_without_id_column(
+    session: AsyncSession,
+) -> None:
+    await _seed_projection(session)
+
+    await session.execute(
+        text(
+            """
+            CREATE TEMP TABLE tmp_pms_reconcile_no_id_refs (
+                item_id INTEGER
+            ) ON COMMIT DROP
+            """
+        )
+    )
+    await session.execute(
+        text(
+            """
+            INSERT INTO tmp_pms_reconcile_no_id_refs (item_id)
+            VALUES (980099)
+            """
+        )
+    )
+
+    result = await reconcile_pms_projection_references(
+        session,
+        item_references=(
+            ItemReference("pg_temp.tmp_pms_reconcile_no_id_refs", None, "item_id"),
+        ),
+        uom_references=(),
+        sku_code_references=(),
+    )
+
+    assert result.ok is False
+    assert result.issue_count == 1
+    issue = result.issues[0]
+    assert issue.issue_type == "ITEM_MISSING_IN_PROJECTION"
+    assert issue.source_table == "pg_temp.tmp_pms_reconcile_no_id_refs"
+    assert issue.source_id


### PR DESCRIPTION
## Summary
- add read-only PMS projection reconciliation service
- compare WMS scalar PMS references against local PMS projection tables
- report missing item projection references
- report missing / mismatched item_uom projection references
- report missing / mismatched sku_code projection references
- add CLI script scripts/pms/reconcile_projection.py
- add make pms-projection-reconcile target
- add service tests and CI boundary guard

## Boundary
- no DB migration is added
- no data repair is performed
- no physical PMS foreign key is dropped
- reconciliation reads only WMS local projection tables
- reconciliation does not read PMS owner tables directly
- HTTP write validation remains the authority for writes
- physical FK retirement remains reserved for the seventh cut

## Validation
- targeted pytest: tests/services/test_pms_projection_reconciliation.py
- targeted pytest: tests/ci/test_wms_pms_projection_reconciliation_boundary.py
- targeted PMS projection / ORM / owner boundary tests
- DEV reconciliation CLI returns ok=true and issue_count=0
- make alembic-check
- DB check confirms PMS physical FK count remains 26
