### PR TITLE
feat(pms): add WMS PMS projection sync admin ops

### DIFF
--- a/alembic/versions/8a4f2d6c9b31_add_wms_pms_projection_sync_admin_ops.py
+++ b/alembic/versions/8a4f2d6c9b31_add_wms_pms_projection_sync_admin_ops.py
@@ -1,0 +1,422 @@
+"""add_wms_pms_projection_sync_admin_ops
+
+Revision ID: 8a4f2d6c9b31
+Revises: 3c6f2a9b8d10
+Create Date: 2026-05-12 12:45:00.000000
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "8a4f2d6c9b31"
+down_revision: Union[str, Sequence[str], None] = "3c6f2a9b8d10"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+NEW_PAGE_ROWS = (
+    ("admin.pms_integration", "PMS 接入管理", "admin", 2, 20),
+    ("admin.pms_integration.items", "商品投影", "admin.pms_integration", 3, 10),
+    ("admin.pms_integration.suppliers", "供应商投影", "admin.pms_integration", 3, 20),
+    ("admin.pms_integration.uoms", "包装单位投影", "admin.pms_integration", 3, 30),
+    ("admin.pms_integration.sku_codes", "SKU 编码投影", "admin.pms_integration", 3, 40),
+    ("admin.pms_integration.barcodes", "条码投影", "admin.pms_integration", 3, 50),
+)
+
+NEW_ROUTE_ROWS = (
+    ("admin.pms_integration", "/admin/pms-integration", 20),
+    ("admin.pms_integration.items", "/admin/pms-integration/items", 10),
+    ("admin.pms_integration.suppliers", "/admin/pms-integration/suppliers", 20),
+    ("admin.pms_integration.uoms", "/admin/pms-integration/uoms", 30),
+    ("admin.pms_integration.sku_codes", "/admin/pms-integration/sku-codes", 40),
+    ("admin.pms_integration.barcodes", "/admin/pms-integration/barcodes", 50),
+)
+
+OLD_PAGE_RESTORE_ROWS = (
+    ("pms", "商品主数据", None, 1, "pms", True, False, False, 80),
+    ("pms.items", "商品列表", "pms", 2, "pms", False, True, True, 10),
+    ("pms.brands", "品牌管理", "pms", 2, "pms", False, True, True, 20),
+    ("pms.categories", "商品分类编码", "pms", 2, "pms", False, True, True, 30),
+    ("pms.item_attributes", "属性模板", "pms", 2, "pms", False, True, True, 40),
+    ("pms.sku_coding", "SKU 编码工具", "pms", 2, "pms", False, True, True, 50),
+    ("pms.item_barcodes", "商品条码", "pms", 2, "pms", False, True, True, 60),
+    ("pms.item_uoms", "包装单位", "pms", 2, "pms", False, True, True, 70),
+)
+
+OLD_ROUTE_RESTORE_ROWS = (
+    ("pms.items", "/items", 10),
+    ("pms.brands", "/pms/brands", 20),
+    ("pms.categories", "/pms/categories", 30),
+    ("pms.item_attributes", "/pms/item-attribute-defs", 40),
+    ("pms.sku_coding", "/items/sku-coding", 50),
+    ("pms.item_barcodes", "/item-barcodes", 60),
+    ("pms.item_uoms", "/item-uoms", 70),
+)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    op.create_table(
+        "wms_pms_projection_sync_runs",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("resource", sa.String(length=32), nullable=False),
+        sa.Column("status", sa.String(length=16), nullable=False),
+        sa.Column("fetched", sa.Integer(), server_default=sa.text("0"), nullable=False),
+        sa.Column("upserted", sa.Integer(), server_default=sa.text("0"), nullable=False),
+        sa.Column("pages", sa.Integer(), server_default=sa.text("0"), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("duration_ms", sa.Integer(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("triggered_by_user_id", sa.Integer(), nullable=True),
+        sa.Column("pms_api_base_url_snapshot", sa.String(length=512), nullable=True),
+        sa.Column("sync_version", sa.String(length=64), nullable=True),
+        sa.PrimaryKeyConstraint("id", name="pk_wms_pms_projection_sync_runs"),
+        sa.ForeignKeyConstraint(
+            ["triggered_by_user_id"],
+            ["users.id"],
+            name="fk_wms_pms_projection_sync_runs_triggered_by_user_id_users",
+            ondelete="SET NULL",
+        ),
+        sa.CheckConstraint(
+            "resource IN ('items', 'suppliers', 'uoms', 'sku-codes', 'barcodes', 'all')",
+            name="ck_wms_pms_projection_sync_runs_resource",
+        ),
+        sa.CheckConstraint(
+            "status IN ('RUNNING', 'SUCCESS', 'FAILED')",
+            name="ck_wms_pms_projection_sync_runs_status",
+        ),
+        sa.CheckConstraint(
+            "fetched >= 0",
+            name="ck_wms_pms_projection_sync_runs_fetched_non_negative",
+        ),
+        sa.CheckConstraint(
+            "upserted >= 0",
+            name="ck_wms_pms_projection_sync_runs_upserted_non_negative",
+        ),
+        sa.CheckConstraint(
+            "pages >= 0",
+            name="ck_wms_pms_projection_sync_runs_pages_non_negative",
+        ),
+        sa.CheckConstraint(
+            "duration_ms IS NULL OR duration_ms >= 0",
+            name="ck_wms_pms_projection_sync_runs_duration_non_negative",
+        ),
+    )
+    op.create_index(
+        "ix_wms_pms_projection_sync_runs_resource_started_at",
+        "wms_pms_projection_sync_runs",
+        ["resource", "started_at"],
+    )
+    op.create_index(
+        "ix_wms_pms_projection_sync_runs_status",
+        "wms_pms_projection_sync_runs",
+        ["status"],
+    )
+
+    conn.execute(
+        sa.text(
+            """
+            DELETE FROM page_route_prefixes
+            WHERE route_prefix IN (
+              '/items',
+              '/item-barcodes',
+              '/item-uoms',
+              '/items/sku-coding',
+              '/pms/brands',
+              '/pms/categories',
+              '/pms/item-attribute-defs'
+            )
+               OR page_code = 'pms'
+               OR page_code LIKE 'pms.%'
+            """
+        )
+    )
+
+    conn.execute(
+        sa.text(
+            """
+            DELETE FROM page_registry
+            WHERE code IN (
+              'pms.item_barcodes',
+              'pms.item_uoms',
+              'pms.sku_coding',
+              'pms.item_attributes',
+              'pms.categories',
+              'pms.brands',
+              'pms.items'
+            )
+            """
+        )
+    )
+    conn.execute(sa.text("DELETE FROM page_registry WHERE code = 'pms'"))
+
+    conn.execute(
+        sa.text(
+            """
+            DELETE FROM permissions
+            WHERE name IN ('page.pms.read', 'page.pms.write')
+            """
+        )
+    )
+
+    for code, name, parent_code, level, sort_order in NEW_PAGE_ROWS:
+        conn.execute(
+            sa.text(
+                """
+                INSERT INTO page_registry (
+                  code,
+                  name,
+                  parent_code,
+                  level,
+                  domain_code,
+                  show_in_topbar,
+                  show_in_sidebar,
+                  inherit_permissions,
+                  read_permission_id,
+                  write_permission_id,
+                  sort_order,
+                  is_active
+                )
+                VALUES (
+                  :code,
+                  :name,
+                  :parent_code,
+                  :level,
+                  'admin',
+                  FALSE,
+                  TRUE,
+                  TRUE,
+                  NULL,
+                  NULL,
+                  :sort_order,
+                  TRUE
+                )
+                ON CONFLICT (code) DO UPDATE
+                SET
+                  name = EXCLUDED.name,
+                  parent_code = EXCLUDED.parent_code,
+                  level = EXCLUDED.level,
+                  domain_code = EXCLUDED.domain_code,
+                  show_in_topbar = EXCLUDED.show_in_topbar,
+                  show_in_sidebar = EXCLUDED.show_in_sidebar,
+                  inherit_permissions = EXCLUDED.inherit_permissions,
+                  read_permission_id = EXCLUDED.read_permission_id,
+                  write_permission_id = EXCLUDED.write_permission_id,
+                  sort_order = EXCLUDED.sort_order,
+                  is_active = EXCLUDED.is_active
+                """
+            ),
+            {
+                "code": code,
+                "name": name,
+                "parent_code": parent_code,
+                "level": level,
+                "sort_order": sort_order,
+            },
+        )
+
+    for page_code, route_prefix, sort_order in NEW_ROUTE_ROWS:
+        conn.execute(
+            sa.text(
+                """
+                INSERT INTO page_route_prefixes (
+                  page_code,
+                  route_prefix,
+                  sort_order,
+                  is_active
+                )
+                VALUES (
+                  :page_code,
+                  :route_prefix,
+                  :sort_order,
+                  TRUE
+                )
+                ON CONFLICT (route_prefix) DO UPDATE
+                SET
+                  page_code = EXCLUDED.page_code,
+                  sort_order = EXCLUDED.sort_order,
+                  is_active = EXCLUDED.is_active
+                """
+            ),
+            {
+                "page_code": page_code,
+                "route_prefix": route_prefix,
+                "sort_order": sort_order,
+            },
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    conn.execute(
+        sa.text(
+            """
+            DELETE FROM page_route_prefixes
+            WHERE route_prefix IN (
+              '/admin/pms-integration',
+              '/admin/pms-integration/items',
+              '/admin/pms-integration/suppliers',
+              '/admin/pms-integration/uoms',
+              '/admin/pms-integration/sku-codes',
+              '/admin/pms-integration/barcodes'
+            )
+               OR page_code = 'admin.pms_integration'
+               OR page_code LIKE 'admin.pms_integration.%'
+            """
+        )
+    )
+
+    conn.execute(sa.text("DELETE FROM page_registry WHERE code LIKE 'admin.pms_integration.%'"))
+    conn.execute(sa.text("DELETE FROM page_registry WHERE code = 'admin.pms_integration'"))
+
+    op.drop_index(
+        "ix_wms_pms_projection_sync_runs_status",
+        table_name="wms_pms_projection_sync_runs",
+    )
+    op.drop_index(
+        "ix_wms_pms_projection_sync_runs_resource_started_at",
+        table_name="wms_pms_projection_sync_runs",
+    )
+    op.drop_table("wms_pms_projection_sync_runs")
+
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO permissions (name)
+            VALUES ('page.pms.read'), ('page.pms.write')
+            ON CONFLICT (name) DO NOTHING
+            """
+        )
+    )
+
+    for code, name, parent_code, level, domain_code, show_in_topbar, show_in_sidebar, inherit_permissions, sort_order in OLD_PAGE_RESTORE_ROWS:
+        conn.execute(
+            sa.text(
+                """
+                INSERT INTO page_registry (
+                  code,
+                  name,
+                  parent_code,
+                  level,
+                  domain_code,
+                  show_in_topbar,
+                  show_in_sidebar,
+                  inherit_permissions,
+                  read_permission_id,
+                  write_permission_id,
+                  sort_order,
+                  is_active
+                )
+                VALUES (
+                  :code,
+                  :name,
+                  :parent_code,
+                  :level,
+                  :domain_code,
+                  :show_in_topbar,
+                  :show_in_sidebar,
+                  :inherit_permissions,
+                  CASE
+                    WHEN :inherit_permissions THEN NULL
+                    ELSE (SELECT id FROM permissions WHERE name = 'page.pms.read')
+                  END,
+                  CASE
+                    WHEN :inherit_permissions THEN NULL
+                    ELSE (SELECT id FROM permissions WHERE name = 'page.pms.write')
+                  END,
+                  :sort_order,
+                  TRUE
+                )
+                ON CONFLICT (code) DO UPDATE
+                SET
+                  name = EXCLUDED.name,
+                  parent_code = EXCLUDED.parent_code,
+                  level = EXCLUDED.level,
+                  domain_code = EXCLUDED.domain_code,
+                  show_in_topbar = EXCLUDED.show_in_topbar,
+                  show_in_sidebar = EXCLUDED.show_in_sidebar,
+                  inherit_permissions = EXCLUDED.inherit_permissions,
+                  read_permission_id = EXCLUDED.read_permission_id,
+                  write_permission_id = EXCLUDED.write_permission_id,
+                  sort_order = EXCLUDED.sort_order,
+                  is_active = EXCLUDED.is_active
+                """
+            ),
+            {
+                "code": code,
+                "name": name,
+                "parent_code": parent_code,
+                "level": level,
+                "domain_code": domain_code,
+                "show_in_topbar": show_in_topbar,
+                "show_in_sidebar": show_in_sidebar,
+                "inherit_permissions": inherit_permissions,
+                "sort_order": sort_order,
+            },
+        )
+
+    for page_code, route_prefix, sort_order in OLD_ROUTE_RESTORE_ROWS:
+        conn.execute(
+            sa.text(
+                """
+                INSERT INTO page_route_prefixes (
+                  page_code,
+                  route_prefix,
+                  sort_order,
+                  is_active
+                )
+                VALUES (
+                  :page_code,
+                  :route_prefix,
+                  :sort_order,
+                  TRUE
+                )
+                ON CONFLICT (route_prefix) DO UPDATE
+                SET
+                  page_code = EXCLUDED.page_code,
+                  sort_order = EXCLUDED.sort_order,
+                  is_active = EXCLUDED.is_active
+                """
+            ),
+            {
+                "page_code": page_code,
+                "route_prefix": route_prefix,
+                "sort_order": sort_order,
+            },
+        )
+
+    conn.execute(
+        sa.text(
+            """
+            WITH mappings AS (
+              SELECT 'page.admin.read' AS source_name, 'page.pms.read' AS target_name
+              UNION ALL
+              SELECT 'page.admin.write', 'page.pms.write'
+            ),
+            pairs AS (
+              SELECT DISTINCT
+                up.user_id AS user_id,
+                tp.id AS permission_id
+              FROM mappings m
+              JOIN permissions sp
+                ON sp.name = m.source_name
+              JOIN user_permissions up
+                ON up.permission_id = sp.id
+              JOIN permissions tp
+                ON tp.name = m.target_name
+            )
+            INSERT INTO user_permissions (user_id, permission_id)
+            SELECT user_id, permission_id
+            FROM pairs
+            ON CONFLICT (user_id, permission_id) DO NOTHING
+            """
+        )
+    )

--- a/app/admin/contracts/pms_integration.py
+++ b/app/admin/contracts/pms_integration.py
@@ -1,0 +1,91 @@
+# app/admin/contracts/pms_integration.py
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+ProjectionResource = Literal["items", "suppliers", "uoms", "sku-codes", "barcodes"]
+SyncRunStatus = Literal["RUNNING", "SUCCESS", "FAILED"]
+
+
+class PmsProjectionSyncRunOut(BaseModel):
+    id: int
+    resource: str
+    status: SyncRunStatus
+    fetched: int = 0
+    upserted: int = 0
+    pages: int = 0
+    started_at: datetime
+    finished_at: datetime | None = None
+    duration_ms: int | None = None
+    error_message: str | None = None
+    triggered_by_user_id: int | None = None
+    pms_api_base_url_snapshot: str | None = None
+    sync_version: str | None = None
+
+
+class PmsProjectionResourceStatusOut(BaseModel):
+    resource: ProjectionResource
+    table_name: str
+    row_count: int
+    max_synced_at: datetime | None = None
+    last_sync_run: PmsProjectionSyncRunOut | None = None
+
+
+class PmsProjectionIntegrationStatusOut(BaseModel):
+    pms_api_base_url_configured: bool
+    resources: list[PmsProjectionResourceStatusOut] = Field(default_factory=list)
+
+
+class PmsProjectionListOut(BaseModel):
+    resource: ProjectionResource
+    table_name: str
+    limit: int
+    offset: int
+    total: int
+    columns: list[str] = Field(default_factory=list)
+    rows: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class PmsProjectionSyncOut(BaseModel):
+    run: PmsProjectionSyncRunOut
+
+
+class PmsProjectionCheckIssueOut(BaseModel):
+    issue_type: str
+    resource: ProjectionResource
+    source_id: str
+    message: str
+    item_id: int | None = None
+    item_uom_id: int | None = None
+    supplier_id: int | None = None
+    projection_item_id: int | None = None
+
+
+class PmsProjectionCheckOut(BaseModel):
+    resource: ProjectionResource
+    ok: bool
+    issue_count: int
+    issues: list[PmsProjectionCheckIssueOut] = Field(default_factory=list)
+
+
+class PmsProjectionSyncRunsOut(BaseModel):
+    resource: ProjectionResource | None = None
+    limit: int
+    runs: list[PmsProjectionSyncRunOut] = Field(default_factory=list)
+
+
+__all__ = [
+    "PmsProjectionCheckIssueOut",
+    "PmsProjectionCheckOut",
+    "PmsProjectionIntegrationStatusOut",
+    "PmsProjectionListOut",
+    "PmsProjectionResourceStatusOut",
+    "PmsProjectionSyncOut",
+    "PmsProjectionSyncRunOut",
+    "PmsProjectionSyncRunsOut",
+    "ProjectionResource",
+    "SyncRunStatus",
+]

--- a/app/admin/router.py
+++ b/app/admin/router.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+from app.admin.routers.pms_integration import router as pms_integration_router
 from app.admin.routers.users import router as users_router
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 router.include_router(users_router)
+router.include_router(pms_integration_router)
 
 __all__ = ["router"]

--- a/app/admin/routers/pms_integration.py
+++ b/app/admin/routers/pms_integration.py
@@ -1,0 +1,103 @@
+# app/admin/routers/pms_integration.py
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.admin.contracts.pms_integration import (
+    PmsProjectionCheckOut,
+    PmsProjectionIntegrationStatusOut,
+    PmsProjectionListOut,
+    PmsProjectionSyncOut,
+    PmsProjectionSyncRunsOut,
+    ProjectionResource,
+)
+from app.admin.services.pms_integration_service import PmsIntegrationAdminService
+from app.db.session import get_db
+from app.integrations.pms.projection_sync import PmsProjectionSyncError
+from app.user.deps.auth import get_current_user
+from app.user.services.user_service import UserService
+
+router = APIRouter(prefix="/pms-integration", tags=["admin-pms-integration"])
+
+
+def _service(db: Session) -> PmsIntegrationAdminService:
+    return PmsIntegrationAdminService(db)
+
+
+@router.get("/status", response_model=PmsProjectionIntegrationStatusOut)
+def get_pms_projection_sync_status(
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    svc = UserService(db)
+    svc.check_permission(current_user, ["page.admin.read"])
+    return _service(db).get_status()
+
+
+@router.get("/sync-runs", response_model=PmsProjectionSyncRunsOut)
+def list_pms_projection_sync_runs(
+    resource: ProjectionResource | None = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=100),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    svc = UserService(db)
+    svc.check_permission(current_user, ["page.admin.read"])
+    return _service(db).list_sync_runs(resource=resource, limit=limit)
+
+
+@router.get("/projections/{resource}", response_model=PmsProjectionListOut)
+def list_pms_projection_rows(
+    resource: ProjectionResource,
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    q: str | None = Query(default=None),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    svc = UserService(db)
+    svc.check_permission(current_user, ["page.admin.read"])
+    return _service(db).list_projection(
+        resource=resource,
+        limit=limit,
+        offset=offset,
+        q=q,
+    )
+
+
+@router.post("/projections/{resource}/sync", response_model=PmsProjectionSyncOut)
+async def sync_pms_projection_resource(
+    resource: ProjectionResource,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    svc = UserService(db)
+    svc.check_permission(current_user, ["page.admin.write"])
+
+    try:
+        run = await _service(db).sync_resource(
+            resource=resource,
+            triggered_by_user_id=int(getattr(current_user, "id")),
+        )
+    except (RuntimeError, PmsProjectionSyncError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"PMS projection sync failed: {exc}")
+
+    return {"run": run}
+
+
+@router.post("/projections/{resource}/check", response_model=PmsProjectionCheckOut)
+def check_pms_projection_resource(
+    resource: ProjectionResource,
+    limit: int = Query(default=200, ge=1, le=1000),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    svc = UserService(db)
+    svc.check_permission(current_user, ["page.admin.read"])
+    return _service(db).check_projection(resource=resource, limit=limit)
+
+
+__all__ = ["router"]

--- a/app/admin/services/pms_integration_service.py
+++ b/app/admin/services/pms_integration_service.py
@@ -1,0 +1,739 @@
+# app/admin/services/pms_integration_service.py
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.admin.contracts.pms_integration import ProjectionResource
+from app.db.session import AsyncSessionLocal
+from app.integrations.pms.projection_sync import (
+    SYNC_VERSION,
+    PmsProjectionSyncResult,
+    sync_pms_read_projection_once,
+)
+
+SyncCallable = Callable[..., Coroutine[Any, Any, PmsProjectionSyncResult]]
+
+
+@dataclass(frozen=True)
+class ProjectionResourceConfig:
+    resource: ProjectionResource
+    table_name: str
+    id_column: str
+    columns: tuple[str, ...]
+    searchable_columns: tuple[str, ...]
+
+
+RESOURCE_CONFIGS: dict[ProjectionResource, ProjectionResourceConfig] = {
+    "items": ProjectionResourceConfig(
+        resource="items",
+        table_name="wms_pms_item_projection",
+        id_column="item_id",
+        columns=(
+            "item_id",
+            "sku",
+            "name",
+            "spec",
+            "enabled",
+            "supplier_id",
+            "brand",
+            "category",
+            "expiry_policy",
+            "shelf_life_value",
+            "shelf_life_unit",
+            "lot_source_policy",
+            "derivation_allowed",
+            "uom_governance_enabled",
+            "pms_updated_at",
+            "source_hash",
+            "sync_version",
+            "synced_at",
+        ),
+        searchable_columns=("sku", "name", "spec", "brand", "category"),
+    ),
+    "suppliers": ProjectionResourceConfig(
+        resource="suppliers",
+        table_name="wms_pms_supplier_projection",
+        id_column="supplier_id",
+        columns=(
+            "supplier_id",
+            "supplier_code",
+            "supplier_name",
+            "active",
+            "website",
+            "pms_updated_at",
+            "source_hash",
+            "sync_version",
+            "synced_at",
+        ),
+        searchable_columns=("supplier_code", "supplier_name", "website"),
+    ),
+    "uoms": ProjectionResourceConfig(
+        resource="uoms",
+        table_name="wms_pms_uom_projection",
+        id_column="item_uom_id",
+        columns=(
+            "item_uom_id",
+            "item_id",
+            "uom",
+            "display_name",
+            "uom_name",
+            "ratio_to_base",
+            "net_weight_kg",
+            "is_base",
+            "is_purchase_default",
+            "is_inbound_default",
+            "is_outbound_default",
+            "pms_updated_at",
+            "source_hash",
+            "sync_version",
+            "synced_at",
+        ),
+        searchable_columns=("uom", "display_name", "uom_name"),
+    ),
+    "sku-codes": ProjectionResourceConfig(
+        resource="sku-codes",
+        table_name="wms_pms_sku_code_projection",
+        id_column="sku_code_id",
+        columns=(
+            "sku_code_id",
+            "item_id",
+            "sku_code",
+            "code_type",
+            "is_primary",
+            "is_active",
+            "effective_from",
+            "effective_to",
+            "pms_updated_at",
+            "source_hash",
+            "sync_version",
+            "synced_at",
+        ),
+        searchable_columns=("sku_code", "code_type"),
+    ),
+    "barcodes": ProjectionResourceConfig(
+        resource="barcodes",
+        table_name="wms_pms_barcode_projection",
+        id_column="barcode_id",
+        columns=(
+            "barcode_id",
+            "item_id",
+            "item_uom_id",
+            "barcode",
+            "symbology",
+            "active",
+            "is_primary",
+            "pms_updated_at",
+            "source_hash",
+            "sync_version",
+            "synced_at",
+        ),
+        searchable_columns=("barcode", "symbology"),
+    ),
+}
+
+RESOURCE_ORDER: tuple[ProjectionResource, ...] = (
+    "items",
+    "suppliers",
+    "uoms",
+    "sku-codes",
+    "barcodes",
+)
+
+
+class PmsIntegrationAdminService:
+    """
+    WMS admin operations for PMS projection sync.
+
+    Boundary:
+    - Reads WMS projection tables and WMS sync-run logs only.
+    - Triggers projection_sync, which reads pms-api read-v1 HTTP feed.
+    - Does not manage PMS authorization clients or secrets.
+    - Must not read or write PMS owner tables.
+    """
+
+    def __init__(
+        self,
+        db: Session,
+        *,
+        sync_callable: SyncCallable = sync_pms_read_projection_once,
+    ) -> None:
+        self.db = db
+        self._sync_callable = sync_callable
+
+    @staticmethod
+    def _config(resource: ProjectionResource) -> ProjectionResourceConfig:
+        try:
+            return RESOURCE_CONFIGS[resource]
+        except KeyError as exc:
+            raise ValueError(f"unsupported PMS projection resource: {resource}") from exc
+
+    @staticmethod
+    def _safe_limit(value: int, *, default: int = 50, max_value: int = 500) -> int:
+        try:
+            number = int(value)
+        except (TypeError, ValueError):
+            number = default
+        return max(1, min(number, max_value))
+
+    @staticmethod
+    def _safe_offset(value: int) -> int:
+        try:
+            number = int(value)
+        except (TypeError, ValueError):
+            number = 0
+        return max(0, number)
+
+    @staticmethod
+    def _pms_api_base_url_snapshot() -> str | None:
+        value = (os.getenv("PMS_API_BASE_URL") or "").strip().rstrip("/")
+        return value or None
+
+    @staticmethod
+    def _jsonable(value: Any) -> Any:
+        if isinstance(value, Decimal):
+            return str(value)
+        return value
+
+    def _sync_run_from_row(self, row: Any) -> dict[str, Any]:
+        data = dict(row)
+        return {
+            "id": int(data["id"]),
+            "resource": str(data["resource"]),
+            "status": str(data["status"]),
+            "fetched": int(data.get("fetched") or 0),
+            "upserted": int(data.get("upserted") or 0),
+            "pages": int(data.get("pages") or 0),
+            "started_at": data["started_at"],
+            "finished_at": data.get("finished_at"),
+            "duration_ms": (
+                int(data["duration_ms"]) if data.get("duration_ms") is not None else None
+            ),
+            "error_message": data.get("error_message"),
+            "triggered_by_user_id": (
+                int(data["triggered_by_user_id"])
+                if data.get("triggered_by_user_id") is not None
+                else None
+            ),
+            "pms_api_base_url_snapshot": data.get("pms_api_base_url_snapshot"),
+            "sync_version": data.get("sync_version"),
+        }
+
+    def _latest_sync_runs(self) -> dict[str, dict[str, Any]]:
+        rows = (
+            self.db.execute(
+                text(
+                    """
+                    SELECT DISTINCT ON (resource)
+                        id,
+                        resource,
+                        status,
+                        fetched,
+                        upserted,
+                        pages,
+                        started_at,
+                        finished_at,
+                        duration_ms,
+                        error_message,
+                        triggered_by_user_id,
+                        pms_api_base_url_snapshot,
+                        sync_version
+                    FROM wms_pms_projection_sync_runs
+                    WHERE resource IN ('items', 'suppliers', 'uoms', 'sku-codes', 'barcodes')
+                    ORDER BY resource, started_at DESC, id DESC
+                    """
+                )
+            )
+            .mappings()
+            .all()
+        )
+        return {str(row["resource"]): self._sync_run_from_row(row) for row in rows}
+
+    def get_status(self) -> dict[str, Any]:
+        latest_runs = self._latest_sync_runs()
+        resources: list[dict[str, Any]] = []
+
+        for resource in RESOURCE_ORDER:
+            cfg = self._config(resource)
+            row = (
+                self.db.execute(
+                    text(
+                        f"""
+                        SELECT
+                            count(*)::bigint AS row_count,
+                            max(synced_at) AS max_synced_at
+                        FROM {cfg.table_name}
+                        """
+                    )
+                )
+                .mappings()
+                .one()
+            )
+            resources.append(
+                {
+                    "resource": resource,
+                    "table_name": cfg.table_name,
+                    "row_count": int(row["row_count"] or 0),
+                    "max_synced_at": row["max_synced_at"],
+                    "last_sync_run": latest_runs.get(resource),
+                }
+            )
+
+        return {
+            "pms_api_base_url_configured": self._pms_api_base_url_snapshot() is not None,
+            "resources": resources,
+        }
+
+    def list_projection(
+        self,
+        *,
+        resource: ProjectionResource,
+        limit: int,
+        offset: int,
+        q: str | None = None,
+    ) -> dict[str, Any]:
+        cfg = self._config(resource)
+        safe_limit = self._safe_limit(limit)
+        safe_offset = self._safe_offset(offset)
+
+        where_sql = ""
+        params: dict[str, Any] = {"limit": safe_limit, "offset": safe_offset}
+        query_text = (q or "").strip()
+        if query_text and cfg.searchable_columns:
+            where_parts = [
+                f"CAST({column} AS TEXT) ILIKE :q"
+                for column in cfg.searchable_columns
+            ]
+            where_sql = "WHERE " + " OR ".join(where_parts)
+            params["q"] = f"%{query_text}%"
+
+        total = int(
+            self.db.execute(
+                text(f"SELECT count(*)::bigint FROM {cfg.table_name} {where_sql}"),
+                params,
+            ).scalar_one()
+        )
+
+        columns_sql = ", ".join(cfg.columns)
+        rows = (
+            self.db.execute(
+                text(
+                    f"""
+                    SELECT {columns_sql}
+                    FROM {cfg.table_name}
+                    {where_sql}
+                    ORDER BY {cfg.id_column} ASC
+                    LIMIT :limit OFFSET :offset
+                    """
+                ),
+                params,
+            )
+            .mappings()
+            .all()
+        )
+
+        return {
+            "resource": resource,
+            "table_name": cfg.table_name,
+            "limit": safe_limit,
+            "offset": safe_offset,
+            "total": total,
+            "columns": list(cfg.columns),
+            "rows": [
+                {key: self._jsonable(value) for key, value in dict(row).items()}
+                for row in rows
+            ],
+        }
+
+    def _create_sync_run(
+        self,
+        *,
+        resource: ProjectionResource,
+        triggered_by_user_id: int | None,
+    ) -> int:
+        row = (
+            self.db.execute(
+                text(
+                    """
+                    INSERT INTO wms_pms_projection_sync_runs (
+                        resource,
+                        status,
+                        fetched,
+                        upserted,
+                        pages,
+                        started_at,
+                        triggered_by_user_id,
+                        pms_api_base_url_snapshot,
+                        sync_version
+                    )
+                    VALUES (
+                        :resource,
+                        'RUNNING',
+                        0,
+                        0,
+                        0,
+                        now(),
+                        :triggered_by_user_id,
+                        :pms_api_base_url_snapshot,
+                        :sync_version
+                    )
+                    RETURNING id
+                    """
+                ),
+                {
+                    "resource": resource,
+                    "triggered_by_user_id": triggered_by_user_id,
+                    "pms_api_base_url_snapshot": self._pms_api_base_url_snapshot(),
+                    "sync_version": SYNC_VERSION,
+                },
+            )
+            .mappings()
+            .one()
+        )
+        self.db.commit()
+        return int(row["id"])
+
+    def _finish_sync_run(
+        self,
+        *,
+        run_id: int,
+        status: str,
+        started_monotonic: float,
+        fetched: int = 0,
+        upserted: int = 0,
+        pages: int = 0,
+        error_message: str | None = None,
+    ) -> dict[str, Any]:
+        duration_ms = int((time.monotonic() - started_monotonic) * 1000)
+        row = (
+            self.db.execute(
+                text(
+                    """
+                    UPDATE wms_pms_projection_sync_runs
+                       SET status = :status,
+                           fetched = :fetched,
+                           upserted = :upserted,
+                           pages = :pages,
+                           finished_at = now(),
+                           duration_ms = :duration_ms,
+                           error_message = :error_message
+                     WHERE id = :run_id
+                    RETURNING
+                        id,
+                        resource,
+                        status,
+                        fetched,
+                        upserted,
+                        pages,
+                        started_at,
+                        finished_at,
+                        duration_ms,
+                        error_message,
+                        triggered_by_user_id,
+                        pms_api_base_url_snapshot,
+                        sync_version
+                    """
+                ),
+                {
+                    "run_id": int(run_id),
+                    "status": status,
+                    "fetched": int(fetched),
+                    "upserted": int(upserted),
+                    "pages": int(pages),
+                    "duration_ms": duration_ms,
+                    "error_message": error_message,
+                },
+            )
+            .mappings()
+            .one()
+        )
+        self.db.commit()
+        return self._sync_run_from_row(row)
+
+    async def sync_resource(
+        self,
+        *,
+        resource: ProjectionResource,
+        triggered_by_user_id: int | None,
+    ) -> dict[str, Any]:
+        self._config(resource)
+        started_monotonic = time.monotonic()
+        run_id = self._create_sync_run(
+            resource=resource,
+            triggered_by_user_id=triggered_by_user_id,
+        )
+
+        try:
+            async with AsyncSessionLocal() as async_session:
+                result = await self._sync_callable(
+                    async_session,
+                    resources=[resource],
+                )
+                await async_session.commit()
+
+            resource_result = result.resources[resource]
+            return self._finish_sync_run(
+                run_id=run_id,
+                status="SUCCESS",
+                started_monotonic=started_monotonic,
+                fetched=resource_result.fetched,
+                upserted=resource_result.upserted,
+                pages=resource_result.pages,
+                error_message=None,
+            )
+        except Exception as exc:
+            self._finish_sync_run(
+                run_id=run_id,
+                status="FAILED",
+                started_monotonic=started_monotonic,
+                error_message=str(exc),
+            )
+            raise
+
+    def list_sync_runs(
+        self,
+        *,
+        resource: ProjectionResource | None,
+        limit: int,
+    ) -> dict[str, Any]:
+        safe_limit = self._safe_limit(limit, default=20, max_value=100)
+        params: dict[str, Any] = {"limit": safe_limit}
+        where_sql = ""
+        if resource is not None:
+            self._config(resource)
+            where_sql = "WHERE resource = :resource"
+            params["resource"] = resource
+
+        rows = (
+            self.db.execute(
+                text(
+                    f"""
+                    SELECT
+                        id,
+                        resource,
+                        status,
+                        fetched,
+                        upserted,
+                        pages,
+                        started_at,
+                        finished_at,
+                        duration_ms,
+                        error_message,
+                        triggered_by_user_id,
+                        pms_api_base_url_snapshot,
+                        sync_version
+                    FROM wms_pms_projection_sync_runs
+                    {where_sql}
+                    ORDER BY started_at DESC, id DESC
+                    LIMIT :limit
+                    """
+                ),
+                params,
+            )
+            .mappings()
+            .all()
+        )
+
+        return {
+            "resource": resource,
+            "limit": safe_limit,
+            "runs": [self._sync_run_from_row(row) for row in rows],
+        }
+
+    def check_projection(
+        self,
+        *,
+        resource: ProjectionResource,
+        limit: int = 200,
+    ) -> dict[str, Any]:
+        self._config(resource)
+        safe_limit = self._safe_limit(limit, default=200, max_value=1000)
+
+        if resource == "items":
+            rows = self._check_items(safe_limit)
+        elif resource == "suppliers":
+            rows = []
+        elif resource == "uoms":
+            rows = self._check_uoms(safe_limit)
+        elif resource == "sku-codes":
+            rows = self._check_sku_codes(safe_limit)
+        elif resource == "barcodes":
+            rows = self._check_barcodes(safe_limit)
+        else:
+            raise ValueError(f"unsupported PMS projection resource: {resource}")
+
+        return {
+            "resource": resource,
+            "ok": len(rows) == 0,
+            "issue_count": len(rows),
+            "issues": rows,
+        }
+
+    def _check_items(self, limit: int) -> list[dict[str, Any]]:
+        rows = (
+            self.db.execute(
+                text(
+                    """
+                    SELECT
+                        i.item_id,
+                        i.supplier_id
+                    FROM wms_pms_item_projection AS i
+                    LEFT JOIN wms_pms_supplier_projection AS s
+                      ON s.supplier_id = i.supplier_id
+                    WHERE i.supplier_id IS NOT NULL
+                      AND s.supplier_id IS NULL
+                    ORDER BY i.item_id ASC
+                    LIMIT :limit
+                    """
+                ),
+                {"limit": int(limit)},
+            )
+            .mappings()
+            .all()
+        )
+        return [
+            {
+                "issue_type": "ITEM_SUPPLIER_MISSING_IN_PROJECTION",
+                "resource": "items",
+                "source_id": str(row["item_id"]),
+                "message": "商品投影中的 supplier_id 在供应商投影中不存在",
+                "item_id": int(row["item_id"]),
+                "supplier_id": int(row["supplier_id"]),
+            }
+            for row in rows
+        ]
+
+    def _check_uoms(self, limit: int) -> list[dict[str, Any]]:
+        rows = (
+            self.db.execute(
+                text(
+                    """
+                    SELECT
+                        u.item_uom_id,
+                        u.item_id
+                    FROM wms_pms_uom_projection AS u
+                    LEFT JOIN wms_pms_item_projection AS i
+                      ON i.item_id = u.item_id
+                    WHERE i.item_id IS NULL
+                    ORDER BY u.item_uom_id ASC
+                    LIMIT :limit
+                    """
+                ),
+                {"limit": int(limit)},
+            )
+            .mappings()
+            .all()
+        )
+        return [
+            {
+                "issue_type": "UOM_ITEM_MISSING_IN_PROJECTION",
+                "resource": "uoms",
+                "source_id": str(row["item_uom_id"]),
+                "message": "包装单位投影中的 item_id 在商品投影中不存在",
+                "item_id": int(row["item_id"]),
+                "item_uom_id": int(row["item_uom_id"]),
+            }
+            for row in rows
+        ]
+
+    def _check_sku_codes(self, limit: int) -> list[dict[str, Any]]:
+        rows = (
+            self.db.execute(
+                text(
+                    """
+                    SELECT
+                        s.sku_code_id,
+                        s.item_id
+                    FROM wms_pms_sku_code_projection AS s
+                    LEFT JOIN wms_pms_item_projection AS i
+                      ON i.item_id = s.item_id
+                    WHERE i.item_id IS NULL
+                    ORDER BY s.sku_code_id ASC
+                    LIMIT :limit
+                    """
+                ),
+                {"limit": int(limit)},
+            )
+            .mappings()
+            .all()
+        )
+        return [
+            {
+                "issue_type": "SKU_CODE_ITEM_MISSING_IN_PROJECTION",
+                "resource": "sku-codes",
+                "source_id": str(row["sku_code_id"]),
+                "message": "SKU 编码投影中的 item_id 在商品投影中不存在",
+                "item_id": int(row["item_id"]),
+            }
+            for row in rows
+        ]
+
+    def _check_barcodes(self, limit: int) -> list[dict[str, Any]]:
+        rows = (
+            self.db.execute(
+                text(
+                    """
+                    SELECT
+                        b.barcode_id,
+                        b.item_id,
+                        b.item_uom_id,
+                        u.item_id AS projection_item_id,
+                        CASE
+                          WHEN i.item_id IS NULL THEN 'BARCODE_ITEM_MISSING_IN_PROJECTION'
+                          WHEN u.item_uom_id IS NULL THEN 'BARCODE_UOM_MISSING_IN_PROJECTION'
+                          WHEN u.item_id <> b.item_id THEN 'BARCODE_UOM_ITEM_MISMATCH'
+                          ELSE 'OK'
+                        END AS issue_type
+                    FROM wms_pms_barcode_projection AS b
+                    LEFT JOIN wms_pms_item_projection AS i
+                      ON i.item_id = b.item_id
+                    LEFT JOIN wms_pms_uom_projection AS u
+                      ON u.item_uom_id = b.item_uom_id
+                    WHERE i.item_id IS NULL
+                       OR u.item_uom_id IS NULL
+                       OR u.item_id <> b.item_id
+                    ORDER BY b.barcode_id ASC
+                    LIMIT :limit
+                    """
+                ),
+                {"limit": int(limit)},
+            )
+            .mappings()
+            .all()
+        )
+
+        messages = {
+            "BARCODE_ITEM_MISSING_IN_PROJECTION": "条码投影中的 item_id 在商品投影中不存在",
+            "BARCODE_UOM_MISSING_IN_PROJECTION": "条码投影中的 item_uom_id 在包装单位投影中不存在",
+            "BARCODE_UOM_ITEM_MISMATCH": "条码投影中的 item_id 与包装单位投影所属 item_id 不一致",
+        }
+        return [
+            {
+                "issue_type": str(row["issue_type"]),
+                "resource": "barcodes",
+                "source_id": str(row["barcode_id"]),
+                "message": messages.get(str(row["issue_type"]), "条码投影一致性异常"),
+                "item_id": int(row["item_id"]),
+                "item_uom_id": int(row["item_uom_id"]),
+                "projection_item_id": (
+                    int(row["projection_item_id"])
+                    if row["projection_item_id"] is not None
+                    else None
+                ),
+            }
+            for row in rows
+        ]
+
+
+__all__ = [
+    "PmsIntegrationAdminService",
+    "RESOURCE_CONFIGS",
+    "RESOURCE_ORDER",
+]

--- a/app/integrations/pms/projection_models.py
+++ b/app/integrations/pms/projection_models.py
@@ -311,9 +311,94 @@ class WmsPmsBarcodeProjection(Base):
     )
 
 
+class WmsPmsProjectionSyncRun(Base):
+    __tablename__ = "wms_pms_projection_sync_runs"
+    __table_args__ = (
+        sa.CheckConstraint(
+            "resource IN ('items', 'suppliers', 'uoms', 'sku-codes', 'barcodes', 'all')",
+            name="ck_wms_pms_projection_sync_runs_resource",
+        ),
+        sa.CheckConstraint(
+            "status IN ('RUNNING', 'SUCCESS', 'FAILED')",
+            name="ck_wms_pms_projection_sync_runs_status",
+        ),
+        sa.CheckConstraint(
+            "fetched >= 0",
+            name="ck_wms_pms_projection_sync_runs_fetched_non_negative",
+        ),
+        sa.CheckConstraint(
+            "upserted >= 0",
+            name="ck_wms_pms_projection_sync_runs_upserted_non_negative",
+        ),
+        sa.CheckConstraint(
+            "pages >= 0",
+            name="ck_wms_pms_projection_sync_runs_pages_non_negative",
+        ),
+        sa.CheckConstraint(
+            "duration_ms IS NULL OR duration_ms >= 0",
+            name="ck_wms_pms_projection_sync_runs_duration_non_negative",
+        ),
+        sa.Index(
+            "ix_wms_pms_projection_sync_runs_resource_started_at",
+            "resource",
+            "started_at",
+        ),
+        sa.Index("ix_wms_pms_projection_sync_runs_status", "status"),
+        {"info": {"owner": "wms-api", "projection_sync_log": True}},
+    )
+
+    id: Mapped[int] = mapped_column(sa.BigInteger, primary_key=True, autoincrement=True)
+    resource: Mapped[str] = mapped_column(sa.String(32), nullable=False)
+    status: Mapped[str] = mapped_column(sa.String(16), nullable=False)
+
+    fetched: Mapped[int] = mapped_column(
+        sa.Integer,
+        nullable=False,
+        server_default=sa.text("0"),
+    )
+    upserted: Mapped[int] = mapped_column(
+        sa.Integer,
+        nullable=False,
+        server_default=sa.text("0"),
+    )
+    pages: Mapped[int] = mapped_column(
+        sa.Integer,
+        nullable=False,
+        server_default=sa.text("0"),
+    )
+
+    started_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    finished_at: Mapped[datetime | None] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=True,
+    )
+    duration_ms: Mapped[int | None] = mapped_column(sa.Integer, nullable=True)
+    error_message: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
+
+    triggered_by_user_id: Mapped[int | None] = mapped_column(
+        sa.Integer,
+        sa.ForeignKey(
+            "users.id",
+            name="fk_wms_pms_projection_sync_runs_triggered_by_user_id_users",
+            ondelete="SET NULL",
+        ),
+        nullable=True,
+    )
+    pms_api_base_url_snapshot: Mapped[str | None] = mapped_column(
+        sa.String(512),
+        nullable=True,
+    )
+    sync_version: Mapped[str | None] = mapped_column(sa.String(64), nullable=True)
+
+
 __all__ = [
     "WmsPmsBarcodeProjection",
     "WmsPmsItemProjection",
+    "WmsPmsProjectionSyncRun",
     "WmsPmsSkuCodeProjection",
     "WmsPmsSupplierProjection",
     "WmsPmsUomProjection",

--- a/tests/api/test_admin_pms_integration_api.py
+++ b/tests/api/test_admin_pms_integration_api.py
@@ -1,0 +1,172 @@
+# tests/api/test_admin_pms_integration_api.py
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def _login_admin_headers(client: AsyncClient) -> dict[str, str]:
+    r = await client.post("/users/login", json={"username": "admin", "password": "admin123"})
+    assert r.status_code == 200, r.text
+    token = r.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_admin_pms_integration_status_lists_projection_resources(
+    client: AsyncClient,
+) -> None:
+    headers = await _login_admin_headers(client)
+
+    r = await client.get("/admin/pms-integration/status", headers=headers)
+    assert r.status_code == 200, r.text
+
+    data = r.json()
+    assert data["pms_api_base_url_configured"] in {True, False}
+
+    resources = {row["resource"]: row for row in data["resources"]}
+    assert list(resources.keys()) == [
+        "items",
+        "suppliers",
+        "uoms",
+        "sku-codes",
+        "barcodes",
+    ]
+
+    assert resources["items"]["table_name"] == "wms_pms_item_projection"
+    assert resources["suppliers"]["table_name"] == "wms_pms_supplier_projection"
+    assert resources["uoms"]["table_name"] == "wms_pms_uom_projection"
+    assert resources["sku-codes"]["table_name"] == "wms_pms_sku_code_projection"
+    assert resources["barcodes"]["table_name"] == "wms_pms_barcode_projection"
+
+    for row in resources.values():
+        assert isinstance(row["row_count"], int)
+        assert row["row_count"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_admin_pms_integration_can_list_projection_rows(
+    client: AsyncClient,
+) -> None:
+    headers = await _login_admin_headers(client)
+
+    r = await client.get(
+        "/admin/pms-integration/projections/items?limit=5&offset=0",
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+
+    data = r.json()
+    assert data["resource"] == "items"
+    assert data["table_name"] == "wms_pms_item_projection"
+    assert data["limit"] == 5
+    assert data["offset"] == 0
+    assert data["total"] >= 0
+    assert "item_id" in data["columns"]
+    assert "sku" in data["columns"]
+    assert isinstance(data["rows"], list)
+
+
+@pytest.mark.asyncio
+async def test_admin_pms_integration_can_check_barcode_projection(
+    client: AsyncClient,
+) -> None:
+    headers = await _login_admin_headers(client)
+
+    r = await client.post(
+        "/admin/pms-integration/projections/barcodes/check",
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+
+    data = r.json()
+    assert data["resource"] == "barcodes"
+    assert isinstance(data["ok"], bool)
+    assert isinstance(data["issue_count"], int)
+    assert isinstance(data["issues"], list)
+
+
+@pytest.mark.asyncio
+async def test_admin_pms_integration_sync_without_pms_base_url_returns_400_and_logs_failed_run(
+    client: AsyncClient,
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PMS_API_BASE_URL", raising=False)
+    headers = await _login_admin_headers(client)
+
+    r = await client.post(
+        "/admin/pms-integration/projections/items/sync",
+        headers=headers,
+    )
+    assert r.status_code == 400, r.text
+    assert "PMS_API_BASE_URL" in r.text
+
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT resource, status, error_message
+                FROM wms_pms_projection_sync_runs
+                WHERE resource = 'items'
+                ORDER BY id DESC
+                LIMIT 1
+                """
+            )
+        )
+    ).mappings().one()
+
+    assert row["resource"] == "items"
+    assert row["status"] == "FAILED"
+    assert "PMS_API_BASE_URL" in str(row["error_message"])
+
+
+@pytest.mark.asyncio
+async def test_admin_pms_integration_sync_runs_can_be_listed(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_pms_projection_sync_runs (
+                resource,
+                status,
+                fetched,
+                upserted,
+                pages,
+                started_at,
+                finished_at,
+                duration_ms,
+                sync_version
+            )
+            VALUES (
+                'suppliers',
+                'SUCCESS',
+                2,
+                2,
+                1,
+                now(),
+                now(),
+                10,
+                'ut-sync-run'
+            )
+            """
+        )
+    )
+    await session.commit()
+
+    headers = await _login_admin_headers(client)
+    r = await client.get(
+        "/admin/pms-integration/sync-runs?resource=suppliers&limit=5",
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+
+    data = r.json()
+    assert data["resource"] == "suppliers"
+    assert data["limit"] == 5
+    assert data["runs"]
+    assert data["runs"][0]["resource"] == "suppliers"

--- a/tests/api/test_user_navigation_api.py
+++ b/tests/api/test_user_navigation_api.py
@@ -312,7 +312,6 @@ async def test_my_navigation_admin_contains_new_wms_tree_and_filters_legacy_shel
     assert "wms.masterdata.warehouses" not in nodes
 
 
-
 @pytest.mark.asyncio
 async def test_my_navigation_retired_partners_supplier_owner_is_absent(client: AsyncClient) -> None:
     headers = await _login_admin_headers(client)
@@ -330,8 +329,11 @@ async def test_my_navigation_retired_partners_supplier_owner_is_absent(client: A
     assert "/partners/suppliers" not in route_map
     assert "/suppliers" not in route_map
 
+
 @pytest.mark.asyncio
-async def test_my_navigation_item_barcodes_page_is_under_pms(client: AsyncClient) -> None:
+async def test_my_navigation_pms_projection_sync_admin_tree_replaces_old_pms_owner_tree(
+    client: AsyncClient,
+) -> None:
     headers = await _login_admin_headers(client)
 
     r = await client.get("/users/me/navigation", headers=headers)
@@ -339,15 +341,84 @@ async def test_my_navigation_item_barcodes_page_is_under_pms(client: AsyncClient
 
     data = r.json()
     nodes = _walk_pages(data["pages"])
+    route_map = _index_route_prefixes(data["route_prefixes"])
 
-    item_barcodes = nodes.get("pms.item_barcodes")
-    assert item_barcodes is not None, "pms.item_barcodes should exist"
+    old_pms_page_codes = [
+        "pms",
+        "pms.items",
+        "pms.brands",
+        "pms.categories",
+        "pms.item_attributes",
+        "pms.sku_coding",
+        "pms.item_barcodes",
+        "pms.item_uoms",
+    ]
+    for code in old_pms_page_codes:
+        assert code not in nodes
 
-    assert item_barcodes["parent_code"] == "pms"
-    assert item_barcodes["domain_code"] == "pms"
-    assert item_barcodes["effective_read_permission"] == "page.pms.read"
-    assert item_barcodes["effective_write_permission"] == "page.pms.write"
+    old_pms_route_prefixes = [
+        "/items",
+        "/item-barcodes",
+        "/item-uoms",
+        "/items/sku-coding",
+        "/pms/brands",
+        "/pms/categories",
+        "/pms/item-attribute-defs",
+    ]
+    for route_prefix in old_pms_route_prefixes:
+        assert route_prefix not in route_map
 
+    admin = nodes["admin"]
+    assert "admin.users" in _child_codes(admin)
+    assert "admin.pms_integration" in _child_codes(admin)
+
+    pms_integration = nodes["admin.pms_integration"]
+    assert pms_integration["name"] == "PMS 接入管理"
+    assert pms_integration["parent_code"] == "admin"
+    assert pms_integration["domain_code"] == "admin"
+    assert pms_integration["effective_read_permission"] == "page.admin.read"
+    assert pms_integration["effective_write_permission"] == "page.admin.write"
+
+    assert _child_codes(pms_integration) == [
+        "admin.pms_integration.items",
+        "admin.pms_integration.suppliers",
+        "admin.pms_integration.uoms",
+        "admin.pms_integration.sku_codes",
+        "admin.pms_integration.barcodes",
+    ]
+
+    expected_names = {
+        "admin.pms_integration.items": "商品投影",
+        "admin.pms_integration.suppliers": "供应商投影",
+        "admin.pms_integration.uoms": "包装单位投影",
+        "admin.pms_integration.sku_codes": "SKU 编码投影",
+        "admin.pms_integration.barcodes": "条码投影",
+    }
+    for code, name in expected_names.items():
+        node = nodes[code]
+        assert node["name"] == name
+        assert node["parent_code"] == "admin.pms_integration"
+        assert node["domain_code"] == "admin"
+        assert node["effective_read_permission"] == "page.admin.read"
+        assert node["effective_write_permission"] == "page.admin.write"
+
+    expected_route_map = {
+        "/admin/pms-integration": "admin.pms_integration",
+        "/admin/pms-integration/items": "admin.pms_integration.items",
+        "/admin/pms-integration/suppliers": "admin.pms_integration.suppliers",
+        "/admin/pms-integration/uoms": "admin.pms_integration.uoms",
+        "/admin/pms-integration/sku-codes": "admin.pms_integration.sku_codes",
+        "/admin/pms-integration/barcodes": "admin.pms_integration.barcodes",
+    }
+    for route_prefix, page_code in expected_route_map.items():
+        route = route_map.get(route_prefix)
+        assert route is not None, f"{route_prefix} should exist in route_prefixes"
+        assert route["page_code"] == page_code
+        assert route["effective_read_permission"] == "page.admin.read"
+        assert route["effective_write_permission"] == "page.admin.write"
+
+    assert "/admin/pms-integration/connection" not in route_map
+    assert "admin.pms_integration.connection" not in nodes
 
 
 @pytest.mark.asyncio
@@ -363,28 +434,38 @@ async def test_my_navigation_route_prefix_mapping_and_effective_permissions(clie
 
     shipping_handoffs_page = nodes["shipping_assist.handoffs"]
     shipping_records_page = nodes["shipping_assist.records"]
-    items_page = nodes["pms.items"]
+    pms_integration_page = nodes["admin.pms_integration"]
+    pms_items_projection_page = nodes["admin.pms_integration.items"]
 
     assert shipping_handoffs_page["effective_read_permission"]
     assert shipping_handoffs_page["effective_write_permission"]
     assert shipping_records_page["effective_read_permission"]
     assert shipping_records_page["effective_write_permission"]
-    assert items_page["effective_read_permission"]
-    assert items_page["effective_write_permission"]
+    assert pms_integration_page["effective_read_permission"] == "page.admin.read"
+    assert pms_integration_page["effective_write_permission"] == "page.admin.write"
+    assert pms_items_projection_page["effective_read_permission"] == "page.admin.read"
+    assert pms_items_projection_page["effective_write_permission"] == "page.admin.write"
 
     assert "/shipping-assist/handoffs" in route_map
     assert "/shipping-assist/records" in route_map
-    assert "/items" in route_map
+    assert "/admin/pms-integration" in route_map
+    assert "/admin/pms-integration/items" in route_map
 
     assert route_map["/shipping-assist/handoffs"]["page_code"] == "shipping_assist.handoffs"
     assert route_map["/shipping-assist/records"]["page_code"] == "shipping_assist.records"
-    assert route_map["/items"]["page_code"] == "pms.items"
+    assert route_map["/admin/pms-integration"]["page_code"] == "admin.pms_integration"
+    assert route_map["/admin/pms-integration/items"]["page_code"] == "admin.pms_integration.items"
 
+    assert "/items" not in route_map
+    assert "/item-barcodes" not in route_map
     assert "/partners/suppliers" not in route_map
+    assert "pms.items" not in nodes
+    assert "pms.item_barcodes" not in nodes
     assert "partners.suppliers" not in nodes
 
+
 @pytest.mark.asyncio
-async def test_my_navigation_item_barcodes_route_prefix_mapping_and_permissions(
+async def test_my_navigation_pms_barcode_projection_route_prefix_mapping_and_permissions(
     client: AsyncClient,
 ) -> None:
     headers = await _login_admin_headers(client)
@@ -395,12 +476,14 @@ async def test_my_navigation_item_barcodes_route_prefix_mapping_and_permissions(
     data = r.json()
     route_map = _index_route_prefixes(data["route_prefixes"])
 
-    item_barcodes_route = route_map.get("/item-barcodes")
-    assert item_barcodes_route is not None, "/item-barcodes should exist in route_prefixes"
+    barcode_projection_route = route_map.get("/admin/pms-integration/barcodes")
+    assert barcode_projection_route is not None
 
-    assert item_barcodes_route["page_code"] == "pms.item_barcodes"
-    assert item_barcodes_route["effective_read_permission"] == "page.pms.read"
-    assert item_barcodes_route["effective_write_permission"] == "page.pms.write"
+    assert barcode_projection_route["page_code"] == "admin.pms_integration.barcodes"
+    assert barcode_projection_route["effective_read_permission"] == "page.admin.read"
+    assert barcode_projection_route["effective_write_permission"] == "page.admin.write"
+
+    assert "/item-barcodes" not in route_map
 
 
 @pytest.mark.asyncio
@@ -438,6 +521,7 @@ async def test_my_navigation_filters_to_only_directly_visible_parent_tree(
     assert "shipping_assist.shipping" not in nodes
     assert "shipping_assist.pricing" not in nodes
     assert "shipping_assist.billing" not in nodes
+    assert "admin.pms_integration" not in nodes
 
     assert all(item["page_code"].startswith("shipping_assist.") for item in route_prefixes)
     assert [item["route_prefix"] for item in route_prefixes] == [

--- a/tests/ci/test_wms_pms_integration_admin_ops_boundary.py
+++ b/tests/ci/test_wms_pms_integration_admin_ops_boundary.py
@@ -1,0 +1,84 @@
+# tests/ci/test_wms_pms_integration_admin_ops_boundary.py
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+FORBIDDEN_OWNER_SQL_RE = re.compile(
+    r"\bFROM\s+(items|item_uoms|item_sku_codes|item_barcodes|suppliers|supplier_contacts)\b"
+    r"|\bJOIN\s+(items|item_uoms|item_sku_codes|item_barcodes|suppliers|supplier_contacts)\b"
+    r"|\bINSERT\s+INTO\s+(items|item_uoms|item_sku_codes|item_barcodes|suppliers|supplier_contacts)\b"
+    r"|\bUPDATE\s+(items|item_uoms|item_sku_codes|item_barcodes|suppliers|supplier_contacts)\b"
+    r"|\bDELETE\s+FROM\s+(items|item_uoms|item_sku_codes|item_barcodes|suppliers|supplier_contacts)\b",
+    re.IGNORECASE,
+)
+
+
+def test_admin_pms_integration_service_uses_projection_tables_only() -> None:
+    text = (ROOT / "app/admin/services/pms_integration_service.py").read_text(encoding="utf-8")
+
+    assert "wms_pms_item_projection" in text
+    assert "wms_pms_supplier_projection" in text
+    assert "wms_pms_uom_projection" in text
+    assert "wms_pms_sku_code_projection" in text
+    assert "wms_pms_barcode_projection" in text
+    assert "wms_pms_projection_sync_runs" in text
+    assert FORBIDDEN_OWNER_SQL_RE.search(text) is None
+
+
+def test_admin_pms_integration_does_not_reintroduce_pms_owner_routes_or_connection_page() -> None:
+    text = (ROOT / "app/admin/routers/pms_integration.py").read_text(encoding="utf-8")
+
+    assert "/items" not in text
+    assert "/item-uoms" not in text
+    assert "/item-barcodes" not in text
+    assert "/pms/brands" not in text
+    assert "/pms/categories" not in text
+    assert "/pms/item-attribute-defs" not in text
+    assert "/connection" not in text
+
+
+def test_admin_pms_integration_migration_retires_old_pms_pages_and_route_prefixes() -> None:
+    text = (
+        ROOT / "alembic/versions/8a4f2d6c9b31_add_wms_pms_projection_sync_admin_ops.py"
+    ).read_text(encoding="utf-8")
+
+    assert "wms_pms_projection_sync_runs" in text
+
+    for old_page_code in [
+        "pms",
+        "pms.items",
+        "pms.brands",
+        "pms.categories",
+        "pms.item_attributes",
+        "pms.sku_coding",
+        "pms.item_barcodes",
+        "pms.item_uoms",
+    ]:
+        assert old_page_code in text
+
+    for old_route_prefix in [
+        "/items",
+        "/item-barcodes",
+        "/item-uoms",
+        "/items/sku-coding",
+        "/pms/brands",
+        "/pms/categories",
+        "/pms/item-attribute-defs",
+    ]:
+        assert old_route_prefix in text
+
+    for new_page_code in [
+        "admin.pms_integration",
+        "admin.pms_integration.items",
+        "admin.pms_integration.suppliers",
+        "admin.pms_integration.uoms",
+        "admin.pms_integration.sku_codes",
+        "admin.pms_integration.barcodes",
+    ]:
+        assert new_page_code in text
+
+    assert "admin.pms_integration.connection" not in text
+    assert "/admin/pms-integration/connection" not in text


### PR DESCRIPTION
## Summary
- retire legacy WMS PMS owner navigation pages and route prefixes
- add admin PMS projection sync management APIs
- add projection sync run log table
- expose read-only projection listing, per-resource sync, per-resource check, and sync run listing
- keep connection authorization page out of this PR

## Tests
- make test TESTS="tests/api/test_admin_pms_integration_api.py tests/api/test_user_navigation_api.py tests/ci/test_pms_owner_routes_not_mounted.py tests/ci/test_no_pms_owner_route_requests.py tests/ci/test_wms_pms_projection_sync_boundary.py tests/ci/test_wms_pms_projection_reconciliation_boundary.py tests/ci/test_wms_pms_integration_admin_ops_boundary.py"
- make alembic-check