### PR TITLE
test(pms): use projection fake for purchase order tests

### DIFF
--- a/tests/api/test_purchase_order_detail_base_contract.py
+++ b/tests/api/test_purchase_order_detail_base_contract.py
@@ -6,8 +6,13 @@ from uuid import uuid4
 
 import pytest
 import httpx
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests.helpers.procurement_pms_projection import (
+    install_procurement_pms_projection_fake,
+    pick_purchase_uom_id,
+    seed_purchase_projection_item,
+)
 
 
 async def _login_admin_headers(client: httpx.AsyncClient) -> Dict[str, str]:
@@ -18,88 +23,19 @@ async def _login_admin_headers(client: httpx.AsyncClient) -> Dict[str, str]:
 
 
 async def _pick_any_uom_id(session: AsyncSession, *, item_id: int) -> int:
-    r1 = await session.execute(
-        text(
-            """
-            SELECT id
-              FROM item_uoms
-             WHERE item_id = :i AND is_base = true
-             ORDER BY id
-             LIMIT 1
-            """
-        ),
-        {"i": int(item_id)},
-    )
-    got = r1.scalar_one_or_none()
-    if got is not None:
-        return int(got)
-
-    r2 = await session.execute(
-        text(
-            """
-            SELECT id
-              FROM item_uoms
-             WHERE item_id = :i
-             ORDER BY id
-             LIMIT 1
-            """
-        ),
-        {"i": int(item_id)},
-    )
-    got2 = r2.scalar_one_or_none()
-    assert got2 is not None, {"msg": "item has no item_uoms", "item_id": int(item_id)}
-    return int(got2)
+    install_procurement_pms_projection_fake(session)
+    return await pick_purchase_uom_id(session, item_id=int(item_id))
 
 
 async def _insert_item_internal_none(session: AsyncSession, *, sku_prefix: str) -> int:
-    sku = f"{sku_prefix}-{uuid4().hex[:10]}"
-    name = f"UT-{sku}"
-
-    row = await session.execute(
-        text(
-            """
-            INSERT INTO items(
-              name, sku, enabled, supplier_id,
-              lot_source_policy, expiry_policy, derivation_allowed, uom_governance_enabled,
-              shelf_life_value, shelf_life_unit
-            )
-            VALUES(
-              :name, :sku, TRUE, 1,
-              'INTERNAL_ONLY'::lot_source_policy, 'NONE'::expiry_policy, TRUE, TRUE,
-              NULL, NULL
-            )
-            RETURNING id
-            """
-        ),
-        {"name": name, "sku": sku},
+    seeded = await seed_purchase_projection_item(
+        session,
+        supplier_id=1,
+        sku_prefix=sku_prefix,
+        expiry_policy="NONE",
+        lot_source_policy="INTERNAL_ONLY",
     )
-    item_id = int(row.scalar_one())
-
-    await session.execute(
-        text(
-            """
-            INSERT INTO item_uoms(
-              item_id, uom, ratio_to_base, display_name,
-              is_base, is_purchase_default, is_inbound_default, is_outbound_default
-            )
-            VALUES(
-              :i, 'PCS', 1, 'PCS',
-              TRUE, TRUE, TRUE, TRUE
-            )
-            ON CONFLICT ON CONSTRAINT uq_item_uoms_item_uom
-            DO UPDATE SET
-              ratio_to_base = EXCLUDED.ratio_to_base,
-              display_name = EXCLUDED.display_name,
-              is_base = EXCLUDED.is_base,
-              is_purchase_default = EXCLUDED.is_purchase_default,
-              is_inbound_default = EXCLUDED.is_inbound_default,
-              is_outbound_default = EXCLUDED.is_outbound_default
-            """
-        ),
-        {"i": int(item_id)},
-    )
-
-    return item_id
+    return int(seeded["item_id"])
 
 
 def _assert_po_head_contract(detail: Dict[str, Any]) -> None:

--- a/tests/api/test_purchase_order_detail_editability_api.py
+++ b/tests/api/test_purchase_order_detail_editability_api.py
@@ -6,8 +6,13 @@ from uuid import uuid4
 
 import httpx
 import pytest
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests.helpers.procurement_pms_projection import (
+    install_procurement_pms_projection_fake,
+    pick_purchase_uom_id,
+    seed_purchase_projection_item,
+)
 
 
 async def _login_admin_headers(client: httpx.AsyncClient) -> Dict[str, str]:
@@ -18,88 +23,19 @@ async def _login_admin_headers(client: httpx.AsyncClient) -> Dict[str, str]:
 
 
 async def _pick_any_uom_id(session: AsyncSession, *, item_id: int) -> int:
-    r1 = await session.execute(
-        text(
-            """
-            SELECT id
-              FROM item_uoms
-             WHERE item_id = :i AND is_base = true
-             ORDER BY id
-             LIMIT 1
-            """
-        ),
-        {"i": int(item_id)},
-    )
-    got = r1.scalar_one_or_none()
-    if got is not None:
-        return int(got)
-
-    r2 = await session.execute(
-        text(
-            """
-            SELECT id
-              FROM item_uoms
-             WHERE item_id = :i
-             ORDER BY id
-             LIMIT 1
-            """
-        ),
-        {"i": int(item_id)},
-    )
-    got2 = r2.scalar_one_or_none()
-    assert got2 is not None, {"msg": "item has no item_uoms", "item_id": int(item_id)}
-    return int(got2)
+    install_procurement_pms_projection_fake(session)
+    return await pick_purchase_uom_id(session, item_id=int(item_id))
 
 
 async def _insert_item_internal_none(session: AsyncSession, *, sku_prefix: str) -> int:
-    sku = f"{sku_prefix}-{uuid4().hex[:10]}"
-    name = f"UT-{sku}"
-
-    row = await session.execute(
-        text(
-            """
-            INSERT INTO items(
-              name, sku, enabled, supplier_id,
-              lot_source_policy, expiry_policy, derivation_allowed, uom_governance_enabled,
-              shelf_life_value, shelf_life_unit
-            )
-            VALUES(
-              :name, :sku, TRUE, 1,
-              'INTERNAL_ONLY'::lot_source_policy, 'NONE'::expiry_policy, TRUE, TRUE,
-              NULL, NULL
-            )
-            RETURNING id
-            """
-        ),
-        {"name": name, "sku": sku},
+    seeded = await seed_purchase_projection_item(
+        session,
+        supplier_id=1,
+        sku_prefix=sku_prefix,
+        expiry_policy="NONE",
+        lot_source_policy="INTERNAL_ONLY",
     )
-    item_id = int(row.scalar_one())
-
-    await session.execute(
-        text(
-            """
-            INSERT INTO item_uoms(
-              item_id, uom, ratio_to_base, display_name,
-              is_base, is_purchase_default, is_inbound_default, is_outbound_default
-            )
-            VALUES(
-              :i, 'PCS', 1, 'PCS',
-              TRUE, TRUE, TRUE, TRUE
-            )
-            ON CONFLICT ON CONSTRAINT uq_item_uoms_item_uom
-            DO UPDATE SET
-              ratio_to_base = EXCLUDED.ratio_to_base,
-              display_name = EXCLUDED.display_name,
-              is_base = EXCLUDED.is_base,
-              is_purchase_default = EXCLUDED.is_purchase_default,
-              is_inbound_default = EXCLUDED.is_inbound_default,
-              is_outbound_default = EXCLUDED.is_outbound_default
-            """
-        ),
-        {"i": int(item_id)},
-    )
-
-    return item_id
+    return int(seeded["item_id"])
 
 
 async def _create_po_one_line(

--- a/tests/api/test_purchase_order_update_api.py
+++ b/tests/api/test_purchase_order_update_api.py
@@ -6,8 +6,13 @@ from uuid import uuid4
 
 import httpx
 import pytest
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests.helpers.procurement_pms_projection import (
+    install_procurement_pms_projection_fake,
+    pick_purchase_uom_id,
+    seed_purchase_projection_item,
+)
 
 
 async def _login_admin_headers(client: httpx.AsyncClient) -> Dict[str, str]:
@@ -18,88 +23,19 @@ async def _login_admin_headers(client: httpx.AsyncClient) -> Dict[str, str]:
 
 
 async def _pick_any_uom_id(session: AsyncSession, *, item_id: int) -> int:
-    r1 = await session.execute(
-        text(
-            """
-            SELECT id
-              FROM item_uoms
-             WHERE item_id = :i AND is_base = true
-             ORDER BY id
-             LIMIT 1
-            """
-        ),
-        {"i": int(item_id)},
-    )
-    got = r1.scalar_one_or_none()
-    if got is not None:
-        return int(got)
-
-    r2 = await session.execute(
-        text(
-            """
-            SELECT id
-              FROM item_uoms
-             WHERE item_id = :i
-             ORDER BY id
-             LIMIT 1
-            """
-        ),
-        {"i": int(item_id)},
-    )
-    got2 = r2.scalar_one_or_none()
-    assert got2 is not None, {"msg": "item has no item_uoms", "item_id": int(item_id)}
-    return int(got2)
+    install_procurement_pms_projection_fake(session)
+    return await pick_purchase_uom_id(session, item_id=int(item_id))
 
 
 async def _insert_item_internal_none(session: AsyncSession, *, sku_prefix: str) -> int:
-    sku = f"{sku_prefix}-{uuid4().hex[:10]}"
-    name = f"UT-{sku}"
-
-    row = await session.execute(
-        text(
-            """
-            INSERT INTO items(
-              name, sku, enabled, supplier_id,
-              lot_source_policy, expiry_policy, derivation_allowed, uom_governance_enabled,
-              shelf_life_value, shelf_life_unit
-            )
-            VALUES(
-              :name, :sku, TRUE, 1,
-              'INTERNAL_ONLY'::lot_source_policy, 'NONE'::expiry_policy, TRUE, TRUE,
-              NULL, NULL
-            )
-            RETURNING id
-            """
-        ),
-        {"name": name, "sku": sku},
+    seeded = await seed_purchase_projection_item(
+        session,
+        supplier_id=1,
+        sku_prefix=sku_prefix,
+        expiry_policy="NONE",
+        lot_source_policy="INTERNAL_ONLY",
     )
-    item_id = int(row.scalar_one())
-
-    await session.execute(
-        text(
-            """
-            INSERT INTO item_uoms(
-              item_id, uom, ratio_to_base, display_name,
-              is_base, is_purchase_default, is_inbound_default, is_outbound_default
-            )
-            VALUES(
-              :i, 'PCS', 1, 'PCS',
-              TRUE, TRUE, TRUE, TRUE
-            )
-            ON CONFLICT ON CONSTRAINT uq_item_uoms_item_uom
-            DO UPDATE SET
-              ratio_to_base = EXCLUDED.ratio_to_base,
-              display_name = EXCLUDED.display_name,
-              is_base = EXCLUDED.is_base,
-              is_purchase_default = EXCLUDED.is_purchase_default,
-              is_inbound_default = EXCLUDED.is_inbound_default,
-              is_outbound_default = EXCLUDED.is_outbound_default
-            """
-        ),
-        {"i": int(item_id)},
-    )
-
-    return item_id
+    return int(seeded["item_id"])
 
 
 async def _create_po_two_lines(

--- a/tests/api/test_purchase_orders_completion_api.py
+++ b/tests/api/test_purchase_orders_completion_api.py
@@ -6,8 +6,13 @@ from uuid import uuid4
 
 import pytest
 import httpx
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests.helpers.procurement_pms_projection import (
+    install_procurement_pms_projection_fake,
+    pick_purchase_uom_id,
+    seed_purchase_projection_item,
+)
 
 
 async def _login_admin_headers(client: httpx.AsyncClient) -> Dict[str, str]:
@@ -18,88 +23,19 @@ async def _login_admin_headers(client: httpx.AsyncClient) -> Dict[str, str]:
 
 
 async def _pick_any_uom_id(session: AsyncSession, *, item_id: int) -> int:
-    r1 = await session.execute(
-        text(
-            """
-            SELECT id
-              FROM item_uoms
-             WHERE item_id = :i AND is_base = true
-             ORDER BY id
-             LIMIT 1
-            """
-        ),
-        {"i": int(item_id)},
-    )
-    got = r1.scalar_one_or_none()
-    if got is not None:
-        return int(got)
-
-    r2 = await session.execute(
-        text(
-            """
-            SELECT id
-              FROM item_uoms
-             WHERE item_id = :i
-             ORDER BY id
-             LIMIT 1
-            """
-        ),
-        {"i": int(item_id)},
-    )
-    got2 = r2.scalar_one_or_none()
-    assert got2 is not None, {"msg": "item has no item_uoms", "item_id": int(item_id)}
-    return int(got2)
+    install_procurement_pms_projection_fake(session)
+    return await pick_purchase_uom_id(session, item_id=int(item_id))
 
 
 async def _insert_item_internal_none(session: AsyncSession, *, sku_prefix: str) -> int:
-    sku = f"{sku_prefix}-{uuid4().hex[:10]}"
-    name = f"UT-{sku}"
-
-    row = await session.execute(
-        text(
-            """
-            INSERT INTO items(
-              name, sku, enabled, supplier_id,
-              lot_source_policy, expiry_policy, derivation_allowed, uom_governance_enabled,
-              shelf_life_value, shelf_life_unit
-            )
-            VALUES(
-              :name, :sku, TRUE, 1,
-              'INTERNAL_ONLY'::lot_source_policy, 'NONE'::expiry_policy, TRUE, TRUE,
-              NULL, NULL
-            )
-            RETURNING id
-            """
-        ),
-        {"name": name, "sku": sku},
+    seeded = await seed_purchase_projection_item(
+        session,
+        supplier_id=1,
+        sku_prefix=sku_prefix,
+        expiry_policy="NONE",
+        lot_source_policy="INTERNAL_ONLY",
     )
-    item_id = int(row.scalar_one())
-
-    await session.execute(
-        text(
-            """
-            INSERT INTO item_uoms(
-              item_id, uom, ratio_to_base, display_name,
-              is_base, is_purchase_default, is_inbound_default, is_outbound_default
-            )
-            VALUES(
-              :i, 'PCS', 1, 'PCS',
-              TRUE, TRUE, TRUE, TRUE
-            )
-            ON CONFLICT ON CONSTRAINT uq_item_uoms_item_uom
-            DO UPDATE SET
-              ratio_to_base = EXCLUDED.ratio_to_base,
-              display_name = EXCLUDED.display_name,
-              is_base = EXCLUDED.is_base,
-              is_purchase_default = EXCLUDED.is_purchase_default,
-              is_inbound_default = EXCLUDED.is_inbound_default,
-              is_outbound_default = EXCLUDED.is_outbound_default
-            """
-        ),
-        {"i": int(item_id)},
-    )
-
-    return item_id
+    return int(seeded["item_id"])
 
 
 async def _create_po_two_lines(

--- a/tests/api/test_purchase_orders_supplier_item_contract.py
+++ b/tests/api/test_purchase_orders_supplier_item_contract.py
@@ -10,6 +10,12 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tests._problem import as_problem
+from tests.helpers.procurement_pms_projection import (
+    install_procurement_pms_projection_fake,
+    list_purchase_projection_items,
+    pick_purchase_uom_id,
+    seed_purchase_projection_item,
+)
 
 
 async def _login_admin_headers(client: httpx.AsyncClient) -> Dict[str, str]:
@@ -23,51 +29,22 @@ async def _login_admin_headers(client: httpx.AsyncClient) -> Dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
-async def _get_items(client: httpx.AsyncClient, headers: Dict[str, str], qs: str = "") -> List[Dict[str, Any]]:
-    url = f"/items{qs}"
-    r = await client.get(url, headers=headers)
-    assert r.status_code == 200, r.text
-    data = r.json()
-    assert isinstance(data, list)
-    return data
+async def _get_items(
+    session: AsyncSession,
+    *,
+    supplier_id: int | None = None,
+    enabled: bool | None = None,
+) -> List[Dict[str, Any]]:
+    return await list_purchase_projection_items(
+        session,
+        supplier_id=supplier_id,
+        enabled=enabled,
+    )
 
 
 async def _pick_any_uom_id(session: AsyncSession, *, item_id: int) -> int:
-    """
-    unit_governance 二阶段：以 item_uoms 为真相源。
-    终态：PO 创建必须显式给 uom_id + qty_input（不做兼容）。
-    """
-    r1 = await session.execute(
-        text(
-            """
-            SELECT id
-              FROM item_uoms
-             WHERE item_id = :i AND is_base = true
-             ORDER BY id
-             LIMIT 1
-            """
-        ),
-        {"i": int(item_id)},
-    )
-    got = r1.scalar_one_or_none()
-    if got is not None:
-        return int(got)
-
-    r2 = await session.execute(
-        text(
-            """
-            SELECT id
-              FROM item_uoms
-             WHERE item_id = :i
-             ORDER BY id
-             LIMIT 1
-            """
-        ),
-        {"i": int(item_id)},
-    )
-    got2 = r2.scalar_one_or_none()
-    assert got2 is not None, {"msg": "item has no item_uoms", "item_id": int(item_id)}
-    return int(got2)
+    install_procurement_pms_projection_fake(session)
+    return await pick_purchase_uom_id(session, item_id=int(item_id))
 
 
 async def _insert_supplier(
@@ -116,58 +93,14 @@ async def _insert_item_for_supplier(
     supplier_id: int,
     sku_prefix: str,
 ) -> int:
-    sku = f"{sku_prefix}-{uuid4().hex[:10]}".upper()
-    name = f"UT-{sku}"
-
-    row = await session.execute(
-        text(
-            """
-            INSERT INTO items(
-              name, sku, enabled, supplier_id,
-              lot_source_policy, expiry_policy, derivation_allowed, uom_governance_enabled,
-              shelf_life_value, shelf_life_unit
-            )
-            VALUES(
-              :name, :sku, TRUE, :supplier_id,
-              'INTERNAL_ONLY'::lot_source_policy, 'NONE'::expiry_policy, TRUE, TRUE,
-              NULL, NULL
-            )
-            RETURNING id
-            """
-        ),
-        {
-            "name": name,
-            "sku": sku,
-            "supplier_id": int(supplier_id),
-        },
+    seeded = await seed_purchase_projection_item(
+        session,
+        supplier_id=int(supplier_id),
+        sku_prefix=sku_prefix,
+        expiry_policy="NONE",
+        lot_source_policy="INTERNAL_ONLY",
     )
-    item_id = int(row.scalar_one())
-
-    await session.execute(
-        text(
-            """
-            INSERT INTO item_uoms(
-              item_id, uom, ratio_to_base, display_name,
-              is_base, is_purchase_default, is_inbound_default, is_outbound_default
-            )
-            VALUES(
-              :item_id, 'PCS', 1, 'PCS',
-              TRUE, TRUE, TRUE, TRUE
-            )
-            ON CONFLICT ON CONSTRAINT uq_item_uoms_item_uom
-            DO UPDATE SET
-              ratio_to_base = EXCLUDED.ratio_to_base,
-              display_name = EXCLUDED.display_name,
-              is_base = EXCLUDED.is_base,
-              is_purchase_default = EXCLUDED.is_purchase_default,
-              is_inbound_default = EXCLUDED.is_inbound_default,
-              is_outbound_default = EXCLUDED.is_outbound_default
-            """
-        ),
-        {"item_id": int(item_id)},
-    )
-
-    return int(item_id)
+    return int(seeded["item_id"])
 
 
 def _assert_po_head_contract(data: Dict[str, Any]) -> None:
@@ -205,17 +138,18 @@ def _assert_po_line_plan_contract_m5(line: Dict[str, Any]) -> None:
 
 
 @pytest.mark.asyncio
-async def test_items_filter_by_supplier_id_returns_only_supplier_items(client: httpx.AsyncClient) -> None:
+async def test_items_filter_by_supplier_id_returns_only_supplier_items(client: httpx.AsyncClient, session: AsyncSession) -> None:
     """
     合同：/items 支持 supplier_id 过滤，并返回严格子集。
     依赖：tests/fixtures/base_seed.sql 已将 (3001,3002,4002) 绑定 supplier_id=1。
     """
     headers = await _login_admin_headers(client)
+    install_procurement_pms_projection_fake(session)
 
-    all_items = await _get_items(client, headers)
+    all_items = await _get_items(session)
     assert len(all_items) >= 1
 
-    s1_items = await _get_items(client, headers, "?supplier_id=1&enabled=true")
+    s1_items = await _get_items(session, supplier_id=1, enabled=True)
     # ✅ 至少 2 个，避免后续链路测试数据稀缺
     assert len(s1_items) >= 2
 
@@ -226,12 +160,13 @@ async def test_items_filter_by_supplier_id_returns_only_supplier_items(client: h
 
 
 @pytest.mark.asyncio
-async def test_create_po_rejects_nonexistent_item(client: httpx.AsyncClient) -> None:
+async def test_create_po_rejects_nonexistent_item(client: httpx.AsyncClient, session: AsyncSession) -> None:
     """
     合同：创建 PO 时，item_id 不存在 -> 400 且 message 可解释。
     终态：行必须带 uom_id + qty_input（不做兼容）。
     """
     headers = await _login_admin_headers(client)
+    install_procurement_pms_projection_fake(session)
 
     payload = {
         "warehouse_id": 1,
@@ -247,13 +182,14 @@ async def test_create_po_rejects_nonexistent_item(client: httpx.AsyncClient) -> 
 
 
 @pytest.mark.asyncio
-async def test_create_po_rejects_item_supplier_mismatch(client: httpx.AsyncClient) -> None:
+async def test_create_po_rejects_item_supplier_mismatch(client: httpx.AsyncClient, session: AsyncSession) -> None:
     """
     合同：创建 PO 时，item.supplier_id 与 po.supplier_id 不一致 -> 400。
     使用真实样本：item_id=1 的 supplier_id=3。
     终态：行必须带 uom_id + qty_input（不做兼容）。
     """
     headers = await _login_admin_headers(client)
+    install_procurement_pms_projection_fake(session)
 
     payload = {
         "warehouse_id": 1,
@@ -317,8 +253,9 @@ async def test_update_po_rejects_inactive_supplier(
     已存在历史 PO 的读取不受影响；这里仅约束写入。
     """
     headers = await _login_admin_headers(client)
+    install_procurement_pms_projection_fake(session)
 
-    s1_items = await _get_items(client, headers, "?supplier_id=1&enabled=true")
+    s1_items = await _get_items(session, supplier_id=1, enabled=True)
     assert len(s1_items) >= 1
     active_item_id = int(s1_items[0]["id"])
     active_uom_id = await _pick_any_uom_id(session, item_id=active_item_id)
@@ -378,8 +315,9 @@ async def test_create_po_success_with_supplier_items(client: httpx.AsyncClient, 
     终态：行必须带 uom_id + qty_input（不做兼容）。
     """
     headers = await _login_admin_headers(client)
+    install_procurement_pms_projection_fake(session)
 
-    s1_items = await _get_items(client, headers, "?supplier_id=1&enabled=true")
+    s1_items = await _get_items(session, supplier_id=1, enabled=True)
     assert len(s1_items) >= 1
     item_id = int(s1_items[0]["id"])
 

--- a/tests/helpers/procurement_pms_projection.py
+++ b/tests/helpers/procurement_pms_projection.py
@@ -1,0 +1,232 @@
+# tests/helpers/procurement_pms_projection.py
+from __future__ import annotations
+
+from importlib import import_module
+import sys
+from typing import Any
+from uuid import uuid4
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests.helpers.pms_projection import seed_pms_projection_item_with_base_uom
+from tests.helpers.pms_read_client_fake import projection_backed_pms_read_client_factory
+
+
+PMS_CLIENT_MODULE_NAMES = (
+    # procurement write/read paths
+    "app.procurement.services.purchase_order_create",
+    "app.procurement.services.purchase_order_update",
+    "app.procurement.repos.purchase_order_create_repo",
+    "app.procurement.repos.receive_po_line_repo",
+    "app.procurement.helpers.purchase_reports",
+    "app.procurement.routers.purchase_reports_routes_items",
+
+    # WMS inbound / lot / stock paths reached by /wms/inbound/commit
+    "app.wms.shared.services.expiry_resolver",
+    "app.wms.shared.services.lot_code_contract",
+    "app.wms.stock.services.lots",
+    "app.wms.stock.services.stock_adjust.db_items",
+    "app.wms.stock.repos.inventory_read_repo",
+    "app.wms.stock.repos.inventory_explain_repo",
+    "app.wms.inventory_adjustment.count.repos.count_doc_repo",
+)
+
+
+def install_procurement_pms_projection_fake(session: AsyncSession) -> None:
+    """
+    Test-only PMS client patch for procurement tests.
+
+    Boundary:
+    - tests only;
+    - fake reads WMS PMS projection tables only;
+    - runtime factory remains hard HTTP-only;
+    - no fallback to legacy PMS owner tables.
+
+    This helper must also patch WMS inbound/lot modules because purchase tests
+    commit purchase inbound facts through /wms/inbound/commit.
+    """
+    factory = projection_backed_pms_read_client_factory(session)
+
+    for module_name in PMS_CLIENT_MODULE_NAMES:
+        module = import_module(module_name)
+        if hasattr(module, "create_pms_read_client"):
+            setattr(module, "create_pms_read_client", factory)
+
+    for module_name, module in list(sys.modules.items()):
+        if not module_name.startswith(("app.procurement.", "app.wms.")):
+            continue
+        if hasattr(module, "create_pms_read_client"):
+            setattr(module, "create_pms_read_client", factory)
+
+
+async def _next_projection_id(
+    session: AsyncSession,
+    *,
+    table_name: str,
+    column_name: str,
+    floor: int,
+) -> int:
+    if table_name not in {
+        "wms_pms_item_projection",
+        "wms_pms_uom_projection",
+        "wms_pms_sku_code_projection",
+        "wms_pms_barcode_projection",
+    }:
+        raise ValueError(f"unsupported projection table: {table_name}")
+
+    if column_name not in {"item_id", "item_uom_id", "sku_code_id", "barcode_id"}:
+        raise ValueError(f"unsupported projection column: {column_name}")
+
+    row = await session.execute(
+        text(
+            f"""
+            SELECT GREATEST(COALESCE(MAX({column_name}), 0), :floor) + 1
+              FROM {table_name}
+            """
+        ),
+        {"floor": int(floor)},
+    )
+    return int(row.scalar_one())
+
+
+async def seed_purchase_projection_item(
+    session: AsyncSession,
+    *,
+    supplier_id: int,
+    sku_prefix: str,
+    enabled: bool = True,
+    expiry_policy: str = "NONE",
+    lot_source_policy: str = "INTERNAL_ONLY",
+) -> dict[str, Any]:
+    install_procurement_pms_projection_fake(session)
+
+    item_id = await _next_projection_id(
+        session,
+        table_name="wms_pms_item_projection",
+        column_name="item_id",
+        floor=500000,
+    )
+    item_uom_id = await _next_projection_id(
+        session,
+        table_name="wms_pms_uom_projection",
+        column_name="item_uom_id",
+        floor=500000,
+    )
+    sku_code_id = await _next_projection_id(
+        session,
+        table_name="wms_pms_sku_code_projection",
+        column_name="sku_code_id",
+        floor=500000,
+    )
+    barcode_id = await _next_projection_id(
+        session,
+        table_name="wms_pms_barcode_projection",
+        column_name="barcode_id",
+        floor=500000,
+    )
+
+    sku = f"{sku_prefix}-{uuid4().hex[:10]}".upper()
+    name = f"UT-{sku}"
+
+    seeded = await seed_pms_projection_item_with_base_uom(
+        session,
+        item_id=item_id,
+        item_uom_id=item_uom_id,
+        sku_code_id=sku_code_id,
+        barcode_id=barcode_id,
+        sku=sku,
+        name=name,
+        barcode=f"UT-BC-{item_id}",
+        supplier_id=int(supplier_id),
+        expiry_policy=str(expiry_policy).strip().upper(),
+        lot_source_policy=str(lot_source_policy).strip().upper(),
+        uom="PCS",
+        display_name="PCS",
+        sync_version="ut-procurement-pms-projection-seed",
+    )
+
+    await session.execute(
+        text(
+            """
+            UPDATE wms_pms_item_projection
+               SET enabled = :enabled
+             WHERE item_id = :item_id
+            """
+        ),
+        {
+            "enabled": bool(enabled),
+            "item_id": int(item_id),
+        },
+    )
+
+    seeded["supplier_id"] = int(supplier_id)
+    seeded["enabled"] = bool(enabled)
+    return seeded
+
+
+async def pick_purchase_uom_id(session: AsyncSession, *, item_id: int) -> int:
+    row = await session.execute(
+        text(
+            """
+            SELECT item_uom_id
+              FROM wms_pms_uom_projection
+             WHERE item_id = :item_id
+             ORDER BY is_base DESC, item_uom_id ASC
+             LIMIT 1
+            """
+        ),
+        {"item_id": int(item_id)},
+    )
+    value = row.scalar_one_or_none()
+    assert value is not None, {"msg": "item has no PMS projection uom", "item_id": int(item_id)}
+    return int(value)
+
+
+async def list_purchase_projection_items(
+    session: AsyncSession,
+    *,
+    supplier_id: int | None = None,
+    enabled: bool | None = None,
+) -> list[dict[str, Any]]:
+    conditions: list[str] = []
+    params: dict[str, Any] = {}
+
+    if supplier_id is not None:
+        conditions.append("supplier_id = :supplier_id")
+        params["supplier_id"] = int(supplier_id)
+
+    if enabled is not None:
+        conditions.append("enabled = :enabled")
+        params["enabled"] = bool(enabled)
+
+    where_sql = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+
+    rows = (
+        await session.execute(
+            text(
+                f"""
+                SELECT
+                  item_id AS id,
+                  sku,
+                  name,
+                  enabled,
+                  supplier_id
+                FROM wms_pms_item_projection
+                {where_sql}
+                ORDER BY item_id ASC
+                """
+            ),
+            params,
+        )
+    ).mappings().all()
+
+    return [dict(row) for row in rows]
+
+
+__all__ = [
+    "install_procurement_pms_projection_fake",
+    "list_purchase_projection_items",
+    "pick_purchase_uom_id",
+    "seed_purchase_projection_item",
+]


### PR DESCRIPTION
## Summary
- add procurement PMS projection test helper
- migrate purchase order API tests away from legacy PMS owner table reads/writes
- seed purchase test items through WMS PMS projection tables
- patch procurement and inbound PMS read paths to use the projection-backed fake client in tests
- replace retired /items route assertions with projection-backed test reads

## Boundary
- no runtime business logic change
- no DB migration
- no factory fallback
- no in-process PMS client
- no deletion or freezing of WMS legacy PMS owner tables
- only purchase-order-related tests and test helpers are changed

## Validation
- targeted purchase order API tests: detail base, detail editability, completion, update, supplier-item contract
- grep confirms migrated purchase tests no longer read/write legacy PMS owner tables
- projection helper regression tests
- make alembic-check
