### PR TITLE
refactor(pms): retire WMS supplier business FKs

### DIFF
--- a/alembic/versions/9f2a4c7d1e8b_retire_wms_supplier_business_fks.py
+++ b/alembic/versions/9f2a4c7d1e8b_retire_wms_supplier_business_fks.py
@@ -1,0 +1,104 @@
+"""retire_wms_supplier_business_fks
+
+Revision ID: 9f2a4c7d1e8b
+Revises: 7c9d1a2e4b6f
+Create Date: 2026-05-12 11:10:00.000000
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "9f2a4c7d1e8b"
+down_revision: Union[str, Sequence[str], None] = "7c9d1a2e4b6f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # WMS no longer owns supplier master data.
+    # Business tables keep supplier_id as scalar reference and rely on:
+    # - wms_pms_supplier_projection for current read/validation
+    # - snapshot columns for historical display
+    # - projection reconciliation for integrity checks
+    #
+    # Keep supplier_contacts -> suppliers FK for now because supplier_contacts
+    # is still the only remaining legacy supplier child table.
+
+    op.drop_constraint("fk_items_supplier", "items", type_="foreignkey")
+    op.drop_constraint("fk_purchase_orders_supplier_id", "purchase_orders", type_="foreignkey")
+    op.drop_constraint("fk_inbound_receipts_supplier", "inbound_receipts", type_="foreignkey")
+    op.drop_constraint(
+        "fk_wms_inbound_operations_supplier",
+        "wms_inbound_operations",
+        type_="foreignkey",
+    )
+
+    op.alter_column(
+        "purchase_orders",
+        "supplier_id",
+        existing_type=sa.Integer(),
+        existing_nullable=False,
+        comment="PMS supplier_id 标量引用（由 wms_pms_supplier_projection 校验，不再是 WMS 本地 FK）",
+    )
+    op.alter_column(
+        "purchase_orders",
+        "supplier_name",
+        existing_type=sa.String(length=255),
+        existing_nullable=False,
+        comment="下单时的供应商名称快照（来自 PMS supplier projection）",
+    )
+
+
+def downgrade() -> None:
+    op.create_foreign_key(
+        "fk_wms_inbound_operations_supplier",
+        "wms_inbound_operations",
+        "suppliers",
+        ["supplier_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.create_foreign_key(
+        "fk_inbound_receipts_supplier",
+        "inbound_receipts",
+        "suppliers",
+        ["supplier_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.create_foreign_key(
+        "fk_purchase_orders_supplier_id",
+        "purchase_orders",
+        "suppliers",
+        ["supplier_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.create_foreign_key(
+        "fk_items_supplier",
+        "items",
+        "suppliers",
+        ["supplier_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+
+    op.alter_column(
+        "purchase_orders",
+        "supplier_id",
+        existing_type=sa.Integer(),
+        existing_nullable=False,
+        comment="FK → suppliers.id（必填）",
+    )
+    op.alter_column(
+        "purchase_orders",
+        "supplier_name",
+        existing_type=sa.String(length=255),
+        existing_nullable=False,
+        comment="下单时的供应商名称快照（必填，通常来自 suppliers.name）",
+    )

--- a/app/procurement/models/purchase_order.py
+++ b/app/procurement/models/purchase_order.py
@@ -50,18 +50,17 @@ class PurchaseOrder(Base):
         comment="采购业务单号（如 PO-123）",
     )
 
-    # ✅ 供应商：只保留主数据 ID + 下单快照（废除 supplier 自由文本）
+    # ✅ 供应商：只保留 PMS supplier_id 标量引用 + 下单快照
     supplier_id: Mapped[int] = mapped_column(
         sa.Integer,
-        sa.ForeignKey("suppliers.id", ondelete="RESTRICT"),
         nullable=False,
         index=True,
-        comment="FK → suppliers.id（必填）",
+        comment="PMS supplier_id 标量引用（由 wms_pms_supplier_projection 校验，不再是 WMS 本地 FK）",
     )
     supplier_name: Mapped[str] = mapped_column(
         sa.String(255),
         nullable=False,
-        comment="下单时的供应商名称快照（必填，通常来自 suppliers.name）",
+        comment="下单时的供应商名称快照（来自 PMS supplier projection）",
     )
 
     # 仓库

--- a/app/wms/inventory_adjustment/return_inbound/models/inbound_operation.py
+++ b/app/wms/inventory_adjustment/return_inbound/models/inbound_operation.py
@@ -30,7 +30,6 @@ class WmsInboundOperation(Base):
 
     supplier_id: Mapped[Optional[int]] = mapped_column(
         Integer,
-        ForeignKey("suppliers.id", name="fk_wms_inbound_operations_supplier", ondelete="RESTRICT"),
         nullable=True,
     )
     supplier_name_snapshot: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)

--- a/app/wms/inventory_adjustment/return_inbound/models/inbound_receipt.py
+++ b/app/wms/inventory_adjustment/return_inbound/models/inbound_receipt.py
@@ -44,7 +44,6 @@ class InboundReceipt(Base):
 
     supplier_id: Mapped[Optional[int]] = mapped_column(
         Integer,
-        ForeignKey("suppliers.id", name="fk_inbound_receipts_supplier", ondelete="RESTRICT"),
         nullable=True,
     )
     counterparty_name_snapshot: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)

--- a/tests/ci/test_wms_supplier_business_fks_retired.py
+++ b/tests/ci/test_wms_supplier_business_fks_retired.py
@@ -1,0 +1,86 @@
+# tests/ci/test_wms_supplier_business_fks_retired.py
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+ROOT = Path(__file__).resolve().parents[2]
+
+FORBIDDEN_APP_SUPPLIER_FK_RE = re.compile(
+    r"""
+    ForeignKey\(["']suppliers\.id["']
+    |
+    fk_items_supplier
+    |
+    fk_purchase_orders_supplier_id
+    |
+    fk_inbound_receipts_supplier
+    |
+    fk_wms_inbound_operations_supplier
+    |
+    FK\s*→\s*suppliers\.id
+    |
+    通常来自\s+suppliers\.name
+    """,
+    re.VERBOSE,
+)
+
+ALLOWED_PREFIXES = (
+    "app/partners/suppliers/",
+)
+
+
+def _rel(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def test_non_owner_models_do_not_declare_supplier_business_fks() -> None:
+    violations: list[str] = []
+
+    for path in sorted((ROOT / "app").rglob("*.py")):
+        rel = _rel(path)
+        if any(rel.startswith(prefix) for prefix in ALLOWED_PREFIXES):
+            continue
+        if "__pycache__" in rel:
+            continue
+
+        for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if FORBIDDEN_APP_SUPPLIER_FK_RE.search(line):
+                violations.append(f"{rel}:{line_no}: {line.strip()}")
+
+    assert violations == []
+
+
+@pytest.mark.asyncio
+async def test_supplier_business_fk_constraints_are_retired_in_database(
+    session: AsyncSession,
+) -> None:
+    rows = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  c.conname AS constraint_name,
+                  c.conrelid::regclass::text AS owner_table,
+                  c.confrelid::regclass::text AS referenced_table
+                FROM pg_constraint c
+                WHERE c.contype = 'f'
+                  AND c.confrelid = 'suppliers'::regclass
+                ORDER BY owner_table, constraint_name
+                """
+            )
+        )
+    ).mappings().all()
+
+    pairs = {(str(row["owner_table"]), str(row["constraint_name"])) for row in rows}
+
+    assert ("items", "fk_items_supplier") not in pairs
+    assert ("purchase_orders", "fk_purchase_orders_supplier_id") not in pairs
+    assert ("inbound_receipts", "fk_inbound_receipts_supplier") not in pairs
+    assert ("wms_inbound_operations", "fk_wms_inbound_operations_supplier") not in pairs
+
+    assert pairs == {("supplier_contacts", "supplier_contacts_supplier_id_fkey")}


### PR DESCRIPTION
## Summary
- retire business FKs from WMS tables to legacy suppliers table
- keep supplier_id as scalar PMS reference on purchase_orders / inbound_receipts / wms_inbound_operations
- keep supplier_contacts -> suppliers FK for now
- keep suppliers and supplier_contacts tables untouched
- rely on wms_pms_supplier_projection + snapshot fields + reconciliation for supplier consistency

## Validation
- alembic upgrade applied to dev/test DB
- DB check confirms only supplier_contacts_supplier_id_fkey still references suppliers
- pytest supplier FK/projection/export/procurement/reconciliation tests: 17 passed
- alembic-check: No new upgrade operations detected
