### PR TITLE
refactor(pms): read suppliers from WMS projection

### DIFF
--- a/app/partners/export/suppliers/services/supplier_read_service.py
+++ b/app/partners/export/suppliers/services/supplier_read_service.py
@@ -3,26 +3,22 @@ from __future__ import annotations
 
 from typing import Optional
 
-from sqlalchemy import or_, select
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
-from app.partners.suppliers.models.supplier import Supplier
 from app.partners.export.suppliers.contracts.supplier_basic import SupplierBasic
-from app.partners.suppliers.repos.supplier_repo import (
-    list_suppliers_basic as repo_list_suppliers_basic,
-)
 
 
 class SupplierReadService:
     """
-    Partners export supplier read service。
+    Partners export supplier read service.
 
-    定位：
-    - 供其他模块读取 Partners 供应商最小事实
-    - 不承载 contacts 聚合
-    - 不承载写入语义
-    - 同时支持 sync Session 与 AsyncSession
+    Boundary:
+    - Read WMS local PMS supplier projection only.
+    - Do not read legacy suppliers owner table.
+    - Do not carry supplier_contacts / owner write semantics.
+    - Sync and async APIs are both kept because routers use Session and procurement uses AsyncSession.
     """
 
     def __init__(self, db: Session | AsyncSession) -> None:
@@ -40,6 +36,58 @@ class SupplierReadService:
             raise TypeError("SupplierReadService async API requires AsyncSession")
         return self.db
 
+    @staticmethod
+    def _query_sql(*, active: Optional[bool], q: Optional[str]) -> tuple[str, dict[str, object]]:
+        where: list[str] = []
+        params: dict[str, object] = {}
+
+        if active is not None:
+            where.append("active = :active")
+            params["active"] = bool(active)
+
+        qv = (q or "").strip()
+        if qv:
+            where.append("(supplier_name ILIKE :q_like OR supplier_code ILIKE :q_like)")
+            params["q_like"] = f"%{qv}%"
+
+        where_sql = f"WHERE {' AND '.join(where)}" if where else ""
+
+        return (
+            f"""
+            SELECT
+              supplier_id AS id,
+              supplier_name AS name,
+              supplier_code AS code,
+              active
+            FROM wms_pms_supplier_projection
+            {where_sql}
+            ORDER BY supplier_id ASC
+            """,
+            params,
+        )
+
+    @staticmethod
+    def _get_sql() -> str:
+        return """
+        SELECT
+          supplier_id AS id,
+          supplier_name AS name,
+          supplier_code AS code,
+          active
+        FROM wms_pms_supplier_projection
+        WHERE supplier_id = :supplier_id
+        LIMIT 1
+        """
+
+    @staticmethod
+    def _to_basic(row) -> SupplierBasic:
+        return SupplierBasic(
+            id=int(row["id"]),
+            name=str(row["name"]),
+            code=str(row["code"]) if row["code"] is not None else None,
+            active=bool(row["active"]),
+        )
+
     def list_basic(
         self,
         *,
@@ -47,8 +95,9 @@ class SupplierReadService:
         q: Optional[str] = None,
     ) -> list[SupplierBasic]:
         db = self._require_sync_db()
-        rows = repo_list_suppliers_basic(db, active=active, q=q)
-        return [self._to_basic(x) for x in rows]
+        sql, params = self._query_sql(active=active, q=q)
+        rows = db.execute(text(sql), params).mappings().all()
+        return [self._to_basic(row) for row in rows]
 
     async def alist_basic(
         self,
@@ -57,45 +106,19 @@ class SupplierReadService:
         q: Optional[str] = None,
     ) -> list[SupplierBasic]:
         db = self._require_async_db()
-
-        stmt = select(Supplier)
-
-        if active is not None:
-            stmt = stmt.where(Supplier.active.is_(bool(active)))
-
-        qv = (q or "").strip()
-        if qv:
-            like = f"%{qv}%"
-            stmt = stmt.where(
-                or_(
-                    Supplier.name.ilike(like),
-                    Supplier.code.ilike(like),
-                )
-            )
-
-        stmt = stmt.order_by(Supplier.id.asc())
-
-        rows = (await db.execute(stmt)).scalars().all()
-        return [self._to_basic(x) for x in rows]
+        sql, params = self._query_sql(active=active, q=q)
+        rows = (await db.execute(text(sql), params)).mappings().all()
+        return [self._to_basic(row) for row in rows]
 
     async def aget_basic_by_id(self, *, supplier_id: int) -> SupplierBasic | None:
         db = self._require_async_db()
+        row = (
+            await db.execute(
+                text(self._get_sql()),
+                {"supplier_id": int(supplier_id)},
+            )
+        ).mappings().first()
 
-        stmt = (
-            select(Supplier)
-            .where(Supplier.id == int(supplier_id))
-            .limit(1)
-        )
-        obj = (await db.execute(stmt)).scalars().first()
-        if obj is None:
+        if row is None:
             return None
-        return self._to_basic(obj)
-
-    @staticmethod
-    def _to_basic(supplier: Supplier) -> SupplierBasic:
-        return SupplierBasic(
-            id=int(supplier.id),
-            name=str(supplier.name),
-            code=supplier.code,
-            active=bool(supplier.active),
-        )
+        return self._to_basic(row)

--- a/app/procurement/services/purchase_order_create.py
+++ b/app/procurement/services/purchase_order_create.py
@@ -26,12 +26,12 @@ async def _load_items_map(session: AsyncSession, item_ids: List[int]) -> Dict[in
     return await create_pms_read_client(session=session).get_item_basics(item_ids=item_ids)
 
 
-async def _require_supplier_snapshot_via_partners(
+async def _require_supplier_snapshot_via_projection(
     session: AsyncSession,
     supplier_id: Optional[int],
 ) -> Tuple[int, str]:
     """
-    供应商真相直接来自 Partners export/service。
+    供应商当前事实来自 WMS 本地 PMS supplier projection。
     返回：
     - supplier_id
     - supplier_name（用于 PO 快照）
@@ -110,7 +110,7 @@ async def create_po_v2(
     if not purchaser_text:
         raise ValueError("purchaser 不能为空：采购单必须填写采购人")
 
-    po_supplier_id, po_supplier_name = await _require_supplier_snapshot_via_partners(
+    po_supplier_id, po_supplier_name = await _require_supplier_snapshot_via_projection(
         session,
         supplier_id,
     )

--- a/app/procurement/services/purchase_order_update.py
+++ b/app/procurement/services/purchase_order_update.py
@@ -27,7 +27,7 @@ from app.procurement.services.purchase_order_create import (
     _load_items_map,
     _maybe_uom_id_from_raw,
     _require_qty_input_from_raw,
-    _require_supplier_snapshot_via_partners,
+    _require_supplier_snapshot_via_projection,
     _trim_or_none,
 )
 
@@ -51,7 +51,7 @@ async def _normalize_update_payload(
 
     purchaser_text = _normalize_purchaser_text(purchaser)
 
-    po_supplier_id, po_supplier_name = await _require_supplier_snapshot_via_partners(
+    po_supplier_id, po_supplier_name = await _require_supplier_snapshot_via_projection(
         session,
         supplier_id,
     )

--- a/app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_write_repo.py
+++ b/app/wms/inventory_adjustment/return_inbound/repos/inbound_receipt_write_repo.py
@@ -114,7 +114,7 @@ async def _load_supplier_name_snapshot(
 ) -> str:
     row = (
         await session.execute(
-            text("SELECT name FROM suppliers WHERE id = :supplier_id LIMIT 1"),
+            text("SELECT supplier_name FROM wms_pms_supplier_projection WHERE supplier_id = :supplier_id LIMIT 1"),
             {"supplier_id": int(supplier_id)},
         )
     ).scalar_one_or_none()

--- a/tests/api/test_purchase_orders_supplier_item_contract.py
+++ b/tests/api/test_purchase_orders_supplier_item_contract.py
@@ -57,34 +57,64 @@ async def _insert_supplier(
     code = f"{name_prefix}-{suffix}".upper()
     name = f"{name_prefix}-{suffix}"
 
-    await session.execute(
-        text(
-            """
-            SELECT setval(
-              pg_get_serial_sequence('suppliers', 'id'),
-              COALESCE((SELECT MAX(id) FROM suppliers), 0) + 1,
-              false
-            )
-            """
-        )
-    )
-
     row = await session.execute(
         text(
             """
-            INSERT INTO suppliers(name, code, active)
-            VALUES (:name, :code, :active)
-            RETURNING id, name
+            SELECT GREATEST(
+              COALESCE((SELECT MAX(supplier_id) FROM wms_pms_supplier_projection), 0),
+              900000
+            ) + 1
+            """
+        )
+    )
+    supplier_id = int(row.scalar_one())
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_pms_supplier_projection (
+              supplier_id,
+              supplier_code,
+              supplier_name,
+              active,
+              website,
+              pms_updated_at,
+              source_hash,
+              sync_version,
+              synced_at
+            )
+            VALUES (
+              :supplier_id,
+              :supplier_code,
+              :supplier_name,
+              :active,
+              NULL,
+              now(),
+              :source_hash,
+              'ut-supplier-projection',
+              now()
+            )
+            ON CONFLICT (supplier_id) DO UPDATE SET
+              supplier_code = EXCLUDED.supplier_code,
+              supplier_name = EXCLUDED.supplier_name,
+              active = EXCLUDED.active,
+              website = EXCLUDED.website,
+              pms_updated_at = EXCLUDED.pms_updated_at,
+              source_hash = EXCLUDED.source_hash,
+              sync_version = EXCLUDED.sync_version,
+              synced_at = now()
             """
         ),
         {
-            "name": name,
-            "code": code,
+            "supplier_id": supplier_id,
+            "supplier_code": code,
+            "supplier_name": name,
             "active": bool(active),
+            "source_hash": f"ut-supplier-projection:{supplier_id}:{code}",
         },
     )
-    got = row.mappings().one()
-    return int(got["id"]), str(got["name"])
+
+    return supplier_id, name
 
 
 async def _insert_item_for_supplier(

--- a/tests/ci/test_wms_supplier_read_projection_boundary.py
+++ b/tests/ci/test_wms_supplier_read_projection_boundary.py
@@ -1,0 +1,81 @@
+# tests/ci/test_wms_supplier_read_projection_boundary.py
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+FORBIDDEN_OLD_SUPPLIER_READ_RE = re.compile(
+    r"""
+    \bFROM\s+suppliers\b
+    |
+    \bJOIN\s+suppliers\b
+    |
+    \bSELECT\b.*\bFROM\s+suppliers\b
+    |
+    \bINSERT\s+INTO\s+suppliers\b
+    |
+    \bUPDATE\s+suppliers\b
+    |
+    \bDELETE\s+FROM\s+suppliers\b
+    |
+    pg_get_serial_sequence\('suppliers'
+    |
+    from\s+app\.partners\.suppliers\.(models|repos)
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+ALLOWED_PREFIXES = (
+    "app/partners/suppliers/",
+)
+
+ALLOWED_FILES = {
+    "tests/fixtures/base_seed.sql",
+    "tests/ci/test_wms_supplier_read_projection_boundary.py",
+}
+
+
+def _rel(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def test_non_owner_supplier_reads_use_wms_pms_supplier_projection() -> None:
+    violations: list[str] = []
+
+    for root_name in ("app", "tests", "scripts"):
+        root = ROOT / root_name
+        if not root.exists():
+            continue
+
+        for path in sorted(root.rglob("*")):
+            if not path.is_file():
+                continue
+            if path.suffix not in {".py", ".sql"}:
+                continue
+
+            rel = _rel(path)
+            if rel in ALLOWED_FILES:
+                continue
+            if any(rel.startswith(prefix) for prefix in ALLOWED_PREFIXES):
+                continue
+            if "__pycache__" in rel:
+                continue
+
+            for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+                if FORBIDDEN_OLD_SUPPLIER_READ_RE.search(line):
+                    violations.append(f"{rel}:{line_no}: {line.strip()}")
+
+    assert violations == []
+
+
+def test_supplier_export_read_service_uses_projection_table() -> None:
+    text = (
+        ROOT / "app/partners/export/suppliers/services/supplier_read_service.py"
+    ).read_text(encoding="utf-8")
+
+    assert "wms_pms_supplier_projection" in text
+    assert "FROM suppliers" not in text
+    assert "app.partners.suppliers.models" not in text
+    assert "app.partners.suppliers.repos" not in text

--- a/tests/fixtures/po_batch_semantics_fixtures.py
+++ b/tests/fixtures/po_batch_semantics_fixtures.py
@@ -18,7 +18,17 @@ def _is_required_expiry_policy(expiry_policy: str) -> bool:
 
 
 async def _get_any_supplier(session: AsyncSession) -> tuple[int, str]:
-    row = await session.execute(text("SELECT id, name FROM suppliers ORDER BY id ASC LIMIT 1"))
+    row = await session.execute(
+        text(
+            """
+            SELECT supplier_id AS id, supplier_name AS name
+            FROM wms_pms_supplier_projection
+            WHERE active IS TRUE
+            ORDER BY supplier_id ASC
+            LIMIT 1
+            """
+        )
+    )
     r = row.first()
     if r is None or r[0] is None:
         raise RuntimeError("tests require at least one supplier seeded in test database.")

--- a/tests/helpers/po_testkit.py
+++ b/tests/helpers/po_testkit.py
@@ -35,10 +35,20 @@ async def get_any_warehouse_id(session: AsyncSession) -> int:
 async def get_any_supplier(session: AsyncSession) -> tuple[int, str]:
     """
     purchase_orders.supplier_id / supplier_name 都是 NOT NULL：
-    - supplier_id 从 suppliers 表拿一条 seed
+    - supplier_id 从 wms_pms_supplier_projection 拿一条 seed
     - supplier_name 兜底成非空字符串
     """
-    row = await session.execute(text("SELECT id, name FROM suppliers ORDER BY id ASC LIMIT 1"))
+    row = await session.execute(
+        text(
+            """
+            SELECT supplier_id AS id, supplier_name AS name
+            FROM wms_pms_supplier_projection
+            WHERE active IS TRUE
+            ORDER BY supplier_id ASC
+            LIMIT 1
+            """
+        )
+    )
     r = row.first()
     if r is None or r[0] is None:
         raise RuntimeError("tests require at least one supplier seeded in test database.")


### PR DESCRIPTION
## Summary
- switch /partners/export/suppliers read service to wms_pms_supplier_projection
- switch procurement supplier snapshot validation to projection-backed supplier read service
- switch manual inbound supplier_name_snapshot lookup to projection
- update supplier-related test helpers to read projection instead of legacy suppliers owner table
- add CI guard to prevent non-owner supplier reads from using legacy suppliers table

## Not changed
- keep legacy suppliers table
- keep supplier_contacts table
- keep existing supplier FKs
- keep /partners/suppliers owner write routes for now

## Validation
- pytest supplier read/procurement/projection boundary tests: 20 passed
- focused supplier export and purchase supplier contract tests: 10 passed
