### PR TITLE
chore(make): add uvicorn target for WMS API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ endif
 # ---- 分模块拆分 ----
 include scripts/make/env.mk
 include scripts/make/db.mk
+include scripts/make/run.mk
 include scripts/make/audit.mk
 include scripts/make/test.mk
 include scripts/make/lint.mk

--- a/scripts/make/run.mk
+++ b/scripts/make/run.mk
@@ -1,0 +1,10 @@
+# ========================
+# Local runtime commands
+# ========================
+
+HOST ?= 0.0.0.0
+PORT ?= 8000
+
+.PHONY: uvicorn
+uvicorn: venv
+	@WMS_ENV=dev WMS_TEST_DATABASE_URL= WMS_DATABASE_URL="$(DEV_DB_DSN)" PYTHONPATH=. $(PY) -m uvicorn app.main:app --host "$(HOST)" --port "$(PORT)" --reload


### PR DESCRIPTION
Add a standard make uvicorn target for local WMS API startup.

Scope:
- Add scripts/make/run.mk
- Add make uvicorn for local uvicorn startup
- Set WMS API local port to 8000
- Inject WMS_DATABASE_URL through Makefile
- Do not run migrations automatically
- No runtime code changes

Validation:
- make -n uvicorn
- make upgrade-dev
- make alembic-check