### PR TITLE
chore(ci): require ripgrep for audit targets

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -53,6 +53,12 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install system audit tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ripgrep
+          rg --version
+
       - name: Create venv & install runtime deps
         run: |
           make venv

--- a/scripts/make/audit.mk
+++ b/scripts/make/audit.mk
@@ -2,8 +2,17 @@
 # audit.mk - 审计 / 守门员规则
 # =================================
 
+.PHONY: audit-require-rg
+audit-require-rg:
+	@bash -c 'set -euo pipefail; \
+	  if ! command -v rg >/dev/null 2>&1; then \
+	    echo "[audit-require-rg] FAIL: ripgrep (rg) is required for audit targets" >&2; \
+	    echo "  Install ripgrep locally, or ensure CI installs it before make audit-all." >&2; \
+	    exit 127; \
+	  fi'
+
 .PHONY: audit-no-legacy-stock-sql
-audit-no-legacy-stock-sql:
+audit-no-legacy-stock-sql: audit-require-rg
 	@bash -c 'set -euo pipefail; \
 	  echo "[audit-no-legacy-stock-sql] forbid SQL access to legacy stocks/batches in app/..."; \
 	  hits="$$(rg -n --hidden \
@@ -30,7 +39,7 @@ audit-no-legacy-stock-sql:
 #   dest_adjustments 这类退役口径重新混入运行/测试代码
 # =================================
 .PHONY: audit-no-legacy-pricing-terms
-audit-no-legacy-pricing-terms:
+audit-no-legacy-pricing-terms: audit-require-rg
 	@bash -c 'set -euo pipefail; \
 	  echo "[audit-no-legacy-pricing-terms] forbid retired pricing terms in app/tests ..."; \
 	  hits="$$(rg -n --hidden \
@@ -53,7 +62,7 @@ audit-no-legacy-pricing-terms:
 # - 白名单仅允许：manual-assign service（devconsole 写入已被禁止）
 # =================================
 .PHONY: audit-no-implicit-warehouse-id
-audit-no-implicit-warehouse-id:
+audit-no-implicit-warehouse-id: audit-require-rg
 	@bash -c 'set -euo pipefail; \
 	  echo "[audit-no-implicit-warehouse-id] forbid implicit writes to orders.warehouse_id ..."; \
 	  hits="$$(rg -n "UPDATE orders\\s+SET\\s+warehouse_id|SET\\s+warehouse_id\\s*=" app -S || true)"; \

--- a/tests/ci/test_audit_requires_ripgrep_boundary.py
+++ b/tests/ci/test_audit_requires_ripgrep_boundary.py
@@ -1,0 +1,26 @@
+# tests/ci/test_audit_requires_ripgrep_boundary.py
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_backend_ci_installs_ripgrep_for_audit_targets() -> None:
+    text = (ROOT / ".github/workflows/backend-ci.yml").read_text(encoding="utf-8")
+
+    assert "Install system audit tools" in text
+    assert "apt-get install -y ripgrep" in text
+    assert "rg --version" in text
+
+
+def test_audit_targets_fail_fast_when_rg_is_missing() -> None:
+    text = (ROOT / "scripts/make/audit.mk").read_text(encoding="utf-8")
+
+    assert ".PHONY: audit-require-rg" in text
+    assert "command -v rg" in text
+    assert "exit 127" in text
+
+    assert "audit-no-legacy-stock-sql: audit-require-rg" in text
+    assert "audit-no-legacy-pricing-terms: audit-require-rg" in text
+    assert "audit-no-implicit-warehouse-id: audit-require-rg" in text


### PR DESCRIPTION
## Summary
- install ripgrep in Backend CI before audit/test targets
- make audit targets fail fast when rg is unavailable
- add boundary tests to prevent audit false positives

## Validation
- make audit-all
- make test TESTS="tests/ci/test_audit_requires_ripgrep_boundary.py"