### PR TITLE
test(pms): truncate projection tables between tests

### DIFF
--- a/tests/ci/test_pms_projection_tables_are_truncated.py
+++ b/tests/ci/test_pms_projection_tables_are_truncated.py
@@ -1,0 +1,27 @@
+# tests/ci/test_pms_projection_tables_are_truncated.py
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+REQUIRED_PROJECTION_TABLES = (
+    "wms_pms_item_projection",
+    "wms_pms_uom_projection",
+    "wms_pms_sku_code_projection",
+    "wms_pms_barcode_projection",
+)
+
+
+def test_test_truncate_clears_pms_projection_tables() -> None:
+    truncate_sql = (ROOT / "tests" / "fixtures" / "truncate.sql").read_text(
+        encoding="utf-8"
+    )
+
+    missing = [
+        table_name
+        for table_name in REQUIRED_PROJECTION_TABLES
+        if table_name not in truncate_sql
+    ]
+
+    assert missing == []

--- a/tests/fixtures/truncate.sql
+++ b/tests/fixtures/truncate.sql
@@ -15,8 +15,19 @@
 -- Pricing Phase-surcharge-config：
 -- - surcharge 主线已切到 surcharge_configs + surcharge_config_cities；
 -- - tests 清库不再触碰 shipping_provider_surcharges 旧表。
+--
+-- PMS Split Stabilization：
+-- - PMS owner 真相已拆到 pms-api / pms DB；
+-- - WMS 测试里 wms_pms_*_projection 是 PMS current-state 测试投影；
+-- - projection 表必须每个 test function 清空，禁止跨用例残留。
 
 TRUNCATE TABLE
+  -- PMS read projections
+  wms_pms_barcode_projection,
+  wms_pms_sku_code_projection,
+  wms_pms_uom_projection,
+  wms_pms_item_projection,
+
   -- platform order ingestion jobs
   -- finance facts
   finance_order_sales_lines,


### PR DESCRIPTION
## Summary
- include WMS PMS projection tables in test truncate baseline
- prevent projection seed data from leaking across test functions
- add CI guard requiring projection tables to stay in truncate.sql

## Boundary
- no runtime business logic change
- no DB migration
- no deletion or freezing of WMS legacy PMS owner tables
- no changes to base_seed.sql / conftest.py legacy PMS owner seed yet
- this PR only fixes test isolation for wms_pms_*_projection tables

## Validation
- static guard: tests/ci/test_pms_projection_tables_are_truncated.py
- projection seed test creates one row in each projection table
- neutral test proves the next test function truncates projection rows back to zero
- targeted regression: projection seed helper, fake PMS read client, shared inventory hints, stock inventory read cases, ledger idempotency, FEFO
- make alembic-check
