### PR TITLE
test(pms): use projection fake for inventory helpers

### DIFF
--- a/tests/api/test_stock_inventory_read_api.py
+++ b/tests/api/test_stock_inventory_read_api.py
@@ -182,10 +182,6 @@ async def test_stock_inventory_q_filter_uses_pms_export_item_search(
     lot_code = "UT-STOCK-Q-001"
 
     await ensure_wh_loc_item(session, wh=warehouse_id, loc=warehouse_id, item=item_id)
-    await session.execute(
-        text("UPDATE items SET expiry_policy='REQUIRED'::expiry_policy WHERE id=:i"),
-        {"i": int(item_id)},
-    )
     await seed_supplier_lot_slot(
         session,
         item=item_id,
@@ -221,10 +217,6 @@ async def test_stock_inventory_explain_uses_pms_export_item_metadata(
     lot_code = "UT-STOCK-EXPLAIN-001"
 
     await ensure_wh_loc_item(session, wh=warehouse_id, loc=warehouse_id, item=item_id)
-    await session.execute(
-        text("UPDATE items SET expiry_policy='REQUIRED'::expiry_policy WHERE id=:i"),
-        {"i": int(item_id)},
-    )
     await seed_supplier_lot_slot(
         session,
         item=item_id,
@@ -278,14 +270,10 @@ async def test_stock_inventory_detail_returns_totals_and_slices(
     warehouse_id = 1
     lot_code = "UT-STOCK-DETAIL-001"
 
-    # 先确保基础行存在；否则直接 UPDATE items 可能打空
+    # 先确保 warehouse + PMS projection 基础行存在
     await ensure_wh_loc_item(session, wh=warehouse_id, loc=warehouse_id, item=item_id)
 
-    # 当前主链：新建 SUPPLIER lot 前，测试商品必须显式走 REQUIRED
-    await session.execute(
-        text("UPDATE items SET expiry_policy='REQUIRED'::expiry_policy WHERE id=:i"),
-        {"i": int(item_id)},
-    )
+    # PMS projection policy is seeded by seed_supplier_lot_slot.
 
     await seed_supplier_lot_slot(
         session,

--- a/tests/helpers/inventory.py
+++ b/tests/helpers/inventory.py
@@ -8,10 +8,16 @@ from typing import Iterable, List, Optional, Tuple
 from sqlalchemy import text as SA
 from sqlalchemy.ext.asyncio import AsyncSession
 
+import app.wms.shared.services.expiry_resolver as expiry_resolver_module
+import app.wms.stock.repos.inventory_explain_repo as inventory_explain_repo_module
+import app.wms.stock.repos.inventory_read_repo as inventory_read_repo_module
+import app.wms.stock.services.lots as lots_module
+import app.wms.stock.services.stock_adjust.db_items as db_items_module
 from app.wms.stock.services.lot_service import ensure_internal_lot_singleton as ensure_internal_lot_singleton_svc
 from app.wms.stock.services.lot_service import ensure_lot_full as ensure_lot_full_svc
 from app.wms.stock.services.stock_adjust import adjust_lot_impl
-from tests.utils.ensure_minimal import ensure_item
+from tests.helpers.pms_projection import seed_pms_projection_item_with_base_uom
+from tests.helpers.pms_read_client_fake import projection_backed_pms_read_client_factory
 
 UTC = timezone.utc
 
@@ -88,6 +94,24 @@ def _stable_required_dates_from_code(code_raw: str, *, days: int) -> tuple[date,
     return production_date, expiry_date
 
 
+def _install_projection_pms_client(session: AsyncSession) -> None:
+    """
+    Test-only PMS client patch for inventory helpers.
+
+    Boundary:
+    - only patches test runtime modules that inventory helper calls indirectly;
+    - fake reads WMS PMS projection tables only;
+    - does not alter app.integrations.pms.factory;
+    - does not reintroduce in-process PMS owner reads.
+    """
+    factory = projection_backed_pms_read_client_factory(session)
+    lots_module.create_pms_read_client = factory
+    db_items_module.create_pms_read_client = factory
+    expiry_resolver_module.create_pms_read_client = factory
+    inventory_read_repo_module.create_pms_read_client = factory
+    inventory_explain_repo_module.create_pms_read_client = factory
+
+
 async def ensure_wh_loc_item(
     session: AsyncSession,
     *,
@@ -96,21 +120,40 @@ async def ensure_wh_loc_item(
     item: int,
     code: Optional[str] = None,
     name: Optional[str] = None,
+    expiry_policy: str = "NONE",
 ) -> None:
     _ = loc
-    _ = code
-    _ = name
+
+    _install_projection_pms_client(session)
 
     await session.execute(
         SA("INSERT INTO warehouses (id, name) VALUES (:w, 'WH') ON CONFLICT (id) DO NOTHING"),
         {"w": int(wh)},
     )
 
-    await ensure_item(session, id=int(item), sku=f"SKU-{item}", name=f"ITEM-{item}")
+    await seed_pms_projection_item_with_base_uom(
+        session,
+        item_id=int(item),
+        item_uom_id=int(item),
+        sku_code_id=int(item),
+        sku=str(code or f"SKU-{item}"),
+        name=str(name or f"ITEM-{item}"),
+        expiry_policy=str(expiry_policy).strip().upper(),
+    )
 
 
 async def _load_item_expiry_policy(session: AsyncSession, *, item_id: int) -> str:
-    row = await session.execute(SA("SELECT expiry_policy::text FROM items WHERE id=:i"), {"i": int(item_id)})
+    row = await session.execute(
+        SA(
+            """
+            SELECT expiry_policy
+              FROM wms_pms_item_projection
+             WHERE item_id = :i
+             LIMIT 1
+            """
+        ),
+        {"i": int(item_id)},
+    )
     v = row.scalar_one_or_none()
     if v is None:
         raise ValueError(f"item_not_found: {item_id}")
@@ -147,13 +190,13 @@ async def seed_supplier_lot_slot(
     """
     ✅ 统一 seed 入口（Phase M-5 终态）：
 
+    - PMS current-state：写入 wms_pms_*_projection 测试投影
     - lot 创建：ensure_lot_full（禁止 tests 直接 INSERT INTO lots）
     - 库存写入：adjust_lot_impl（禁止 tests 直接 INSERT/UPDATE stocks_lot）
     - “设置为某个 qty”语义：读当前 qty -> delta -> adjust_lot_impl 写入
-      （等价于旧实现的 ON CONFLICT DO UPDATE SET qty）
 
     关键：日期合同必须认真对待
-    - seed_supplier_lot_slot 的语义就是“造一个 SUPPLIER lot slot”，因此商品必须走 REQUIRED
+    - seed_supplier_lot_slot 的语义就是“造一个 SUPPLIER lot slot”，因此 projection 商品必须走 REQUIRED
     - REQUIRED 且发生入库（delta>0）时，必须提供 production/expiry 事实
     """
     wh = _wh_from_loc(loc)
@@ -161,20 +204,21 @@ async def seed_supplier_lot_slot(
     if not code_raw:
         raise ValueError("code empty")
 
-    # 确保主数据存在（很多测试假设 item/wh 已存在）
+    _install_projection_pms_client(session)
+
     await session.execute(
         SA("INSERT INTO warehouses (id, name) VALUES (:w, 'WH') ON CONFLICT (id) DO NOTHING"),
         {"w": int(wh)},
     )
 
-    # 当前 helper 语义就是“造 batch slot”，因此显式把商品设为 REQUIRED。
-    # 不能用 ensure_item 默认值（expiry_required=False），否则会把上游已设好的 REQUIRED 冲回 NONE。
-    await ensure_item(
+    await seed_pms_projection_item_with_base_uom(
         session,
-        id=int(item),
+        item_id=int(item),
+        item_uom_id=int(item),
+        sku_code_id=int(item),
         sku=f"SKU-{item}",
         name=f"ITEM-{item}",
-        expiry_required=True,
+        expiry_policy="REQUIRED",
     )
 
     expiry_policy = await _load_item_expiry_policy(session, item_id=int(item))
@@ -273,6 +317,18 @@ async def insert_snapshot(
 ) -> None:
     _ = ts
     wh = _wh_from_loc(loc)
+
+    _install_projection_pms_client(session)
+
+    await seed_pms_projection_item_with_base_uom(
+        session,
+        item_id=int(item),
+        item_uom_id=int(item),
+        sku_code_id=int(item),
+        sku=f"SKU-{item}",
+        name=f"ITEM-{item}",
+        expiry_policy="NONE",
+    )
 
     # 快照必须绑定真实 lot_id；这里用 INTERNAL 单例 lot 承载“无指定展示码”的快照场景
     got = await ensure_internal_lot_singleton_svc(

--- a/tests/helpers/pms_read_client_fake.py
+++ b/tests/helpers/pms_read_client_fake.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.integrations.pms.contracts import (
     ItemBasic,
     ItemPolicy,
+    PmsExportBarcode,
     PmsExportUom,
 )
 
@@ -32,6 +33,61 @@ class ProjectionBackedFakePmsReadClient:
 
     def __init__(self, session: AsyncSession) -> None:
         self.session = session
+
+    async def list_item_basics(
+        self,
+        *,
+        query=None,
+    ) -> list[ItemBasic]:
+        conditions = []
+        params: dict[str, Any] = {"limit": 500}
+
+        if query is not None:
+            data = query.model_dump(exclude_none=True) if hasattr(query, "model_dump") else {}
+            keyword = (
+                data.get("keyword")
+                or data.get("q")
+                or data.get("search")
+                or data.get("sku")
+                or data.get("name")
+            )
+            if keyword:
+                conditions.append("(sku ILIKE :keyword OR name ILIKE :keyword)")
+                params["keyword"] = f"%{str(keyword).strip()}%"
+
+            if data.get("enabled") is not None:
+                conditions.append("enabled IS :enabled")
+                params["enabled"] = bool(data["enabled"])
+
+            if data.get("limit") is not None:
+                params["limit"] = int(data["limit"])
+
+        where_sql = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+
+        rows = (
+            await self.session.execute(
+                text(
+                    f"""
+                    SELECT
+                        item_id AS id,
+                        sku,
+                        name,
+                        spec,
+                        enabled,
+                        supplier_id,
+                        brand,
+                        category
+                    FROM wms_pms_item_projection
+                    {where_sql}
+                    ORDER BY item_id ASC
+                    LIMIT :limit
+                    """
+                ),
+                params,
+            )
+        ).mappings().all()
+
+        return [ItemBasic.model_validate(dict(row)) for row in rows]
 
     async def get_item_basic(self, *, item_id: int) -> ItemBasic | None:
         rows = await self.get_item_basics(item_ids=[int(item_id)])
@@ -196,6 +252,99 @@ class ProjectionBackedFakePmsReadClient:
 
     async def list_uoms_by_item_id(self, *, item_id: int) -> list[PmsExportUom]:
         return await self.list_uoms(item_ids=[int(item_id)])
+
+    async def get_barcode(self, *, barcode_id: int) -> PmsExportBarcode | None:
+        rows = await self.list_barcodes(item_ids=None, item_uom_ids=None, barcode_id=int(barcode_id))
+        return rows[0] if rows else None
+
+    async def list_barcodes(
+        self,
+        *,
+        item_ids: Sequence[int] | None = None,
+        item_uom_ids: Sequence[int] | None = None,
+        barcode: str | None = None,
+        barcode_id: int | None = None,
+        active: bool | None = None,
+        primary_only: bool = False,
+    ) -> list[PmsExportBarcode]:
+        conditions: list[str] = []
+        params: dict[str, Any] = {}
+
+        item_ids_clean = _clean_ids(item_ids or [])
+        item_uom_ids_clean = _clean_ids(item_uom_ids or [])
+
+        if item_ids_clean:
+            conditions.append("b.item_id = ANY(:item_ids)")
+            params["item_ids"] = item_ids_clean
+
+        if item_uom_ids_clean:
+            conditions.append("b.item_uom_id = ANY(:item_uom_ids)")
+            params["item_uom_ids"] = item_uom_ids_clean
+
+        if barcode_id is not None:
+            conditions.append("b.barcode_id = :barcode_id")
+            params["barcode_id"] = int(barcode_id)
+
+        if barcode is not None:
+            clean_barcode = str(barcode).strip()
+            if clean_barcode:
+                conditions.append("b.barcode = :barcode")
+                params["barcode"] = clean_barcode
+
+        if active is not None:
+            conditions.append("b.active = :active")
+            params["active"] = bool(active)
+
+        if primary_only:
+            conditions.append("b.is_primary IS TRUE")
+
+        if not conditions:
+            return []
+
+        rows = (
+            await self.session.execute(
+                text(
+                    f"""
+                    SELECT
+                        b.barcode_id AS id,
+                        b.item_id,
+                        b.item_uom_id,
+                        b.barcode,
+                        b.symbology,
+                        b.active,
+                        b.is_primary,
+                        u.uom,
+                        u.display_name,
+                        u.uom_name,
+                        u.ratio_to_base
+                    FROM wms_pms_barcode_projection b
+                    JOIN wms_pms_uom_projection u
+                      ON u.item_uom_id = b.item_uom_id
+                    WHERE {" AND ".join(conditions)}
+                    ORDER BY
+                        b.item_id ASC,
+                        b.is_primary DESC,
+                        b.barcode_id ASC
+                    """
+                ),
+                params,
+            )
+        ).mappings().all()
+
+        return [PmsExportBarcode.model_validate(dict(row)) for row in rows]
+
+    async def list_barcodes_by_item_id(
+        self,
+        *,
+        item_id: int,
+        active: bool | None = True,
+        primary_only: bool = False,
+    ) -> list[PmsExportBarcode]:
+        return await self.list_barcodes(
+            item_ids=[int(item_id)],
+            active=active,
+            primary_only=primary_only,
+        )
 
     async def get_purchase_default_or_base_uom(self, *, item_id: int) -> PmsExportUom | None:
         return await self._get_default_or_base_uom(item_id=int(item_id), field="is_purchase_default")

--- a/tests/services/test_inbound_service.py
+++ b/tests/services/test_inbound_service.py
@@ -2,7 +2,6 @@
 from datetime import date, datetime, timedelta, timezone
 
 import pytest
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 # 测试辅助：按项目实际路径导入
@@ -35,14 +34,7 @@ async def test_inbound_creates_batch_and_increases_stock(session: AsyncSession):
     """
     wh, loc, item, code = 1, 1, 5001, "INB-DEMO-BATCH"
 
-    await ensure_wh_loc_item(session, wh=wh, loc=loc, item=item)
-
-    # 当前主链：要创建新的 SUPPLIER lot，测试商品必须显式走 REQUIRED
-    await session.execute(
-        text("UPDATE items SET expiry_policy='REQUIRED'::expiry_policy WHERE id=:i"),
-        {"i": int(item)},
-    )
-    await session.commit()
+    await ensure_wh_loc_item(session, wh=wh, loc=loc, item=item, expiry_policy="REQUIRED")
 
     ref = f"IN-{int(datetime.now(UTC).timestamp())}"
     prod = date.today()


### PR DESCRIPTION
## Summary
- migrate tests/helpers/inventory.py away from legacy PMS owner table reads/writes
- seed PMS current-state through WMS PMS projection test helpers
- patch test-only PMS read fake into inventory helper dependency modules
- extend projection-backed fake PMS read client with inventory read support
- migrate touched inbound / stock inventory tests away from UPDATE items

## Boundary
- no runtime business logic change
- no DB migration
- no factory fallback
- no in-process PMS client
- no deletion or freezing of WMS legacy PMS owner tables
- only test helpers and directly affected tests are changed

## Validation
- targeted pytest for inbound service, stock inventory read cases, shared inventory hints, PMS fake client, and projection seed helpers
- grep confirms tests/helpers/inventory.py no longer reads/writes legacy PMS owner tables
- grep confirms touched tests no longer UPDATE/INSERT legacy PMS owner tables
- make alembic-check
