### PR TITLE
test(pms): remove conftest from legacy owner allowlist

### DIFF
--- a/tests/ci/test_pms_nonbaseline_legacy_owner_usage_guard.py
+++ b/tests/ci/test_pms_nonbaseline_legacy_owner_usage_guard.py
@@ -8,7 +8,6 @@ ROOT = Path(__file__).resolve().parents[2]
 TESTS_DIR = ROOT / "tests"
 
 LEGACY_BASELINE_ALLOWLIST = {
-    Path("tests/conftest.py"),
     Path("tests/fixtures/base_seed.sql"),
     Path("tests/ci/test_pms_projection_baseline_seed.py"),
     Path("tests/ci/test_pms_nonbaseline_legacy_owner_usage_guard.py"),
@@ -26,7 +25,7 @@ LEGACY_OWNER_WRITE_PATTERN = re.compile(
       (items|item_uoms|item_barcodes|item_sku_codes|
        pms_brands|pms_business_categories|
        item_attribute_defs|item_attribute_options|item_attribute_values|
-       sku_code_templates|sku_code_template_segments)\b
+       sku_code_templates|sku_code_segments|sku_code_template_segments)\b
     |
     \bDELETE\s+FROM\s+
       (items|item_uoms|item_barcodes|item_sku_codes|
@@ -74,10 +73,10 @@ def test_nonbaseline_tests_do_not_write_legacy_pms_owner_tables() -> None:
     """
     PMS 已拆出独立进程/库后，WMS 普通测试层不得再写旧 PMS owner 表。
 
-    允许项只剩 legacy baseline 过渡区：
+    当前仅允许 legacy baseline seed 文件保留旧 owner seed：
     - tests/fixtures/base_seed.sql
-    - tests/conftest.py
-    - tests/ci/test_pms_projection_baseline_seed.py
+
+    tests/conftest.py 已完成 projection-only policy 对齐，不再允许作为例外。
     """
     hits = _scan(LEGACY_OWNER_WRITE_PATTERN)
     assert hits == []


### PR DESCRIPTION
## Summary
- remove tests/conftest.py from the legacy PMS owner usage allowlist
- keep only base_seed.sql as the remaining legacy owner baseline exception
- document that conftest now aligns batch policy through projection only

## Validation
- compile legacy owner usage guard
- old owner scan excluding base_seed and guard files
- PMS baseline guards
