### PR TITLE
test(pms): seed projection baseline from legacy PMS fixtures

### DIFF
--- a/tests/ci/test_pms_projection_baseline_seed.py
+++ b/tests/ci/test_pms_projection_baseline_seed.py
@@ -1,0 +1,33 @@
+# tests/ci/test_pms_projection_baseline_seed.py
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+REQUIRED_PROJECTION_TABLES = (
+    "wms_pms_item_projection",
+    "wms_pms_uom_projection",
+    "wms_pms_sku_code_projection",
+    "wms_pms_barcode_projection",
+)
+
+
+def test_base_seed_materializes_pms_projection_baseline() -> None:
+    sql = (ROOT / "tests" / "fixtures" / "base_seed.sql").read_text(encoding="utf-8")
+
+    missing = [
+        table_name
+        for table_name in REQUIRED_PROJECTION_TABLES
+        if table_name not in sql
+    ]
+
+    assert missing == []
+
+
+def test_conftest_keeps_projection_batch_policy_aligned_with_legacy_seed() -> None:
+    conftest = (ROOT / "tests" / "conftest.py").read_text(encoding="utf-8")
+
+    assert "UPDATE items" in conftest
+    assert "UPDATE wms_pms_item_projection" in conftest
+    assert "test-baseline:required:" in conftest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,6 +146,22 @@ async def _db_clean_and_seed(async_engine: AsyncEngine):
                 """
             )
         )
+        await conn.execute(
+            text(
+                """
+                UPDATE wms_pms_item_projection
+                   SET expiry_policy = 'REQUIRED',
+                       lot_source_policy = 'SUPPLIER_ONLY',
+                       shelf_life_value = COALESCE(shelf_life_value, 30),
+                       shelf_life_unit = COALESCE(shelf_life_unit, 'DAY'),
+                       pms_updated_at = CURRENT_TIMESTAMP,
+                       source_hash = 'test-baseline:required:' || item_id::text || ':' || COALESCE(sku, ''),
+                       sync_version = 'test-baseline',
+                       synced_at = CURRENT_TIMESTAMP
+                 WHERE expiry_policy IS DISTINCT FROM 'REQUIRED'
+                """
+            )
+        )
 
         # 3) Route C 测试基线：服务省份规则 + 店铺绑定（显式）
         row = await conn.execute(text("SELECT id FROM warehouses ORDER BY id ASC LIMIT 1"))

--- a/tests/fixtures/base_seed.sql
+++ b/tests/fixtures/base_seed.sql
@@ -347,3 +347,205 @@ UPDATE items
 SET supplier_id = 3,
     enabled = true
 WHERE id = 1;
+
+
+-- ===== WMS PMS read projections (PMS split test baseline) =====
+-- PMS owner 真相已拆到 pms-api / pms DB。
+-- WMS 测试仍暂时保留旧 PMS owner seed 以支撑尚未迁移的历史测试；
+-- 同时必须把相同 PMS current-state 复制到 wms_pms_*_projection，
+-- 供新测试路径通过 projection-backed fake PMS read client 读取。
+INSERT INTO wms_pms_item_projection (
+  item_id,
+  sku,
+  name,
+  spec,
+  enabled,
+  supplier_id,
+  brand,
+  category,
+  expiry_policy,
+  shelf_life_value,
+  shelf_life_unit,
+  lot_source_policy,
+  derivation_allowed,
+  uom_governance_enabled,
+  pms_updated_at,
+  source_hash,
+  sync_version,
+  synced_at
+)
+SELECT
+  i.id,
+  i.sku,
+  i.name,
+  i.spec,
+  COALESCE(i.enabled, TRUE),
+  i.supplier_id,
+  b.name_cn,
+  c.category_name,
+  i.expiry_policy::text,
+  i.shelf_life_value,
+  i.shelf_life_unit::text,
+  i.lot_source_policy::text,
+  COALESCE(i.derivation_allowed, TRUE),
+  COALESCE(i.uom_governance_enabled, TRUE),
+  COALESCE(i.updated_at, CURRENT_TIMESTAMP),
+  'test-baseline:item:' || i.id::text || ':' || COALESCE(i.sku, ''),
+  'test-baseline',
+  CURRENT_TIMESTAMP
+FROM items i
+LEFT JOIN pms_brands b
+  ON b.id = i.brand_id
+LEFT JOIN pms_business_categories c
+  ON c.id = i.category_id
+WHERE i.id IN (1, 3001, 3002, 3003, 4001, 4002)
+ON CONFLICT (item_id) DO UPDATE SET
+  sku = EXCLUDED.sku,
+  name = EXCLUDED.name,
+  spec = EXCLUDED.spec,
+  enabled = EXCLUDED.enabled,
+  supplier_id = EXCLUDED.supplier_id,
+  brand = EXCLUDED.brand,
+  category = EXCLUDED.category,
+  expiry_policy = EXCLUDED.expiry_policy,
+  shelf_life_value = EXCLUDED.shelf_life_value,
+  shelf_life_unit = EXCLUDED.shelf_life_unit,
+  lot_source_policy = EXCLUDED.lot_source_policy,
+  derivation_allowed = EXCLUDED.derivation_allowed,
+  uom_governance_enabled = EXCLUDED.uom_governance_enabled,
+  pms_updated_at = EXCLUDED.pms_updated_at,
+  source_hash = EXCLUDED.source_hash,
+  sync_version = EXCLUDED.sync_version,
+  synced_at = CURRENT_TIMESTAMP;
+
+INSERT INTO wms_pms_uom_projection (
+  item_uom_id,
+  item_id,
+  uom,
+  display_name,
+  uom_name,
+  ratio_to_base,
+  net_weight_kg,
+  is_base,
+  is_purchase_default,
+  is_inbound_default,
+  is_outbound_default,
+  pms_updated_at,
+  source_hash,
+  sync_version,
+  synced_at
+)
+SELECT
+  u.id,
+  u.item_id,
+  u.uom,
+  u.display_name,
+  COALESCE(NULLIF(u.display_name, ''), NULLIF(u.uom, ''), u.uom),
+  u.ratio_to_base,
+  u.net_weight_kg,
+  u.is_base,
+  u.is_purchase_default,
+  u.is_inbound_default,
+  u.is_outbound_default,
+  COALESCE(u.updated_at, CURRENT_TIMESTAMP),
+  'test-baseline:uom:' || u.id::text || ':' || u.item_id::text || ':' || COALESCE(u.uom, ''),
+  'test-baseline',
+  CURRENT_TIMESTAMP
+FROM item_uoms u
+WHERE u.item_id IN (1, 3001, 3002, 3003, 4001, 4002)
+ON CONFLICT (item_uom_id) DO UPDATE SET
+  item_id = EXCLUDED.item_id,
+  uom = EXCLUDED.uom,
+  display_name = EXCLUDED.display_name,
+  uom_name = EXCLUDED.uom_name,
+  ratio_to_base = EXCLUDED.ratio_to_base,
+  net_weight_kg = EXCLUDED.net_weight_kg,
+  is_base = EXCLUDED.is_base,
+  is_purchase_default = EXCLUDED.is_purchase_default,
+  is_inbound_default = EXCLUDED.is_inbound_default,
+  is_outbound_default = EXCLUDED.is_outbound_default,
+  pms_updated_at = EXCLUDED.pms_updated_at,
+  source_hash = EXCLUDED.source_hash,
+  sync_version = EXCLUDED.sync_version,
+  synced_at = CURRENT_TIMESTAMP;
+
+INSERT INTO wms_pms_sku_code_projection (
+  sku_code_id,
+  item_id,
+  sku_code,
+  code_type,
+  is_primary,
+  is_active,
+  effective_from,
+  effective_to,
+  pms_updated_at,
+  source_hash,
+  sync_version,
+  synced_at
+)
+SELECT
+  sc.id,
+  sc.item_id,
+  sc.code,
+  sc.code_type,
+  sc.is_primary,
+  sc.is_active,
+  sc.effective_from,
+  sc.effective_to,
+  COALESCE(sc.updated_at, CURRENT_TIMESTAMP),
+  'test-baseline:sku-code:' || sc.id::text || ':' || COALESCE(sc.code, ''),
+  'test-baseline',
+  CURRENT_TIMESTAMP
+FROM item_sku_codes sc
+WHERE sc.item_id IN (1, 3001, 3002, 3003, 4001, 4002)
+ON CONFLICT (sku_code_id) DO UPDATE SET
+  item_id = EXCLUDED.item_id,
+  sku_code = EXCLUDED.sku_code,
+  code_type = EXCLUDED.code_type,
+  is_primary = EXCLUDED.is_primary,
+  is_active = EXCLUDED.is_active,
+  effective_from = EXCLUDED.effective_from,
+  effective_to = EXCLUDED.effective_to,
+  pms_updated_at = EXCLUDED.pms_updated_at,
+  source_hash = EXCLUDED.source_hash,
+  sync_version = EXCLUDED.sync_version,
+  synced_at = CURRENT_TIMESTAMP;
+
+INSERT INTO wms_pms_barcode_projection (
+  barcode_id,
+  item_id,
+  item_uom_id,
+  barcode,
+  symbology,
+  active,
+  is_primary,
+  pms_updated_at,
+  source_hash,
+  sync_version,
+  synced_at
+)
+SELECT
+  b.id,
+  b.item_id,
+  b.item_uom_id,
+  b.barcode,
+  b.symbology,
+  b.active,
+  b.is_primary,
+  COALESCE(b.updated_at, CURRENT_TIMESTAMP),
+  'test-baseline:barcode:' || b.id::text || ':' || COALESCE(b.barcode, ''),
+  'test-baseline',
+  CURRENT_TIMESTAMP
+FROM item_barcodes b
+WHERE b.item_id IN (1, 3001, 3002, 3003, 4001, 4002)
+ON CONFLICT (barcode_id) DO UPDATE SET
+  item_id = EXCLUDED.item_id,
+  item_uom_id = EXCLUDED.item_uom_id,
+  barcode = EXCLUDED.barcode,
+  symbology = EXCLUDED.symbology,
+  active = EXCLUDED.active,
+  is_primary = EXCLUDED.is_primary,
+  pms_updated_at = EXCLUDED.pms_updated_at,
+  source_hash = EXCLUDED.source_hash,
+  sync_version = EXCLUDED.sync_version,
+  synced_at = CURRENT_TIMESTAMP;


### PR DESCRIPTION
## Summary
- seed WMS PMS projection baseline from existing legacy PMS fixture rows
- keep old PMS owner seed in place for tests that still read legacy owner tables
- sync conftest REQUIRED policy adjustment into wms_pms_item_projection
- add CI guard requiring base_seed.sql and conftest.py to maintain projection baseline

## Boundary
- no runtime business logic change
- no DB migration
- no deletion or freezing of WMS legacy PMS owner tables
- no removal of legacy PMS owner seed yet
- this PR only adds projection baseline alongside existing legacy seed

## Validation
- static guards: tests/ci/test_pms_projection_baseline_seed.py and tests/ci/test_pms_projection_tables_are_truncated.py
- neutral test materializes projection baseline
- projection baseline counts: items/uoms/sku-codes/barcodes = 6 each
- targeted regression: projection seed helper, fake PMS read client, shared inventory hints, ledger idempotency, FEFO, stock inventory reads
- make alembic-check
