### PR TITLE
feat(oms): add fulfillment projection ops API

### DIFF
--- a/app/oms/fulfillment_projection/__init__.py
+++ b/app/oms/fulfillment_projection/__init__.py
@@ -1,0 +1,12 @@
+# app/oms/fulfillment_projection/__init__.py
+"""
+WMS-side OMS fulfillment projection operations.
+
+Directory style follows app/wms modules:
+- contracts/
+- repos/
+- routers/
+- services/
+
+Do not use generic files such as service.py, router.py, or contracts.py here.
+"""

--- a/app/oms/fulfillment_projection/contracts/__init__.py
+++ b/app/oms/fulfillment_projection/contracts/__init__.py
@@ -1,0 +1,1 @@
+# app/oms/fulfillment_projection/contracts/__init__.py

--- a/app/oms/fulfillment_projection/contracts/fulfillment_projection.py
+++ b/app/oms/fulfillment_projection/contracts/fulfillment_projection.py
@@ -1,0 +1,102 @@
+# app/oms/fulfillment_projection/contracts/fulfillment_projection.py
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+OmsProjectionResource = Literal["orders", "lines", "components"]
+OmsProjectionSyncResource = Literal["fulfillment-ready-orders"]
+OmsProjectionPlatform = Literal["pdd", "taobao", "jd"]
+SyncRunStatus = Literal["RUNNING", "SUCCESS", "FAILED"]
+
+
+class OmsProjectionSyncRunOut(BaseModel):
+    id: int
+    resource: OmsProjectionSyncResource
+    platform: OmsProjectionPlatform | None = None
+    store_code: str | None = None
+    status: SyncRunStatus
+    fetched: int = 0
+    upserted_orders: int = 0
+    upserted_lines: int = 0
+    upserted_components: int = 0
+    pages: int = 0
+    started_at: datetime
+    finished_at: datetime | None = None
+    duration_ms: int | None = None
+    error_message: str | None = None
+    triggered_by_user_id: int | None = None
+    oms_api_base_url_snapshot: str | None = None
+    sync_version: str | None = None
+
+
+class OmsProjectionResourceStatusOut(BaseModel):
+    resource: OmsProjectionResource
+    table_name: str
+    row_count: int
+    max_synced_at: datetime | None = None
+    last_sync_run: OmsProjectionSyncRunOut | None = None
+
+
+class OmsProjectionStatusOut(BaseModel):
+    oms_api_base_url_configured: bool
+    oms_api_token_configured: bool
+    resources: list[OmsProjectionResourceStatusOut] = Field(default_factory=list)
+
+
+class OmsProjectionListOut(BaseModel):
+    resource: OmsProjectionResource
+    table_name: str
+    limit: int
+    offset: int
+    total: int
+    columns: list[str] = Field(default_factory=list)
+    rows: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class OmsProjectionSyncOut(BaseModel):
+    run: OmsProjectionSyncRunOut
+
+
+class OmsProjectionCheckIssueOut(BaseModel):
+    issue_type: str
+    resource: OmsProjectionResource
+    source_id: str
+    message: str
+    ready_order_id: str | None = None
+    ready_line_id: str | None = None
+    ready_component_id: str | None = None
+    expected_value: str | None = None
+    actual_value: str | None = None
+
+
+class OmsProjectionCheckOut(BaseModel):
+    resource: OmsProjectionResource
+    ok: bool
+    issue_count: int
+    issues: list[OmsProjectionCheckIssueOut] = Field(default_factory=list)
+
+
+class OmsProjectionSyncRunsOut(BaseModel):
+    resource: OmsProjectionSyncResource | None = None
+    platform: OmsProjectionPlatform | None = None
+    limit: int
+    runs: list[OmsProjectionSyncRunOut] = Field(default_factory=list)
+
+
+__all__ = [
+    "OmsProjectionCheckIssueOut",
+    "OmsProjectionCheckOut",
+    "OmsProjectionListOut",
+    "OmsProjectionPlatform",
+    "OmsProjectionResource",
+    "OmsProjectionResourceStatusOut",
+    "OmsProjectionStatusOut",
+    "OmsProjectionSyncOut",
+    "OmsProjectionSyncResource",
+    "OmsProjectionSyncRunOut",
+    "OmsProjectionSyncRunsOut",
+    "SyncRunStatus",
+]

--- a/app/oms/fulfillment_projection/repos/__init__.py
+++ b/app/oms/fulfillment_projection/repos/__init__.py
@@ -1,0 +1,1 @@
+# app/oms/fulfillment_projection/repos/__init__.py

--- a/app/oms/fulfillment_projection/repos/fulfillment_projection_repo.py
+++ b/app/oms/fulfillment_projection/repos/fulfillment_projection_repo.py
@@ -1,0 +1,673 @@
+# app/oms/fulfillment_projection/repos/fulfillment_projection_repo.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.oms.fulfillment_projection.contracts.fulfillment_projection import (
+    OmsProjectionPlatform,
+    OmsProjectionResource,
+)
+
+
+@dataclass(frozen=True)
+class ProjectionResourceConfig:
+    resource: OmsProjectionResource
+    table_name: str
+    id_column: str
+    columns: tuple[str, ...]
+    searchable_columns: tuple[str, ...]
+    order_by_sql: str
+
+
+RESOURCE_CONFIGS: dict[OmsProjectionResource, ProjectionResourceConfig] = {
+    "orders": ProjectionResourceConfig(
+        resource="orders",
+        table_name="wms_oms_fulfillment_order_projection",
+        id_column="ready_order_id",
+        columns=(
+            "ready_order_id",
+            "source_order_id",
+            "platform",
+            "store_code",
+            "store_name",
+            "platform_order_no",
+            "platform_status",
+            "receiver_name",
+            "receiver_phone",
+            "receiver_province",
+            "receiver_city",
+            "receiver_district",
+            "receiver_address",
+            "receiver_postcode",
+            "buyer_remark",
+            "seller_remark",
+            "ready_status",
+            "ready_at",
+            "source_updated_at",
+            "line_count",
+            "component_count",
+            "total_required_qty",
+            "source_hash",
+            "sync_version",
+            "synced_at",
+        ),
+        searchable_columns=(
+            "ready_order_id",
+            "platform",
+            "store_code",
+            "store_name",
+            "platform_order_no",
+            "receiver_name",
+            "receiver_phone",
+        ),
+        order_by_sql="source_updated_at DESC, ready_order_id ASC",
+    ),
+    "lines": ProjectionResourceConfig(
+        resource="lines",
+        table_name="wms_oms_fulfillment_line_projection",
+        id_column="ready_line_id",
+        columns=(
+            "ready_line_id",
+            "ready_order_id",
+            "source_line_id",
+            "platform",
+            "store_code",
+            "identity_kind",
+            "identity_value",
+            "merchant_sku",
+            "platform_item_id",
+            "platform_sku_id",
+            "platform_goods_name",
+            "platform_sku_name",
+            "ordered_qty",
+            "fsku_id",
+            "fsku_code",
+            "fsku_name",
+            "fsku_status_snapshot",
+            "source_hash",
+            "sync_version",
+            "synced_at",
+        ),
+        searchable_columns=(
+            "ready_line_id",
+            "ready_order_id",
+            "platform",
+            "store_code",
+            "identity_kind",
+            "identity_value",
+            "merchant_sku",
+            "platform_item_id",
+            "platform_sku_id",
+            "platform_goods_name",
+            "fsku_code",
+            "fsku_name",
+        ),
+        order_by_sql="ready_order_id ASC, source_line_id ASC",
+    ),
+    "components": ProjectionResourceConfig(
+        resource="components",
+        table_name="wms_oms_fulfillment_component_projection",
+        id_column="ready_component_id",
+        columns=(
+            "ready_component_id",
+            "ready_line_id",
+            "ready_order_id",
+            "resolved_item_id",
+            "resolved_item_sku_code_id",
+            "resolved_item_uom_id",
+            "component_sku_code",
+            "sku_code_snapshot",
+            "item_name_snapshot",
+            "uom_snapshot",
+            "qty_per_fsku",
+            "required_qty",
+            "alloc_unit_price",
+            "sort_order",
+            "source_hash",
+            "sync_version",
+            "synced_at",
+        ),
+        searchable_columns=(
+            "ready_component_id",
+            "ready_line_id",
+            "ready_order_id",
+            "component_sku_code",
+            "sku_code_snapshot",
+            "item_name_snapshot",
+            "uom_snapshot",
+        ),
+        order_by_sql="ready_order_id ASC, ready_line_id ASC, sort_order ASC",
+    ),
+}
+
+RESOURCE_ORDER: tuple[OmsProjectionResource, ...] = ("orders", "lines", "components")
+SYNC_RESOURCE = "fulfillment-ready-orders"
+
+
+class OmsFulfillmentProjectionRepo:
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    @staticmethod
+    def config(resource: OmsProjectionResource) -> ProjectionResourceConfig:
+        try:
+            return RESOURCE_CONFIGS[resource]
+        except KeyError as exc:
+            raise ValueError(f"unsupported OMS projection resource: {resource}") from exc
+
+    @staticmethod
+    def jsonable(value: Any) -> Any:
+        if isinstance(value, Decimal):
+            return str(value)
+        return value
+
+    @staticmethod
+    def sync_run_from_row(row: Any) -> dict[str, Any]:
+        data = dict(row)
+        return {
+            "id": int(data["id"]),
+            "resource": str(data["resource"]),
+            "platform": data.get("platform"),
+            "store_code": data.get("store_code"),
+            "status": str(data["status"]),
+            "fetched": int(data.get("fetched") or 0),
+            "upserted_orders": int(data.get("upserted_orders") or 0),
+            "upserted_lines": int(data.get("upserted_lines") or 0),
+            "upserted_components": int(data.get("upserted_components") or 0),
+            "pages": int(data.get("pages") or 0),
+            "started_at": data["started_at"],
+            "finished_at": data.get("finished_at"),
+            "duration_ms": (
+                int(data["duration_ms"]) if data.get("duration_ms") is not None else None
+            ),
+            "error_message": data.get("error_message"),
+            "triggered_by_user_id": (
+                int(data["triggered_by_user_id"])
+                if data.get("triggered_by_user_id") is not None
+                else None
+            ),
+            "oms_api_base_url_snapshot": data.get("oms_api_base_url_snapshot"),
+            "sync_version": data.get("sync_version"),
+        }
+
+    def latest_sync_run(self) -> dict[str, Any] | None:
+        row = (
+            self.db.execute(
+                text(
+                    """
+                    SELECT
+                        id,
+                        resource,
+                        platform,
+                        store_code,
+                        status,
+                        fetched,
+                        upserted_orders,
+                        upserted_lines,
+                        upserted_components,
+                        pages,
+                        started_at,
+                        finished_at,
+                        duration_ms,
+                        error_message,
+                        triggered_by_user_id,
+                        oms_api_base_url_snapshot,
+                        sync_version
+                    FROM wms_oms_fulfillment_projection_sync_runs
+                    WHERE resource = 'fulfillment-ready-orders'
+                    ORDER BY started_at DESC, id DESC
+                    LIMIT 1
+                    """
+                )
+            )
+            .mappings()
+            .first()
+        )
+        return self.sync_run_from_row(row) if row is not None else None
+
+    def resource_stats(self, cfg: ProjectionResourceConfig) -> dict[str, Any]:
+        row = (
+            self.db.execute(
+                text(
+                    f"""
+                    SELECT
+                        count(*)::bigint AS row_count,
+                        max(synced_at) AS max_synced_at
+                    FROM {cfg.table_name}
+                    """
+                )
+            )
+            .mappings()
+            .one()
+        )
+        return {
+            "row_count": int(row["row_count"] or 0),
+            "max_synced_at": row["max_synced_at"],
+        }
+
+    def list_projection_rows(
+        self,
+        *,
+        cfg: ProjectionResourceConfig,
+        limit: int,
+        offset: int,
+        q: str | None,
+    ) -> dict[str, Any]:
+        where_sql = ""
+        params: dict[str, Any] = {"limit": int(limit), "offset": int(offset)}
+        query_text = (q or "").strip()
+        if query_text and cfg.searchable_columns:
+            where_parts = [
+                f"CAST({column} AS TEXT) ILIKE :q"
+                for column in cfg.searchable_columns
+            ]
+            where_sql = "WHERE " + " OR ".join(where_parts)
+            params["q"] = f"%{query_text}%"
+
+        total = int(
+            self.db.execute(
+                text(f"SELECT count(*)::bigint FROM {cfg.table_name} {where_sql}"),
+                params,
+            ).scalar_one()
+        )
+
+        rows = (
+            self.db.execute(
+                text(
+                    f"""
+                    SELECT {", ".join(cfg.columns)}
+                    FROM {cfg.table_name}
+                    {where_sql}
+                    ORDER BY {cfg.order_by_sql}
+                    LIMIT :limit OFFSET :offset
+                    """
+                ),
+                params,
+            )
+            .mappings()
+            .all()
+        )
+
+        return {
+            "resource": cfg.resource,
+            "table_name": cfg.table_name,
+            "limit": int(limit),
+            "offset": int(offset),
+            "total": total,
+            "columns": list(cfg.columns),
+            "rows": [
+                {key: self.jsonable(value) for key, value in dict(row).items()}
+                for row in rows
+            ],
+        }
+
+    def create_sync_run(
+        self,
+        *,
+        platform: OmsProjectionPlatform | None,
+        store_code: str | None,
+        triggered_by_user_id: int | None,
+        oms_api_base_url_snapshot: str | None,
+        sync_version: str,
+    ) -> int:
+        row = (
+            self.db.execute(
+                text(
+                    """
+                    INSERT INTO wms_oms_fulfillment_projection_sync_runs (
+                        resource,
+                        platform,
+                        store_code,
+                        status,
+                        fetched,
+                        upserted_orders,
+                        upserted_lines,
+                        upserted_components,
+                        pages,
+                        started_at,
+                        triggered_by_user_id,
+                        oms_api_base_url_snapshot,
+                        sync_version
+                    )
+                    VALUES (
+                        'fulfillment-ready-orders',
+                        :platform,
+                        :store_code,
+                        'RUNNING',
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        now(),
+                        :triggered_by_user_id,
+                        :oms_api_base_url_snapshot,
+                        :sync_version
+                    )
+                    RETURNING id
+                    """
+                ),
+                {
+                    "platform": platform,
+                    "store_code": store_code,
+                    "triggered_by_user_id": triggered_by_user_id,
+                    "oms_api_base_url_snapshot": oms_api_base_url_snapshot,
+                    "sync_version": sync_version,
+                },
+            )
+            .mappings()
+            .one()
+        )
+        self.db.commit()
+        return int(row["id"])
+
+    def finish_sync_run(
+        self,
+        *,
+        run_id: int,
+        status: str,
+        duration_ms: int,
+        fetched: int = 0,
+        upserted_orders: int = 0,
+        upserted_lines: int = 0,
+        upserted_components: int = 0,
+        pages: int = 0,
+        error_message: str | None = None,
+    ) -> dict[str, Any]:
+        row = (
+            self.db.execute(
+                text(
+                    """
+                    UPDATE wms_oms_fulfillment_projection_sync_runs
+                       SET status = :status,
+                           fetched = :fetched,
+                           upserted_orders = :upserted_orders,
+                           upserted_lines = :upserted_lines,
+                           upserted_components = :upserted_components,
+                           pages = :pages,
+                           finished_at = now(),
+                           duration_ms = :duration_ms,
+                           error_message = :error_message
+                     WHERE id = :run_id
+                    RETURNING
+                        id,
+                        resource,
+                        platform,
+                        store_code,
+                        status,
+                        fetched,
+                        upserted_orders,
+                        upserted_lines,
+                        upserted_components,
+                        pages,
+                        started_at,
+                        finished_at,
+                        duration_ms,
+                        error_message,
+                        triggered_by_user_id,
+                        oms_api_base_url_snapshot,
+                        sync_version
+                    """
+                ),
+                {
+                    "run_id": int(run_id),
+                    "status": status,
+                    "fetched": int(fetched),
+                    "upserted_orders": int(upserted_orders),
+                    "upserted_lines": int(upserted_lines),
+                    "upserted_components": int(upserted_components),
+                    "pages": int(pages),
+                    "duration_ms": int(duration_ms),
+                    "error_message": error_message,
+                },
+            )
+            .mappings()
+            .one()
+        )
+        self.db.commit()
+        return self.sync_run_from_row(row)
+
+    def list_sync_runs(
+        self,
+        *,
+        platform: OmsProjectionPlatform | None,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        where_parts = ["resource = 'fulfillment-ready-orders'"]
+        params: dict[str, Any] = {"limit": int(limit)}
+        if platform is not None:
+            where_parts.append("platform = :platform")
+            params["platform"] = platform
+
+        rows = (
+            self.db.execute(
+                text(
+                    f"""
+                    SELECT
+                        id,
+                        resource,
+                        platform,
+                        store_code,
+                        status,
+                        fetched,
+                        upserted_orders,
+                        upserted_lines,
+                        upserted_components,
+                        pages,
+                        started_at,
+                        finished_at,
+                        duration_ms,
+                        error_message,
+                        triggered_by_user_id,
+                        oms_api_base_url_snapshot,
+                        sync_version
+                    FROM wms_oms_fulfillment_projection_sync_runs
+                    WHERE {" AND ".join(where_parts)}
+                    ORDER BY started_at DESC, id DESC
+                    LIMIT :limit
+                    """
+                ),
+                params,
+            )
+            .mappings()
+            .all()
+        )
+        return [self.sync_run_from_row(row) for row in rows]
+
+    def check_orders(self, limit: int) -> list[dict[str, Any]]:
+        rows = (
+            self.db.execute(
+                text(
+                    """
+                    WITH line_actuals AS (
+                      SELECT
+                        ready_order_id,
+                        count(*)::int AS actual_line_count
+                      FROM wms_oms_fulfillment_line_projection
+                      GROUP BY ready_order_id
+                    ),
+                    component_actuals AS (
+                      SELECT
+                        ready_order_id,
+                        count(*)::int AS actual_component_count,
+                        COALESCE(sum(required_qty), 0)::numeric(18, 6) AS actual_required_qty
+                      FROM wms_oms_fulfillment_component_projection
+                      GROUP BY ready_order_id
+                    )
+                    SELECT
+                      o.ready_order_id,
+                      o.line_count AS expected_line_count,
+                      COALESCE(l.actual_line_count, 0) AS actual_line_count,
+                      o.component_count AS expected_component_count,
+                      COALESCE(c.actual_component_count, 0) AS actual_component_count,
+                      o.total_required_qty AS expected_required_qty,
+                      COALESCE(c.actual_required_qty, 0)::numeric(18, 6) AS actual_required_qty
+                    FROM wms_oms_fulfillment_order_projection AS o
+                    LEFT JOIN line_actuals AS l
+                      ON l.ready_order_id = o.ready_order_id
+                    LEFT JOIN component_actuals AS c
+                      ON c.ready_order_id = o.ready_order_id
+                    WHERE o.line_count <> COALESCE(l.actual_line_count, 0)
+                       OR o.component_count <> COALESCE(c.actual_component_count, 0)
+                       OR o.total_required_qty <> COALESCE(c.actual_required_qty, 0)
+                    ORDER BY o.ready_order_id ASC
+                    LIMIT :limit
+                    """
+                ),
+                {"limit": int(limit)},
+            )
+            .mappings()
+            .all()
+        )
+
+        issues: list[dict[str, Any]] = []
+        for row in rows:
+            ready_order_id = str(row["ready_order_id"])
+            if row["expected_line_count"] != row["actual_line_count"]:
+                issues.append(
+                    {
+                        "issue_type": "ORDER_LINE_COUNT_MISMATCH",
+                        "resource": "orders",
+                        "source_id": ready_order_id,
+                        "message": "订单投影 line_count 与行投影实际数量不一致",
+                        "ready_order_id": ready_order_id,
+                        "expected_value": str(row["expected_line_count"]),
+                        "actual_value": str(row["actual_line_count"]),
+                    }
+                )
+            if row["expected_component_count"] != row["actual_component_count"]:
+                issues.append(
+                    {
+                        "issue_type": "ORDER_COMPONENT_COUNT_MISMATCH",
+                        "resource": "orders",
+                        "source_id": ready_order_id,
+                        "message": "订单投影 component_count 与组件投影实际数量不一致",
+                        "ready_order_id": ready_order_id,
+                        "expected_value": str(row["expected_component_count"]),
+                        "actual_value": str(row["actual_component_count"]),
+                    }
+                )
+            if row["expected_required_qty"] != row["actual_required_qty"]:
+                issues.append(
+                    {
+                        "issue_type": "ORDER_REQUIRED_QTY_MISMATCH",
+                        "resource": "orders",
+                        "source_id": ready_order_id,
+                        "message": "订单投影 total_required_qty 与组件 required_qty 合计不一致",
+                        "ready_order_id": ready_order_id,
+                        "expected_value": str(row["expected_required_qty"]),
+                        "actual_value": str(row["actual_required_qty"]),
+                    }
+                )
+
+        return issues[:limit]
+
+    def check_lines(self, limit: int) -> list[dict[str, Any]]:
+        rows = (
+            self.db.execute(
+                text(
+                    """
+                    SELECT
+                        l.ready_line_id,
+                        l.ready_order_id
+                    FROM wms_oms_fulfillment_line_projection AS l
+                    LEFT JOIN wms_oms_fulfillment_order_projection AS o
+                      ON o.ready_order_id = l.ready_order_id
+                    WHERE o.ready_order_id IS NULL
+                    ORDER BY l.ready_line_id ASC
+                    LIMIT :limit
+                    """
+                ),
+                {"limit": int(limit)},
+            )
+            .mappings()
+            .all()
+        )
+        return [
+            {
+                "issue_type": "LINE_ORDER_MISSING_IN_PROJECTION",
+                "resource": "lines",
+                "source_id": str(row["ready_line_id"]),
+                "message": "行投影中的 ready_order_id 在订单投影中不存在",
+                "ready_order_id": str(row["ready_order_id"]),
+                "ready_line_id": str(row["ready_line_id"]),
+            }
+            for row in rows
+        ]
+
+    def check_components(self, limit: int) -> list[dict[str, Any]]:
+        rows = (
+            self.db.execute(
+                text(
+                    """
+                    SELECT
+                        c.ready_component_id,
+                        c.ready_line_id,
+                        c.ready_order_id,
+                        l.ready_order_id AS line_ready_order_id,
+                        o.ready_order_id AS order_ready_order_id,
+                        CASE
+                          WHEN o.ready_order_id IS NULL THEN 'COMPONENT_ORDER_MISSING_IN_PROJECTION'
+                          WHEN l.ready_line_id IS NULL THEN 'COMPONENT_LINE_MISSING_IN_PROJECTION'
+                          WHEN l.ready_order_id <> c.ready_order_id THEN 'COMPONENT_LINE_ORDER_MISMATCH'
+                          ELSE 'OK'
+                        END AS issue_type
+                    FROM wms_oms_fulfillment_component_projection AS c
+                    LEFT JOIN wms_oms_fulfillment_order_projection AS o
+                      ON o.ready_order_id = c.ready_order_id
+                    LEFT JOIN wms_oms_fulfillment_line_projection AS l
+                      ON l.ready_line_id = c.ready_line_id
+                    WHERE o.ready_order_id IS NULL
+                       OR l.ready_line_id IS NULL
+                       OR l.ready_order_id <> c.ready_order_id
+                    ORDER BY c.ready_component_id ASC
+                    LIMIT :limit
+                    """
+                ),
+                {"limit": int(limit)},
+            )
+            .mappings()
+            .all()
+        )
+
+        messages = {
+            "COMPONENT_ORDER_MISSING_IN_PROJECTION": "组件投影中的 ready_order_id 在订单投影中不存在",
+            "COMPONENT_LINE_MISSING_IN_PROJECTION": "组件投影中的 ready_line_id 在行投影中不存在",
+            "COMPONENT_LINE_ORDER_MISMATCH": "组件投影的 ready_order_id 与行投影所属 ready_order_id 不一致",
+        }
+        return [
+            {
+                "issue_type": str(row["issue_type"]),
+                "resource": "components",
+                "source_id": str(row["ready_component_id"]),
+                "message": messages.get(str(row["issue_type"]), "OMS 履约组件投影一致性异常"),
+                "ready_order_id": str(row["ready_order_id"]),
+                "ready_line_id": str(row["ready_line_id"]),
+                "ready_component_id": str(row["ready_component_id"]),
+                "expected_value": (
+                    str(row["ready_order_id"])
+                    if row["issue_type"] == "COMPONENT_LINE_ORDER_MISMATCH"
+                    else None
+                ),
+                "actual_value": (
+                    str(row["line_ready_order_id"])
+                    if row["issue_type"] == "COMPONENT_LINE_ORDER_MISMATCH"
+                    else None
+                ),
+            }
+            for row in rows
+        ]
+
+
+__all__ = [
+    "OmsFulfillmentProjectionRepo",
+    "ProjectionResourceConfig",
+    "RESOURCE_CONFIGS",
+    "RESOURCE_ORDER",
+    "SYNC_RESOURCE",
+]

--- a/app/oms/fulfillment_projection/routers/__init__.py
+++ b/app/oms/fulfillment_projection/routers/__init__.py
@@ -1,0 +1,1 @@
+# app/oms/fulfillment_projection/routers/__init__.py

--- a/app/oms/fulfillment_projection/routers/fulfillment_projection.py
+++ b/app/oms/fulfillment_projection/routers/fulfillment_projection.py
@@ -1,0 +1,113 @@
+# app/oms/fulfillment_projection/routers/fulfillment_projection.py
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.integrations.oms.projection_sync import OmsFulfillmentProjectionSyncError
+from app.oms.fulfillment_projection.contracts.fulfillment_projection import (
+    OmsProjectionCheckOut,
+    OmsProjectionListOut,
+    OmsProjectionPlatform,
+    OmsProjectionResource,
+    OmsProjectionStatusOut,
+    OmsProjectionSyncOut,
+    OmsProjectionSyncRunsOut,
+)
+from app.oms.fulfillment_projection.services.fulfillment_projection_service import (
+    OmsFulfillmentProjectionService,
+)
+from app.user.deps.auth import get_current_user
+from app.user.services.user_service import UserService
+
+router = APIRouter(
+    prefix="/fulfillment-projection",
+    tags=["oms-fulfillment-projection"],
+)
+
+
+def _service(db: Session) -> OmsFulfillmentProjectionService:
+    return OmsFulfillmentProjectionService(db)
+
+
+@router.get("/status", response_model=OmsProjectionStatusOut)
+def get_oms_fulfillment_projection_status(
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    svc = UserService(db)
+    svc.check_permission(current_user, ["page.oms.read"])
+    return _service(db).get_status()
+
+
+@router.get("/sync-runs", response_model=OmsProjectionSyncRunsOut)
+def list_oms_fulfillment_projection_sync_runs(
+    platform: OmsProjectionPlatform | None = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=100),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    svc = UserService(db)
+    svc.check_permission(current_user, ["page.oms.read"])
+    return _service(db).list_sync_runs(platform=platform, limit=limit)
+
+
+@router.get("/projections/{resource}", response_model=OmsProjectionListOut)
+def list_oms_fulfillment_projection_rows(
+    resource: OmsProjectionResource,
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    q: str | None = Query(default=None),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    svc = UserService(db)
+    svc.check_permission(current_user, ["page.oms.read"])
+    return _service(db).list_projection(
+        resource=resource,
+        limit=limit,
+        offset=offset,
+        q=q,
+    )
+
+
+@router.post("/projections/fulfillment-ready-orders/sync", response_model=OmsProjectionSyncOut)
+async def sync_oms_fulfillment_ready_orders(
+    platform: OmsProjectionPlatform | None = Query(default=None),
+    store_code: str | None = Query(default=None, min_length=1, max_length=128),
+    limit: int = Query(default=200, ge=1, le=500),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    svc = UserService(db)
+    svc.check_permission(current_user, ["page.oms.write"])
+
+    try:
+        run = await _service(db).sync_fulfillment_ready_orders(
+            platform=platform,
+            store_code=store_code,
+            limit=limit,
+            triggered_by_user_id=int(getattr(current_user, "id")),
+        )
+    except (RuntimeError, OmsFulfillmentProjectionSyncError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"OMS fulfillment projection sync failed: {exc}")
+
+    return {"run": run}
+
+
+@router.post("/projections/{resource}/check", response_model=OmsProjectionCheckOut)
+def check_oms_fulfillment_projection_resource(
+    resource: OmsProjectionResource,
+    limit: int = Query(default=200, ge=1, le=1000),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    svc = UserService(db)
+    svc.check_permission(current_user, ["page.oms.read"])
+    return _service(db).check_projection(resource=resource, limit=limit)
+
+
+__all__ = ["router"]

--- a/app/oms/fulfillment_projection/services/__init__.py
+++ b/app/oms/fulfillment_projection/services/__init__.py
@@ -1,0 +1,1 @@
+# app/oms/fulfillment_projection/services/__init__.py

--- a/app/oms/fulfillment_projection/services/fulfillment_projection_service.py
+++ b/app/oms/fulfillment_projection/services/fulfillment_projection_service.py
@@ -1,0 +1,211 @@
+# app/oms/fulfillment_projection/services/fulfillment_projection_service.py
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.db.session import AsyncSessionLocal
+from app.integrations.oms.projection_sync import (
+    SYNC_VERSION,
+    OmsFulfillmentProjectionSyncResult,
+    sync_oms_fulfillment_projection_once,
+)
+from app.oms.fulfillment_projection.contracts.fulfillment_projection import (
+    OmsProjectionPlatform,
+    OmsProjectionResource,
+)
+from app.oms.fulfillment_projection.repos.fulfillment_projection_repo import (
+    RESOURCE_ORDER,
+    SYNC_RESOURCE,
+    OmsFulfillmentProjectionRepo,
+)
+
+SyncCallable = Callable[..., Coroutine[Any, Any, OmsFulfillmentProjectionSyncResult]]
+
+
+class OmsFulfillmentProjectionService:
+    """
+    WMS-local operations for OMS fulfillment projection.
+
+    Boundary:
+    - Reads WMS-owned OMS projection tables and WMS sync-run logs only.
+    - Triggers projection_sync, which reads oms-api read-v1 HTTP output.
+    - Does not manage OMS authorization clients or secrets.
+    - Must not read or write OMS owner tables.
+    """
+
+    def __init__(
+        self,
+        db: Session,
+        *,
+        sync_callable: SyncCallable = sync_oms_fulfillment_projection_once,
+    ) -> None:
+        self.db = db
+        self.repo = OmsFulfillmentProjectionRepo(db)
+        self._sync_callable = sync_callable
+
+    @staticmethod
+    def _safe_limit(value: int, *, default: int = 50, max_value: int = 500) -> int:
+        try:
+            number = int(value)
+        except (TypeError, ValueError):
+            number = default
+        return max(1, min(number, max_value))
+
+    @staticmethod
+    def _safe_offset(value: int) -> int:
+        try:
+            number = int(value)
+        except (TypeError, ValueError):
+            number = 0
+        return max(0, number)
+
+    @staticmethod
+    def _oms_api_base_url_snapshot() -> str | None:
+        value = (os.getenv("OMS_API_BASE_URL") or "").strip().rstrip("/")
+        return value or None
+
+    @staticmethod
+    def _oms_api_token_configured() -> bool:
+        return bool((os.getenv("OMS_API_TOKEN") or "").strip())
+
+    def get_status(self) -> dict[str, Any]:
+        latest_run = self.repo.latest_sync_run()
+        resources: list[dict[str, Any]] = []
+
+        for resource in RESOURCE_ORDER:
+            cfg = self.repo.config(resource)
+            stats = self.repo.resource_stats(cfg)
+            resources.append(
+                {
+                    "resource": resource,
+                    "table_name": cfg.table_name,
+                    "row_count": stats["row_count"],
+                    "max_synced_at": stats["max_synced_at"],
+                    "last_sync_run": latest_run,
+                }
+            )
+
+        return {
+            "oms_api_base_url_configured": self._oms_api_base_url_snapshot() is not None,
+            "oms_api_token_configured": self._oms_api_token_configured(),
+            "resources": resources,
+        }
+
+    def list_projection(
+        self,
+        *,
+        resource: OmsProjectionResource,
+        limit: int,
+        offset: int,
+        q: str | None = None,
+    ) -> dict[str, Any]:
+        cfg = self.repo.config(resource)
+        safe_limit = self._safe_limit(limit)
+        safe_offset = self._safe_offset(offset)
+
+        return self.repo.list_projection_rows(
+            cfg=cfg,
+            limit=safe_limit,
+            offset=safe_offset,
+            q=q,
+        )
+
+    async def sync_fulfillment_ready_orders(
+        self,
+        *,
+        platform: OmsProjectionPlatform | None,
+        store_code: str | None,
+        limit: int,
+        triggered_by_user_id: int | None,
+    ) -> dict[str, Any]:
+        safe_limit = self._safe_limit(limit, default=200, max_value=500)
+        normalized_store_code = (store_code or "").strip() or None
+        started_monotonic = time.monotonic()
+
+        run_id = self.repo.create_sync_run(
+            platform=platform,
+            store_code=normalized_store_code,
+            triggered_by_user_id=triggered_by_user_id,
+            oms_api_base_url_snapshot=self._oms_api_base_url_snapshot(),
+            sync_version=SYNC_VERSION,
+        )
+
+        try:
+            async with AsyncSessionLocal() as async_session:
+                result = await self._sync_callable(
+                    async_session,
+                    platform=platform,
+                    store_code=normalized_store_code,
+                    limit=safe_limit,
+                )
+                await async_session.commit()
+
+            duration_ms = int((time.monotonic() - started_monotonic) * 1000)
+            return self.repo.finish_sync_run(
+                run_id=run_id,
+                status="SUCCESS",
+                duration_ms=duration_ms,
+                fetched=result.fetched,
+                upserted_orders=result.upserted_orders,
+                upserted_lines=result.upserted_lines,
+                upserted_components=result.upserted_components,
+                pages=result.pages,
+                error_message=None,
+            )
+        except Exception as exc:
+            duration_ms = int((time.monotonic() - started_monotonic) * 1000)
+            self.repo.finish_sync_run(
+                run_id=run_id,
+                status="FAILED",
+                duration_ms=duration_ms,
+                error_message=str(exc),
+            )
+            raise
+
+    def list_sync_runs(
+        self,
+        *,
+        platform: OmsProjectionPlatform | None,
+        limit: int,
+    ) -> dict[str, Any]:
+        safe_limit = self._safe_limit(limit, default=20, max_value=100)
+
+        return {
+            "resource": SYNC_RESOURCE,
+            "platform": platform,
+            "limit": safe_limit,
+            "runs": self.repo.list_sync_runs(platform=platform, limit=safe_limit),
+        }
+
+    def check_projection(
+        self,
+        *,
+        resource: OmsProjectionResource,
+        limit: int = 200,
+    ) -> dict[str, Any]:
+        self.repo.config(resource)
+        safe_limit = self._safe_limit(limit, default=200, max_value=1000)
+
+        if resource == "orders":
+            rows = self.repo.check_orders(safe_limit)
+        elif resource == "lines":
+            rows = self.repo.check_lines(safe_limit)
+        elif resource == "components":
+            rows = self.repo.check_components(safe_limit)
+        else:
+            raise ValueError(f"unsupported OMS projection resource: {resource}")
+
+        return {
+            "resource": resource,
+            "ok": len(rows) == 0,
+            "issue_count": len(rows),
+            "issues": rows,
+        }
+
+
+__all__ = ["OmsFulfillmentProjectionService"]

--- a/app/oms/router.py
+++ b/app/oms/router.py
@@ -10,6 +10,7 @@ from app.oms.routers.platform_orders_resolve_preview import router as platform_o
 from app.oms.routers.stores import router as stores_router
 from app.oms.orders.routers.order_outbound_options import router as order_outbound_options_router
 from app.oms.orders.routers.order_outbound_view import router as order_outbound_view_router
+from app.oms.fulfillment_projection.routers.fulfillment_projection import router as fulfillment_projection_router
 
 router = APIRouter(prefix="/oms", tags=["OMS"])
 router.include_router(order_facts_router)
@@ -23,3 +24,4 @@ router.include_router(stores_router)
 router.include_router(fsku_router)
 router.include_router(order_outbound_options_router)
 router.include_router(order_outbound_view_router)
+router.include_router(fulfillment_projection_router)

--- a/tests/api/test_oms_fulfillment_projection_ops_api.py
+++ b/tests/api/test_oms_fulfillment_projection_ops_api.py
@@ -1,0 +1,337 @@
+# tests/api/test_oms_fulfillment_projection_ops_api.py
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def _login_admin_headers(client: AsyncClient) -> dict[str, str]:
+    r = await client.post("/users/login", json={"username": "admin", "password": "admin123"})
+    assert r.status_code == 200, r.text
+    token = r.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _clear_oms_projection(session: AsyncSession) -> None:
+    await session.execute(text("DELETE FROM wms_oms_fulfillment_component_projection"))
+    await session.execute(text("DELETE FROM wms_oms_fulfillment_line_projection"))
+    await session.execute(text("DELETE FROM wms_oms_fulfillment_order_projection"))
+    await session.execute(text("DELETE FROM wms_oms_fulfillment_projection_sync_runs"))
+    await session.commit()
+
+
+async def _insert_ready_order(session: AsyncSession) -> None:
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_oms_fulfillment_order_projection (
+                ready_order_id,
+                source_order_id,
+                platform,
+                store_code,
+                store_name,
+                platform_order_no,
+                receiver_name,
+                receiver_phone,
+                receiver_province,
+                receiver_city,
+                receiver_address,
+                ready_status,
+                ready_at,
+                source_updated_at,
+                line_count,
+                component_count,
+                total_required_qty,
+                synced_at
+            )
+            VALUES (
+                'pdd:8801',
+                8801,
+                'pdd',
+                'UT-PDD-STORE',
+                'PDD 测试店',
+                'PDD-8801',
+                '张三',
+                '13800000000',
+                '浙江省',
+                '杭州市',
+                '文三路 1 号',
+                'READY',
+                now(),
+                now(),
+                1,
+                1,
+                2,
+                now()
+            )
+            ON CONFLICT (ready_order_id) DO UPDATE
+            SET store_code = EXCLUDED.store_code,
+                store_name = EXCLUDED.store_name,
+                platform_order_no = EXCLUDED.platform_order_no,
+                line_count = EXCLUDED.line_count,
+                component_count = EXCLUDED.component_count,
+                total_required_qty = EXCLUDED.total_required_qty,
+                synced_at = now()
+            """
+        )
+    )
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_oms_fulfillment_line_projection (
+                ready_line_id,
+                ready_order_id,
+                source_line_id,
+                platform,
+                store_code,
+                identity_kind,
+                identity_value,
+                ordered_qty,
+                fsku_id,
+                fsku_code,
+                fsku_name,
+                fsku_status_snapshot,
+                synced_at
+            )
+            VALUES (
+                'pdd:8801:line:1',
+                'pdd:8801',
+                88011,
+                'pdd',
+                'UT-PDD-STORE',
+                'merchant_code',
+                'MERCHANT-8801',
+                1,
+                18801,
+                'FSKU-8801',
+                '履约商品8801',
+                'published',
+                now()
+            )
+            ON CONFLICT (ready_line_id) DO NOTHING
+            """
+        )
+    )
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_oms_fulfillment_component_projection (
+                ready_component_id,
+                ready_line_id,
+                ready_order_id,
+                resolved_item_id,
+                resolved_item_sku_code_id,
+                resolved_item_uom_id,
+                component_sku_code,
+                sku_code_snapshot,
+                item_name_snapshot,
+                uom_snapshot,
+                qty_per_fsku,
+                required_qty,
+                alloc_unit_price,
+                sort_order,
+                synced_at
+            )
+            VALUES (
+                'pdd:8801:line:1:component:1',
+                'pdd:8801:line:1',
+                'pdd:8801',
+                28801,
+                38801,
+                48801,
+                'SKU-8801',
+                'SKU-8801',
+                '商品8801',
+                '件',
+                2,
+                2,
+                1,
+                1,
+                now()
+            )
+            ON CONFLICT (ready_component_id) DO NOTHING
+            """
+        )
+    )
+    await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_oms_fulfillment_projection_status_lists_resources(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    await _clear_oms_projection(session)
+    headers = await _login_admin_headers(client)
+
+    r = await client.get("/oms/fulfillment-projection/status", headers=headers)
+    assert r.status_code == 200, r.text
+
+    data = r.json()
+    assert data["oms_api_base_url_configured"] in {True, False}
+    assert data["oms_api_token_configured"] in {True, False}
+
+    resources = {row["resource"]: row for row in data["resources"]}
+    assert list(resources.keys()) == ["orders", "lines", "components"]
+
+    assert resources["orders"]["table_name"] == "wms_oms_fulfillment_order_projection"
+    assert resources["lines"]["table_name"] == "wms_oms_fulfillment_line_projection"
+    assert resources["components"]["table_name"] == "wms_oms_fulfillment_component_projection"
+
+
+@pytest.mark.asyncio
+async def test_oms_fulfillment_projection_can_list_rows(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    await _clear_oms_projection(session)
+    await _insert_ready_order(session)
+    headers = await _login_admin_headers(client)
+
+    r = await client.get(
+        "/oms/fulfillment-projection/projections/orders?limit=5&offset=0&q=PDD-8801",
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+
+    data = r.json()
+    assert data["resource"] == "orders"
+    assert data["table_name"] == "wms_oms_fulfillment_order_projection"
+    assert data["limit"] == 5
+    assert data["offset"] == 0
+    assert data["total"] >= 1
+    assert "ready_order_id" in data["columns"]
+    assert "platform_order_no" in data["columns"]
+
+    matched = [row for row in data["rows"] if row.get("ready_order_id") == "pdd:8801"]
+    assert matched
+    assert matched[0]["platform_order_no"] == "PDD-8801"
+
+
+@pytest.mark.asyncio
+async def test_oms_fulfillment_projection_can_check_projection(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    await _clear_oms_projection(session)
+    await _insert_ready_order(session)
+    headers = await _login_admin_headers(client)
+
+    r = await client.post(
+        "/oms/fulfillment-projection/projections/orders/check",
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+
+    data = r.json()
+    assert data["resource"] == "orders"
+    assert data["ok"] is True
+    assert data["issue_count"] == 0
+    assert data["issues"] == []
+
+
+@pytest.mark.asyncio
+async def test_oms_fulfillment_projection_sync_without_token_returns_400_and_logs_failed_run(
+    client: AsyncClient,
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await _clear_oms_projection(session)
+    monkeypatch.setenv("OMS_API_BASE_URL", "http://oms-api.test")
+    monkeypatch.delenv("OMS_API_TOKEN", raising=False)
+
+    headers = await _login_admin_headers(client)
+
+    r = await client.post(
+        "/oms/fulfillment-projection/projections/fulfillment-ready-orders/sync?platform=pdd&store_code=UT-PDD",
+        headers=headers,
+    )
+    assert r.status_code == 400, r.text
+    assert "OMS_API_TOKEN" in r.text
+
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                    resource,
+                    platform,
+                    store_code,
+                    status,
+                    error_message
+                FROM wms_oms_fulfillment_projection_sync_runs
+                WHERE resource = 'fulfillment-ready-orders'
+                ORDER BY id DESC
+                LIMIT 1
+                """
+            )
+        )
+    ).mappings().one()
+
+    assert row["resource"] == "fulfillment-ready-orders"
+    assert row["platform"] == "pdd"
+    assert row["store_code"] == "UT-PDD"
+    assert row["status"] == "FAILED"
+    assert "OMS_API_TOKEN" in str(row["error_message"])
+
+
+@pytest.mark.asyncio
+async def test_oms_fulfillment_projection_sync_runs_can_be_listed(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    await _clear_oms_projection(session)
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_oms_fulfillment_projection_sync_runs (
+                resource,
+                platform,
+                store_code,
+                status,
+                fetched,
+                upserted_orders,
+                upserted_lines,
+                upserted_components,
+                pages,
+                started_at,
+                finished_at,
+                duration_ms,
+                sync_version
+            )
+            VALUES (
+                'fulfillment-ready-orders',
+                'taobao',
+                'UT-TB',
+                'SUCCESS',
+                2,
+                2,
+                3,
+                4,
+                1,
+                now(),
+                now(),
+                10,
+                'ut-sync-run'
+            )
+            """
+        )
+    )
+    await session.commit()
+
+    headers = await _login_admin_headers(client)
+    r = await client.get(
+        "/oms/fulfillment-projection/sync-runs?platform=taobao&limit=5",
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+
+    data = r.json()
+    assert data["resource"] == "fulfillment-ready-orders"
+    assert data["platform"] == "taobao"
+    assert data["limit"] == 5
+    assert data["runs"]
+    assert data["runs"][0]["resource"] == "fulfillment-ready-orders"
+    assert data["runs"][0]["platform"] == "taobao"

--- a/tests/ci/test_wms_oms_fulfillment_projection_ops_boundary.py
+++ b/tests/ci/test_wms_oms_fulfillment_projection_ops_boundary.py
@@ -1,0 +1,75 @@
+# tests/ci/test_wms_oms_fulfillment_projection_ops_boundary.py
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+FORBIDDEN_OWNER_SQL_RE = re.compile(
+    r"\bFROM\s+(orders|order_lines|oms_fskus|oms_fsku_components|platform_code_fsku_mappings)\b"
+    r"|\bJOIN\s+(orders|order_lines|oms_fskus|oms_fsku_components|platform_code_fsku_mappings)\b"
+    r"|\bINSERT\s+INTO\s+(orders|order_lines|oms_fskus|oms_fsku_components|platform_code_fsku_mappings)\b"
+    r"|\bUPDATE\s+(orders|order_lines|oms_fskus|oms_fsku_components|platform_code_fsku_mappings)\b"
+    r"|\bDELETE\s+FROM\s+(orders|order_lines|oms_fskus|oms_fsku_components|platform_code_fsku_mappings)\b",
+    re.IGNORECASE,
+)
+
+
+def test_oms_fulfillment_projection_module_uses_wms_directory_style() -> None:
+    base = ROOT / "app/oms/fulfillment_projection"
+
+    assert (base / "contracts/fulfillment_projection.py").is_file()
+    assert (base / "repos/fulfillment_projection_repo.py").is_file()
+    assert (base / "routers/fulfillment_projection.py").is_file()
+    assert (base / "services/fulfillment_projection_service.py").is_file()
+
+    assert not (base / "contracts.py").exists()
+    assert not (base / "service.py").exists()
+    assert not (base / "router.py").exists()
+
+    assert not (base / "contract").exists()
+    assert not (base / "repo").exists()
+    assert not (base / "router").exists()
+    assert not (base / "service").exists()
+
+
+def test_oms_fulfillment_projection_repo_uses_projection_tables_only() -> None:
+    text = (ROOT / "app/oms/fulfillment_projection/repos/fulfillment_projection_repo.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "wms_oms_fulfillment_order_projection" in text
+    assert "wms_oms_fulfillment_line_projection" in text
+    assert "wms_oms_fulfillment_component_projection" in text
+    assert "wms_oms_fulfillment_projection_sync_runs" in text
+
+    assert FORBIDDEN_OWNER_SQL_RE.search(text) is None
+    assert "wms_logistics_" not in text
+    assert "outbound_event" not in text
+    assert "wms_pms_" not in text
+
+
+def test_oms_fulfillment_projection_router_uses_oms_permissions_and_business_prefix() -> None:
+    text = (ROOT / "app/oms/fulfillment_projection/routers/fulfillment_projection.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'prefix="/fulfillment-projection"' in text
+    assert "page.oms.read" in text
+    assert "page.oms.write" in text
+    assert "/projections/fulfillment-ready-orders/sync" in text
+
+    assert "page.admin.read" not in text
+    assert "page.admin.write" not in text
+    assert "/admin" not in text
+    assert "/collector" not in text
+    assert "/connection" not in text
+
+
+def test_oms_router_mounts_fulfillment_projection_router() -> None:
+    text = (ROOT / "app/oms/router.py").read_text(encoding="utf-8")
+
+    assert "fulfillment_projection_router" in text
+    assert "router.include_router(fulfillment_projection_router)" in text
+    assert "app.oms.fulfillment_projection.routers.fulfillment_projection" in text


### PR DESCRIPTION
## Summary
- add OMS-domain fulfillment projection ops API
- expose projection status, rows, sync runs, checks, and manual sync
- use page.oms read/write permissions instead of admin permissions
- follow WMS module directory style: contracts/repos/routers/services
- keep WMS projection reads isolated from OMS owner tables

## Validation
- make env
- make alembic-check
- make test TESTS="tests/api/test_oms_fulfillment_projection_ops_api.py tests/ci/test_wms_oms_fulfillment_projection_ops_boundary.py tests/ci/test_wms_oms_fulfillment_projection_sync_boundary.py tests/ci/test_wms_oms_fulfillment_projection_metadata.py"