### PR TITLE
chore(make): load WMS local env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,68 +1,13 @@
-# ===== WMS-DU Runtime Env (copy to .env or `source .env`) =====
-# 时区与 Python 模块路径
-export TZ=Asia/Shanghai
-export PYTHONPATH=.
+# WMS API local development environment.
+# Copy this file to .env.local and adjust values for your machine.
+#
+# .env.local is intentionally not committed.
 
-# 数据库（Alembic 迁移要求同步驱动；应用层异步用例在测试里自带 asyncpg URL）
-# 本地/CI/服务器保持一致端口：5433 (PG14)
-export DATABASE_URL='postgresql+psycopg://wms:wms@127.0.0.1:5433/wms'
+DEV_DB_DSN=postgresql+psycopg://wms:wms@127.0.0.1:5433/wms
+DEV_TEST_DB_DSN=postgresql+psycopg://wms:wms@127.0.0.1:5433/wms_test
 
-# -------------------------------
-# 平台/特性开关（v1.0 观测期默认关闭）
-# -------------------------------
-export ENABLE_PDD_PULL=false
-export ENABLE_PDD_PUSH=false
-export ENABLE_MULTI_WAREHOUSE=false
-
-# -------------------------------
-# Web 服务
-# -------------------------------
-export WMS_HOST=0.0.0.0
-export WMS_PORT=8000
-export WMS_WORKERS=2
-
-# -------------------------------
-# 运行时路径（systemd / 脚本会使用）
-# -------------------------------
-export WMS_VENV="$HOME/wms-api/.venv"
-export WMS_REPO_DIR="$HOME/wms-api"
-export WMS_VAR_DIR="$HOME/wms-api/var"
-# 首次加载时创建对账等目录（安全幂等）
-mkdir -p "$WMS_VAR_DIR/reconcile"
-
-# ===============================================================
-# 扫码通路 · 网关配置（v1.0）
-# ===============================================================
-# 约定：LOC:01R0000000 → RECEIVE（接收入库位）；LOC:01S9000000 → STAGE（上架暂存位）
-# 你刚刚已在 DB 中创建：
-#   RECEIVE id=10002 (code=01R0000000)
-#   STAGE   id=10003 (code=01S9000000)
-
-# —— 默认库位 ——（缺省时网关兜底）
-export SCAN_RECEIVE_DEFAULT_LOCATION_ID=10002   # 接收入库位
-export SCAN_STAGE_LOCATION_ID=10003             # 上架源位（暂存）
-
-# —— 真动作开关（默认关闭；仅在需要真实落账时开启）——
-# 关闭 = 探活（保存点内执行、随后回滚，不落账）
-# 开启 = 真动作（提交事务，写入台账与库存）
-export SCAN_REAL_RECEIVE=0
-export SCAN_REAL_PUTAWAY=0
-export SCAN_REAL_PICK=0
-export SCAN_REAL_COUNT=0
-
-# 说明：
-# - 测试“探活”：
-#     PYTHONPATH=. pytest -q tests/services/test_scan_receive.py::test_scan_receive_probe -s -x
-# - 测试“真动”：
-#     export SCAN_REAL_RECEIVE=1
-#     PYTHONPATH=. pytest -q tests/services/test_scan_receive.py::test_scan_receive_real_commit -s -x
-# - 扫码契约总跑（当前含 receive+putaway 的探活/真动）：
-#     PYTHONPATH=. pytest -q -m grp_scan -s
-
-# ===============================================================
-# 日志/可观测（需要时再开启）
-# ===============================================================
-# export LOG_LEVEL=INFO
-# export SQLALCHEMY_ECHO=false
-
-# add your secrets locally
+WMS_ENV=dev
+WMS_TEST_DATABASE_URL=
+WMS_DATABASE_URL=postgresql+psycopg://wms:wms@127.0.0.1:5433/wms
+PMS_API_BASE_URL=http://127.0.0.1:8005
+PYTHONPATH=.

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 SHELL := /bin/bash
 VENV  := .venv
-PY    := $(VENV)/bin/python
+PY    := $(shell if [ -x "$(VENV)/bin/python3" ]; then echo "$(VENV)/bin/python3"; elif [ -x "$(VENV)/bin/python" ]; then echo "$(VENV)/bin/python"; else echo "python3"; fi)
 PIP   := $(VENV)/bin/pip
 ALEMB := $(PY) -m alembic
 PYTEST:= $(VENV)/bin/pytest
@@ -12,14 +12,25 @@ PYTEST:= $(VENV)/bin/pytest
 # ========================
 # Database DSN
 # ========================
-TEST_DB_DSN := postgresql+psycopg://postgres:wms@127.0.0.1:55432/postgres
-DEV_DB_DSN  := postgresql+psycopg://wms:wms@127.0.0.1:5433/wms
-DEV_TEST_DB_DSN := postgresql+psycopg://wms:wms@127.0.0.1:5433/wms_test
+TEST_DB_DSN ?= postgresql+psycopg://postgres:wms@127.0.0.1:55432/postgres
+DEV_DB_DSN  ?= postgresql+psycopg://wms:wms@127.0.0.1:5433/wms
+DEV_TEST_DB_DSN ?= postgresql+psycopg://wms:wms@127.0.0.1:5433/wms_test
+
+# ========================
+# Local runtime env defaults
+# ========================
+WMS_ENV ?= dev
+WMS_TEST_DATABASE_URL ?=
+WMS_DATABASE_URL ?= $(DEV_DB_DSN)
+PMS_API_BASE_URL ?= http://127.0.0.1:8005
 
 # ---- 自动加载 .env.local ----
 ifneq (,$(wildcard .env.local))
 include .env.local
 endif
+
+DEV_ENV := WMS_ENV="$(WMS_ENV)" WMS_TEST_DATABASE_URL="$(WMS_TEST_DATABASE_URL)" WMS_DATABASE_URL="$(WMS_DATABASE_URL)" PMS_API_BASE_URL="$(PMS_API_BASE_URL)" PYTHONPATH=.
+TEST_ENV := WMS_ENV=test WMS_TEST_DATABASE_URL="$(DEV_TEST_DB_DSN)" WMS_DATABASE_URL="$(DEV_TEST_DB_DSN)" PMS_API_BASE_URL="$(PMS_API_BASE_URL)" PYTHONPATH=.
 
 # ---- 分模块拆分 ----
 include scripts/make/env.mk

--- a/scripts/make/env.mk
+++ b/scripts/make/env.mk
@@ -6,37 +6,74 @@
 help:
 	@echo ""
 	@echo "WMS-DU Makefile 帮助："
-	@echo "  make venv                     - 创建虚拟环境"
-	@echo "  make deps                     - 安装依赖"
-	@echo "  make clean-pyc                - 清缓存"
-	@echo "  make alembic-check            - alembic check (默认 DEV 5433)"
-	@echo "  make upgrade-head             - alembic 升级到 HEAD (默认 DEV 5433)"
-	@echo "  make alembic-current-dev      - 查看当前 DEV 库 revision（5433）"
-	@echo "  make alembic-history-dev      - 查看 DEV 库最近迁移历史（tail 30）"
+	@echo "  make env                     - 打印当前本地开发环境变量"
+	@echo "  make env-check               - 检查 WMS 本地环境与 PMS projection feed"
+	@echo "  make venv                    - 创建虚拟环境"
+	@echo "  make deps                    - 安装依赖"
+	@echo "  make clean-pyc               - 清缓存"
+	@echo "  make uvicorn                 - 启动本地后端，默认端口 8000"
+	@echo "  make alembic-check           - alembic check (默认 DEV 5433)"
+	@echo "  make upgrade-head            - alembic 升级到 HEAD (默认 DEV 5433)"
+	@echo "  make alembic-current-dev     - 查看当前 DEV 库 revision（5433）"
+	@echo "  make alembic-history-dev     - 查看 DEV 库最近迁移历史（tail 30）"
 	@echo ""
-	@echo "  make dev-reset-db             - 重置 5433 开发库（慎用，核爆）"
-	@echo "  make dev-reset-test-db        - 重置 5433 测试库 wms_test（推荐，pytest 使用）"
-	@echo "  make dev-ensure-admin         - 在 5433 开发库添加 admin/admin123"
-	@echo "  make pilot-ensure-admin       - 在 55432 中试库添加 admin（自定义密码）"
+	@echo "  make dev-reset-db            - 重置 5433 开发库（慎用，核爆）"
+	@echo "  make dev-reset-test-db       - 重置 5433 测试库 wms_test（推荐，pytest 使用）"
+	@echo "  make dev-ensure-admin        - 在 5433 开发库添加 admin/admin123"
+	@echo "  make pilot-ensure-admin      - 在 55432 中试库添加 admin（自定义密码）"
 	@echo ""
-	@echo "  make audit-uom                - 审计：services 层禁止散落 qty_ordered * units_per_case（仅允许 qty_base.py）"
-	@echo "  make audit-consistency        - 审计：禁止绕过库存底座（禁止在非底座模块直接 await write_ledger()）"
-	@echo "  make audit-all                - 口径 + 一致性双审计"
+	@echo "  make audit-uom               - 审计：services 层禁止散落 qty_ordered * units_per_case（仅允许 qty_base.py）"
+	@echo "  make audit-consistency       - 审计：禁止绕过库存底座（禁止在非底座模块直接 await write_ledger()）"
+	@echo "  make audit-all               - 口径 + 一致性双审计"
 	@echo "  make seed-opening-ledger-test - 制度化：按 stocks 补齐 opening ledger（用于三账一致性）"
-	@echo "  make audit-three-books        - 三账一致性自检（TEST DB 上运行 snapshot + compare）"
+	@echo "  make audit-three-books       - 三账一致性自检（TEST DB 上运行 snapshot + compare）"
 	@echo ""
-	@echo "  make test                     - pytest（默认跑 wms_test；pytest 后自动补账 + 三账体检）"
-	@echo "  make test-core                - 只跑 grp_core"
-	@echo "  make test-flow                - 只跑 grp_flow"
-	@echo "  make test-snapshot            - 只跑 grp_snapshot"
-	@echo "  make test-rbac                - RBAC 测试"
-	@echo "  make test-internal-outbound   - 内部出库 Golden Flow E2E"
+	@echo "  make pms-projection-sync     - 从 PMS 同步 WMS 本地 projection"
+	@echo "  make test                    - pytest（默认跑 wms_test；pytest 后自动补账 + 三账体检）"
+	@echo "  make test-core               - 只跑 grp_core"
+	@echo "  make test-flow               - 只跑 grp_flow"
+	@echo "  make test-snapshot           - 只跑 grp_snapshot"
+	@echo "  make test-rbac               - RBAC 测试"
+	@echo "  make test-internal-outbound  - 内部出库 Golden Flow E2E"
 	@echo "  make test-phase5-service-assignment - Phase5: service assignment tests (CI gate)"
 
-	@echo "  make test-all                 - 全量回归（不含三账体检后置步骤）"
+	@echo "  make test-all                - 全量回归（不含三账体检后置步骤）"
 	@echo ""
-	@echo "  make lint-backend             - pre-commit/ruff"
+	@echo "  make lint-backend            - pre-commit/ruff"
 	@echo ""
+
+.PHONY: env env-dev env-test env-check
+env: env-dev
+
+env-dev:
+	@printf '%s\n' 'export WMS_ENV="$(WMS_ENV)"'
+	@printf '%s\n' 'export WMS_TEST_DATABASE_URL="$(WMS_TEST_DATABASE_URL)"'
+	@printf '%s\n' 'export WMS_DATABASE_URL="$(WMS_DATABASE_URL)"'
+	@printf '%s\n' 'export PMS_API_BASE_URL="$(PMS_API_BASE_URL)"'
+	@printf '%s\n' 'export PYTHONPATH=.'
+
+env-test:
+	@printf '%s\n' 'export WMS_ENV=test'
+	@printf '%s\n' 'export WMS_TEST_DATABASE_URL="$(DEV_TEST_DB_DSN)"'
+	@printf '%s\n' 'export WMS_DATABASE_URL="$(DEV_TEST_DB_DSN)"'
+	@printf '%s\n' 'export PMS_API_BASE_URL="$(PMS_API_BASE_URL)"'
+	@printf '%s\n' 'export PYTHONPATH=.'
+
+env-check:
+	@echo "===== WMS API env ====="
+	@echo "PY=$(PY)"
+	@echo "HOST=$(HOST)"
+	@echo "PORT=$(PORT)"
+	@echo "WMS_ENV=$(WMS_ENV)"
+	@echo "WMS_TEST_DATABASE_URL=$(WMS_TEST_DATABASE_URL)"
+	@echo "WMS_DATABASE_URL=$(WMS_DATABASE_URL)"
+	@echo "PMS_API_BASE_URL=$(PMS_API_BASE_URL)"
+	@echo
+	@echo "===== WMS app import check ====="
+	@$(DEV_ENV) $(PY) -c "from app.main import app; print('WMS app import OK:', len(app.routes), 'routes')"
+	@echo
+	@echo "===== PMS projection feed check ====="
+	@curl --max-time 3 -fsS "$(PMS_API_BASE_URL)/pms/read/v1/projection-feed/suppliers?limit=1&offset=0" >/dev/null && echo "PMS projection feed OK: $(PMS_API_BASE_URL)" || (echo "PMS projection feed FAILED: $(PMS_API_BASE_URL)" >&2; exit 2)
 
 .PHONY: venv
 venv:

--- a/scripts/make/run.mk
+++ b/scripts/make/run.mk
@@ -7,4 +7,4 @@ PORT ?= 8000
 
 .PHONY: uvicorn
 uvicorn: venv
-	@WMS_ENV=dev WMS_TEST_DATABASE_URL= WMS_DATABASE_URL="$(DEV_DB_DSN)" PYTHONPATH=. $(PY) -m uvicorn app.main:app --host "$(HOST)" --port "$(PORT)" --reload
+	@$(DEV_ENV) $(PY) -m uvicorn app.main:app --host "$(HOST)" --port "$(PORT)" --reload

--- a/scripts/make/test.mk
+++ b/scripts/make/test.mk
@@ -238,7 +238,7 @@ test-pricing-smoke: dev-reset-test-db audit-all
 # ---------------------------------
 .PHONY: pms-http-smoke
 pms-http-smoke: venv
-	@PMS_CLIENT_MODE=http PMS_API_BASE_URL="$${PMS_API_BASE_URL:-http://127.0.0.1:8002}" PYTHONPATH=. $(PY) scripts/pms/http_smoke.py
+	@$(DEV_ENV) PMS_CLIENT_MODE=http $(PY) scripts/pms/http_smoke.py
 
 
 # ---------------------------------
@@ -249,7 +249,7 @@ pms-http-smoke: venv
 # ---------------------------------
 .PHONY: pms-http-business-smoke
 pms-http-business-smoke: venv
-	@PMS_CLIENT_MODE=http PMS_API_BASE_URL="$${PMS_API_BASE_URL:-http://127.0.0.1:8002}" PYTHONPATH=. $(PY) scripts/pms/http_business_smoke.py
+	@$(DEV_ENV) PMS_CLIENT_MODE=http $(PY) scripts/pms/http_business_smoke.py
 
 # ---------------------------------
 # PMS projection sync
@@ -258,7 +258,7 @@ pms-http-business-smoke: venv
 # ---------------------------------
 .PHONY: pms-projection-sync
 pms-projection-sync: venv
-	@PMS_API_BASE_URL="$${PMS_API_BASE_URL:-http://127.0.0.1:8002}" PYTHONPATH=. $(PY) scripts/pms/sync_projection.py --limit "$${PMS_PROJECTION_SYNC_LIMIT:-500}"
+	@$(DEV_ENV) $(PY) scripts/pms/sync_projection.py --limit "$${PMS_PROJECTION_SYNC_LIMIT:-500}"
 
 # ---------------------------------
 # PMS projection reconciliation


### PR DESCRIPTION
## Summary
- add .env.example for WMS local development
- load .env.local into a shared local runtime contract
- make uvicorn and PMS projection local commands use the same WMS/PMS environment

## Validation
- make env
- make env-check
- make -n uvicorn
- make -n pms-projection-sync
- make alembic-check
- make test TESTS="tests/api/test_admin_pms_integration_api.py tests/ci/test_pms_metadata_boundary.py"