### PR TITLE
test(pms): use projection fake for outbound tests

### DIFF
--- a/tests/api/test_manual_outbound_docs_api.py
+++ b/tests/api/test_manual_outbound_docs_api.py
@@ -7,6 +7,8 @@ from httpx import AsyncClient
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tests.helpers.procurement_pms_projection import install_procurement_pms_projection_fake
+
 
 pytestmark = pytest.mark.asyncio
 
@@ -19,19 +21,21 @@ async def _login_admin_headers(client: AsyncClient) -> dict[str, str]:
 
 
 async def _pick_any_item_and_uom(session: AsyncSession) -> tuple[int, int, str, str | None]:
+    install_procurement_pms_projection_fake(session)
+
     row = (
         await session.execute(
             text(
                 """
                 SELECT
-                  i.id AS item_id,
-                  iu.id AS item_uom_id,
+                  i.item_id AS item_id,
+                  iu.item_uom_id AS item_uom_id,
                   COALESCE(iu.display_name, iu.uom) AS uom_name,
                   i.spec AS item_spec
-                FROM items i
-                JOIN item_uoms iu
-                  ON iu.item_id = i.id
-                ORDER BY iu.is_outbound_default DESC, iu.is_base DESC, i.id ASC, iu.id ASC
+                FROM wms_pms_item_projection i
+                JOIN wms_pms_uom_projection iu
+                  ON iu.item_id = i.item_id
+                ORDER BY iu.is_outbound_default DESC, iu.is_base DESC, i.item_id ASC, iu.item_uom_id ASC
                 LIMIT 1
                 """
             )

--- a/tests/api/test_manual_outbound_submit_api.py
+++ b/tests/api/test_manual_outbound_submit_api.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.wms.stock.services.lots import ensure_internal_lot_singleton, ensure_lot_full
 from app.wms.stock.services.stock_adjust import adjust_lot_impl
+from tests.helpers.procurement_pms_projection import install_procurement_pms_projection_fake
 
 
 pytestmark = pytest.mark.asyncio
@@ -24,25 +25,27 @@ async def _login_admin_headers(client: AsyncClient) -> dict[str, str]:
 
 
 async def _pick_any_item_and_uom(session: AsyncSession) -> tuple[int, int, str, str | None, bool]:
+    install_procurement_pms_projection_fake(session)
+
     row = (
         await session.execute(
             text(
                 """
                 SELECT
-                  i.id AS item_id,
-                  iu.id AS item_uom_id,
+                  i.item_id AS item_id,
+                  iu.item_uom_id AS item_uom_id,
                   COALESCE(iu.display_name, iu.uom) AS uom_name,
                   i.spec AS item_spec,
-                  i.expiry_policy::text AS expiry_policy
-                FROM items i
-                JOIN item_uoms iu
-                  ON iu.item_id = i.id
+                  i.expiry_policy AS expiry_policy
+                FROM wms_pms_item_projection i
+                JOIN wms_pms_uom_projection iu
+                  ON iu.item_id = i.item_id
                 ORDER BY
-                  CASE WHEN i.expiry_policy::text = 'NONE' THEN 0 ELSE 1 END,
+                  CASE WHEN COALESCE(i.expiry_policy, 'NONE') = 'NONE' THEN 0 ELSE 1 END,
                   iu.is_outbound_default DESC,
                   iu.is_base DESC,
-                  i.id ASC,
-                  iu.id ASC
+                  i.item_id ASC,
+                  iu.item_uom_id ASC
                 LIMIT 1
                 """
             )
@@ -78,6 +81,8 @@ async def _seed_manual_doc_and_stock(
     *,
     requested_qty: int = 2,
 ) -> tuple[int, int, int, int, int]:
+    install_procurement_pms_projection_fake(session)
+
     warehouse_id = await _ensure_warehouse(session, 1)
     item_id, item_uom_id, uom_name, item_spec, requires_expiry = await _pick_any_item_and_uom(session)
     uniq = uuid4().hex[:10]

--- a/tests/api/test_order_outbound_submit_api.py
+++ b/tests/api/test_order_outbound_submit_api.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.wms.stock.services.lots import ensure_internal_lot_singleton, ensure_lot_full
 from app.wms.stock.services.stock_adjust import adjust_lot_impl
+from tests.helpers.procurement_pms_projection import install_procurement_pms_projection_fake
 from tests.services._helpers import ensure_store
 
 pytestmark = pytest.mark.asyncio
@@ -29,15 +30,17 @@ async def _pick_any_item_id(session: AsyncSession) -> tuple[int, bool]:
     - item_id
     - requires_expiry
     """
+    install_procurement_pms_projection_fake(session)
+
     row = (
         await session.execute(
             text(
                 """
-                SELECT id, expiry_policy::text
-                FROM items
+                SELECT item_id, expiry_policy
+                FROM wms_pms_item_projection
                 ORDER BY
-                  CASE WHEN expiry_policy::text = 'NONE' THEN 0 ELSE 1 END,
-                  id ASC
+                  CASE WHEN COALESCE(expiry_policy, 'NONE') = 'NONE' THEN 0 ELSE 1 END,
+                  item_id ASC
                 LIMIT 1
                 """
             )
@@ -50,6 +53,8 @@ async def _pick_any_item_id(session: AsyncSession) -> tuple[int, bool]:
 
 
 async def _seed_order_and_stock(session: AsyncSession) -> tuple[int, int, int, int, int]:
+    install_procurement_pms_projection_fake(session)
+
     platform = "PDD"
     store_code = "1"
     warehouse_id = 1

--- a/tests/api/test_order_outbound_view_api.py
+++ b/tests/api/test_order_outbound_view_api.py
@@ -7,6 +7,7 @@ from httpx import AsyncClient
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tests.helpers.procurement_pms_projection import install_procurement_pms_projection_fake
 from tests.services._helpers import ensure_store
 
 pytestmark = pytest.mark.asyncio
@@ -20,13 +21,15 @@ async def _login_admin_headers(client: AsyncClient) -> dict[str, str]:
 
 
 async def _pick_any_item_id(session: AsyncSession) -> int:
+    install_procurement_pms_projection_fake(session)
+
     row = (
         await session.execute(
             text(
                 """
-                SELECT id
-                FROM items
-                ORDER BY id ASC
+                SELECT item_id
+                FROM wms_pms_item_projection
+                ORDER BY item_id ASC
                 LIMIT 1
                 """
             )
@@ -129,6 +132,7 @@ async def test_order_outbound_view_reads_orders_and_order_lines_only(
 ) -> None:
     headers = await _login_admin_headers(client)
     order_id, order_line_id, item_id = await _seed_order(session)
+    install_procurement_pms_projection_fake(session)
 
     resp = await client.get(f"/oms/orders/{order_id}/outbound-view", headers=headers)
     assert resp.status_code == 200, resp.text

--- a/tests/api/test_outbound_summary_api.py
+++ b/tests/api/test_outbound_summary_api.py
@@ -7,6 +7,7 @@ from httpx import AsyncClient
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tests.helpers.procurement_pms_projection import install_procurement_pms_projection_fake
 from tests.services._helpers import ensure_store
 
 pytestmark = pytest.mark.asyncio
@@ -35,19 +36,21 @@ async def _ensure_warehouse(session: AsyncSession, warehouse_id: int = 1) -> int
 
 
 async def _pick_any_item_and_uom(session: AsyncSession) -> tuple[int, int, str, str | None]:
+    install_procurement_pms_projection_fake(session)
+
     row = (
         await session.execute(
             text(
                 """
                 SELECT
-                  i.id AS item_id,
-                  iu.id AS item_uom_id,
+                  i.item_id AS item_id,
+                  iu.item_uom_id AS item_uom_id,
                   COALESCE(iu.display_name, iu.uom) AS uom_name,
                   i.spec AS item_spec
-                FROM items i
-                JOIN item_uoms iu
-                  ON iu.item_id = i.id
-                ORDER BY iu.is_outbound_default DESC, iu.is_base DESC, i.id ASC, iu.id ASC
+                FROM wms_pms_item_projection i
+                JOIN wms_pms_uom_projection iu
+                  ON iu.item_id = i.item_id
+                ORDER BY iu.is_outbound_default DESC, iu.is_base DESC, i.item_id ASC, iu.item_uom_id ASC
                 LIMIT 1
                 """
             )

--- a/tests/helpers/procurement_pms_projection.py
+++ b/tests/helpers/procurement_pms_projection.py
@@ -21,6 +21,7 @@ PMS_CLIENT_MODULE_NAMES = (
     "app.procurement.repos.receive_po_line_repo",
     "app.procurement.helpers.purchase_reports",
     "app.procurement.routers.purchase_reports_routes_items",
+    "app.oms.orders.repos.order_outbound_view_repo",
 
     # WMS inbound / lot / stock paths reached by /wms/inbound/commit
     "app.wms.shared.services.expiry_resolver",

--- a/tests/quick/test_outbound_core_v2.py
+++ b/tests/quick/test_outbound_core_v2.py
@@ -7,17 +7,20 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.wms.shared.enums import MovementType
 from app.wms.stock.services.lots import ensure_internal_lot_singleton, ensure_lot_full
 from app.wms.stock.services.stock_adjust import adjust_lot_impl
+from tests.helpers.procurement_pms_projection import install_procurement_pms_projection_fake
 
 UTC = timezone.utc
 
 
 async def _requires_batch(session: AsyncSession, item_id: int) -> bool:
     """
-    Phase M 第一阶段：测试也不再读取 has_shelf_life（镜像字段）。
-    批次受控唯一真相源：items.expiry_policy == 'REQUIRED'
+    PMS 拆库后，测试只读取 WMS PMS projection。
+    批次受控唯一真相源：PMS projection expiry_policy == 'REQUIRED'
     """
+    install_procurement_pms_projection_fake(session)
+
     row = await session.execute(
-        text("SELECT expiry_policy FROM items WHERE id=:i LIMIT 1"),
+        text("SELECT expiry_policy FROM wms_pms_item_projection WHERE item_id=:i LIMIT 1"),
         {"i": int(item_id)},
     )
     v = row.scalar_one_or_none()
@@ -63,6 +66,8 @@ async def _qty(session: AsyncSession, item_id: int, wh: int, code: str | None) -
 
 
 async def _lot_id_for_slot(session: AsyncSession, *, item_id: int, wh: int, code: str | None) -> int:
+    install_procurement_pms_projection_fake(session)
+
     if code is None:
         return int(
             await ensure_internal_lot_singleton(
@@ -99,6 +104,8 @@ async def _write_delta(
     ref: str,
     ref_line: int,
 ):
+    install_procurement_pms_projection_fake(session)
+
     lot_id = await _lot_id_for_slot(session, item_id=int(item_id), wh=int(wh), code=code)
     prod = date.today() if code is not None else None
     exp = (prod + timedelta(days=365)) if prod is not None else None

--- a/tests/services/test_outbound_reversal_service.py
+++ b/tests/services/test_outbound_reversal_service.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+import app.oms.orders.models.order_line  # noqa: F401 - register order_lines table metadata for outbound_event_lines FK
 from app.wms.inbound.contracts.inbound_commit import InboundCommitIn
 from app.wms.inbound.models.inbound_event import WmsEvent
 from app.wms.inbound.services.inbound_commit_service import commit_inbound
@@ -20,7 +21,7 @@ from app.wms.inventory_adjustment.outbound_reversal.services.outbound_reversal_s
     list_outbound_reversal_options,
     reverse_outbound_event,
 )
-from app.wms.outbound.models.outbound_event import OutboundEventLine
+from tests.helpers.procurement_pms_projection import install_procurement_pms_projection_fake
 from app.wms.outbound.repos.outbound_event_repo import (
     insert_outbound_stock_ledger,
     load_stocks_lot_for_update,
@@ -33,6 +34,8 @@ def _date_to_utc_datetime(d: date) -> datetime:
 
 
 async def _pick_seed_item_uom(session: AsyncSession) -> dict[str, object]:
+    install_procurement_pms_projection_fake(session)
+
     wh_row = await session.execute(
         text(
             """
@@ -49,19 +52,19 @@ async def _pick_seed_item_uom(session: AsyncSession) -> dict[str, object]:
         text(
             """
             SELECT
-              i.id AS item_id,
-              u.id AS uom_id,
-              COALESCE(i.lot_source_policy::text, 'INTERNAL_ONLY') AS lot_source_policy,
-              COALESCE(i.expiry_policy::text, 'NONE') AS expiry_policy
-            FROM item_uoms u
-            JOIN items i
-              ON i.id = u.item_id
+              i.item_id AS item_id,
+              u.item_uom_id AS uom_id,
+              COALESCE(i.lot_source_policy, 'INTERNAL_ONLY') AS lot_source_policy,
+              COALESCE(i.expiry_policy, 'NONE') AS expiry_policy
+            FROM wms_pms_uom_projection u
+            JOIN wms_pms_item_projection i
+              ON i.item_id = u.item_id
             ORDER BY
               CASE
-                WHEN COALESCE(i.lot_source_policy::text, 'INTERNAL_ONLY') IN ('SUPPLIER_ONLY', 'SUPPLIER') THEN 0
+                WHEN COALESCE(i.lot_source_policy, 'INTERNAL_ONLY') IN ('SUPPLIER_ONLY', 'SUPPLIER') THEN 0
                 ELSE 1
               END,
-              u.id ASC
+              u.item_uom_id ASC
             LIMIT 1
             """
         )
@@ -110,6 +113,8 @@ async def _load_stocks_lot_qty(
 
 
 async def _seed_outbound_source_event(session: AsyncSession) -> dict[str, object]:
+    install_procurement_pms_projection_fake(session)
+
     picked = await _pick_seed_item_uom(session)
 
     warehouse_id = int(picked["warehouse_id"])
@@ -182,22 +187,49 @@ async def _seed_outbound_source_event(session: AsyncSession) -> dict[str, object
     session.add(event)
     await session.flush()
 
-    line = OutboundEventLine(
-        event_id=int(event.id),
-        ref_line=1,
-        item_id=int(item_id),
-        qty_outbound=int(qty_outbound),
-        lot_id=int(lot_id),
-        lot_code_snapshot=lot_code_input,
-        order_line_id=None,
-        manual_doc_line_id=1,
-        item_name_snapshot="ut item",
-        item_sku_snapshot="ut-sku",
-        item_spec_snapshot="ut-spec",
-        remark="ut outbound line",
+    await session.execute(
+        text(
+            """
+            INSERT INTO outbound_event_lines (
+              event_id,
+              ref_line,
+              item_id,
+              qty_outbound,
+              lot_id,
+              lot_code_snapshot,
+              order_line_id,
+              manual_doc_line_id,
+              item_name_snapshot,
+              item_sku_snapshot,
+              item_spec_snapshot,
+              remark
+            )
+            VALUES (
+              :event_id,
+              1,
+              :item_id,
+              :qty_outbound,
+              :lot_id,
+              :lot_code_snapshot,
+              NULL,
+              1,
+              'ut item',
+              'ut-sku',
+              'ut-spec',
+              'ut outbound line'
+            )
+            """
+        ),
+        {
+            "event_id": int(event.id),
+            "item_id": int(item_id),
+            "qty_outbound": int(qty_outbound),
+            "lot_id": int(lot_id),
+            "lot_code_snapshot": lot_code_input,
+        },
     )
-    session.add(line)
     await session.flush()
+
 
     slot_qty = await load_stocks_lot_for_update(
         session,


### PR DESCRIPTION
## Summary
- migrate outbound-related tests away from legacy PMS owner table reads
- read outbound item/uom/policy data from WMS PMS projection tables
- install projection-backed PMS fake for manual outbound, order outbound, OMS outbound view, quick outbound, and outbound reversal paths
- register order_lines metadata in outbound reversal test to keep outbound_event_lines FK resolution stable

## Boundary
- no runtime business logic change
- no DB migration
- no factory fallback
- no in-process PMS client
- no deletion or freezing of WMS legacy PMS owner tables
- only outbound-related tests and test fake coverage are changed

## Validation
- target outbound tests
- grep confirms migrated outbound target files no longer read/write legacy PMS owner tables
- related inventory-adjustment / count / stock / inbound / projection regression smoke
- make alembic-check
