### PR TITLE
test(pms): use projection fake for inventory adjustment APIs

### DIFF
--- a/tests/api/test_inbound_receipts_manual_api.py
+++ b/tests/api/test_inbound_receipts_manual_api.py
@@ -8,6 +8,8 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tests.helpers.procurement_pms_projection import install_procurement_pms_projection_fake
+
 
 async def _login_admin_headers(client: httpx.AsyncClient) -> dict[str, str]:
     r = await client.post("/users/login", json={"username": "admin", "password": "admin123"})
@@ -34,25 +36,27 @@ async def _pick_active_warehouse_id(session: AsyncSession) -> int:
 
 
 async def _pick_enabled_item_with_uom(session: AsyncSession) -> dict[str, Any]:
+    install_procurement_pms_projection_fake(session)
+
     row = (
         await session.execute(
             text(
                 """
                 SELECT
-                  i.id AS item_id,
+                  i.item_id AS item_id,
                   i.name AS item_name,
                   i.spec AS item_spec,
-                  u.id AS item_uom_id,
+                  u.item_uom_id AS item_uom_id,
                   COALESCE(NULLIF(u.display_name, ''), u.uom) AS uom_name,
                   u.ratio_to_base AS ratio_to_base
-                FROM items i
-                JOIN item_uoms u
-                  ON u.item_id = i.id
+                FROM wms_pms_item_projection i
+                JOIN wms_pms_uom_projection u
+                  ON u.item_id = i.item_id
                 WHERE COALESCE(i.enabled, true) = true
                 ORDER BY
                   CASE WHEN u.is_inbound_default THEN 0 WHEN u.is_base THEN 1 ELSE 2 END,
-                  i.id,
-                  u.id
+                  i.item_id,
+                  u.item_uom_id
                 LIMIT 1
                 """
             )
@@ -70,14 +74,14 @@ async def _pick_mismatched_item_and_uom(session: AsyncSession) -> tuple[int, int
             text(
                 """
                 SELECT
-                  i.id AS item_id,
-                  u.id AS item_uom_id
-                FROM items i
-                JOIN item_uoms u
-                  ON u.item_id = i.id
+                  i.item_id AS item_id,
+                  u.item_uom_id AS item_uom_id
+                FROM wms_pms_item_projection i
+                JOIN wms_pms_uom_projection u
+                  ON u.item_id = i.item_id
                 WHERE COALESCE(i.enabled, true) = true
-                  AND i.id <> :item_id
-                ORDER BY i.id, u.id
+                  AND i.item_id <> :item_id
+                ORDER BY i.item_id, u.item_uom_id
                 LIMIT 1
                 """
             ),

--- a/tests/api/test_inventory_adjustment_count_doc_execution_api.py
+++ b/tests/api/test_inventory_adjustment_count_doc_execution_api.py
@@ -8,6 +8,7 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tests.helpers.procurement_pms_projection import install_procurement_pms_projection_fake
 from tests.utils.ensure_minimal import set_stock_qty
 
 pytestmark = pytest.mark.asyncio
@@ -39,19 +40,22 @@ async def _pick_active_warehouse_id(session: AsyncSession) -> int:
 
 
 async def _pick_enabled_item(session: AsyncSession) -> dict[str, object]:
+    install_procurement_pms_projection_fake(session)
+
     row = await session.execute(
         text(
             """
-            SELECT DISTINCT ON (i.id)
-              i.id AS item_id,
-              i.name AS item_name,
-              i.spec AS item_spec
-            FROM items i
-            JOIN item_uoms u
-              ON u.item_id = i.id
-            WHERE COALESCE(i.enabled, true) = true
-            ORDER BY i.id ASC, u.id ASC
-            LIMIT 1
+                            SELECT DISTINCT ON (i.item_id)
+                  i.item_id AS item_id,
+                  i.name AS item_name,
+                  i.spec AS item_spec
+                FROM wms_pms_item_projection i
+                JOIN wms_pms_uom_projection u
+                  ON u.item_id = i.item_id
+                WHERE COALESCE(i.enabled, true) = true
+                ORDER BY i.item_id ASC, u.item_uom_id ASC
+                LIMIT 1
+
             """
         )
     )

--- a/tests/api/test_inventory_adjustment_count_doc_mainline_api.py
+++ b/tests/api/test_inventory_adjustment_count_doc_mainline_api.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.wms.shared.services.three_books_consistency import verify_commit_three_books
 from app.wms.snapshot.services.snapshot_run import run_snapshot
+from tests.helpers.procurement_pms_projection import install_procurement_pms_projection_fake
 from tests.utils.ensure_minimal import set_stock_qty
 
 pytestmark = pytest.mark.asyncio
@@ -45,23 +46,25 @@ async def _pick_enabled_items_with_base_uom(
     *,
     limit: int,
 ) -> list[dict[str, object]]:
+    install_procurement_pms_projection_fake(session)
+
     rows = (
         await session.execute(
             text(
                 """
-                SELECT DISTINCT ON (i.id)
-                  i.id AS item_id,
+                SELECT DISTINCT ON (i.item_id)
+                  i.item_id AS item_id,
                   i.name AS item_name,
                   i.spec AS item_spec,
-                  u.id AS item_uom_id,
+                  u.item_uom_id AS item_uom_id,
                   COALESCE(NULLIF(u.display_name, ''), u.uom) AS uom_name,
                   u.ratio_to_base AS ratio_to_base
-                FROM items i
-                JOIN item_uoms u
-                  ON u.item_id = i.id
+                FROM wms_pms_item_projection i
+                JOIN wms_pms_uom_projection u
+                  ON u.item_id = i.item_id
                 WHERE COALESCE(i.enabled, true) = true
                   AND COALESCE(u.is_base, false) = true
-                ORDER BY i.id ASC, u.id ASC
+                ORDER BY i.item_id ASC, u.item_uom_id ASC
                 """
             )
         )

--- a/tests/api/test_inventory_adjustment_summary_api.py
+++ b/tests/api/test_inventory_adjustment_summary_api.py
@@ -7,6 +7,8 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tests.helpers.procurement_pms_projection import install_procurement_pms_projection_fake
+
 
 REQUIRED_ROW_KEYS = {
     "adjustment_type",
@@ -45,6 +47,8 @@ async def _scalar_required(session: AsyncSession, sql: str) -> int:
 
 
 async def _seed_count_summary_row(session: AsyncSession) -> dict[str, int | str]:
+    install_procurement_pms_projection_fake(session)
+
     now = datetime.now(timezone.utc)
     suffix = uuid4().hex[:8].upper()
 
@@ -54,7 +58,7 @@ async def _seed_count_summary_row(session: AsyncSession) -> dict[str, int | str]
     )
     item_id = await _scalar_required(
         session,
-        "SELECT id FROM items ORDER BY id ASC LIMIT 1",
+        "SELECT item_id FROM wms_pms_item_projection ORDER BY item_id ASC LIMIT 1",
     )
 
     lot_id = (
@@ -131,12 +135,12 @@ async def _seed_count_summary_row(session: AsyncSession) -> dict[str, int | str]
             text(
                 """
                 SELECT
-                  id,
+                  item_uom_id AS id,
                   COALESCE(NULLIF(display_name, ''), uom) AS uom_name
-                FROM item_uoms
+                FROM wms_pms_uom_projection
                 WHERE item_id = :item_id
                   AND is_base IS TRUE
-                ORDER BY id ASC
+                ORDER BY item_uom_id ASC
                 LIMIT 1
                 """
             ),
@@ -152,8 +156,8 @@ async def _seed_count_summary_row(session: AsyncSession) -> dict[str, int | str]
                 SELECT
                   name,
                   spec
-                FROM items
-                WHERE id = :item_id
+                FROM wms_pms_item_projection
+                WHERE item_id = :item_id
                 LIMIT 1
                 """
             ),

--- a/tests/api/test_stock_inventory_recount_freeze_guard_api.py
+++ b/tests/api/test_stock_inventory_recount_freeze_guard_api.py
@@ -8,6 +8,7 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tests.helpers.procurement_pms_projection import install_procurement_pms_projection_fake
 from tests.utils.ensure_minimal import set_stock_qty
 
 
@@ -68,25 +69,27 @@ async def _pick_active_warehouse_id(session: AsyncSession) -> int:
 
 
 async def _pick_enabled_item_with_base_uom(session: AsyncSession) -> dict[str, object]:
+    install_procurement_pms_projection_fake(session)
+
     row = (
         await session.execute(
             text(
                 """
-                SELECT DISTINCT ON (i.id)
-                  i.id AS item_id,
-                  u.id AS item_uom_id
-                FROM items i
-                JOIN item_uoms u
-                  ON u.item_id = i.id
+                SELECT DISTINCT ON (i.item_id)
+                  i.item_id AS item_id,
+                  u.item_uom_id AS item_uom_id
+                FROM wms_pms_item_projection i
+                JOIN wms_pms_uom_projection u
+                  ON u.item_id = i.item_id
                 WHERE COALESCE(i.enabled, true) = true
                 ORDER BY
-                  i.id ASC,
+                  i.item_id ASC,
                   CASE
                     WHEN COALESCE(u.is_inbound_default, false) THEN 0
                     WHEN COALESCE(u.is_base, false) THEN 1
                     ELSE 2
                   END,
-                  u.id ASC
+                  u.item_uom_id ASC
                 LIMIT 1
                 """
             )

--- a/tests/helpers/procurement_pms_projection.py
+++ b/tests/helpers/procurement_pms_projection.py
@@ -30,6 +30,7 @@ PMS_CLIENT_MODULE_NAMES = (
     "app.wms.stock.repos.inventory_read_repo",
     "app.wms.stock.repos.inventory_explain_repo",
     "app.wms.inventory_adjustment.count.repos.count_doc_repo",
+    "app.wms.inventory_adjustment.summary.repos.summary_repo",
     "app.wms.inbound.services.inbound_commit_service",
     "app.wms.inbound.repos.barcode_resolve_repo",
     "app.wms.inbound.repos.item_lookup_repo",


### PR DESCRIPTION
## Summary
- migrate inventory adjustment API tests away from legacy PMS owner table reads
- read item/uom/snapshot data from WMS PMS projection tables
- install projection-backed PMS fake for manual receipt, recount, count-doc, and summary detail paths
- extend procurement PMS projection fake coverage to inventory adjustment summary enrichment

## Boundary
- no runtime business logic change
- no DB migration
- no factory fallback
- no in-process PMS client
- no deletion or freezing of WMS legacy PMS owner tables
- only inventory-adjustment-related API tests and test fake coverage are changed

## Validation
- target inventory adjustment API tests
- grep confirms migrated target files no longer read/write legacy PMS owner tables
- related count/stock/quick-inbound/receive/return/projection regression smoke
- make alembic-check
