### PR TITLE
refactor(nav): rehome projection pages by business domain

### DIFF
--- a/alembic/versions/20260513130400_rehome_projection_pages.py
+++ b/alembic/versions/20260513130400_rehome_projection_pages.py
@@ -1,0 +1,380 @@
+# alembic/versions/20260513130400_rehome_projection_pages.py
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "20260513130400_rehome_projection_pages"
+down_revision: str | Sequence[str] | None = "20260513122748_wms_oms_fulfillment_projection"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+PMS_PROJECTION_PAGE_ROWS = (
+    ("pms", "商品管理", None, 1, "pms", True, False, False, "page.pms.read", "page.pms.write", 80, True),
+    ("pms.projections", "PMS 商品投影", "pms", 2, "pms", False, True, True, None, None, 90, True),
+    ("pms.projections.items", "商品投影", "pms.projections", 3, "pms", False, True, True, None, None, 10, True),
+    ("pms.projections.suppliers", "供应商投影", "pms.projections", 3, "pms", False, True, True, None, None, 20, True),
+    ("pms.projections.uoms", "包装单位投影", "pms.projections", 3, "pms", False, True, True, None, None, 30, True),
+    ("pms.projections.sku_codes", "SKU 编码投影", "pms.projections", 3, "pms", False, True, True, None, None, 40, True),
+    ("pms.projections.barcodes", "条码投影", "pms.projections", 3, "pms", False, True, True, None, None, 50, True),
+)
+
+PMS_PROJECTION_ROUTE_ROWS = (
+    ("/pms/projections", "pms.projections", 90),
+    ("/pms/projections/items", "pms.projections.items", 91),
+    ("/pms/projections/suppliers", "pms.projections.suppliers", 92),
+    ("/pms/projections/uoms", "pms.projections.uoms", 93),
+    ("/pms/projections/sku-codes", "pms.projections.sku_codes", 94),
+    ("/pms/projections/barcodes", "pms.projections.barcodes", 95),
+)
+
+OMS_PROJECTION_PAGE_ROWS = (
+    ("oms.fulfillment_projection", "履约投影", "oms", 2, "oms", False, True, True, None, None, 90, True),
+    ("oms.fulfillment_projection.orders", "订单投影", "oms.fulfillment_projection", 3, "oms", False, True, True, None, None, 10, True),
+    ("oms.fulfillment_projection.lines", "订单行投影", "oms.fulfillment_projection", 3, "oms", False, True, True, None, None, 20, True),
+    ("oms.fulfillment_projection.components", "履约组件投影", "oms.fulfillment_projection", 3, "oms", False, True, True, None, None, 30, True),
+)
+
+OMS_PROJECTION_ROUTE_ROWS = (
+    ("/oms/fulfillment-projection", "oms.fulfillment_projection", 90),
+    ("/oms/fulfillment-projection/orders", "oms.fulfillment_projection.orders", 91),
+    ("/oms/fulfillment-projection/lines", "oms.fulfillment_projection.lines", 92),
+    ("/oms/fulfillment-projection/components", "oms.fulfillment_projection.components", 93),
+)
+
+OLD_ADMIN_PMS_PAGE_CODES = (
+    "admin.pms_integration.items",
+    "admin.pms_integration.suppliers",
+    "admin.pms_integration.uoms",
+    "admin.pms_integration.sku_codes",
+    "admin.pms_integration.barcodes",
+    "admin.pms_integration",
+)
+
+OLD_ADMIN_PMS_ROUTE_PREFIXES = (
+    "/admin/pms-integration",
+    "/admin/pms-integration/items",
+    "/admin/pms-integration/suppliers",
+    "/admin/pms-integration/uoms",
+    "/admin/pms-integration/sku-codes",
+    "/admin/pms-integration/barcodes",
+)
+
+
+def _insert_page(
+    *,
+    code: str,
+    name: str,
+    parent_code: str | None,
+    level: int,
+    domain_code: str,
+    show_in_topbar: bool,
+    show_in_sidebar: bool,
+    inherit_permissions: bool,
+    read_permission: str | None,
+    write_permission: str | None,
+    sort_order: int,
+    is_active: bool,
+) -> None:
+    params: dict[str, object] = {
+        "code": code,
+        "name": name,
+        "parent_code": parent_code,
+        "level": level,
+        "domain_code": domain_code,
+        "show_in_topbar": show_in_topbar,
+        "show_in_sidebar": show_in_sidebar,
+        "inherit_permissions": inherit_permissions,
+        "sort_order": sort_order,
+        "is_active": is_active,
+    }
+
+    if read_permission is None:
+        read_permission_sql = "NULL"
+    else:
+        read_permission_sql = "(SELECT id FROM permissions WHERE name = :read_permission)"
+        params["read_permission"] = read_permission
+
+    if write_permission is None:
+        write_permission_sql = "NULL"
+    else:
+        write_permission_sql = "(SELECT id FROM permissions WHERE name = :write_permission)"
+        params["write_permission"] = write_permission
+
+    op.get_bind().execute(
+        sa.text(
+            f"""
+            INSERT INTO page_registry (
+              code,
+              name,
+              parent_code,
+              level,
+              domain_code,
+              show_in_topbar,
+              show_in_sidebar,
+              inherit_permissions,
+              read_permission_id,
+              write_permission_id,
+              sort_order,
+              is_active
+            )
+            VALUES (
+              :code,
+              :name,
+              :parent_code,
+              :level,
+              :domain_code,
+              :show_in_topbar,
+              :show_in_sidebar,
+              :inherit_permissions,
+              {read_permission_sql},
+              {write_permission_sql},
+              :sort_order,
+              :is_active
+            )
+            ON CONFLICT (code) DO UPDATE
+            SET
+              name = EXCLUDED.name,
+              parent_code = EXCLUDED.parent_code,
+              level = EXCLUDED.level,
+              domain_code = EXCLUDED.domain_code,
+              show_in_topbar = EXCLUDED.show_in_topbar,
+              show_in_sidebar = EXCLUDED.show_in_sidebar,
+              inherit_permissions = EXCLUDED.inherit_permissions,
+              read_permission_id = EXCLUDED.read_permission_id,
+              write_permission_id = EXCLUDED.write_permission_id,
+              sort_order = EXCLUDED.sort_order,
+              is_active = EXCLUDED.is_active
+            """
+        ),
+        params,
+    )
+
+
+def _insert_route(route_prefix: str, page_code: str, sort_order: int) -> None:
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO page_route_prefixes (
+              route_prefix,
+              page_code,
+              sort_order,
+              is_active
+            )
+            VALUES (
+              :route_prefix,
+              :page_code,
+              :sort_order,
+              TRUE
+            )
+            ON CONFLICT (route_prefix) DO UPDATE
+            SET
+              page_code = EXCLUDED.page_code,
+              sort_order = EXCLUDED.sort_order,
+              is_active = TRUE
+            """
+        ).bindparams(
+            route_prefix=route_prefix,
+            page_code=page_code,
+            sort_order=sort_order,
+        )
+    )
+
+
+def upgrade() -> None:
+    # 商品投影从系统管理迁回商品管理。
+    op.execute(
+        """
+        INSERT INTO permissions (name)
+        VALUES ('page.pms.read'), ('page.pms.write')
+        ON CONFLICT (name) DO NOTHING
+        """
+    )
+
+    # 保证原来能看系统管理 PMS projection 的用户，迁移后仍能看商品管理下 projection。
+    op.execute(
+        """
+        WITH mappings AS (
+          SELECT 'page.admin.read' AS source_name, 'page.pms.read' AS target_name
+          UNION ALL
+          SELECT 'page.admin.write', 'page.pms.write'
+        ),
+        pairs AS (
+          SELECT DISTINCT
+            up.user_id,
+            tp.id AS permission_id
+          FROM mappings m
+          JOIN permissions sp ON sp.name = m.source_name
+          JOIN user_permissions up ON up.permission_id = sp.id
+          JOIN permissions tp ON tp.name = m.target_name
+        )
+        INSERT INTO user_permissions (user_id, permission_id)
+        SELECT user_id, permission_id
+        FROM pairs
+        ON CONFLICT (user_id, permission_id) DO NOTHING
+        """
+    )
+
+    op.execute(
+        """
+        DELETE FROM page_route_prefixes
+        WHERE route_prefix IN (
+          '/admin/pms-integration',
+          '/admin/pms-integration/items',
+          '/admin/pms-integration/suppliers',
+          '/admin/pms-integration/uoms',
+          '/admin/pms-integration/sku-codes',
+          '/admin/pms-integration/barcodes'
+        )
+           OR page_code = 'admin.pms_integration'
+           OR page_code LIKE 'admin.pms_integration.%'
+        """
+    )
+
+    op.execute(
+        """
+        DELETE FROM page_registry
+        WHERE code IN (
+          'admin.pms_integration.items',
+          'admin.pms_integration.suppliers',
+          'admin.pms_integration.uoms',
+          'admin.pms_integration.sku_codes',
+          'admin.pms_integration.barcodes'
+        )
+        """
+    )
+    op.execute("DELETE FROM page_registry WHERE code = 'admin.pms_integration'")
+
+    for row in PMS_PROJECTION_PAGE_ROWS:
+        _insert_page(
+            code=row[0],
+            name=row[1],
+            parent_code=row[2],
+            level=row[3],
+            domain_code=row[4],
+            show_in_topbar=row[5],
+            show_in_sidebar=row[6],
+            inherit_permissions=row[7],
+            read_permission=row[8],
+            write_permission=row[9],
+            sort_order=row[10],
+            is_active=row[11],
+        )
+
+    for route_prefix, page_code, sort_order in PMS_PROJECTION_ROUTE_ROWS:
+        _insert_route(route_prefix, page_code, sort_order)
+
+    # OMS fulfillment projection 归订单管理。
+    for row in OMS_PROJECTION_PAGE_ROWS:
+        _insert_page(
+            code=row[0],
+            name=row[1],
+            parent_code=row[2],
+            level=row[3],
+            domain_code=row[4],
+            show_in_topbar=row[5],
+            show_in_sidebar=row[6],
+            inherit_permissions=row[7],
+            read_permission=row[8],
+            write_permission=row[9],
+            sort_order=row[10],
+            is_active=row[11],
+        )
+
+    for route_prefix, page_code, sort_order in OMS_PROJECTION_ROUTE_ROWS:
+        _insert_route(route_prefix, page_code, sort_order)
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DELETE FROM page_route_prefixes
+        WHERE route_prefix IN (
+          '/pms/projections',
+          '/pms/projections/items',
+          '/pms/projections/suppliers',
+          '/pms/projections/uoms',
+          '/pms/projections/sku-codes',
+          '/pms/projections/barcodes',
+          '/oms/fulfillment-projection',
+          '/oms/fulfillment-projection/orders',
+          '/oms/fulfillment-projection/lines',
+          '/oms/fulfillment-projection/components'
+        )
+           OR page_code = 'pms.projections'
+           OR page_code LIKE 'pms.projections.%'
+           OR page_code = 'oms.fulfillment_projection'
+           OR page_code LIKE 'oms.fulfillment_projection.%'
+        """
+    )
+
+    op.execute(
+        """
+        DELETE FROM page_registry
+        WHERE code IN (
+          'pms.projections.items',
+          'pms.projections.suppliers',
+          'pms.projections.uoms',
+          'pms.projections.sku_codes',
+          'pms.projections.barcodes',
+          'oms.fulfillment_projection.orders',
+          'oms.fulfillment_projection.lines',
+          'oms.fulfillment_projection.components'
+        )
+        """
+    )
+    op.execute(
+        """
+        DELETE FROM page_registry
+        WHERE code IN (
+          'pms.projections',
+          'oms.fulfillment_projection'
+        )
+        """
+    )
+    op.execute(
+        """
+        DELETE FROM page_registry
+        WHERE code = 'pms'
+          AND NOT EXISTS (
+            SELECT 1 FROM page_registry child WHERE child.parent_code = 'pms'
+          )
+        """
+    )
+
+    for code, name, parent_code, level, sort_order in (
+        ("admin.pms_integration", "PMS 接入管理", "admin", 2, 20),
+        ("admin.pms_integration.items", "商品投影", "admin.pms_integration", 3, 10),
+        ("admin.pms_integration.suppliers", "供应商投影", "admin.pms_integration", 3, 20),
+        ("admin.pms_integration.uoms", "包装单位投影", "admin.pms_integration", 3, 30),
+        ("admin.pms_integration.sku_codes", "SKU 编码投影", "admin.pms_integration", 3, 40),
+        ("admin.pms_integration.barcodes", "条码投影", "admin.pms_integration", 3, 50),
+    ):
+        _insert_page(
+            code=code,
+            name=name,
+            parent_code=parent_code,
+            level=level,
+            domain_code="admin",
+            show_in_topbar=False,
+            show_in_sidebar=True,
+            inherit_permissions=True,
+            read_permission=None,
+            write_permission=None,
+            sort_order=sort_order,
+            is_active=True,
+        )
+
+    for route_prefix, page_code, sort_order in (
+        ("/admin/pms-integration", "admin.pms_integration", 20),
+        ("/admin/pms-integration/items", "admin.pms_integration.items", 10),
+        ("/admin/pms-integration/suppliers", "admin.pms_integration.suppliers", 20),
+        ("/admin/pms-integration/uoms", "admin.pms_integration.uoms", 30),
+        ("/admin/pms-integration/sku-codes", "admin.pms_integration.sku_codes", 40),
+        ("/admin/pms-integration/barcodes", "admin.pms_integration.barcodes", 50),
+    ):
+        _insert_route(route_prefix, page_code, sort_order)

--- a/tests/api/test_user_navigation_api.py
+++ b/tests/api/test_user_navigation_api.py
@@ -331,7 +331,7 @@ async def test_my_navigation_retired_partners_supplier_owner_is_absent(client: A
 
 
 @pytest.mark.asyncio
-async def test_my_navigation_pms_projection_sync_admin_tree_replaces_old_pms_owner_tree(
+async def test_my_navigation_pms_projection_tree_lives_under_product_management(
     client: AsyncClient,
 ) -> None:
     headers = await _login_admin_headers(client)
@@ -343,8 +343,7 @@ async def test_my_navigation_pms_projection_sync_admin_tree_replaces_old_pms_own
     nodes = _walk_pages(data["pages"])
     route_map = _index_route_prefixes(data["route_prefixes"])
 
-    old_pms_page_codes = [
-        "pms",
+    old_pms_owner_page_codes = [
         "pms.items",
         "pms.brands",
         "pms.categories",
@@ -353,7 +352,17 @@ async def test_my_navigation_pms_projection_sync_admin_tree_replaces_old_pms_own
         "pms.item_barcodes",
         "pms.item_uoms",
     ]
-    for code in old_pms_page_codes:
+    for code in old_pms_owner_page_codes:
+        assert code not in nodes
+
+    for code in [
+        "admin.pms_integration",
+        "admin.pms_integration.items",
+        "admin.pms_integration.suppliers",
+        "admin.pms_integration.uoms",
+        "admin.pms_integration.sku_codes",
+        "admin.pms_integration.barcodes",
+    ]:
         assert code not in nodes
 
     old_pms_route_prefixes = [
@@ -364,58 +373,67 @@ async def test_my_navigation_pms_projection_sync_admin_tree_replaces_old_pms_own
         "/pms/brands",
         "/pms/categories",
         "/pms/item-attribute-defs",
+        "/admin/pms-integration",
+        "/admin/pms-integration/items",
+        "/admin/pms-integration/suppliers",
+        "/admin/pms-integration/uoms",
+        "/admin/pms-integration/sku-codes",
+        "/admin/pms-integration/barcodes",
     ]
     for route_prefix in old_pms_route_prefixes:
         assert route_prefix not in route_map
 
-    admin = nodes["admin"]
-    assert "admin.users" in _child_codes(admin)
-    assert "admin.pms_integration" in _child_codes(admin)
+    pms = nodes["pms"]
+    assert pms["name"] == "商品管理"
+    assert pms["parent_code"] is None
+    assert pms["domain_code"] == "pms"
+    assert pms["effective_read_permission"] == "page.pms.read"
+    assert pms["effective_write_permission"] == "page.pms.write"
 
-    pms_integration = nodes["admin.pms_integration"]
-    assert pms_integration["name"] == "PMS 接入管理"
-    assert pms_integration["parent_code"] == "admin"
-    assert pms_integration["domain_code"] == "admin"
-    assert pms_integration["effective_read_permission"] == "page.admin.read"
-    assert pms_integration["effective_write_permission"] == "page.admin.write"
+    assert _child_codes(pms) == ["pms.projections"]
 
-    assert _child_codes(pms_integration) == [
-        "admin.pms_integration.items",
-        "admin.pms_integration.suppliers",
-        "admin.pms_integration.uoms",
-        "admin.pms_integration.sku_codes",
-        "admin.pms_integration.barcodes",
+    pms_projections = nodes["pms.projections"]
+    assert pms_projections["name"] == "PMS 商品投影"
+    assert pms_projections["parent_code"] == "pms"
+    assert pms_projections["domain_code"] == "pms"
+
+    assert _child_codes(pms_projections) == [
+        "pms.projections.items",
+        "pms.projections.suppliers",
+        "pms.projections.uoms",
+        "pms.projections.sku_codes",
+        "pms.projections.barcodes",
     ]
 
     expected_names = {
-        "admin.pms_integration.items": "商品投影",
-        "admin.pms_integration.suppliers": "供应商投影",
-        "admin.pms_integration.uoms": "包装单位投影",
-        "admin.pms_integration.sku_codes": "SKU 编码投影",
-        "admin.pms_integration.barcodes": "条码投影",
+        "pms.projections.items": "商品投影",
+        "pms.projections.suppliers": "供应商投影",
+        "pms.projections.uoms": "包装单位投影",
+        "pms.projections.sku_codes": "SKU 编码投影",
+        "pms.projections.barcodes": "条码投影",
     }
     for code, name in expected_names.items():
         node = nodes[code]
         assert node["name"] == name
-        assert node["parent_code"] == "admin.pms_integration"
-        assert node["domain_code"] == "admin"
-        assert node["effective_read_permission"] == "page.admin.read"
-        assert node["effective_write_permission"] == "page.admin.write"
+        assert node["parent_code"] == "pms.projections"
+        assert node["domain_code"] == "pms"
+        assert node["effective_read_permission"] == "page.pms.read"
+        assert node["effective_write_permission"] == "page.pms.write"
 
     expected_route_map = {
-        "/admin/pms-integration": "admin.pms_integration",
-        "/admin/pms-integration/items": "admin.pms_integration.items",
-        "/admin/pms-integration/suppliers": "admin.pms_integration.suppliers",
-        "/admin/pms-integration/uoms": "admin.pms_integration.uoms",
-        "/admin/pms-integration/sku-codes": "admin.pms_integration.sku_codes",
-        "/admin/pms-integration/barcodes": "admin.pms_integration.barcodes",
+        "/pms/projections": "pms.projections",
+        "/pms/projections/items": "pms.projections.items",
+        "/pms/projections/suppliers": "pms.projections.suppliers",
+        "/pms/projections/uoms": "pms.projections.uoms",
+        "/pms/projections/sku-codes": "pms.projections.sku_codes",
+        "/pms/projections/barcodes": "pms.projections.barcodes",
     }
     for route_prefix, page_code in expected_route_map.items():
         route = route_map.get(route_prefix)
         assert route is not None, f"{route_prefix} should exist in route_prefixes"
         assert route["page_code"] == page_code
-        assert route["effective_read_permission"] == "page.admin.read"
-        assert route["effective_write_permission"] == "page.admin.write"
+        assert route["effective_read_permission"] == "page.pms.read"
+        assert route["effective_write_permission"] == "page.pms.write"
 
     assert "/admin/pms-integration/connection" not in route_map
     assert "admin.pms_integration.connection" not in nodes
@@ -434,34 +452,37 @@ async def test_my_navigation_route_prefix_mapping_and_effective_permissions(clie
 
     shipping_handoffs_page = nodes["shipping_assist.handoffs"]
     shipping_records_page = nodes["shipping_assist.records"]
-    pms_integration_page = nodes["admin.pms_integration"]
-    pms_items_projection_page = nodes["admin.pms_integration.items"]
+    pms_projection_page = nodes["pms.projections"]
+    pms_items_projection_page = nodes["pms.projections.items"]
 
     assert shipping_handoffs_page["effective_read_permission"]
     assert shipping_handoffs_page["effective_write_permission"]
     assert shipping_records_page["effective_read_permission"]
     assert shipping_records_page["effective_write_permission"]
-    assert pms_integration_page["effective_read_permission"] == "page.admin.read"
-    assert pms_integration_page["effective_write_permission"] == "page.admin.write"
-    assert pms_items_projection_page["effective_read_permission"] == "page.admin.read"
-    assert pms_items_projection_page["effective_write_permission"] == "page.admin.write"
+    assert pms_projection_page["effective_read_permission"] == "page.pms.read"
+    assert pms_projection_page["effective_write_permission"] == "page.pms.write"
+    assert pms_items_projection_page["effective_read_permission"] == "page.pms.read"
+    assert pms_items_projection_page["effective_write_permission"] == "page.pms.write"
 
     assert "/shipping-assist/handoffs" in route_map
     assert "/shipping-assist/records" in route_map
-    assert "/admin/pms-integration" in route_map
-    assert "/admin/pms-integration/items" in route_map
+    assert "/pms/projections" in route_map
+    assert "/pms/projections/items" in route_map
 
     assert route_map["/shipping-assist/handoffs"]["page_code"] == "shipping_assist.handoffs"
     assert route_map["/shipping-assist/records"]["page_code"] == "shipping_assist.records"
-    assert route_map["/admin/pms-integration"]["page_code"] == "admin.pms_integration"
-    assert route_map["/admin/pms-integration/items"]["page_code"] == "admin.pms_integration.items"
+    assert route_map["/pms/projections"]["page_code"] == "pms.projections"
+    assert route_map["/pms/projections/items"]["page_code"] == "pms.projections.items"
 
     assert "/items" not in route_map
     assert "/item-barcodes" not in route_map
     assert "/partners/suppliers" not in route_map
+    assert "/admin/pms-integration" not in route_map
+    assert "/admin/pms-integration/items" not in route_map
     assert "pms.items" not in nodes
     assert "pms.item_barcodes" not in nodes
     assert "partners.suppliers" not in nodes
+    assert "admin.pms_integration" not in nodes
 
 
 @pytest.mark.asyncio
@@ -476,14 +497,15 @@ async def test_my_navigation_pms_barcode_projection_route_prefix_mapping_and_per
     data = r.json()
     route_map = _index_route_prefixes(data["route_prefixes"])
 
-    barcode_projection_route = route_map.get("/admin/pms-integration/barcodes")
+    barcode_projection_route = route_map.get("/pms/projections/barcodes")
     assert barcode_projection_route is not None
 
-    assert barcode_projection_route["page_code"] == "admin.pms_integration.barcodes"
-    assert barcode_projection_route["effective_read_permission"] == "page.admin.read"
-    assert barcode_projection_route["effective_write_permission"] == "page.admin.write"
+    assert barcode_projection_route["page_code"] == "pms.projections.barcodes"
+    assert barcode_projection_route["effective_read_permission"] == "page.pms.read"
+    assert barcode_projection_route["effective_write_permission"] == "page.pms.write"
 
     assert "/item-barcodes" not in route_map
+    assert "/admin/pms-integration/barcodes" not in route_map
 
 
 @pytest.mark.asyncio

--- a/tests/ci/test_wms_oms_projection_page_rehome_boundary.py
+++ b/tests/ci/test_wms_oms_projection_page_rehome_boundary.py
@@ -1,0 +1,27 @@
+# tests/ci/test_wms_oms_projection_page_rehome_boundary.py
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_oms_fulfillment_projection_pages_are_registered_under_order_management() -> None:
+    migration_text = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (ROOT / "alembic/versions").glob("*rehome_projection_pages.py")
+    )
+
+    assert "oms.fulfillment_projection" in migration_text
+    assert "oms.fulfillment_projection.orders" in migration_text
+    assert "oms.fulfillment_projection.lines" in migration_text
+    assert "oms.fulfillment_projection.components" in migration_text
+
+    assert "/oms/fulfillment-projection" in migration_text
+    assert "/oms/fulfillment-projection/orders" in migration_text
+    assert "/oms/fulfillment-projection/lines" in migration_text
+    assert "/oms/fulfillment-projection/components" in migration_text
+
+    assert "domain_code\", \"oms\"" not in migration_text
+    assert "page.oms.read" not in migration_text
+    assert "page.oms.write" not in migration_text

--- a/tests/ci/test_wms_pms_integration_admin_ops_boundary.py
+++ b/tests/ci/test_wms_pms_integration_admin_ops_boundary.py
@@ -40,45 +40,26 @@ def test_admin_pms_integration_does_not_reintroduce_pms_owner_routes_or_connecti
     assert "/connection" not in text
 
 
-def test_admin_pms_integration_migration_retires_old_pms_pages_and_route_prefixes() -> None:
-    text = (
-        ROOT / "alembic/versions/8a4f2d6c9b31_add_wms_pms_projection_sync_admin_ops.py"
-    ).read_text(encoding="utf-8")
+def test_pms_projection_pages_are_rehomed_to_product_management_navigation() -> None:
+    migration_text = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (ROOT / "alembic/versions").glob("*rehome_projection_pages.py")
+    )
 
-    assert "wms_pms_projection_sync_runs" in text
+    assert "pms.projections" in migration_text
+    assert "pms.projections.items" in migration_text
+    assert "pms.projections.suppliers" in migration_text
+    assert "pms.projections.uoms" in migration_text
+    assert "pms.projections.sku_codes" in migration_text
+    assert "pms.projections.barcodes" in migration_text
 
-    for old_page_code in [
-        "pms",
-        "pms.items",
-        "pms.brands",
-        "pms.categories",
-        "pms.item_attributes",
-        "pms.sku_coding",
-        "pms.item_barcodes",
-        "pms.item_uoms",
-    ]:
-        assert old_page_code in text
+    assert "/pms/projections/items" in migration_text
+    assert "/pms/projections/suppliers" in migration_text
+    assert "/pms/projections/uoms" in migration_text
+    assert "/pms/projections/sku-codes" in migration_text
+    assert "/pms/projections/barcodes" in migration_text
 
-    for old_route_prefix in [
-        "/items",
-        "/item-barcodes",
-        "/item-uoms",
-        "/items/sku-coding",
-        "/pms/brands",
-        "/pms/categories",
-        "/pms/item-attribute-defs",
-    ]:
-        assert old_route_prefix in text
-
-    for new_page_code in [
-        "admin.pms_integration",
-        "admin.pms_integration.items",
-        "admin.pms_integration.suppliers",
-        "admin.pms_integration.uoms",
-        "admin.pms_integration.sku_codes",
-        "admin.pms_integration.barcodes",
-    ]:
-        assert new_page_code in text
-
-    assert "admin.pms_integration.connection" not in text
-    assert "/admin/pms-integration/connection" not in text
+    assert "admin.pms_integration.items" in migration_text
+    assert "/admin/pms-integration/items" in migration_text
+    assert "page.pms.read" in migration_text
+    assert "page.pms.write" in migration_text


### PR DESCRIPTION
## Summary
- move PMS projection pages from system management to product management
- register OMS fulfillment projection pages under order management
- update navigation tests and boundary guards
- keep existing backend projection APIs unchanged

## Validation
- make upgrade-head
- make alembic-check
- make test TESTS="tests/api/test_user_navigation_api.py tests/api/test_admin_navigation_api.py tests/ci/test_wms_pms_integration_admin_ops_boundary.py tests/ci/test_wms_oms_projection_page_rehome_boundary.py"