### PR TITLE
test(pms): use projection fake for OMS FSKU finance tests

### DIFF
--- a/tests/api/test_finance_purchase_sku_ledger_api.py
+++ b/tests/api/test_finance_purchase_sku_ledger_api.py
@@ -26,14 +26,14 @@ async def _pick_supplier_item(session: AsyncSession) -> int:
         await session.execute(
             text(
                 """
-                SELECT i.id
-                  FROM items i
-                  JOIN item_uoms u
-                    ON u.item_id = i.id
+                SELECT i.item_id
+                  FROM wms_pms_item_projection i
+                  JOIN wms_pms_uom_projection u
+                    ON u.item_id = i.item_id
                    AND (u.is_purchase_default IS TRUE OR u.is_base IS TRUE)
                  WHERE i.supplier_id = 1
                    AND i.enabled IS TRUE
-                 ORDER BY i.id ASC
+                 ORDER BY i.item_id ASC
                  LIMIT 1
                 """
             )
@@ -48,10 +48,10 @@ async def _pick_purchase_uom(session: AsyncSession, *, item_id: int) -> tuple[in
         await session.execute(
             text(
                 """
-                SELECT id, ratio_to_base
-                  FROM item_uoms
+                SELECT item_uom_id AS id, ratio_to_base
+                  FROM wms_pms_uom_projection
                  WHERE item_id = :item_id
-                 ORDER BY is_purchase_default DESC, is_base DESC, id ASC
+                 ORDER BY is_purchase_default DESC, is_base DESC, item_uom_id ASC
                  LIMIT 1
                 """
             ),
@@ -68,20 +68,16 @@ async def _load_item_basic(session: AsyncSession, *, item_id: int) -> ItemBasic:
             text(
                 """
                 SELECT
-                    i.id,
-                    i.sku,
-                    i.name,
-                    i.spec,
-                    i.enabled,
-                    i.supplier_id,
-                    b.name_cn AS brand,
-                    c.category_name AS category
-                  FROM items i
-             LEFT JOIN pms_brands b
-                    ON b.id = i.brand_id
-             LEFT JOIN pms_business_categories c
-                    ON c.id = i.category_id
-                 WHERE i.id = :item_id
+                    item_id AS id,
+                    sku,
+                    name,
+                    spec,
+                    enabled,
+                    supplier_id,
+                    brand,
+                    category
+                  FROM wms_pms_item_projection
+                 WHERE item_id = :item_id
                  LIMIT 1
                 """
             ),
@@ -108,7 +104,7 @@ async def _load_uom(session: AsyncSession, *, item_uom_id: int) -> PmsExportUom:
             text(
                 """
                 SELECT
-                    id,
+                    item_uom_id AS id,
                     item_id,
                     uom,
                     display_name,
@@ -119,8 +115,8 @@ async def _load_uom(session: AsyncSession, *, item_uom_id: int) -> PmsExportUom:
                     is_purchase_default,
                     is_inbound_default,
                     is_outbound_default
-                  FROM item_uoms
-                 WHERE id = :item_uom_id
+                  FROM wms_pms_uom_projection
+                 WHERE item_uom_id = :item_uom_id
                  LIMIT 1
                 """
             ),

--- a/tests/api/test_fskus_contract.py
+++ b/tests/api/test_fskus_contract.py
@@ -35,17 +35,17 @@ async def _pick_any_item_id(session: AsyncSession) -> int:
         await session.execute(
             text(
                 """
-                SELECT i.id
-                  FROM items i
-                  JOIN item_sku_codes c
-                    ON c.item_id = i.id
-                   AND c.code = i.sku
+                SELECT i.item_id
+                  FROM wms_pms_item_projection i
+                  JOIN wms_pms_sku_code_projection c
+                    ON c.item_id = i.item_id
+                   AND c.sku_code = i.sku
                    AND c.is_active IS TRUE
-                  JOIN item_uoms u
-                    ON u.item_id = i.id
+                  JOIN wms_pms_uom_projection u
+                    ON u.item_id = i.item_id
                    AND (u.is_outbound_default IS TRUE OR u.is_base IS TRUE)
                  WHERE i.enabled IS TRUE
-                 ORDER BY i.id ASC
+                 ORDER BY i.item_id ASC
                  LIMIT 1
                 """
             )
@@ -61,8 +61,8 @@ async def _pick_item_sku_by_id(session: AsyncSession, *, item_id: int) -> str:
             text(
                 """
                 SELECT sku
-                  FROM items
-                 WHERE id = :item_id
+                  FROM wms_pms_item_projection
+                 WHERE item_id = :item_id
                  LIMIT 1
                 """
             ),
@@ -85,28 +85,28 @@ async def _load_resolution_by_sku(
             text(
                 """
                 SELECT
-                    c.id AS sku_code_id,
-                    i.id AS item_id,
-                    c.code AS sku_code,
-                    c.code_type::text AS code_type,
+                    c.sku_code_id AS sku_code_id,
+                    i.item_id AS item_id,
+                    c.sku_code AS sku_code,
+                    c.code_type AS code_type,
                     c.is_primary AS is_primary,
                     i.sku AS item_sku,
                     i.name AS item_name,
-                    u.id AS item_uom_id,
+                    u.item_uom_id AS item_uom_id,
                     u.uom AS uom,
                     u.display_name AS display_name,
                     COALESCE(NULLIF(u.display_name, ''), u.uom) AS uom_name,
                     u.ratio_to_base AS ratio_to_base
-                  FROM item_sku_codes c
-                  JOIN items i
-                    ON i.id = c.item_id
-                  JOIN item_uoms u
-                    ON u.item_id = i.id
+                  FROM wms_pms_sku_code_projection c
+                  JOIN wms_pms_item_projection i
+                    ON i.item_id = c.item_id
+                  JOIN wms_pms_uom_projection u
+                    ON u.item_id = i.item_id
                    AND (u.is_outbound_default IS TRUE OR u.is_base IS TRUE)
-                 WHERE c.code = :sku
+                 WHERE c.sku_code = :sku
                    AND c.is_active IS TRUE
                    AND i.enabled IS TRUE
-                 ORDER BY u.is_outbound_default DESC, u.is_base DESC, u.id ASC
+                 ORDER BY u.is_outbound_default DESC, u.is_base DESC, u.item_uom_id ASC
                  LIMIT 1
                 """
             ),

--- a/tests/api/test_oms_order_sku_resolution_api.py
+++ b/tests/api/test_oms_order_sku_resolution_api.py
@@ -23,29 +23,29 @@ async def _pick_item_resolution(session) -> dict[str, object]:
             text(
                 """
                 SELECT
-                  sc.id AS item_sku_code_id,
+                  sc.sku_code_id AS item_sku_code_id,
                   sc.item_id AS item_id,
-                  sc.code AS sku_code,
+                  sc.sku_code AS sku_code,
                   i.name AS item_name,
-                  u.id AS item_uom_id,
+                  u.item_uom_id AS item_uom_id,
                   COALESCE(NULLIF(u.display_name, ''), u.uom) AS uom
-                FROM item_sku_codes sc
-                JOIN items i ON i.id = sc.item_id
+                FROM wms_pms_sku_code_projection sc
+                JOIN wms_pms_item_projection i ON i.item_id = sc.item_id
                 JOIN LATERAL (
-                  SELECT id, uom, display_name
-                  FROM item_uoms
-                  WHERE item_id = i.id
+                  SELECT item_uom_id, uom, display_name
+                  FROM wms_pms_uom_projection
+                  WHERE item_id = i.item_id
                   ORDER BY
                     is_outbound_default DESC,
                     is_base DESC,
-                    id ASC
+                    item_uom_id ASC
                   LIMIT 1
                 ) u ON TRUE
                 WHERE sc.is_active = TRUE
                   AND i.enabled = TRUE
                 ORDER BY
                   sc.is_primary DESC,
-                  sc.id ASC
+                  sc.sku_code_id ASC
                 LIMIT 1
                 """
             )

--- a/tests/api/test_platform_orders_ingest_next_actions_contract.py
+++ b/tests/api/test_platform_orders_ingest_next_actions_contract.py
@@ -5,6 +5,8 @@ from uuid import uuid4
 import pytest
 from sqlalchemy import text
 
+from tests.helpers.procurement_pms_projection import install_procurement_pms_projection_fake
+
 
 def _uniq(prefix: str) -> str:
     return f"{prefix}-{uuid4().hex[:8]}"
@@ -12,34 +14,36 @@ def _uniq(prefix: str) -> str:
 
 async def _pick_item_resolution(async_session_maker) -> dict[str, object]:
     async with async_session_maker() as session:
+        install_procurement_pms_projection_fake(session)
+
         row = (
             await session.execute(
                 text(
                     """
                     SELECT
-                      sc.id AS item_sku_code_id,
+                      sc.sku_code_id AS item_sku_code_id,
                       sc.item_id AS item_id,
-                      sc.code AS sku_code,
+                      sc.sku_code AS sku_code,
                       i.name AS item_name,
-                      u.id AS item_uom_id,
+                      u.item_uom_id AS item_uom_id,
                       COALESCE(NULLIF(u.display_name, ''), u.uom) AS uom
-                    FROM item_sku_codes sc
-                    JOIN items i ON i.id = sc.item_id
+                    FROM wms_pms_sku_code_projection sc
+                    JOIN wms_pms_item_projection i ON i.item_id = sc.item_id
                     JOIN LATERAL (
-                      SELECT id, uom, display_name
-                      FROM item_uoms
-                      WHERE item_id = i.id
+                      SELECT item_uom_id, uom, display_name
+                      FROM wms_pms_uom_projection
+                      WHERE item_id = i.item_id
                       ORDER BY
                         is_outbound_default DESC,
                         is_base DESC,
-                        id ASC
+                        item_uom_id ASC
                       LIMIT 1
                     ) u ON TRUE
                     WHERE sc.is_active = TRUE
                       AND i.enabled = TRUE
                     ORDER BY
                       sc.is_primary DESC,
-                      sc.id ASC
+                      sc.sku_code_id ASC
                     LIMIT 1
                     """
                 )
@@ -56,6 +60,8 @@ async def _create_published_fsku_with_component(async_session_maker) -> int:
     expr = f"{item['sku_code']}*1*1"
 
     async with async_session_maker() as session:
+        install_procurement_pms_projection_fake(session)
+
         row = (
             await session.execute(
                 text(
@@ -245,6 +251,8 @@ async def test_platform_code_mapping_persists_and_ingest_can_resolve(client, asy
     assert int(b1["data"]["fsku_id"]) == int(fsku_id)
 
     async with async_session_maker() as session:
+        install_procurement_pms_projection_fake(session)
+
         row = (
             await session.execute(
                 text(

--- a/tests/api/test_platform_orders_replay_contract.py
+++ b/tests/api/test_platform_orders_replay_contract.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.deps import get_async_session as get_session
 from app.main import app
+from tests.helpers.procurement_pms_projection import install_procurement_pms_projection_fake
 
 
 @pytest.fixture
@@ -139,6 +140,8 @@ async def _create_published_fsku_with_component(
     item_id: int,
     component_qty: int = 1,
 ) -> tuple[int, str]:
+    install_procurement_pms_projection_fake(session)
+
     uniq = uuid.uuid4().hex[:10]
     code = f"UT-REPLAY-{uniq}"
     name = f"UT-REPLAY-FSKU-{uniq}"
@@ -149,24 +152,24 @@ async def _create_published_fsku_with_component(
                 """
                 WITH code_row AS (
                   SELECT
-                    c.id AS sku_code_id,
+                    c.sku_code_id AS sku_code_id,
                     c.item_id,
-                    c.code AS sku_code
-                  FROM item_sku_codes c
+                    c.sku_code AS sku_code
+                  FROM wms_pms_sku_code_projection c
                   WHERE c.item_id = :item_id
                     AND c.is_active = TRUE
-                  ORDER BY c.is_primary DESC, c.id ASC
+                  ORDER BY c.is_primary DESC, c.sku_code_id ASC
                   LIMIT 1
                 ),
                 uom_row AS (
                   SELECT
-                    u.id AS item_uom_id,
+                    u.item_uom_id AS item_uom_id,
                     u.item_id,
                     COALESCE(NULLIF(u.display_name, ''), NULLIF(u.uom, ''), u.uom) AS uom_name
-                  FROM item_uoms u
+                  FROM wms_pms_uom_projection u
                   WHERE u.item_id = :item_id
                     AND (u.is_outbound_default = TRUE OR u.is_base = TRUE)
-                  ORDER BY u.is_outbound_default DESC, u.is_base DESC, u.id ASC
+                  ORDER BY u.is_outbound_default DESC, u.is_base DESC, u.item_uom_id ASC
                   LIMIT 1
                 )
                 SELECT
@@ -176,7 +179,7 @@ async def _create_published_fsku_with_component(
                   ur.item_uom_id,
                   ur.uom_name
                 FROM code_row cr
-                JOIN items i ON i.id = cr.item_id
+                JOIN wms_pms_item_projection i ON i.item_id = cr.item_id
                 JOIN uom_row ur ON ur.item_id = cr.item_id
                 """
             ),

--- a/tests/api/test_platform_orders_resolve_preview_contract.py
+++ b/tests/api/test_platform_orders_resolve_preview_contract.py
@@ -10,6 +10,8 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tests.helpers.procurement_pms_projection import install_procurement_pms_projection_fake
+
 pytestmark = pytest.mark.asyncio
 
 
@@ -121,6 +123,8 @@ async def _create_published_fsku_with_component(
     item_id: int,
     component_qty: int = 1,
 ) -> Tuple[int, str]:
+    install_procurement_pms_projection_fake(session)
+
     uniq = uuid4().hex[:10]
     code = f"UT-PREVIEW-{uniq}"
     name = f"UT-PREVIEW-FSKU-{uniq}"
@@ -131,24 +135,24 @@ async def _create_published_fsku_with_component(
                 """
                 WITH code_row AS (
                   SELECT
-                    c.id AS sku_code_id,
+                    c.sku_code_id AS sku_code_id,
                     c.item_id,
-                    c.code AS sku_code
-                  FROM item_sku_codes c
+                    c.sku_code AS sku_code
+                  FROM wms_pms_sku_code_projection c
                   WHERE c.item_id = :item_id
                     AND c.is_active = TRUE
-                  ORDER BY c.is_primary DESC, c.id ASC
+                  ORDER BY c.is_primary DESC, c.sku_code_id ASC
                   LIMIT 1
                 ),
                 uom_row AS (
                   SELECT
-                    u.id AS item_uom_id,
+                    u.item_uom_id AS item_uom_id,
                     u.item_id,
                     COALESCE(NULLIF(u.display_name, ''), NULLIF(u.uom, ''), u.uom) AS uom_name
-                  FROM item_uoms u
+                  FROM wms_pms_uom_projection u
                   WHERE u.item_id = :item_id
                     AND (u.is_outbound_default = TRUE OR u.is_base = TRUE)
-                  ORDER BY u.is_outbound_default DESC, u.is_base DESC, u.id ASC
+                  ORDER BY u.is_outbound_default DESC, u.is_base DESC, u.item_uom_id ASC
                   LIMIT 1
                 )
                 SELECT
@@ -158,7 +162,7 @@ async def _create_published_fsku_with_component(
                   ur.item_uom_id,
                   ur.uom_name
                 FROM code_row cr
-                JOIN items i ON i.id = cr.item_id
+                JOIN wms_pms_item_projection i ON i.item_id = cr.item_id
                 JOIN uom_row ur ON ur.item_id = cr.item_id
                 """
             ),

--- a/tests/fixtures/po_batch_semantics_fixtures.py
+++ b/tests/fixtures/po_batch_semantics_fixtures.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.procurement.models.purchase_order import PurchaseOrder
 from app.procurement.models.purchase_order_line import PurchaseOrderLine
+from tests.helpers.procurement_pms_projection import seed_purchase_projection_item
 
 
 def _is_required_expiry_policy(expiry_policy: str) -> bool:
@@ -41,56 +42,15 @@ async def _create_test_item(
     expiry_policy: str,
 ) -> tuple[int, str, str]:
     exp = str(expiry_policy or "").strip().upper() or "NONE"
-    sku = f"UT-SKU-{uuid4().hex[:16]}"
-    name = "UT-Item"
-
-    row = (
-        await session.execute(
-            text(
-                """
-                INSERT INTO items (
-                    name,
-                    sku,
-                    enabled,
-                    supplier_id,
-                    lot_source_policy,
-                    expiry_policy,
-                    derivation_allowed,
-                    uom_governance_enabled,
-                    shelf_life_value,
-                    shelf_life_unit
-                )
-                VALUES (
-                    :name,
-                    :sku,
-                    TRUE,
-                    :supplier_id,
-                    CAST('SUPPLIER_ONLY' AS lot_source_policy),
-                    CAST(:expiry_policy AS expiry_policy),
-                    TRUE,
-                    TRUE,
-                    :shelf_life_value,
-                    CASE
-                        WHEN :shelf_life_unit IS NULL THEN NULL
-                        ELSE CAST(:shelf_life_unit AS shelf_life_unit)
-                    END
-                )
-                RETURNING id, sku, name
-                """
-            ),
-            {
-                "name": name,
-                "sku": sku,
-                "supplier_id": int(supplier_id),
-                "expiry_policy": exp,
-                "shelf_life_value": 30 if _is_required_expiry_policy(exp) else None,
-                "shelf_life_unit": "DAY" if _is_required_expiry_policy(exp) else None,
-            },
-        )
-    ).first()
-
-    assert row is not None
-    return int(row[0]), str(row[1]), str(row[2])
+    seeded = await seed_purchase_projection_item(
+        session,
+        supplier_id=int(supplier_id),
+        sku_prefix=f"UT-SKU-{uuid4().hex[:8]}",
+        enabled=True,
+        expiry_policy=exp,
+        lot_source_policy="SUPPLIER_ONLY" if _is_required_expiry_policy(exp) else "INTERNAL_ONLY",
+    )
+    return int(seeded["item_id"]), str(seeded["sku"]), str(seeded["name"])
 
 
 async def _create_base_item_uom(session: AsyncSession, *, item_id: int) -> int:
@@ -98,27 +58,12 @@ async def _create_base_item_uom(session: AsyncSession, *, item_id: int) -> int:
         await session.execute(
             text(
                 """
-                INSERT INTO item_uoms (
-                    item_id,
-                    uom,
-                    ratio_to_base,
-                    display_name,
-                    is_base,
-                    is_purchase_default,
-                    is_inbound_default,
-                    is_outbound_default
-                )
-                VALUES (
-                    :item_id,
-                    'EA',
-                    1,
-                    NULL,
-                    TRUE,
-                    TRUE,
-                    TRUE,
-                    TRUE
-                )
-                RETURNING id
+                SELECT item_uom_id
+                  FROM wms_pms_uom_projection
+                 WHERE item_id = :item_id
+                   AND is_base IS TRUE
+                 ORDER BY item_uom_id ASC
+                 LIMIT 1
                 """
             ),
             {"item_id": int(item_id)},

--- a/tests/helpers/po_testkit.py
+++ b/tests/helpers/po_testkit.py
@@ -8,6 +8,8 @@ from typing import Optional, Tuple
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tests.helpers.procurement_pms_projection import install_procurement_pms_projection_fake
+
 
 @dataclass(frozen=True)
 class PoLineWorld:
@@ -69,13 +71,15 @@ async def _require_base_item_uom(session: AsyncSession, *, item_id: int) -> Tupl
     - uom_id（item_uoms.id）
     - ratio_to_base（item_uoms.ratio_to_base）
     """
+    install_procurement_pms_projection_fake(session)
+
     row = await session.execute(
         text(
             """
-            SELECT id, ratio_to_base
-            FROM item_uoms
+            SELECT item_uom_id AS id, ratio_to_base
+            FROM wms_pms_uom_projection
             WHERE item_id = :i AND is_base = true
-            ORDER BY id ASC
+            ORDER BY item_uom_id ASC
             LIMIT 1
             """
         ),

--- a/tests/helpers/procurement_pms_projection.py
+++ b/tests/helpers/procurement_pms_projection.py
@@ -22,6 +22,9 @@ PMS_CLIENT_MODULE_NAMES = (
     "app.procurement.helpers.purchase_reports",
     "app.procurement.routers.purchase_reports_routes_items",
     "app.oms.orders.repos.order_outbound_view_repo",
+    "app.oms.services.platform_order_resolve_loaders",
+    "app.oms.services.platform_order_resolve_service",
+    "app.oms.services.platform_order_ingest_flow",
 
     # WMS inbound / lot / stock paths reached by /wms/inbound/commit
     "app.wms.shared.services.expiry_resolver",


### PR DESCRIPTION
## Summary
- migrate OMS / FSKU / finance tests away from legacy PMS owner table reads/writes
- read item, uom, SKU code, and resolution data from WMS PMS projection tables
- install projection-backed PMS fake for OMS platform order ingest / replay / resolve-preview paths
- migrate PO test helpers and PO batch semantics fixtures to PMS projection seed/read helpers

## Boundary
- no runtime business logic change
- no DB migration
- no factory fallback
- no in-process PMS client
- no deletion or freezing of WMS legacy PMS owner tables
- only OMS / FSKU / finance tests, PO test helpers, and test fake coverage are changed

## Validation
- target OMS / FSKU / finance tests
- grep confirms migrated target files no longer read/write legacy PMS owner tables
- related outbound / inventory-adjustment / projection regression smoke
- make alembic-check
