### PR TITLE
feat(pms): include supplier display fields in item projection admin API

### DIFF
--- a/app/admin/services/pms_integration_service.py
+++ b/app/admin/services/pms_integration_service.py
@@ -29,6 +29,9 @@ class ProjectionResourceConfig:
     id_column: str
     columns: tuple[str, ...]
     searchable_columns: tuple[str, ...]
+    select_expressions: tuple[str, ...] | None = None
+    from_sql: str | None = None
+    order_by_sql: str | None = None
 
 
 RESOURCE_CONFIGS: dict[ProjectionResource, ProjectionResourceConfig] = {
@@ -43,6 +46,8 @@ RESOURCE_CONFIGS: dict[ProjectionResource, ProjectionResourceConfig] = {
             "spec",
             "enabled",
             "supplier_id",
+            "supplier_code",
+            "supplier_name",
             "brand",
             "category",
             "expiry_policy",
@@ -56,7 +61,43 @@ RESOURCE_CONFIGS: dict[ProjectionResource, ProjectionResourceConfig] = {
             "sync_version",
             "synced_at",
         ),
-        searchable_columns=("sku", "name", "spec", "brand", "category"),
+        searchable_columns=(
+            "i.sku",
+            "i.name",
+            "i.spec",
+            "i.brand",
+            "i.category",
+            "s.supplier_code",
+            "s.supplier_name",
+        ),
+        select_expressions=(
+            "i.item_id",
+            "i.sku",
+            "i.name",
+            "i.spec",
+            "i.enabled",
+            "i.supplier_id",
+            "s.supplier_code AS supplier_code",
+            "s.supplier_name AS supplier_name",
+            "i.brand",
+            "i.category",
+            "i.expiry_policy",
+            "i.shelf_life_value",
+            "i.shelf_life_unit",
+            "i.lot_source_policy",
+            "i.derivation_allowed",
+            "i.uom_governance_enabled",
+            "i.pms_updated_at",
+            "i.source_hash",
+            "i.sync_version",
+            "i.synced_at",
+        ),
+        from_sql=(
+            "wms_pms_item_projection AS i "
+            "LEFT JOIN wms_pms_supplier_projection AS s "
+            "ON s.supplier_id = i.supplier_id"
+        ),
+        order_by_sql="i.item_id ASC",
     ),
     "suppliers": ProjectionResourceConfig(
         resource="suppliers",
@@ -202,6 +243,18 @@ class PmsIntegrationAdminService:
             return str(value)
         return value
 
+    @staticmethod
+    def _select_sql(cfg: ProjectionResourceConfig) -> str:
+        return ", ".join(cfg.select_expressions or cfg.columns)
+
+    @staticmethod
+    def _from_sql(cfg: ProjectionResourceConfig) -> str:
+        return cfg.from_sql or cfg.table_name
+
+    @staticmethod
+    def _order_by_sql(cfg: ProjectionResourceConfig) -> str:
+        return cfg.order_by_sql or f"{cfg.id_column} ASC"
+
     def _sync_run_from_row(self, row: Any) -> dict[str, Any]:
         data = dict(row)
         return {
@@ -314,22 +367,22 @@ class PmsIntegrationAdminService:
             where_sql = "WHERE " + " OR ".join(where_parts)
             params["q"] = f"%{query_text}%"
 
+        from_sql = self._from_sql(cfg)
         total = int(
             self.db.execute(
-                text(f"SELECT count(*)::bigint FROM {cfg.table_name} {where_sql}"),
+                text(f"SELECT count(*)::bigint FROM {from_sql} {where_sql}"),
                 params,
             ).scalar_one()
         )
 
-        columns_sql = ", ".join(cfg.columns)
         rows = (
             self.db.execute(
                 text(
                     f"""
-                    SELECT {columns_sql}
-                    FROM {cfg.table_name}
+                    SELECT {self._select_sql(cfg)}
+                    FROM {from_sql}
                     {where_sql}
-                    ORDER BY {cfg.id_column} ASC
+                    ORDER BY {self._order_by_sql(cfg)}
                     LIMIT :limit OFFSET :offset
                     """
                 ),

--- a/tests/api/test_admin_pms_integration_api.py
+++ b/tests/api/test_admin_pms_integration_api.py
@@ -64,9 +64,103 @@ async def test_admin_pms_integration_can_list_projection_rows(
     assert data["limit"] == 5
     assert data["offset"] == 0
     assert data["total"] >= 0
+
     assert "item_id" in data["columns"]
     assert "sku" in data["columns"]
+    assert "supplier_id" in data["columns"]
+    assert "supplier_code" in data["columns"]
+    assert "supplier_name" in data["columns"]
     assert isinstance(data["rows"], list)
+
+    if data["rows"]:
+        first_row = data["rows"][0]
+        assert "supplier_id" in first_row
+        assert "supplier_code" in first_row
+        assert "supplier_name" in first_row
+
+
+@pytest.mark.asyncio
+async def test_admin_pms_integration_item_projection_can_search_supplier_display_fields(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_pms_supplier_projection (
+                supplier_id,
+                supplier_code,
+                supplier_name,
+                active,
+                synced_at
+            )
+            VALUES (
+                990001,
+                'SUP-ADMIN-SEARCH',
+                '投影搜索供应商',
+                true,
+                now()
+            )
+            ON CONFLICT (supplier_id) DO UPDATE
+            SET supplier_code = EXCLUDED.supplier_code,
+                supplier_name = EXCLUDED.supplier_name,
+                active = EXCLUDED.active,
+                synced_at = EXCLUDED.synced_at
+            """
+        )
+    )
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_pms_item_projection (
+                item_id,
+                sku,
+                name,
+                enabled,
+                supplier_id,
+                synced_at
+            )
+            VALUES (
+                990002,
+                'SKU-ADMIN-SUPPLIER-SEARCH',
+                '供应商搜索商品',
+                true,
+                990001,
+                now()
+            )
+            ON CONFLICT (item_id) DO UPDATE
+            SET sku = EXCLUDED.sku,
+                name = EXCLUDED.name,
+                enabled = EXCLUDED.enabled,
+                supplier_id = EXCLUDED.supplier_id,
+                synced_at = EXCLUDED.synced_at
+            """
+        )
+    )
+    await session.commit()
+
+    headers = await _login_admin_headers(client)
+
+    r = await client.get(
+        "/admin/pms-integration/projections/items?limit=10&offset=0&q=SUP-ADMIN-SEARCH",
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+
+    data = r.json()
+    assert data["resource"] == "items"
+    assert data["total"] >= 1
+    assert "supplier_code" in data["columns"]
+    assert "supplier_name" in data["columns"]
+
+    matched = [
+        row
+        for row in data["rows"]
+        if row.get("item_id") == 990002
+    ]
+    assert matched
+    assert matched[0]["supplier_code"] == "SUP-ADMIN-SEARCH"
+    assert matched[0]["supplier_name"] == "投影搜索供应商"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add supplier_code and supplier_name to item projection admin API rows and columns
- search item projection by supplier_code and supplier_name
- keep the read model limited to WMS PMS projection tables with LEFT JOIN
- do not change DB schema, sync logic, or PMS owner boundaries

## Tests
- make test TESTS="tests/api/test_admin_pms_integration_api.py tests/ci/test_wms_pms_integration_admin_ops_boundary.py"
- make alembic-check