### PR TITLE
test(pms): use projection fake for remaining WMS service tests

### DIFF
--- a/tests/api/test_shipping_assist_handoffs_ready_api.py
+++ b/tests/api/test_shipping_assist_handoffs_ready_api.py
@@ -22,7 +22,7 @@ async def _login_admin_headers(client: AsyncClient) -> dict[str, str]:
 
 
 async def _pick_any_item_id(session: AsyncSession) -> int:
-    row = await session.execute(text("SELECT id FROM items ORDER BY id ASC LIMIT 1"))
+    row = await session.execute(text("SELECT item_id FROM wms_pms_item_projection ORDER BY item_id ASC LIMIT 1"))
     item_id = row.scalar_one_or_none()
     assert item_id is not None
     return int(item_id)

--- a/tests/ci/test_db_invariants.py
+++ b/tests/ci/test_db_invariants.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.wms.stock.services.lots import ensure_lot_full
 from app.wms.stock.services.stock_adjust import adjust_lot_impl
 from tests.utils.ensure_minimal import ensure_item
+from tests.helpers.procurement_pms_projection import install_procurement_pms_projection_fake
 
 pytestmark = pytest.mark.grp_snapshot  # 分组标记，可按需调整
 
@@ -30,6 +31,8 @@ async def _seed_wh_item_lot_stock(
 
     返回 lot_id。
     """
+    install_procurement_pms_projection_fake(session)
+
     await session.execute(
         text(
             """
@@ -175,14 +178,14 @@ async def test_item_sku_codes_primary_invariant(session: AsyncSession):
     missing_or_duplicate_primary = await session.execute(
         text(
             """
-            SELECT i.id, COUNT(c.id) AS primary_count
-              FROM items i
-              LEFT JOIN item_sku_codes c
-                ON c.item_id = i.id
+            SELECT i.item_id, COUNT(c.sku_code_id) AS primary_count
+              FROM wms_pms_item_projection i
+              LEFT JOIN wms_pms_sku_code_projection c
+                ON c.item_id = i.item_id
                AND c.is_primary = TRUE
-             GROUP BY i.id
-            HAVING COUNT(c.id) <> 1
-            ORDER BY i.id
+             GROUP BY i.item_id
+            HAVING COUNT(c.sku_code_id) <> 1
+            ORDER BY i.item_id
             """
         )
     )
@@ -192,15 +195,15 @@ async def test_item_sku_codes_primary_invariant(session: AsyncSession):
     inactive_or_closed_primary = await session.execute(
         text(
             """
-            SELECT id, item_id, code, is_active, effective_to
-              FROM item_sku_codes
+            SELECT sku_code_id AS id, item_id, sku_code AS code, is_active, effective_to
+              FROM wms_pms_sku_code_projection
              WHERE is_primary = TRUE
                AND (
                  is_active IS DISTINCT FROM TRUE
                  OR effective_to IS NOT NULL
                  OR code_type <> 'PRIMARY'
                )
-             ORDER BY item_id, id
+             ORDER BY item_id, sku_code_id
             """
         )
     )
@@ -210,13 +213,13 @@ async def test_item_sku_codes_primary_invariant(session: AsyncSession):
     projection_mismatch = await session.execute(
         text(
             """
-            SELECT i.id, i.sku, c.code
-              FROM items i
-              JOIN item_sku_codes c
-                ON c.item_id = i.id
+            SELECT i.item_id AS id, i.sku, c.sku_code AS code
+              FROM wms_pms_item_projection i
+              JOIN wms_pms_sku_code_projection c
+                ON c.item_id = i.item_id
                AND c.is_primary = TRUE
-             WHERE c.code <> upper(trim(i.sku))
-             ORDER BY i.id
+             WHERE c.sku_code <> upper(trim(i.sku))
+             ORDER BY i.item_id
             """
         )
     )
@@ -226,11 +229,11 @@ async def test_item_sku_codes_primary_invariant(session: AsyncSession):
     case_duplicates = await session.execute(
         text(
             """
-            SELECT lower(code) AS norm_code, COUNT(*) AS cnt
-              FROM item_sku_codes
-             GROUP BY lower(code)
+            SELECT lower(sku_code) AS norm_code, COUNT(*) AS cnt
+              FROM wms_pms_sku_code_projection
+             GROUP BY lower(sku_code)
             HAVING COUNT(*) > 1
-             ORDER BY lower(code)
+             ORDER BY lower(sku_code)
             """
         )
     )

--- a/tests/ci/test_outbound_metrics_view.py
+++ b/tests/ci/test_outbound_metrics_view.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.wms.stock.services.lots import ensure_internal_lot_singleton, ensure_lot_full
 from app.wms.stock.services.stock_adjust import adjust_lot_impl
+from tests.helpers.procurement_pms_projection import install_procurement_pms_projection_fake
 
 pytestmark = pytest.mark.asyncio
 
@@ -13,8 +14,10 @@ UTC = timezone.utc
 
 
 async def _item_requires_batch(session: AsyncSession, *, item_id: int) -> bool:
+    install_procurement_pms_projection_fake(session)
+
     row = await session.execute(
-        text("SELECT expiry_policy::text FROM items WHERE id=:i LIMIT 1"),
+        text("SELECT expiry_policy FROM wms_pms_item_projection WHERE item_id=:i LIMIT 1"),
         {"i": int(item_id)},
     )
     val = row.scalar_one_or_none()
@@ -24,6 +27,8 @@ async def _item_requires_batch(session: AsyncSession, *, item_id: int) -> bool:
 
 
 async def _pick_one_lot_id_for_item(session: AsyncSession, *, warehouse_id: int, item_id: int) -> int:
+    install_procurement_pms_projection_fake(session)
+
     """
     终态：stock_ledger 必须带 lot_id（lot-world）。
     从 stocks_lot 中挑一个现存槽位的 lot_id（qty 可以为 0）。

--- a/tests/helpers/pms_read_client_fake.py
+++ b/tests/helpers/pms_read_client_fake.py
@@ -9,6 +9,8 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.integrations.pms.contracts import (
+    BarcodeProbeOut,
+    BarcodeProbeStatus,
     ItemBasic,
     ItemPolicy,
     PmsExportBarcode,
@@ -344,6 +346,42 @@ class ProjectionBackedFakePmsReadClient:
             item_ids=[int(item_id)],
             active=active,
             primary_only=primary_only,
+        )
+
+    async def probe_barcode(self, *, barcode: str) -> BarcodeProbeOut:
+        code = str(barcode or "").strip()
+        if not code:
+            return BarcodeProbeOut(
+                ok=True,
+                status=BarcodeProbeStatus.UNBOUND,
+                barcode=code,
+            )
+
+        rows = await self.list_barcodes(
+            barcode=code,
+            active=True,
+        )
+        if not rows:
+            return BarcodeProbeOut(
+                ok=True,
+                status=BarcodeProbeStatus.UNBOUND,
+                barcode=code,
+            )
+
+        row = rows[0]
+        item_basic = await self.get_item_basic(item_id=int(row.item_id))
+
+        return BarcodeProbeOut(
+            ok=True,
+            status=BarcodeProbeStatus.BOUND,
+            barcode=code,
+            item_id=int(row.item_id),
+            item_uom_id=int(row.item_uom_id),
+            ratio_to_base=int(row.ratio_to_base),
+            symbology=str(row.symbology),
+            active=bool(row.active),
+            item_basic=item_basic,
+            errors=[],
         )
 
     async def get_purchase_default_or_base_uom(self, *, item_id: int) -> PmsExportUom | None:

--- a/tests/phase5_service_assignment/test_service_assignment.py
+++ b/tests/phase5_service_assignment/test_service_assignment.py
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.asyncio
 
 
 async def _pick_any_item_id(session) -> int:
-    row = await session.execute(text("SELECT id FROM items ORDER BY id ASC LIMIT 1"))
+    row = await session.execute(text("SELECT item_id FROM wms_pms_item_projection ORDER BY item_id ASC LIMIT 1"))
     iid = row.scalar_one_or_none()
     if iid is None:
         raise RuntimeError("tests baseline seed 没有 items，无法跑 service_assignment tests")

--- a/tests/sandbox/test_routing_sandbox_multi_warehouse.py
+++ b/tests/sandbox/test_routing_sandbox_multi_warehouse.py
@@ -97,7 +97,7 @@ async def _pick_existing_item_ids(session: AsyncSession, n: int = 3) -> List[int
     从测试基线（seed_test_baseline）已存在的 items 中挑选若干个 item_id，
     避免在沙盘测试里硬插 items 导致 NOT NULL/约束漂移。
     """
-    rows = await session.execute(sa.text("SELECT id FROM items ORDER BY id ASC LIMIT :n"), {"n": int(n)})
+    rows = await session.execute(sa.text("SELECT item_id FROM wms_pms_item_projection ORDER BY item_id ASC LIMIT :n"), {"n": int(n)})
     ids = [int(r[0]) for r in rows.fetchall()]
     if len(ids) < n:
         raise RuntimeError(f"sandbox requires at least {n} seeded items, got {ids}")

--- a/tests/services/test_inbound_reversal_service.py
+++ b/tests/services/test_inbound_reversal_service.py
@@ -12,12 +12,15 @@ from app.wms.inbound.services.inbound_commit_service import commit_inbound
 from app.wms.inventory_adjustment.inbound_reversal.contracts.inbound_reversal import (
     InboundReversalIn,
 )
+from tests.helpers.procurement_pms_projection import install_procurement_pms_projection_fake
 from app.wms.inventory_adjustment.inbound_reversal.services.inbound_reversal_service import (
     reverse_inbound_event,
 )
 
 
 async def _pick_seed_item_uom(session):
+    install_procurement_pms_projection_fake(session)
+
     wh_row = await session.execute(
         text(
             """
@@ -34,19 +37,19 @@ async def _pick_seed_item_uom(session):
         text(
             """
             SELECT
-              i.id AS item_id,
-              u.id AS uom_id,
-              i.lot_source_policy::text AS lot_source_policy,
-              i.expiry_policy::text AS expiry_policy
-            FROM item_uoms u
-            JOIN items i
-              ON i.id = u.item_id
+              i.item_id AS item_id,
+              u.item_uom_id AS uom_id,
+              i.lot_source_policy AS lot_source_policy,
+              i.expiry_policy AS expiry_policy
+            FROM wms_pms_uom_projection u
+            JOIN wms_pms_item_projection i
+              ON i.item_id = u.item_id
             ORDER BY
               CASE
-                WHEN i.lot_source_policy::text IN ('SUPPLIER_ONLY', 'SUPPLIER') THEN 0
+                WHEN COALESCE(i.lot_source_policy, 'INTERNAL_ONLY') IN ('SUPPLIER_ONLY', 'SUPPLIER') THEN 0
                 ELSE 1
               END,
-              u.id ASC
+              u.item_uom_id ASC
             LIMIT 1
             """
         )

--- a/tests/services/test_order_rma_and_reconcile.py
+++ b/tests/services/test_order_rma_and_reconcile.py
@@ -29,22 +29,25 @@ from app.wms.inventory_adjustment.return_inbound.routers.order_refs import (
 )
 from app.wms.stock.services.lots import ensure_internal_lot_singleton, ensure_lot_full
 from app.wms.stock.services.stock_adjust import adjust_lot_impl
+from tests.helpers.procurement_pms_projection import install_procurement_pms_projection_fake
 
 UTC = timezone.utc
 
 
 async def _item_batch_mode_is_required(session: AsyncSession, *, item_id: int) -> bool:
     """
-    Phase M 第一阶段：测试不再读取 has_shelf_life（镜像字段）。
-    批次受控唯一真相源：items.expiry_policy == 'REQUIRED'
+    PMS 拆库后，测试只读取 WMS PMS projection。
+    批次受控唯一真相源：PMS projection expiry_policy == 'REQUIRED'
     """
+    install_procurement_pms_projection_fake(session)
+
     row = (
         await session.execute(
             text(
                 """
                 SELECT expiry_policy
-                  FROM items
-                 WHERE id = :iid
+                  FROM wms_pms_item_projection
+                 WHERE item_id = :iid
                  LIMIT 1
                 """
             ),
@@ -59,15 +62,17 @@ async def _item_batch_mode_is_required(session: AsyncSession, *, item_id: int) -
 async def _pick_base_uom_and_ratio(session: AsyncSession, *, item_id: int) -> Tuple[int, int]:
     """
     终态：收货行必须显式落 uom_id + ratio_to_base_snapshot + qty_base。
-    这里选 base uom（is_base=true），保证测试稳定。
+    PMS 拆库后，测试只读取 WMS PMS projection。
     """
+    install_procurement_pms_projection_fake(session)
+
     row = await session.execute(
         text(
             """
-            SELECT id, ratio_to_base
-              FROM item_uoms
+            SELECT item_uom_id AS id, ratio_to_base
+              FROM wms_pms_uom_projection
              WHERE item_id = :i AND is_base = true
-             ORDER BY id
+             ORDER BY item_uom_id
              LIMIT 1
             """
         ),
@@ -79,6 +84,8 @@ async def _pick_base_uom_and_ratio(session: AsyncSession, *, item_id: int) -> Tu
 
 
 async def _ensure_supplier_lot(session: AsyncSession, *, warehouse_id: int, item_id: int, code: str) -> int:
+    install_procurement_pms_projection_fake(session)
+
     """
     SUPPLIER lot（当前终态合同）：
     - REQUIRED lot 身份 = (warehouse_id, item_id, production_date)
@@ -107,6 +114,8 @@ async def _ensure_supplier_lot(session: AsyncSession, *, warehouse_id: int, item
 
 
 async def _ensure_internal_lot_for_receipt(session: AsyncSession, *, warehouse_id: int, item_id: int, receipt_id: int) -> int:
+    install_procurement_pms_projection_fake(session)
+
     """
     INTERNAL lot（终态合同）：
     - 单例：每 (warehouse_id,item_id) 只有一个 INTERNAL lot
@@ -168,6 +177,8 @@ async def _write_stock_delta_for_test(
     production_date: Optional[date],
     expiry_date: Optional[date],
 ) -> None:
+    install_procurement_pms_projection_fake(session)
+
     lot_id = await _ensure_stock_lot_for_adjust(
         session,
         warehouse_id=int(warehouse_id),
@@ -309,9 +320,9 @@ async def _insert_released_return_receipt(
                 :item_id,
                 :uom_id,
                 :qty_input,
-                (SELECT name FROM items WHERE id = :item_id),
-                (SELECT spec FROM items WHERE id = :item_id),
-                (SELECT COALESCE(NULLIF(display_name, ''), NULLIF(uom, '')) FROM item_uoms WHERE id = :uom_id),
+                (SELECT name FROM wms_pms_item_projection WHERE item_id = :item_id),
+                (SELECT spec FROM wms_pms_item_projection WHERE item_id = :item_id),
+                (SELECT COALESCE(NULLIF(display_name, ''), NULLIF(uom, '')) FROM wms_pms_uom_projection WHERE item_uom_id = :uom_id),
                 :ratio,
                 'UT-RMA-LINE',
                 NOW(),
@@ -397,10 +408,10 @@ async def _insert_released_return_receipt(
                 :op_id,
                 1,
                 :item_id,
-                (SELECT name FROM items WHERE id = :item_id),
-                (SELECT spec FROM items WHERE id = :item_id),
+                (SELECT name FROM wms_pms_item_projection WHERE item_id = :item_id),
+                (SELECT spec FROM wms_pms_item_projection WHERE item_id = :item_id),
                 :uom_id,
-                (SELECT COALESCE(NULLIF(display_name, ''), NULLIF(uom, '')) FROM item_uoms WHERE id = :uom_id),
+                (SELECT COALESCE(NULLIF(display_name, ''), NULLIF(uom, '')) FROM wms_pms_uom_projection WHERE item_uom_id = :uom_id),
                 :ratio,
                 :qty_input,
                 :qty_base,
@@ -891,13 +902,15 @@ async def test_return_order_ref_summary_item_display_uses_pms_export(
 async def test_return_inbound_probe_loads_uom_name_through_pms_export(
     session: AsyncSession,
 ) -> None:
+    install_procurement_pms_projection_fake(session)
+
     row = (
         await session.execute(
             text(
                 """
-                SELECT id, item_id, COALESCE(NULLIF(display_name, ''), uom) AS uom_name
-                FROM item_uoms
-                ORDER BY id
+                SELECT item_uom_id AS id, item_id, COALESCE(NULLIF(display_name, ''), uom) AS uom_name
+                FROM wms_pms_uom_projection
+                ORDER BY item_uom_id
                 LIMIT 1
                 """
             )
@@ -934,21 +947,23 @@ async def test_return_inbound_probe_loads_uom_name_through_pms_export(
 async def test_return_inbound_manual_line_snapshot_reads_through_pms_export(
     session: AsyncSession,
 ) -> None:
+    install_procurement_pms_projection_fake(session)
+
     row = (
         await session.execute(
             text(
                 """
                 SELECT
-                  i.id AS item_id,
+                  i.item_id AS item_id,
                   i.name AS item_name,
                   i.spec AS item_spec,
-                  u.id AS item_uom_id,
+                  u.item_uom_id AS item_uom_id,
                   COALESCE(NULLIF(u.display_name, ''), u.uom) AS uom_name,
                   u.ratio_to_base AS ratio_to_base
-                FROM items i
-                JOIN item_uoms u
-                  ON u.item_id = i.id
-                ORDER BY i.id ASC, u.id ASC
+                FROM wms_pms_item_projection i
+                JOIN wms_pms_uom_projection u
+                  ON u.item_id = i.item_id
+                ORDER BY i.item_id ASC, u.item_uom_id ASC
                 LIMIT 1
                 """
             )
@@ -974,13 +989,15 @@ async def test_return_inbound_manual_line_snapshot_reads_through_pms_export(
 async def test_return_inbound_manual_line_snapshot_rejects_mismatched_uom(
     session: AsyncSession,
 ) -> None:
+    install_procurement_pms_projection_fake(session)
+
     rows = (
         await session.execute(
             text(
                 """
-                SELECT item_id, id AS item_uom_id
-                FROM item_uoms
-                ORDER BY item_id ASC, id ASC
+                SELECT item_id, item_uom_id
+                FROM wms_pms_uom_projection
+                ORDER BY item_id ASC, item_uom_id ASC
                 LIMIT 20
                 """
             )
@@ -1014,17 +1031,19 @@ async def test_return_inbound_manual_line_snapshot_rejects_mismatched_uom(
 async def test_return_inbound_operation_loads_uom_snapshot_through_pms_export(
     session: AsyncSession,
 ) -> None:
+    install_procurement_pms_projection_fake(session)
+
     row = (
         await session.execute(
             text(
                 """
                 SELECT
-                  id AS item_uom_id,
+                  item_uom_id,
                   item_id,
                   COALESCE(NULLIF(display_name, ''), uom) AS uom_name,
                   ratio_to_base
-                FROM item_uoms
-                ORDER BY item_id ASC, id ASC
+                FROM wms_pms_uom_projection
+                ORDER BY item_id ASC, item_uom_id ASC
                 LIMIT 1
                 """
             )
@@ -1047,6 +1066,8 @@ async def test_return_inbound_operation_loads_uom_snapshot_through_pms_export(
 async def test_return_inbound_operation_resolves_barcode_through_pms_export(
     session: AsyncSession,
 ) -> None:
+    install_procurement_pms_projection_fake(session)
+
     row = (
         await session.execute(
             text(
@@ -1057,12 +1078,12 @@ async def test_return_inbound_operation_resolves_barcode_through_pms_export(
                   ib.item_uom_id,
                   COALESCE(NULLIF(u.display_name, ''), u.uom) AS uom_name,
                   u.ratio_to_base
-                FROM item_barcodes ib
-                JOIN item_uoms u
-                  ON u.id = ib.item_uom_id
+                FROM wms_pms_barcode_projection ib
+                JOIN wms_pms_uom_projection u
+                  ON u.item_uom_id = ib.item_uom_id
                  AND u.item_id = ib.item_id
                 WHERE ib.active IS TRUE
-                ORDER BY ib.is_primary DESC, ib.id ASC
+                ORDER BY ib.is_primary DESC, ib.barcode_id ASC
                 LIMIT 1
                 """
             )
@@ -1086,6 +1107,8 @@ async def test_return_inbound_operation_resolves_barcode_through_pms_export(
 async def test_return_inbound_operation_rejects_barcode_item_mismatch(
     session: AsyncSession,
 ) -> None:
+    install_procurement_pms_projection_fake(session)
+
     row = (
         await session.execute(
             text(
@@ -1093,9 +1116,9 @@ async def test_return_inbound_operation_rejects_barcode_item_mismatch(
                 SELECT
                   ib.barcode,
                   ib.item_id
-                FROM item_barcodes ib
+                FROM wms_pms_barcode_projection ib
                 WHERE ib.active IS TRUE
-                ORDER BY ib.is_primary DESC, ib.id ASC
+                ORDER BY ib.is_primary DESC, ib.barcode_id ASC
                 LIMIT 1
                 """
             )

--- a/tests/services/test_stock_adjust_trace_id.py
+++ b/tests/services/test_stock_adjust_trace_id.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.wms.stock.services.lots import ensure_lot_full
 from app.wms.stock.services.stock_adjust import adjust_lot_impl
+from tests.helpers.procurement_pms_projection import install_procurement_pms_projection_fake
 
 pytestmark = pytest.mark.asyncio
 UTC = timezone.utc
@@ -27,10 +28,27 @@ async def test_stock_adjust_writes_trace_id(session: AsyncSession):
       4) 在同一个测试中查询 stock_ledger，按 ref='UT-ADJUST-1' 过滤；
       5) 断言存在一条记录，且 trace_id='TR-UNIT-1'。
     """
+    install_procurement_pms_projection_fake(session)
+
     now = datetime.now(UTC)
 
-    # 1) 取一个已经存在的 item_id，避免触发 items 外键错误（Phase 4E：批次主档已迁移到 lots）
-    row = await session.execute(text("SELECT id FROM items ORDER BY id ASC LIMIT 1"))
+    # 1) 取一个已经存在的 item_id，避免触发旧 PMS owner 表依赖
+    row = await session.execute(
+        text(
+            """
+            SELECT item_id
+              FROM wms_pms_item_projection
+             ORDER BY
+               CASE
+                 WHEN COALESCE(lot_source_policy, 'INTERNAL_ONLY') IN ('SUPPLIER_ONLY', 'SUPPLIER') THEN 0
+                 WHEN COALESCE(expiry_policy, 'NONE') = 'REQUIRED' THEN 1
+                 ELSE 2
+               END,
+               item_id ASC
+             LIMIT 1
+            """
+        )
+    )
     item_id = row.scalar_one()
     assert item_id is not None
 


### PR DESCRIPTION
## Summary
- migrate remaining WMS service/API tests away from legacy PMS owner table reads
- read item/uom/barcode/SKU policy data from WMS PMS projection tables
- install projection-backed PMS fake for shipping assist, outbound metrics, service assignment, sandbox routing, inbound reversal, stock trace, and RMA reconcile paths
- extend projection-backed PMS fake with barcode probing support

## Boundary
- no runtime business logic change
- no DB migration
- no factory fallback
- no in-process PMS client
- no deletion or freezing of WMS legacy PMS owner tables
- only remaining WMS tests and test fake coverage are changed

## Validation
- target remaining WMS service tests
- grep confirms migrated target files no longer read/write legacy PMS owner tables
- related OMS / FSKU / finance / outbound / inventory-adjustment / projection regression smoke
- make alembic-check
