### PR TITLE
feat(pms): add supplier projection sync

### DIFF
--- a/alembic/versions/4f8c2a19d6b3_add_wms_pms_supplier_projection.py
+++ b/alembic/versions/4f8c2a19d6b3_add_wms_pms_supplier_projection.py
@@ -1,0 +1,83 @@
+"""add_wms_pms_supplier_projection
+
+Revision ID: 4f8c2a19d6b3
+Revises: 9b7f2c1d8e44
+Create Date: 2026-05-12 10:25:00.000000
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "4f8c2a19d6b3"
+down_revision: Union[str, Sequence[str], None] = "9b7f2c1d8e44"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "wms_pms_supplier_projection",
+        sa.Column("supplier_id", sa.Integer(), autoincrement=False, nullable=False),
+        sa.Column("supplier_code", sa.String(length=64), nullable=False),
+        sa.Column("supplier_name", sa.String(length=255), nullable=False),
+        sa.Column("active", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.Column("website", sa.String(length=255), nullable=True),
+        sa.Column("pms_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("source_hash", sa.String(length=128), nullable=True),
+        sa.Column("sync_version", sa.String(length=64), nullable=True),
+        sa.Column(
+            "synced_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("supplier_id", name="pk_wms_pms_supplier_projection"),
+        sa.UniqueConstraint(
+            "supplier_code",
+            name="uq_wms_pms_supplier_projection_supplier_code",
+        ),
+        sa.CheckConstraint(
+            "length(trim(supplier_code)) > 0",
+            name="ck_wms_pms_supplier_projection_supplier_code_non_empty",
+        ),
+        sa.CheckConstraint(
+            "length(trim(supplier_name)) > 0",
+            name="ck_wms_pms_supplier_projection_supplier_name_non_empty",
+        ),
+    )
+    op.create_index(
+        "ix_wms_pms_supplier_projection_active",
+        "wms_pms_supplier_projection",
+        ["active"],
+    )
+    op.create_index(
+        "ix_wms_pms_supplier_projection_supplier_name",
+        "wms_pms_supplier_projection",
+        ["supplier_name"],
+    )
+    op.create_index(
+        "ix_wms_pms_supplier_projection_synced_at",
+        "wms_pms_supplier_projection",
+        ["synced_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_wms_pms_supplier_projection_synced_at",
+        table_name="wms_pms_supplier_projection",
+    )
+    op.drop_index(
+        "ix_wms_pms_supplier_projection_supplier_name",
+        table_name="wms_pms_supplier_projection",
+    )
+    op.drop_index(
+        "ix_wms_pms_supplier_projection_active",
+        table_name="wms_pms_supplier_projection",
+    )
+    op.drop_table("wms_pms_supplier_projection")

--- a/app/integrations/pms/projection_contracts.py
+++ b/app/integrations/pms/projection_contracts.py
@@ -50,6 +50,19 @@ class WmsPmsItemProjectionRow(_Base):
     synced_at: datetime
 
 
+class WmsPmsSupplierProjectionRow(_Base):
+    supplier_id: int = Field(gt=0)
+    supplier_code: str = Field(min_length=1, max_length=64)
+    supplier_name: str = Field(min_length=1, max_length=255)
+    active: bool = True
+    website: str | None = Field(default=None, max_length=255)
+
+    pms_updated_at: datetime | None = None
+    source_hash: str | None = Field(default=None, max_length=128)
+    sync_version: str | None = Field(default=None, max_length=64)
+    synced_at: datetime
+
+
 class WmsPmsUomProjectionRow(_Base):
     item_uom_id: int = Field(gt=0)
     item_id: int = Field(gt=0)
@@ -114,5 +127,6 @@ __all__ = [
     "WmsPmsBarcodeProjectionRow",
     "WmsPmsItemProjectionRow",
     "WmsPmsSkuCodeProjectionRow",
+    "WmsPmsSupplierProjectionRow",
     "WmsPmsUomProjectionRow",
 ]

--- a/app/integrations/pms/projection_models.py
+++ b/app/integrations/pms/projection_models.py
@@ -97,6 +97,50 @@ class WmsPmsItemProjection(Base):
     )
 
 
+class WmsPmsSupplierProjection(Base):
+    __tablename__ = "wms_pms_supplier_projection"
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "supplier_code",
+            name="uq_wms_pms_supplier_projection_supplier_code",
+        ),
+        sa.CheckConstraint(
+            "length(trim(supplier_code)) > 0",
+            name="ck_wms_pms_supplier_projection_supplier_code_non_empty",
+        ),
+        sa.CheckConstraint(
+            "length(trim(supplier_name)) > 0",
+            name="ck_wms_pms_supplier_projection_supplier_name_non_empty",
+        ),
+        sa.Index("ix_wms_pms_supplier_projection_active", "active"),
+        sa.Index("ix_wms_pms_supplier_projection_supplier_name", "supplier_name"),
+        sa.Index("ix_wms_pms_supplier_projection_synced_at", "synced_at"),
+        {"info": PROJECTION_TABLE_INFO},
+    )
+
+    supplier_id: Mapped[int] = mapped_column(sa.Integer, primary_key=True, autoincrement=False)
+    supplier_code: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+    supplier_name: Mapped[str] = mapped_column(sa.String(255), nullable=False)
+    active: Mapped[bool] = mapped_column(
+        sa.Boolean(),
+        nullable=False,
+        server_default=sa.text("true"),
+    )
+    website: Mapped[str | None] = mapped_column(sa.String(255), nullable=True)
+
+    pms_updated_at: Mapped[datetime | None] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=True,
+    )
+    source_hash: Mapped[str | None] = mapped_column(sa.String(128), nullable=True)
+    sync_version: Mapped[str | None] = mapped_column(sa.String(64), nullable=True)
+    synced_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+
+
 class WmsPmsUomProjection(Base):
     __tablename__ = "wms_pms_uom_projection"
     __table_args__ = (
@@ -271,5 +315,6 @@ __all__ = [
     "WmsPmsBarcodeProjection",
     "WmsPmsItemProjection",
     "WmsPmsSkuCodeProjection",
+    "WmsPmsSupplierProjection",
     "WmsPmsUomProjection",
 ]

--- a/app/integrations/pms/projection_reconciliation.py
+++ b/app/integrations/pms/projection_reconciliation.py
@@ -26,6 +26,7 @@ IssueType = Literal[
     "UOM_ITEM_MISMATCH",
     "SKU_CODE_MISSING_IN_PROJECTION",
     "SKU_CODE_ITEM_MISMATCH",
+    "SUPPLIER_MISSING_IN_PROJECTION",
 ]
 
 _IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
@@ -55,6 +56,13 @@ class SkuCodeReference:
 
 
 @dataclass(frozen=True)
+class SupplierReference:
+    source_table: str
+    source_id_column: str | None
+    supplier_id_column: str
+
+
+@dataclass(frozen=True)
 class PmsProjectionReconciliationIssue:
     issue_type: IssueType
     source_table: str
@@ -63,6 +71,7 @@ class PmsProjectionReconciliationIssue:
     item_id: int | None = None
     item_uom_id: int | None = None
     sku_code_id: int | None = None
+    supplier_id: int | None = None
     projection_item_id: int | None = None
 
 
@@ -133,6 +142,15 @@ DEFAULT_UOM_REFERENCES: tuple[UomReference, ...] = (
 
 DEFAULT_SKU_CODE_REFERENCES: tuple[SkuCodeReference, ...] = (
     SkuCodeReference("oms_fsku_components", "id", "resolved_item_id", "resolved_item_sku_code_id"),
+)
+
+DEFAULT_SUPPLIER_REFERENCES: tuple[SupplierReference, ...] = (
+    SupplierReference("wms_pms_item_projection", "item_id", "supplier_id"),
+    SupplierReference("purchase_orders", "id", "supplier_id"),
+    SupplierReference("inbound_receipts", "id", "supplier_id"),
+    SupplierReference("wms_inbound_operations", "id", "supplier_id"),
+    SupplierReference("purchase_order_line_completion", None, "supplier_id"),
+    SupplierReference("finance_purchase_price_ledger_lines", "id", "supplier_id"),
 )
 
 
@@ -317,12 +335,57 @@ async def _collect_sku_code_issues(
     ]
 
 
+
+async def _collect_supplier_issues(
+    session: AsyncSession,
+    *,
+    ref: SupplierReference,
+    limit: int,
+) -> list[PmsProjectionReconciliationIssue]:
+    source_table_sql = _quote_identifier(ref.source_table, kind="table")
+    source_id_select_sql, source_id_order_sql = _source_id_select_and_order(
+        ref.source_id_column
+    )
+    supplier_id_sql = _quote_identifier(ref.supplier_id_column, kind="column")
+
+    rows = (
+        await session.execute(
+            text(
+                f"""
+                SELECT
+                    {source_id_select_sql} AS source_id,
+                    t.{supplier_id_sql} AS supplier_id
+                FROM {source_table_sql} AS t
+                LEFT JOIN wms_pms_supplier_projection AS s
+                  ON s.supplier_id = t.{supplier_id_sql}
+                WHERE t.{supplier_id_sql} IS NOT NULL
+                  AND s.supplier_id IS NULL
+                ORDER BY {source_id_order_sql}
+                LIMIT :limit
+                """
+            ),
+            {"limit": int(limit)},
+        )
+    ).mappings().all()
+
+    return [
+        PmsProjectionReconciliationIssue(
+            issue_type="SUPPLIER_MISSING_IN_PROJECTION",
+            source_table=ref.source_table,
+            source_column=ref.supplier_id_column,
+            source_id=str(row["source_id"]),
+            supplier_id=int(row["supplier_id"]),
+        )
+        for row in rows
+    ]
+
 async def reconcile_pms_projection_references(
     session: AsyncSession,
     *,
     item_references: tuple[ItemReference, ...] = DEFAULT_ITEM_REFERENCES,
     uom_references: tuple[UomReference, ...] = DEFAULT_UOM_REFERENCES,
     sku_code_references: tuple[SkuCodeReference, ...] = DEFAULT_SKU_CODE_REFERENCES,
+    supplier_references: tuple[SupplierReference, ...] = DEFAULT_SUPPLIER_REFERENCES,
     per_reference_limit: int = 200,
 ) -> PmsProjectionReconciliationResult:
     safe_limit = max(1, min(int(per_reference_limit), 1000))
@@ -337,17 +400,22 @@ async def reconcile_pms_projection_references(
     for ref in sku_code_references:
         issues.extend(await _collect_sku_code_issues(session, ref=ref, limit=safe_limit))
 
+    for ref in supplier_references:
+        issues.extend(await _collect_supplier_issues(session, ref=ref, limit=safe_limit))
+
     return PmsProjectionReconciliationResult(issues=issues)
 
 
 __all__ = [
     "DEFAULT_ITEM_REFERENCES",
     "DEFAULT_SKU_CODE_REFERENCES",
+    "DEFAULT_SUPPLIER_REFERENCES",
     "DEFAULT_UOM_REFERENCES",
     "ItemReference",
     "PmsProjectionReconciliationIssue",
     "PmsProjectionReconciliationResult",
     "SkuCodeReference",
+    "SupplierReference",
     "UomReference",
     "reconcile_pms_projection_references",
 ]

--- a/app/integrations/pms/projection_sync.py
+++ b/app/integrations/pms/projection_sync.py
@@ -24,7 +24,7 @@ import httpx
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-ProjectionResource = Literal["items", "uoms", "sku-codes", "barcodes"]
+ProjectionResource = Literal["items", "suppliers", "uoms", "sku-codes", "barcodes"]
 
 SYNC_VERSION = "pms-read-v1-projection-feed"
 DEFAULT_LIMIT = 500
@@ -32,6 +32,7 @@ MAX_LIMIT = 500
 
 RESOURCE_ORDER: tuple[ProjectionResource, ...] = (
     "items",
+    "suppliers",
     "uoms",
     "sku-codes",
     "barcodes",
@@ -39,6 +40,7 @@ RESOURCE_ORDER: tuple[ProjectionResource, ...] = (
 
 RESOURCE_PATHS: dict[ProjectionResource, str] = {
     "items": "/pms/read/v1/projection-feed/items",
+    "suppliers": "/pms/read/v1/projection-feed/suppliers",
     "uoms": "/pms/read/v1/projection-feed/uoms",
     "sku-codes": "/pms/read/v1/projection-feed/sku-codes",
     "barcodes": "/pms/read/v1/projection-feed/barcodes",
@@ -188,6 +190,20 @@ def _item_params(row: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
+def _supplier_params(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "supplier_id": _required_int(row, "supplier_id"),
+        "supplier_code": _required_str(row, "supplier_code"),
+        "supplier_name": _required_str(row, "supplier_name"),
+        "active": _required_bool(row, "active"),
+        "website": _optional_str(row, "website"),
+        "pms_updated_at": _optional_datetime(row, "source_updated_at"),
+        "source_hash": _source_hash(row),
+        "sync_version": SYNC_VERSION,
+    }
+
+
+
 def _uom_params(row: Mapping[str, Any]) -> dict[str, Any]:
     return {
         "item_uom_id": _required_int(row, "item_uom_id"),
@@ -294,6 +310,39 @@ UPSERT_SQL: dict[ProjectionResource, str] = {
             lot_source_policy = EXCLUDED.lot_source_policy,
             derivation_allowed = EXCLUDED.derivation_allowed,
             uom_governance_enabled = EXCLUDED.uom_governance_enabled,
+            pms_updated_at = EXCLUDED.pms_updated_at,
+            source_hash = EXCLUDED.source_hash,
+            sync_version = EXCLUDED.sync_version,
+            synced_at = now()
+    """,
+    "suppliers": """
+        INSERT INTO wms_pms_supplier_projection (
+            supplier_id,
+            supplier_code,
+            supplier_name,
+            active,
+            website,
+            pms_updated_at,
+            source_hash,
+            sync_version,
+            synced_at
+        )
+        VALUES (
+            :supplier_id,
+            :supplier_code,
+            :supplier_name,
+            :active,
+            :website,
+            :pms_updated_at,
+            :source_hash,
+            :sync_version,
+            now()
+        )
+        ON CONFLICT (supplier_id) DO UPDATE SET
+            supplier_code = EXCLUDED.supplier_code,
+            supplier_name = EXCLUDED.supplier_name,
+            active = EXCLUDED.active,
+            website = EXCLUDED.website,
             pms_updated_at = EXCLUDED.pms_updated_at,
             source_hash = EXCLUDED.source_hash,
             sync_version = EXCLUDED.sync_version,
@@ -440,6 +489,8 @@ def _params_for_resource(
 ) -> dict[str, Any]:
     if resource == "items":
         return _item_params(row)
+    if resource == "suppliers":
+        return _supplier_params(row)
     if resource == "uoms":
         return _uom_params(row)
     if resource == "sku-codes":

--- a/tests/ci/test_pms_projection_baseline_seed.py
+++ b/tests/ci/test_pms_projection_baseline_seed.py
@@ -12,6 +12,7 @@ SEED_SCRIPT_PATH = ROOT / "scripts" / "seed_test_baseline.py"
 CONFTEST_PATH = ROOT / "tests" / "conftest.py"
 
 REQUIRED_PROJECTION_TABLES = (
+    "wms_pms_supplier_projection",
     "wms_pms_item_projection",
     "wms_pms_uom_projection",
     "wms_pms_sku_code_projection",

--- a/tests/ci/test_pms_projection_tables_are_truncated.py
+++ b/tests/ci/test_pms_projection_tables_are_truncated.py
@@ -6,6 +6,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 
 REQUIRED_PROJECTION_TABLES = (
+    "wms_pms_supplier_projection",
     "wms_pms_item_projection",
     "wms_pms_uom_projection",
     "wms_pms_sku_code_projection",

--- a/tests/ci/test_wms_pms_projection_reconciliation_boundary.py
+++ b/tests/ci/test_wms_pms_projection_reconciliation_boundary.py
@@ -21,6 +21,7 @@ def test_pms_projection_reconciliation_reads_projection_not_owner_tables() -> No
     assert "wms_pms_item_projection" in text
     assert "wms_pms_uom_projection" in text
     assert "wms_pms_sku_code_projection" in text
+    assert "wms_pms_supplier_projection" in text
     assert "wms_pms_barcode_projection" not in text
     assert FORBIDDEN_OWNER_SQL_RE.search(text) is None
 

--- a/tests/ci/test_wms_pms_projection_sync_boundary.py
+++ b/tests/ci/test_wms_pms_projection_sync_boundary.py
@@ -17,6 +17,7 @@ def test_pms_projection_sync_uses_read_v1_feed_endpoints_only() -> None:
     text = (ROOT / "app/integrations/pms/projection_sync.py").read_text(encoding="utf-8")
 
     assert "/pms/read/v1/projection-feed/items" in text
+    assert "/pms/read/v1/projection-feed/suppliers" in text
     assert "/pms/read/v1/projection-feed/uoms" in text
     assert "/pms/read/v1/projection-feed/sku-codes" in text
     assert "/pms/read/v1/projection-feed/barcodes" in text
@@ -36,6 +37,7 @@ def test_pms_projection_sync_writes_projection_tables_only() -> None:
     text = (ROOT / "app/integrations/pms/projection_sync.py").read_text(encoding="utf-8")
 
     assert "INSERT INTO wms_pms_item_projection" in text
+    assert "INSERT INTO wms_pms_supplier_projection" in text
     assert "INSERT INTO wms_pms_uom_projection" in text
     assert "INSERT INTO wms_pms_sku_code_projection" in text
     assert "INSERT INTO wms_pms_barcode_projection" in text

--- a/tests/ci/test_wms_pms_read_projection_boundary.py
+++ b/tests/ci/test_wms_pms_read_projection_boundary.py
@@ -13,6 +13,17 @@ from app.db.base import Base, init_models
 ROOT = Path(__file__).resolve().parents[2]
 
 PROJECTION_COLUMNS: dict[str, set[str]] = {
+    "wms_pms_supplier_projection": {
+        "supplier_id",
+        "supplier_code",
+        "supplier_name",
+        "active",
+        "website",
+        "pms_updated_at",
+        "source_hash",
+        "sync_version",
+        "synced_at",
+    },
     "wms_pms_item_projection": {
         "item_id",
         "sku",
@@ -166,6 +177,7 @@ async def test_wms_pms_projection_primary_keys_have_no_db_defaults(
             FROM information_schema.columns
             WHERE table_schema = 'public'
               AND (table_name, column_name) IN (
+                ('wms_pms_supplier_projection', 'supplier_id'),
                 ('wms_pms_item_projection', 'item_id'),
                 ('wms_pms_uom_projection', 'item_uom_id'),
                 ('wms_pms_sku_code_projection', 'sku_code_id'),
@@ -184,6 +196,7 @@ async def test_wms_pms_projection_primary_keys_have_no_db_defaults(
     assert got == {
         ("wms_pms_barcode_projection", "barcode_id"): None,
         ("wms_pms_item_projection", "item_id"): None,
+        ("wms_pms_supplier_projection", "supplier_id"): None,
         ("wms_pms_sku_code_projection", "sku_code_id"): None,
         ("wms_pms_uom_projection", "item_uom_id"): None,
     }

--- a/tests/fixtures/pms_projection_seed.sql
+++ b/tests/fixtures/pms_projection_seed.sql
@@ -13,6 +13,33 @@
 -- - projection baseline 不再从 legacy owner 表 SELECT / JOIN 物化。
 -- - 这里的 *_id 使用稳定测试 ID，避免依赖 legacy owner 表自增序列。
 
+-- ===== WMS PMS supplier projection baseline =====
+INSERT INTO wms_pms_supplier_projection (
+  supplier_id,
+  supplier_code,
+  supplier_name,
+  active,
+  website,
+  pms_updated_at,
+  source_hash,
+  sync_version,
+  synced_at
+)
+VALUES
+  (1, 'SUP-1', 'UT-SUPPLIER-1', TRUE, NULL, CURRENT_TIMESTAMP, 'test-baseline:supplier:1', 'test-baseline', CURRENT_TIMESTAMP),
+  (2, 'SUP-2', 'UT-SUPPLIER-2', TRUE, NULL, CURRENT_TIMESTAMP, 'test-baseline:supplier:2', 'test-baseline', CURRENT_TIMESTAMP),
+  (3, 'SUP-3', 'UT-SUPPLIER-3', TRUE, NULL, CURRENT_TIMESTAMP, 'test-baseline:supplier:3', 'test-baseline', CURRENT_TIMESTAMP),
+  (4, 'SUP-4', 'UT-SUPPLIER-4', TRUE, NULL, CURRENT_TIMESTAMP, 'test-baseline:supplier:4', 'test-baseline', CURRENT_TIMESTAMP)
+ON CONFLICT (supplier_id) DO UPDATE SET
+  supplier_code = EXCLUDED.supplier_code,
+  supplier_name = EXCLUDED.supplier_name,
+  active = EXCLUDED.active,
+  website = EXCLUDED.website,
+  pms_updated_at = EXCLUDED.pms_updated_at,
+  source_hash = EXCLUDED.source_hash,
+  sync_version = EXCLUDED.sync_version,
+  synced_at = CURRENT_TIMESTAMP;
+
 -- ===== WMS PMS item projection baseline =====
 INSERT INTO wms_pms_item_projection (
   item_id,

--- a/tests/fixtures/truncate.sql
+++ b/tests/fixtures/truncate.sql
@@ -26,6 +26,7 @@ TRUNCATE TABLE
   wms_pms_barcode_projection,
   wms_pms_sku_code_projection,
   wms_pms_uom_projection,
+  wms_pms_supplier_projection,
   wms_pms_item_projection,
 
   -- platform order ingestion jobs

--- a/tests/services/test_pms_projection_reconciliation.py
+++ b/tests/services/test_pms_projection_reconciliation.py
@@ -297,6 +297,7 @@ async def test_pms_projection_reconciliation_reports_missing_and_mismatch(
                 "sku_code_id",
             ),
         ),
+        supplier_references=(),
     )
 
     assert result.ok is False
@@ -366,6 +367,7 @@ async def test_pms_projection_reconciliation_returns_ok_for_clean_refs(
                 "sku_code_id",
             ),
         ),
+        supplier_references=(),
     )
 
     assert result.ok is True
@@ -402,6 +404,7 @@ async def test_pms_projection_reconciliation_supports_reference_table_without_id
         ),
         uom_references=(),
         sku_code_references=(),
+        supplier_references=(),
     )
 
     assert result.ok is False

--- a/tests/services/test_pms_projection_sync.py
+++ b/tests/services/test_pms_projection_sync.py
@@ -22,6 +22,7 @@ async def _clear_projection_tables(session: AsyncSession) -> None:
         "wms_pms_sku_code_projection",
         "wms_pms_uom_projection",
         "wms_pms_item_projection",
+        "wms_pms_supplier_projection",
     ):
         await session.execute(text(f"DELETE FROM {table_name}"))
 
@@ -68,6 +69,39 @@ def _transport(calls: list[tuple[str, str]]) -> httpx.MockTransport:
                     "derivation_allowed": False,
                     "uom_governance_enabled": True,
                     "pms_updated_at": "2026-01-02T00:00:00Z",
+                },
+            ]
+            page = rows[offset : offset + limit]
+            has_more = offset + limit < len(rows)
+            return httpx.Response(
+                200,
+                json={
+                    "rows": page,
+                    "limit": limit,
+                    "offset": offset,
+                    "next_offset": offset + limit if has_more else None,
+                    "has_more": has_more,
+                },
+            )
+
+
+        if path == "/pms/read/v1/projection-feed/suppliers":
+            rows = [
+                {
+                    "supplier_id": 7001,
+                    "supplier_code": "SYNC-SUP-1",
+                    "supplier_name": "同步供应商1",
+                    "active": True,
+                    "website": None,
+                    "source_updated_at": "2026-01-02T08:00:00Z",
+                },
+                {
+                    "supplier_id": 7002,
+                    "supplier_code": "SYNC-SUP-2",
+                    "supplier_name": "同步供应商2",
+                    "active": False,
+                    "website": "https://supplier.example",
+                    "source_updated_at": "2026-01-02T09:00:00Z",
                 },
             ]
             page = rows[offset : offset + limit]
@@ -174,10 +208,12 @@ async def test_sync_pms_read_projection_upserts_feed_rows(session: AsyncSession)
     )
     await session.flush()
 
-    assert result.fetched == 5
-    assert result.upserted == 5
+    assert result.fetched == 7
+    assert result.upserted == 7
     assert result.resources["items"].pages == 2
     assert result.resources["items"].fetched == 2
+    assert result.resources["suppliers"].pages == 2
+    assert result.resources["suppliers"].fetched == 2
 
     item = (
         await session.execute(
@@ -208,6 +244,25 @@ async def test_sync_pms_read_projection_upserts_feed_rows(session: AsyncSession)
     assert item["lot_source_policy"] == "SUPPLIER_ONLY"
     assert item["source_hash"]
     assert item["sync_version"] == SYNC_VERSION
+
+
+    supplier = (
+        await session.execute(
+            text(
+                """
+                SELECT supplier_id, supplier_code, supplier_name, active, website, source_hash, sync_version
+                FROM wms_pms_supplier_projection
+                WHERE supplier_id = 7002
+                """
+            )
+        )
+    ).mappings().one()
+    assert supplier["supplier_code"] == "SYNC-SUP-2"
+    assert supplier["supplier_name"] == "同步供应商2"
+    assert supplier["active"] is False
+    assert supplier["website"] == "https://supplier.example"
+    assert supplier["source_hash"]
+    assert supplier["sync_version"] == SYNC_VERSION
 
     uom = (
         await session.execute(
@@ -261,6 +316,8 @@ async def test_sync_pms_read_projection_upserts_feed_rows(session: AsyncSession)
     assert called_paths == [
         "/pms/read/v1/projection-feed/items",
         "/pms/read/v1/projection-feed/items",
+        "/pms/read/v1/projection-feed/suppliers",
+        "/pms/read/v1/projection-feed/suppliers",
         "/pms/read/v1/projection-feed/uoms",
         "/pms/read/v1/projection-feed/sku-codes",
         "/pms/read/v1/projection-feed/barcodes",

--- a/tests/services/test_pms_supplier_projection_reconciliation.py
+++ b/tests/services/test_pms_supplier_projection_reconciliation.py
@@ -1,0 +1,171 @@
+# tests/services/test_pms_supplier_projection_reconciliation.py
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.integrations.pms.projection_reconciliation import (
+    SupplierReference,
+    reconcile_pms_projection_references,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_supplier_projection_reconciliation_reports_missing_supplier(
+    session: AsyncSession,
+) -> None:
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_pms_supplier_projection (
+                supplier_id,
+                supplier_code,
+                supplier_name,
+                active,
+                website,
+                pms_updated_at,
+                source_hash,
+                sync_version,
+                synced_at
+            )
+            VALUES (
+                880001,
+                'UT-SUP-880001',
+                'UT Supplier 880001',
+                TRUE,
+                NULL,
+                now(),
+                'ut-supplier-880001',
+                'ut-supplier-projection',
+                now()
+            )
+            ON CONFLICT (supplier_id) DO UPDATE SET
+                supplier_code = EXCLUDED.supplier_code,
+                supplier_name = EXCLUDED.supplier_name,
+                active = EXCLUDED.active,
+                website = EXCLUDED.website,
+                pms_updated_at = EXCLUDED.pms_updated_at,
+                source_hash = EXCLUDED.source_hash,
+                sync_version = EXCLUDED.sync_version,
+                synced_at = now()
+            """
+        )
+    )
+
+    await session.execute(
+        text(
+            """
+            CREATE TEMP TABLE tmp_pms_reconcile_supplier_refs (
+                id INTEGER NOT NULL,
+                supplier_id INTEGER
+            ) ON COMMIT DROP
+            """
+        )
+    )
+    await session.execute(
+        text(
+            """
+            INSERT INTO tmp_pms_reconcile_supplier_refs (id, supplier_id)
+            VALUES
+              (1, 880001),
+              (2, 880099)
+            """
+        )
+    )
+
+    result = await reconcile_pms_projection_references(
+        session,
+        item_references=(),
+        uom_references=(),
+        sku_code_references=(),
+        supplier_references=(
+            SupplierReference("pg_temp.tmp_pms_reconcile_supplier_refs", "id", "supplier_id"),
+        ),
+    )
+
+    assert result.ok is False
+    assert result.issue_count == 1
+    assert result.summary_by_type() == {"SUPPLIER_MISSING_IN_PROJECTION": 1}
+
+    issue = result.issues[0]
+    assert issue.issue_type == "SUPPLIER_MISSING_IN_PROJECTION"
+    assert issue.source_table == "pg_temp.tmp_pms_reconcile_supplier_refs"
+    assert issue.source_column == "supplier_id"
+    assert issue.source_id == "2"
+    assert issue.supplier_id == 880099
+
+
+async def test_supplier_projection_reconciliation_returns_ok_for_clean_supplier_refs(
+    session: AsyncSession,
+) -> None:
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_pms_supplier_projection (
+                supplier_id,
+                supplier_code,
+                supplier_name,
+                active,
+                website,
+                pms_updated_at,
+                source_hash,
+                sync_version,
+                synced_at
+            )
+            VALUES (
+                880002,
+                'UT-SUP-880002',
+                'UT Supplier 880002',
+                TRUE,
+                NULL,
+                now(),
+                'ut-supplier-880002',
+                'ut-supplier-projection',
+                now()
+            )
+            ON CONFLICT (supplier_id) DO UPDATE SET
+                supplier_code = EXCLUDED.supplier_code,
+                supplier_name = EXCLUDED.supplier_name,
+                active = EXCLUDED.active,
+                website = EXCLUDED.website,
+                pms_updated_at = EXCLUDED.pms_updated_at,
+                source_hash = EXCLUDED.source_hash,
+                sync_version = EXCLUDED.sync_version,
+                synced_at = now()
+            """
+        )
+    )
+
+    await session.execute(
+        text(
+            """
+            CREATE TEMP TABLE tmp_pms_reconcile_supplier_clean_refs (
+                id INTEGER NOT NULL,
+                supplier_id INTEGER
+            ) ON COMMIT DROP
+            """
+        )
+    )
+    await session.execute(
+        text(
+            """
+            INSERT INTO tmp_pms_reconcile_supplier_clean_refs (id, supplier_id)
+            VALUES (1, 880002)
+            """
+        )
+    )
+
+    result = await reconcile_pms_projection_references(
+        session,
+        item_references=(),
+        uom_references=(),
+        sku_code_references=(),
+        supplier_references=(
+            SupplierReference("pg_temp.tmp_pms_reconcile_supplier_clean_refs", "id", "supplier_id"),
+        ),
+    )
+
+    assert result.ok is True
+    assert result.issue_count == 0


### PR DESCRIPTION
## Summary
- add wms_pms_supplier_projection table
- add supplier projection ORM and contract
- sync suppliers from pms-api /pms/read/v1/projection-feed/suppliers
- add supplier reference reconciliation against local projection
- seed/truncate supplier projection in test fixtures
- extend CI guards for projection schema, sync boundary, and reconciliation boundary

## Validation
- pytest PMS projection CI/service tests: 27 passed
- alembic upgrade applied to dev/test DB
- sync_projection.py --resource suppliers fetched=4 upserted=4
- wms_pms_supplier_projection count=4
- reconcile_projection.py ok=true
- alembic-check: No new upgrade operations detected
