### PR TITLE
feat(outbound): import OMS projection orders into WMS execution

### DIFF
--- a/alembic/versions/737e3e8199df_add_wms_oms_fulfillment_order_import_.py
+++ b/alembic/versions/737e3e8199df_add_wms_oms_fulfillment_order_import_.py
@@ -1,0 +1,139 @@
+"""add wms oms fulfillment order import bridge tables
+
+Revision ID: 737e3e8199df
+Revises: 20260513152656_drop_wms_legacy_oms_owner_schema
+Create Date: 2026-05-13
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "737e3e8199df"
+down_revision: Union[str, Sequence[str], None] = "20260513152656_drop_wms_legacy_oms_owner_schema"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "wms_oms_fulfillment_order_imports",
+        sa.Column("ready_order_id", sa.String(length=192), nullable=False),
+        sa.Column("order_id", sa.BigInteger(), nullable=False),
+        sa.Column("platform", sa.String(length=16), nullable=False),
+        sa.Column("store_code", sa.String(length=128), nullable=False),
+        sa.Column("platform_order_no", sa.String(length=128), nullable=False),
+        sa.Column("source_order_id", sa.BigInteger(), nullable=False),
+        sa.Column("source_hash", sa.String(length=128), nullable=True),
+        sa.Column("import_status", sa.String(length=32), nullable=False, server_default=sa.text("'IMPORTED'")),
+        sa.Column("order_line_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("component_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("imported_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("imported_by_user_id", sa.Integer(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("ready_order_id", name="pk_wms_oms_fulfill_order_imports"),
+        sa.UniqueConstraint("order_id", name="uq_wms_oms_fulfill_order_import_order_id"),
+        sa.UniqueConstraint(
+            "platform",
+            "store_code",
+            "platform_order_no",
+            name="uq_wms_oms_fulfill_order_import_platform_store_no",
+        ),
+        sa.CheckConstraint(
+            "import_status IN ('IMPORTED')",
+            name="ck_wms_oms_fulfill_order_import_status",
+        ),
+        sa.CheckConstraint(
+            "order_line_count >= 0",
+            name="ck_wms_oms_fulfill_order_import_line_count_ge0",
+        ),
+        sa.CheckConstraint(
+            "component_count >= 0",
+            name="ck_wms_oms_fulfill_order_import_component_count_ge0",
+        ),
+        sa.ForeignKeyConstraint(
+            ["order_id"],
+            ["orders.id"],
+            name="fk_wms_oms_fulfill_order_import_order",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["imported_by_user_id"],
+            ["users.id"],
+            name="fk_wms_oms_fulfill_order_import_user",
+            ondelete="SET NULL",
+        ),
+    )
+
+    op.create_index(
+        "ix_wms_oms_fulfill_order_import_imported_at",
+        "wms_oms_fulfillment_order_imports",
+        ["imported_at"],
+    )
+
+    op.create_table(
+        "wms_oms_fulfillment_component_imports",
+        sa.Column("ready_component_id", sa.String(length=256), nullable=False),
+        sa.Column("ready_order_id", sa.String(length=192), nullable=False),
+        sa.Column("ready_line_id", sa.String(length=192), nullable=False),
+        sa.Column("order_id", sa.BigInteger(), nullable=False),
+        sa.Column("order_line_id", sa.BigInteger(), nullable=False),
+        sa.Column("resolved_item_id", sa.BigInteger(), nullable=False),
+        sa.Column("resolved_item_sku_code_id", sa.BigInteger(), nullable=False),
+        sa.Column("resolved_item_uom_id", sa.BigInteger(), nullable=False),
+        sa.Column("component_sku_code", sa.String(length=128), nullable=False),
+        sa.Column("sku_code_snapshot", sa.String(length=128), nullable=False),
+        sa.Column("item_name_snapshot", sa.String(length=255), nullable=False),
+        sa.Column("uom_snapshot", sa.String(length=64), nullable=False),
+        sa.Column("required_qty", sa.Numeric(18, 6), nullable=False),
+        sa.Column("source_hash", sa.String(length=128), nullable=True),
+        sa.Column("imported_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.PrimaryKeyConstraint("ready_component_id", name="pk_wms_oms_fulfill_component_imports"),
+        sa.UniqueConstraint("order_line_id", name="uq_wms_oms_fulfill_component_import_order_line"),
+        sa.CheckConstraint(
+            "required_qty > 0",
+            name="ck_wms_oms_fulfill_component_import_required_qty_pos",
+        ),
+        sa.ForeignKeyConstraint(
+            ["ready_order_id"],
+            ["wms_oms_fulfillment_order_imports.ready_order_id"],
+            name="fk_wms_oms_fulfill_component_import_order_import",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["order_id"],
+            ["orders.id"],
+            name="fk_wms_oms_fulfill_component_import_order",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["order_line_id"],
+            ["order_lines.id"],
+            name="fk_wms_oms_fulfill_component_import_order_line",
+            ondelete="RESTRICT",
+        ),
+    )
+
+    op.create_index(
+        "ix_wms_oms_fulfill_component_import_ready_order",
+        "wms_oms_fulfillment_component_imports",
+        ["ready_order_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_wms_oms_fulfill_component_import_ready_order",
+        table_name="wms_oms_fulfillment_component_imports",
+    )
+    op.drop_table("wms_oms_fulfillment_component_imports")
+
+    op.drop_index(
+        "ix_wms_oms_fulfill_order_import_imported_at",
+        table_name="wms_oms_fulfillment_order_imports",
+    )
+    op.drop_table("wms_oms_fulfillment_order_imports")

--- a/app/integrations/oms/projection_models.py
+++ b/app/integrations/oms/projection_models.py
@@ -270,6 +270,157 @@ class WmsOmsFulfillmentComponentProjection(Base):
     )
 
 
+class WmsOmsFulfillmentOrderImport(Base):
+    __tablename__ = "wms_oms_fulfillment_order_imports"
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "order_id",
+            name="uq_wms_oms_fulfill_order_import_order_id",
+        ),
+        sa.UniqueConstraint(
+            "platform",
+            "store_code",
+            "platform_order_no",
+            name="uq_wms_oms_fulfill_order_import_platform_store_no",
+        ),
+        sa.CheckConstraint(
+            "import_status IN ('IMPORTED')",
+            name="ck_wms_oms_fulfill_order_import_status",
+        ),
+        sa.CheckConstraint(
+            "order_line_count >= 0",
+            name="ck_wms_oms_fulfill_order_import_line_count_ge0",
+        ),
+        sa.CheckConstraint(
+            "component_count >= 0",
+            name="ck_wms_oms_fulfill_order_import_component_count_ge0",
+        ),
+        sa.Index(
+            "ix_wms_oms_fulfill_order_import_imported_at",
+            "imported_at",
+        ),
+        {"info": {"owner": "wms-api", "projection_import_audit": True}},
+    )
+
+    ready_order_id: Mapped[str] = mapped_column(sa.String(192), primary_key=True)
+    order_id: Mapped[int] = mapped_column(
+        sa.BigInteger,
+        sa.ForeignKey(
+            "orders.id",
+            name="fk_wms_oms_fulfill_order_import_order",
+            ondelete="RESTRICT",
+        ),
+        nullable=False,
+    )
+
+    platform: Mapped[str] = mapped_column(sa.String(16), nullable=False)
+    store_code: Mapped[str] = mapped_column(sa.String(128), nullable=False)
+    platform_order_no: Mapped[str] = mapped_column(sa.String(128), nullable=False)
+
+    source_order_id: Mapped[int] = mapped_column(sa.BigInteger, nullable=False)
+    source_hash: Mapped[str | None] = mapped_column(sa.String(128), nullable=True)
+
+    import_status: Mapped[str] = mapped_column(
+        sa.String(32),
+        nullable=False,
+        server_default=sa.text("'IMPORTED'"),
+    )
+    order_line_count: Mapped[int] = mapped_column(
+        sa.Integer,
+        nullable=False,
+        server_default=sa.text("0"),
+    )
+    component_count: Mapped[int] = mapped_column(
+        sa.Integer,
+        nullable=False,
+        server_default=sa.text("0"),
+    )
+
+    imported_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    imported_by_user_id: Mapped[int | None] = mapped_column(
+        sa.Integer,
+        sa.ForeignKey(
+            "users.id",
+            name="fk_wms_oms_fulfill_order_import_user",
+            ondelete="SET NULL",
+        ),
+        nullable=True,
+    )
+    error_message: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
+
+
+class WmsOmsFulfillmentComponentImport(Base):
+    __tablename__ = "wms_oms_fulfillment_component_imports"
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "order_line_id",
+            name="uq_wms_oms_fulfill_component_import_order_line",
+        ),
+        sa.CheckConstraint(
+            "required_qty > 0",
+            name="ck_wms_oms_fulfill_component_import_required_qty_pos",
+        ),
+        sa.Index(
+            "ix_wms_oms_fulfill_component_import_ready_order",
+            "ready_order_id",
+        ),
+        {"info": {"owner": "wms-api", "projection_import_audit": True}},
+    )
+
+    ready_component_id: Mapped[str] = mapped_column(sa.String(256), primary_key=True)
+    ready_order_id: Mapped[str] = mapped_column(
+        sa.String(192),
+        sa.ForeignKey(
+            "wms_oms_fulfillment_order_imports.ready_order_id",
+            name="fk_wms_oms_fulfill_component_import_order_import",
+            ondelete="CASCADE",
+        ),
+        nullable=False,
+    )
+    ready_line_id: Mapped[str] = mapped_column(sa.String(192), nullable=False)
+
+    order_id: Mapped[int] = mapped_column(
+        sa.BigInteger,
+        sa.ForeignKey(
+            "orders.id",
+            name="fk_wms_oms_fulfill_component_import_order",
+            ondelete="RESTRICT",
+        ),
+        nullable=False,
+    )
+    order_line_id: Mapped[int] = mapped_column(
+        sa.BigInteger,
+        sa.ForeignKey(
+            "order_lines.id",
+            name="fk_wms_oms_fulfill_component_import_order_line",
+            ondelete="RESTRICT",
+        ),
+        nullable=False,
+    )
+
+    resolved_item_id: Mapped[int] = mapped_column(sa.BigInteger, nullable=False)
+    resolved_item_sku_code_id: Mapped[int] = mapped_column(sa.BigInteger, nullable=False)
+    resolved_item_uom_id: Mapped[int] = mapped_column(sa.BigInteger, nullable=False)
+
+    component_sku_code: Mapped[str] = mapped_column(sa.String(128), nullable=False)
+    sku_code_snapshot: Mapped[str] = mapped_column(sa.String(128), nullable=False)
+    item_name_snapshot: Mapped[str] = mapped_column(sa.String(255), nullable=False)
+    uom_snapshot: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+
+    required_qty: Mapped[Decimal] = mapped_column(sa.Numeric(18, 6), nullable=False)
+    source_hash: Mapped[str | None] = mapped_column(sa.String(128), nullable=True)
+
+    imported_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+
+
 class WmsOmsFulfillmentProjectionSyncRun(Base):
     __tablename__ = "wms_oms_fulfillment_projection_sync_runs"
     __table_args__ = (
@@ -363,5 +514,7 @@ __all__ = [
     "WmsOmsFulfillmentComponentProjection",
     "WmsOmsFulfillmentLineProjection",
     "WmsOmsFulfillmentOrderProjection",
+    "WmsOmsFulfillmentOrderImport",
+    "WmsOmsFulfillmentComponentImport",
     "WmsOmsFulfillmentProjectionSyncRun",
 ]

--- a/app/router_mount.py
+++ b/app/router_mount.py
@@ -31,6 +31,7 @@ def mount_routers(app: FastAPI) -> None:
     from app.wms.inventory_adjustment.inbound_reversal.routers.inbound_reversal import (
         router as inbound_reversal_router,
     )
+    from app.wms.outbound.routers.order_import import router as outbound_order_import_router
     from app.wms.outbound.routers.order_read import router as outbound_order_read_router
     from app.wms.outbound.routers.order_submit import router as order_submit_router
     from app.wms.outbound.routers.manual_docs import router as manual_docs_router
@@ -89,6 +90,7 @@ def mount_routers(app: FastAPI) -> None:
     app.include_router(orders_fulfillment_v2_router)
     app.include_router(orders_fulfillment_debug_router)
 
+    app.include_router(outbound_order_import_router)
     app.include_router(outbound_order_read_router)
     app.include_router(order_submit_router)
     app.include_router(manual_docs_router)

--- a/app/wms/outbound/contracts/order_import.py
+++ b/app/wms/outbound/contracts/order_import.py
@@ -1,0 +1,46 @@
+# app/wms/outbound/contracts/order_import.py
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class OmsProjectionOrderImportIn(BaseModel):
+    """
+    从 WMS 本地 OMS fulfillment projection 手动导入 WMS 执行订单。
+
+    Boundary:
+    - 输入是 ready_order_id。
+    - 来源只允许 wms_oms_fulfillment_* projection。
+    - 输出写入 WMS 执行 facts：orders / order_address / order_items / order_lines / order_fulfillment。
+    - 不写回 projection 表。
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    ready_order_ids: list[str] = Field(min_length=1, max_length=200)
+    dry_run: bool = False
+
+
+class OmsProjectionOrderImportRowOut(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    ready_order_id: str
+    status: str
+    order_id: int | None = None
+    platform: str | None = None
+    store_code: str | None = None
+    platform_order_no: str | None = None
+    order_line_count: int = 0
+    component_count: int = 0
+    message: str | None = None
+
+
+class OmsProjectionOrderImportOut(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    dry_run: bool
+    requested: int
+    imported: int
+    already_imported: int
+    failed: int
+    results: list[OmsProjectionOrderImportRowOut]

--- a/app/wms/outbound/routers/order_import.py
+++ b/app/wms/outbound/routers/order_import.py
@@ -1,0 +1,36 @@
+# app/wms/outbound/routers/order_import.py
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.deps import get_async_session as get_session
+from app.user.deps.auth import get_current_user
+from app.wms.outbound.contracts.order_import import (
+    OmsProjectionOrderImportIn,
+    OmsProjectionOrderImportOut,
+)
+from app.wms.outbound.services.oms_projection_order_import_service import (
+    import_orders_from_oms_projection,
+)
+
+router = APIRouter(prefix="/wms/outbound", tags=["wms-outbound-order-import"])
+
+
+@router.post(
+    "/orders/import-from-oms-projection",
+    response_model=OmsProjectionOrderImportOut,
+)
+async def import_wms_orders_from_oms_projection(
+    payload: OmsProjectionOrderImportIn,
+    session: AsyncSession = Depends(get_session),
+    user=Depends(get_current_user),
+) -> OmsProjectionOrderImportOut:
+    result = await import_orders_from_oms_projection(
+        session,
+        ready_order_ids=payload.ready_order_ids,
+        dry_run=bool(payload.dry_run),
+        imported_by_user_id=getattr(user, "id", None),
+    )
+    await session.commit()
+    return result

--- a/app/wms/outbound/services/oms_projection_order_import_service.py
+++ b/app/wms/outbound/services/oms_projection_order_import_service.py
@@ -1,0 +1,841 @@
+# app/wms/outbound/services/oms_projection_order_import_service.py
+from __future__ import annotations
+
+import hashlib
+import json
+from decimal import Decimal
+from typing import Any, Mapping
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.wms.outbound.contracts.order_import import (
+    OmsProjectionOrderImportOut,
+    OmsProjectionOrderImportRowOut,
+)
+
+
+def _dedupe_ready_order_ids(values: list[str]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        ready_order_id = str(value or "").strip()
+        if not ready_order_id or ready_order_id in seen:
+            continue
+        seen.add(ready_order_id)
+        out.append(ready_order_id)
+    return out
+
+
+def _build_in_filter(name: str, values: list[str]) -> tuple[str, dict[str, str]]:
+    params = {f"{name}_{idx}": value for idx, value in enumerate(values)}
+    placeholders = ", ".join(f":{key}" for key in params)
+    return placeholders, params
+
+
+def _platform_to_wms(value: object) -> str:
+    raw = str(value or "").strip()
+    mapping = {
+        "pdd": "PDD",
+        "taobao": "TAOBAO",
+        "jd": "JD",
+    }
+    return mapping.get(raw.lower(), raw.upper())
+
+
+def _clean_text(value: object | None) -> str | None:
+    if value is None:
+        return None
+    text_value = str(value).strip()
+    return text_value or None
+
+
+def _trace_id_for_ready_order(ready_order_id: str) -> str:
+    return hashlib.sha256(f"oms-projection:{ready_order_id}".encode("utf-8")).hexdigest()
+
+
+def _required_qty_to_int(value: object) -> int | None:
+    try:
+        qty = Decimal(str(value))
+    except Exception:
+        return None
+
+    if qty <= 0:
+        return None
+
+    if qty != qty.to_integral_value():
+        return None
+
+    return int(qty)
+
+
+def _result(
+    *,
+    ready_order_id: str,
+    status: str,
+    order_id: int | None = None,
+    order: Mapping[str, Any] | None = None,
+    order_line_count: int = 0,
+    component_count: int = 0,
+    message: str | None = None,
+) -> OmsProjectionOrderImportRowOut:
+    return OmsProjectionOrderImportRowOut(
+        ready_order_id=ready_order_id,
+        status=status,
+        order_id=order_id,
+        platform=_platform_to_wms(order.get("platform")) if order is not None else None,
+        store_code=str(order.get("store_code")) if order is not None else None,
+        platform_order_no=str(order.get("platform_order_no")) if order is not None else None,
+        order_line_count=int(order_line_count),
+        component_count=int(component_count),
+        message=message,
+    )
+
+
+async def _load_projection_orders(
+    session: AsyncSession,
+    *,
+    ready_order_ids: list[str],
+) -> dict[str, dict[str, Any]]:
+    placeholders, params = _build_in_filter("ready_order_id", ready_order_ids)
+
+    rows = (
+        await session.execute(
+            text(
+                f"""
+                SELECT
+                  ready_order_id,
+                  source_order_id,
+                  platform,
+                  store_code,
+                  store_name,
+                  platform_order_no,
+                  platform_status,
+                  receiver_name,
+                  receiver_phone,
+                  receiver_province,
+                  receiver_city,
+                  receiver_district,
+                  receiver_address,
+                  receiver_postcode,
+                  buyer_remark,
+                  seller_remark,
+                  ready_status,
+                  ready_at,
+                  source_updated_at,
+                  line_count,
+                  component_count,
+                  total_required_qty,
+                  source_hash,
+                  sync_version,
+                  synced_at
+                FROM wms_oms_fulfillment_order_projection
+                WHERE ready_order_id IN ({placeholders})
+                """
+            ),
+            params,
+        )
+    ).mappings().all()
+
+    return {str(row["ready_order_id"]): dict(row) for row in rows}
+
+
+async def _load_projection_components(
+    session: AsyncSession,
+    *,
+    ready_order_ids: list[str],
+) -> dict[str, list[dict[str, Any]]]:
+    placeholders, params = _build_in_filter("ready_order_id", ready_order_ids)
+
+    rows = (
+        await session.execute(
+            text(
+                f"""
+                SELECT
+                  ready_component_id,
+                  ready_line_id,
+                  ready_order_id,
+                  resolved_item_id,
+                  resolved_item_sku_code_id,
+                  resolved_item_uom_id,
+                  component_sku_code,
+                  sku_code_snapshot,
+                  item_name_snapshot,
+                  uom_snapshot,
+                  qty_per_fsku,
+                  required_qty,
+                  alloc_unit_price,
+                  sort_order,
+                  source_hash,
+                  sync_version,
+                  synced_at
+                FROM wms_oms_fulfillment_component_projection
+                WHERE ready_order_id IN ({placeholders})
+                ORDER BY ready_order_id ASC, ready_line_id ASC, sort_order ASC, ready_component_id ASC
+                """
+            ),
+            params,
+        )
+    ).mappings().all()
+
+    out: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        data = dict(row)
+        out.setdefault(str(data["ready_order_id"]), []).append(data)
+
+    return out
+
+
+async def _load_existing_imports(
+    session: AsyncSession,
+    *,
+    ready_order_ids: list[str],
+) -> dict[str, int]:
+    placeholders, params = _build_in_filter("ready_order_id", ready_order_ids)
+
+    rows = (
+        await session.execute(
+            text(
+                f"""
+                SELECT ready_order_id, order_id
+                FROM wms_oms_fulfillment_order_imports
+                WHERE ready_order_id IN ({placeholders})
+                """
+            ),
+            params,
+        )
+    ).mappings().all()
+
+    return {str(row["ready_order_id"]): int(row["order_id"]) for row in rows}
+
+
+async def _load_existing_order_conflicts(
+    session: AsyncSession,
+    *,
+    ready_order_ids: list[str],
+) -> dict[str, int]:
+    placeholders, params = _build_in_filter("ready_order_id", ready_order_ids)
+
+    rows = (
+        await session.execute(
+            text(
+                f"""
+                SELECT
+                  p.ready_order_id,
+                  o.id AS order_id
+                FROM wms_oms_fulfillment_order_projection AS p
+                JOIN orders AS o
+                  ON UPPER(o.platform) = UPPER(p.platform)
+                 AND o.store_code = p.store_code
+                 AND o.ext_order_no = p.platform_order_no
+                WHERE p.ready_order_id IN ({placeholders})
+                """
+            ),
+            params,
+        )
+    ).mappings().all()
+
+    return {str(row["ready_order_id"]): int(row["order_id"]) for row in rows}
+
+
+async def _ensure_store_from_projection(
+    session: AsyncSession,
+    *,
+    order: Mapping[str, Any],
+) -> int:
+    platform = _platform_to_wms(order["platform"])
+    store_code = str(order["store_code"])
+    store_name = str(order.get("store_name") or store_code)
+
+    row = (
+        await session.execute(
+            text(
+                """
+                INSERT INTO stores (
+                  platform,
+                  store_code,
+                  store_name,
+                  active
+                )
+                VALUES (
+                  :platform,
+                  :store_code,
+                  :store_name,
+                  TRUE
+                )
+                ON CONFLICT (platform, store_code) DO UPDATE
+                   SET store_name = EXCLUDED.store_name,
+                       active = TRUE,
+                       updated_at = now()
+                RETURNING id
+                """
+            ),
+            {
+                "platform": platform,
+                "store_code": store_code,
+                "store_name": store_name,
+            },
+        )
+    ).scalar_one()
+
+    return int(row)
+
+
+async def _insert_execution_order(
+    session: AsyncSession,
+    *,
+    order: Mapping[str, Any],
+    store_id: int,
+) -> int:
+    platform = _platform_to_wms(order["platform"])
+    store_code = str(order["store_code"])
+    platform_order_no = str(order["platform_order_no"])
+    trace_id = _trace_id_for_ready_order(str(order["ready_order_id"]))
+
+    row = (
+        await session.execute(
+            text(
+                """
+                INSERT INTO orders (
+                  status,
+                  created_at,
+                  updated_at,
+                  total_amount,
+                  buyer_name,
+                  buyer_phone,
+                  order_amount,
+                  pay_amount,
+                  order_no,
+                  platform,
+                  store_code,
+                  ext_order_no,
+                  trace_id,
+                  store_id
+                )
+                VALUES (
+                  'CREATED',
+                  COALESCE(:created_at, now()),
+                  now(),
+                  0,
+                  :buyer_name,
+                  :buyer_phone,
+                  0,
+                  0,
+                  :order_no,
+                  :platform,
+                  :store_code,
+                  :ext_order_no,
+                  :trace_id,
+                  :store_id
+                )
+                ON CONFLICT ON CONSTRAINT uq_orders_platform_store_ext DO NOTHING
+                RETURNING id
+                """
+            ),
+            {
+                "created_at": order.get("ready_at"),
+                "buyer_name": _clean_text(order.get("receiver_name")),
+                "buyer_phone": _clean_text(order.get("receiver_phone")),
+                "order_no": platform_order_no,
+                "platform": platform,
+                "store_code": store_code,
+                "ext_order_no": platform_order_no,
+                "trace_id": trace_id,
+                "store_id": int(store_id),
+            },
+        )
+    ).scalar_one_or_none()
+
+    if row is not None:
+        return int(row)
+
+    existing = (
+        await session.execute(
+            text(
+                """
+                SELECT id
+                FROM orders
+                WHERE UPPER(platform) = UPPER(:platform)
+                  AND store_code = :store_code
+                  AND ext_order_no = :ext_order_no
+                LIMIT 1
+                """
+            ),
+            {
+                "platform": platform,
+                "store_code": store_code,
+                "ext_order_no": platform_order_no,
+            },
+        )
+    ).scalar_one()
+
+    return int(existing)
+
+
+async def _upsert_execution_order_address(
+    session: AsyncSession,
+    *,
+    order_id: int,
+    order: Mapping[str, Any],
+) -> None:
+    await session.execute(
+        text(
+            """
+            INSERT INTO order_address (
+              order_id,
+              receiver_name,
+              receiver_phone,
+              province,
+              city,
+              district,
+              detail,
+              zipcode
+            )
+            VALUES (
+              :order_id,
+              :receiver_name,
+              :receiver_phone,
+              :province,
+              :city,
+              :district,
+              :detail,
+              :zipcode
+            )
+            ON CONFLICT (order_id) DO UPDATE
+               SET receiver_name = EXCLUDED.receiver_name,
+                   receiver_phone = EXCLUDED.receiver_phone,
+                   province = EXCLUDED.province,
+                   city = EXCLUDED.city,
+                   district = EXCLUDED.district,
+                   detail = EXCLUDED.detail,
+                   zipcode = EXCLUDED.zipcode
+            """
+        ),
+        {
+            "order_id": int(order_id),
+            "receiver_name": _clean_text(order.get("receiver_name")),
+            "receiver_phone": _clean_text(order.get("receiver_phone")),
+            "province": _clean_text(order.get("receiver_province")),
+            "city": _clean_text(order.get("receiver_city")),
+            "district": _clean_text(order.get("receiver_district")),
+            "detail": _clean_text(order.get("receiver_address")),
+            "zipcode": _clean_text(order.get("receiver_postcode")),
+        },
+    )
+
+
+async def _insert_order_fulfillment_placeholder(
+    session: AsyncSession,
+    *,
+    order_id: int,
+) -> None:
+    await session.execute(
+        text(
+            """
+            INSERT INTO order_fulfillment (
+              order_id,
+              planned_warehouse_id,
+              actual_warehouse_id,
+              fulfillment_status,
+              blocked_reasons,
+              execution_stage
+            )
+            VALUES (
+              :order_id,
+              NULL,
+              NULL,
+              'OMS_IMPORTED',
+              NULL,
+              NULL
+            )
+            ON CONFLICT (order_id) DO NOTHING
+            """
+        ),
+        {"order_id": int(order_id)},
+    )
+
+
+async def _insert_order_item_from_component(
+    session: AsyncSession,
+    *,
+    order_id: int,
+    component: Mapping[str, Any],
+    qty: int,
+) -> None:
+    unit_price = Decimal(str(component.get("alloc_unit_price") or "0"))
+    line_amount = Decimal(qty) * unit_price
+    extras = {
+        "source": "OMS_FULFILLMENT_PROJECTION",
+        "ready_order_id": str(component["ready_order_id"]),
+        "ready_line_id": str(component["ready_line_id"]),
+        "ready_component_id": str(component["ready_component_id"]),
+        "resolved_item_sku_code_id": int(component["resolved_item_sku_code_id"]),
+        "resolved_item_uom_id": int(component["resolved_item_uom_id"]),
+        "uom_snapshot": str(component["uom_snapshot"]),
+    }
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO order_items (
+              order_id,
+              item_id,
+              qty,
+              unit_price,
+              line_amount,
+              sku_id,
+              title,
+              price,
+              discount,
+              amount,
+              extras
+            )
+            VALUES (
+              :order_id,
+              :item_id,
+              :qty,
+              :unit_price,
+              :line_amount,
+              :sku_id,
+              :title,
+              :price,
+              0,
+              :amount,
+              CAST(:extras AS jsonb)
+            )
+            ON CONFLICT ON CONSTRAINT uq_order_items_ord_sku DO UPDATE
+               SET qty = COALESCE(order_items.qty, 0) + EXCLUDED.qty,
+                   line_amount = COALESCE(order_items.line_amount, 0) + EXCLUDED.line_amount,
+                   amount = COALESCE(order_items.amount, 0) + EXCLUDED.amount,
+                   extras = order_items.extras || EXCLUDED.extras
+            """
+        ),
+        {
+            "order_id": int(order_id),
+            "item_id": int(component["resolved_item_id"]),
+            "qty": int(qty),
+            "unit_price": unit_price,
+            "line_amount": line_amount,
+            "sku_id": str(component["sku_code_snapshot"]),
+            "title": str(component["item_name_snapshot"]),
+            "price": unit_price,
+            "amount": line_amount,
+            "extras": json.dumps(extras, ensure_ascii=False),
+        },
+    )
+
+
+async def _insert_order_import_audit(
+    session: AsyncSession,
+    *,
+    order_id: int,
+    order: Mapping[str, Any],
+    component_count: int,
+    imported_by_user_id: int | None,
+) -> None:
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_oms_fulfillment_order_imports (
+              ready_order_id,
+              order_id,
+              platform,
+              store_code,
+              platform_order_no,
+              source_order_id,
+              source_hash,
+              import_status,
+              order_line_count,
+              component_count,
+              imported_by_user_id
+            )
+            VALUES (
+              :ready_order_id,
+              :order_id,
+              :platform,
+              :store_code,
+              :platform_order_no,
+              :source_order_id,
+              :source_hash,
+              'IMPORTED',
+              :order_line_count,
+              :component_count,
+              :imported_by_user_id
+            )
+            """
+        ),
+        {
+            "ready_order_id": str(order["ready_order_id"]),
+            "order_id": int(order_id),
+            "platform": _platform_to_wms(order["platform"]),
+            "store_code": str(order["store_code"]),
+            "platform_order_no": str(order["platform_order_no"]),
+            "source_order_id": int(order["source_order_id"]),
+            "source_hash": _clean_text(order.get("source_hash")),
+            "order_line_count": int(component_count),
+            "component_count": int(component_count),
+            "imported_by_user_id": imported_by_user_id,
+        },
+    )
+
+
+async def _import_order_lines_and_items(
+    session: AsyncSession,
+    *,
+    order_id: int,
+    components: list[Mapping[str, Any]],
+) -> None:
+    for component in components:
+        qty = _required_qty_to_int(component.get("required_qty"))
+        if qty is None:
+            raise ValueError(
+                "component_required_qty_must_be_positive_integer:"
+                f" ready_component_id={component.get('ready_component_id')}"
+            )
+
+        order_line_id = (
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO order_lines (
+                      order_id,
+                      item_id,
+                      req_qty
+                    )
+                    VALUES (
+                      :order_id,
+                      :item_id,
+                      :req_qty
+                    )
+                    RETURNING id
+                    """
+                ),
+                {
+                    "order_id": int(order_id),
+                    "item_id": int(component["resolved_item_id"]),
+                    "req_qty": int(qty),
+                },
+            )
+        ).scalar_one()
+
+        await _insert_order_item_from_component(
+            session,
+            order_id=int(order_id),
+            component=component,
+            qty=int(qty),
+        )
+
+        await session.execute(
+            text(
+                """
+                INSERT INTO wms_oms_fulfillment_component_imports (
+                  ready_component_id,
+                  ready_order_id,
+                  ready_line_id,
+                  order_id,
+                  order_line_id,
+                  resolved_item_id,
+                  resolved_item_sku_code_id,
+                  resolved_item_uom_id,
+                  component_sku_code,
+                  sku_code_snapshot,
+                  item_name_snapshot,
+                  uom_snapshot,
+                  required_qty,
+                  source_hash
+                )
+                VALUES (
+                  :ready_component_id,
+                  :ready_order_id,
+                  :ready_line_id,
+                  :order_id,
+                  :order_line_id,
+                  :resolved_item_id,
+                  :resolved_item_sku_code_id,
+                  :resolved_item_uom_id,
+                  :component_sku_code,
+                  :sku_code_snapshot,
+                  :item_name_snapshot,
+                  :uom_snapshot,
+                  :required_qty,
+                  :source_hash
+                )
+                """
+            ),
+            {
+                "ready_component_id": str(component["ready_component_id"]),
+                "ready_order_id": str(component["ready_order_id"]),
+                "ready_line_id": str(component["ready_line_id"]),
+                "order_id": int(order_id),
+                "order_line_id": int(order_line_id),
+                "resolved_item_id": int(component["resolved_item_id"]),
+                "resolved_item_sku_code_id": int(component["resolved_item_sku_code_id"]),
+                "resolved_item_uom_id": int(component["resolved_item_uom_id"]),
+                "component_sku_code": str(component["component_sku_code"]),
+                "sku_code_snapshot": str(component["sku_code_snapshot"]),
+                "item_name_snapshot": str(component["item_name_snapshot"]),
+                "uom_snapshot": str(component["uom_snapshot"]),
+                "required_qty": component["required_qty"],
+                "source_hash": _clean_text(component.get("source_hash")),
+            },
+        )
+
+
+async def import_orders_from_oms_projection(
+    session: AsyncSession,
+    *,
+    ready_order_ids: list[str],
+    dry_run: bool,
+    imported_by_user_id: int | None,
+) -> OmsProjectionOrderImportOut:
+    ids = _dedupe_ready_order_ids(ready_order_ids)
+
+    orders = await _load_projection_orders(session, ready_order_ids=ids)
+    components_by_order = await _load_projection_components(session, ready_order_ids=ids)
+    existing_imports = await _load_existing_imports(session, ready_order_ids=ids)
+    existing_order_conflicts = await _load_existing_order_conflicts(session, ready_order_ids=ids)
+
+    results: list[OmsProjectionOrderImportRowOut] = []
+
+    for ready_order_id in ids:
+        order = orders.get(ready_order_id)
+        if order is None:
+            results.append(
+                _result(
+                    ready_order_id=ready_order_id,
+                    status="FAILED",
+                    message="projection_order_not_found",
+                )
+            )
+            continue
+
+        if ready_order_id in existing_imports:
+            results.append(
+                _result(
+                    ready_order_id=ready_order_id,
+                    status="ALREADY_IMPORTED",
+                    order_id=existing_imports[ready_order_id],
+                    order=order,
+                    message="order_already_imported",
+                )
+            )
+            continue
+
+        if ready_order_id in existing_order_conflicts:
+            results.append(
+                _result(
+                    ready_order_id=ready_order_id,
+                    status="FAILED",
+                    order_id=existing_order_conflicts[ready_order_id],
+                    order=order,
+                    message="existing_execution_order_conflict",
+                )
+            )
+            continue
+
+        components = components_by_order.get(ready_order_id, [])
+        expected_component_count = int(order.get("component_count") or 0)
+        if not components:
+            results.append(
+                _result(
+                    ready_order_id=ready_order_id,
+                    status="FAILED",
+                    order=order,
+                    message="projection_components_not_found",
+                )
+            )
+            continue
+
+        if expected_component_count != len(components):
+            results.append(
+                _result(
+                    ready_order_id=ready_order_id,
+                    status="FAILED",
+                    order=order,
+                    component_count=len(components),
+                    message=(
+                        "projection_component_count_mismatch:"
+                        f" expected={expected_component_count}, actual={len(components)}"
+                    ),
+                )
+            )
+            continue
+
+        invalid_component = next(
+            (
+                component
+                for component in components
+                if _required_qty_to_int(component.get("required_qty")) is None
+            ),
+            None,
+        )
+        if invalid_component is not None:
+            results.append(
+                _result(
+                    ready_order_id=ready_order_id,
+                    status="FAILED",
+                    order=order,
+                    component_count=len(components),
+                    message=(
+                        "component_required_qty_must_be_positive_integer:"
+                        f" ready_component_id={invalid_component.get('ready_component_id')}"
+                    ),
+                )
+            )
+            continue
+
+        if dry_run:
+            results.append(
+                _result(
+                    ready_order_id=ready_order_id,
+                    status="DRY_RUN",
+                    order=order,
+                    order_line_count=len(components),
+                    component_count=len(components),
+                    message="would_import_execution_order",
+                )
+            )
+            continue
+
+        store_id = await _ensure_store_from_projection(session, order=order)
+        order_id = await _insert_execution_order(session, order=order, store_id=store_id)
+
+        await _upsert_execution_order_address(session, order_id=order_id, order=order)
+        await _insert_order_fulfillment_placeholder(session, order_id=order_id)
+        await _insert_order_import_audit(
+            session,
+            order_id=order_id,
+            order=order,
+            component_count=len(components),
+            imported_by_user_id=imported_by_user_id,
+        )
+        await _import_order_lines_and_items(
+            session,
+            order_id=order_id,
+            components=components,
+        )
+
+        results.append(
+            _result(
+                ready_order_id=ready_order_id,
+                status="IMPORTED",
+                order_id=order_id,
+                order=order,
+                order_line_count=len(components),
+                component_count=len(components),
+                message="imported_execution_order",
+            )
+        )
+
+    imported = sum(1 for row in results if row.status == "IMPORTED")
+    already_imported = sum(1 for row in results if row.status == "ALREADY_IMPORTED")
+    failed = sum(1 for row in results if row.status == "FAILED")
+
+    return OmsProjectionOrderImportOut(
+        dry_run=bool(dry_run),
+        requested=len(ids),
+        imported=imported,
+        already_imported=already_imported,
+        failed=failed,
+        results=results,
+    )

--- a/tests/api/test_oms_projection_order_import_api.py
+++ b/tests/api/test_oms_projection_order_import_api.py
@@ -1,0 +1,366 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _login_admin_headers(client: AsyncClient) -> dict[str, str]:
+    resp = await client.post("/users/login", json={"username": "admin", "password": "admin123"})
+    assert resp.status_code == 200, resp.text
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+async def _seed_projection_order(session: AsyncSession) -> str:
+    suffix = uuid4().hex[:10]
+    ready_order_id = f"ut-import:{suffix}"
+    ready_line_id = f"{ready_order_id}:line:1"
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_oms_fulfillment_order_projection (
+              ready_order_id,
+              source_order_id,
+              platform,
+              store_code,
+              store_name,
+              platform_order_no,
+              platform_status,
+              receiver_name,
+              receiver_phone,
+              receiver_province,
+              receiver_city,
+              receiver_district,
+              receiver_address,
+              receiver_postcode,
+              buyer_remark,
+              seller_remark,
+              ready_status,
+              ready_at,
+              source_updated_at,
+              line_count,
+              component_count,
+              total_required_qty,
+              source_hash,
+              sync_version
+            )
+            VALUES (
+              :ready_order_id,
+              900001,
+              'pdd',
+              :store_code,
+              'UT Import Store',
+              :platform_order_no,
+              'WAIT_SELLER_SEND_GOODS',
+              '赵六',
+              '13600000000',
+              '浙江省',
+              '杭州市',
+              '西湖区',
+              '文三路 100 号',
+              '310000',
+              'buyer remark',
+              'seller remark',
+              'READY',
+              now(),
+              now(),
+              1,
+              2,
+              5,
+              :source_hash,
+              'ut-sync'
+            )
+            """
+        ),
+        {
+            "ready_order_id": ready_order_id,
+            "store_code": f"UT-IMPORT-STORE-{suffix}",
+            "platform_order_no": f"UT-IMPORT-ORDER-{suffix}",
+            "source_hash": f"order-hash-{suffix}",
+        },
+    )
+
+    await session.execute(
+        text(
+            """
+            INSERT INTO wms_oms_fulfillment_line_projection (
+              ready_line_id,
+              ready_order_id,
+              source_line_id,
+              platform,
+              store_code,
+              identity_kind,
+              identity_value,
+              merchant_sku,
+              platform_item_id,
+              platform_sku_id,
+              platform_goods_name,
+              platform_sku_name,
+              ordered_qty,
+              fsku_id,
+              fsku_code,
+              fsku_name,
+              fsku_status_snapshot,
+              source_hash,
+              sync_version
+            )
+            SELECT
+              :ready_line_id,
+              ready_order_id,
+              1,
+              platform,
+              store_code,
+              'merchant_code',
+              'UT-MERCHANT',
+              'UT-MERCHANT',
+              'UT-GOODS',
+              'UT-SKU',
+              'UT Platform Goods',
+              '规格',
+              1,
+              9900,
+              'UT-FSKU',
+              'UT FSKU',
+              'published',
+              :source_hash,
+              'ut-sync'
+            FROM wms_oms_fulfillment_order_projection
+            WHERE ready_order_id = :ready_order_id
+            """
+        ),
+        {
+            "ready_order_id": ready_order_id,
+            "ready_line_id": ready_line_id,
+            "source_hash": f"line-hash-{suffix}",
+        },
+    )
+
+    for idx, item_id, qty in (
+        (1, 880001, Decimal("2")),
+        (2, 880002, Decimal("3")),
+    ):
+        await session.execute(
+            text(
+                """
+                INSERT INTO wms_oms_fulfillment_component_projection (
+                  ready_component_id,
+                  ready_line_id,
+                  ready_order_id,
+                  resolved_item_id,
+                  resolved_item_sku_code_id,
+                  resolved_item_uom_id,
+                  component_sku_code,
+                  sku_code_snapshot,
+                  item_name_snapshot,
+                  uom_snapshot,
+                  qty_per_fsku,
+                  required_qty,
+                  alloc_unit_price,
+                  sort_order,
+                  source_hash,
+                  sync_version
+                )
+                VALUES (
+                  :ready_component_id,
+                  :ready_line_id,
+                  :ready_order_id,
+                  :resolved_item_id,
+                  :resolved_item_sku_code_id,
+                  :resolved_item_uom_id,
+                  :component_sku_code,
+                  :sku_code_snapshot,
+                  :item_name_snapshot,
+                  '件',
+                  :qty_per_fsku,
+                  :required_qty,
+                  1,
+                  :sort_order,
+                  :source_hash,
+                  'ut-sync'
+                )
+                """
+            ),
+            {
+                "ready_component_id": f"{ready_line_id}:component:{idx}",
+                "ready_line_id": ready_line_id,
+                "ready_order_id": ready_order_id,
+                "resolved_item_id": item_id,
+                "resolved_item_sku_code_id": item_id + 1000,
+                "resolved_item_uom_id": item_id + 2000,
+                "component_sku_code": f"UT-SKU-{idx}",
+                "sku_code_snapshot": f"UT-SKU-{idx}",
+                "item_name_snapshot": f"UT Import Item {idx}",
+                "qty_per_fsku": qty,
+                "required_qty": qty,
+                "sort_order": idx,
+                "source_hash": f"component-hash-{suffix}-{idx}",
+            },
+        )
+
+    await session.commit()
+    return ready_order_id
+
+
+async def test_import_oms_projection_order_creates_wms_execution_order(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    ready_order_id = await _seed_projection_order(session)
+
+    dry_run = await client.post(
+        "/wms/outbound/orders/import-from-oms-projection",
+        headers=headers,
+        json={"ready_order_ids": [ready_order_id], "dry_run": True},
+    )
+    assert dry_run.status_code == 200, dry_run.text
+    dry_data = dry_run.json()
+    assert dry_data["dry_run"] is True
+    assert dry_data["imported"] == 0
+    assert dry_data["results"][0]["status"] == "DRY_RUN"
+
+    created_before = (
+        await session.execute(
+            text(
+                """
+                SELECT count(*)
+                FROM wms_oms_fulfillment_order_imports
+                WHERE ready_order_id = :ready_order_id
+                """
+            ),
+            {"ready_order_id": ready_order_id},
+        )
+    ).scalar_one()
+    assert int(created_before) == 0
+
+    resp = await client.post(
+        "/wms/outbound/orders/import-from-oms-projection",
+        headers=headers,
+        json={"ready_order_ids": [ready_order_id], "dry_run": False},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    assert data["dry_run"] is False
+    assert data["imported"] == 1
+    assert data["already_imported"] == 0
+    assert data["failed"] == 0
+
+    row = data["results"][0]
+    assert row["status"] == "IMPORTED"
+    assert row["order_id"]
+    assert row["platform"] == "PDD"
+    assert row["order_line_count"] == 2
+    assert row["component_count"] == 2
+
+    order_id = int(row["order_id"])
+
+    order_row = (
+        await session.execute(
+            text(
+                """
+                SELECT platform, store_code, ext_order_no, status
+                FROM orders
+                WHERE id = :order_id
+                """
+            ),
+            {"order_id": order_id},
+        )
+    ).mappings().one()
+    assert order_row["platform"] == "PDD"
+    assert order_row["status"] == "CREATED"
+
+    address_row = (
+        await session.execute(
+            text(
+                """
+                SELECT receiver_name, receiver_phone, province, city, district, detail, zipcode
+                FROM order_address
+                WHERE order_id = :order_id
+                """
+            ),
+            {"order_id": order_id},
+        )
+    ).mappings().one()
+    assert address_row["receiver_name"] == "赵六"
+    assert address_row["city"] == "杭州市"
+
+    line_count = (
+        await session.execute(
+            text("SELECT count(*) FROM order_lines WHERE order_id = :order_id"),
+            {"order_id": order_id},
+        )
+    ).scalar_one()
+    assert int(line_count) == 2
+
+    qty_sum = (
+        await session.execute(
+            text("SELECT COALESCE(sum(req_qty), 0) FROM order_lines WHERE order_id = :order_id"),
+            {"order_id": order_id},
+        )
+    ).scalar_one()
+    assert int(qty_sum) == 5
+
+    item_count = (
+        await session.execute(
+            text("SELECT count(*) FROM order_items WHERE order_id = :order_id"),
+            {"order_id": order_id},
+        )
+    ).scalar_one()
+    assert int(item_count) == 2
+
+    fulfillment_status = (
+        await session.execute(
+            text(
+                """
+                SELECT fulfillment_status
+                FROM order_fulfillment
+                WHERE order_id = :order_id
+                """
+            ),
+            {"order_id": order_id},
+        )
+    ).scalar_one()
+    assert fulfillment_status == "OMS_IMPORTED"
+
+    component_import_count = (
+        await session.execute(
+            text(
+                """
+                SELECT count(*)
+                FROM wms_oms_fulfillment_component_imports
+                WHERE ready_order_id = :ready_order_id
+                """
+            ),
+            {"ready_order_id": ready_order_id},
+        )
+    ).scalar_one()
+    assert int(component_import_count) == 2
+
+    options = await client.get(
+        "/wms/outbound/orders/options",
+        headers=headers,
+        params={"q": str(order_id)},
+    )
+    assert options.status_code == 200, options.text
+    options_data = options.json()
+    assert options_data["total"] == 1
+    assert int(options_data["items"][0]["id"]) == order_id
+
+    duplicate = await client.post(
+        "/wms/outbound/orders/import-from-oms-projection",
+        headers=headers,
+        json={"ready_order_ids": [ready_order_id], "dry_run": False},
+    )
+    assert duplicate.status_code == 200, duplicate.text
+    duplicate_data = duplicate.json()
+    assert duplicate_data["imported"] == 0
+    assert duplicate_data["already_imported"] == 1
+    assert duplicate_data["results"][0]["order_id"] == order_id

--- a/tests/ci/test_wms_oms_projection_order_import_boundary.py
+++ b/tests/ci/test_wms_oms_projection_order_import_boundary.py
@@ -1,0 +1,43 @@
+# tests/ci/test_wms_oms_projection_order_import_boundary.py
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.main import app
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _runtime_paths() -> list[str]:
+    return sorted(str(getattr(route, "path", "")) for route in app.routes)
+
+
+def test_oms_projection_import_route_lives_under_wms_outbound() -> None:
+    paths = _runtime_paths()
+
+    assert "/wms/outbound/orders/import-from-oms-projection" in paths
+    assert all(not path.startswith("/oms/orders") for path in paths)
+
+
+def test_oms_projection_import_service_uses_projection_as_source_and_execution_as_target() -> None:
+    text = (
+        ROOT / "app/wms/outbound/services/oms_projection_order_import_service.py"
+    ).read_text(encoding="utf-8")
+
+    assert "FROM wms_oms_fulfillment_order_projection" in text
+    assert "FROM wms_oms_fulfillment_component_projection" in text
+    assert "INSERT INTO orders" in text
+    assert "INSERT INTO order_lines" in text
+    assert "INSERT INTO order_items" in text
+    assert "INSERT INTO order_address" in text
+    assert "UPDATE wms_oms_fulfillment_order_projection" not in text
+    assert "UPDATE wms_oms_fulfillment_component_projection" not in text
+
+
+def test_oms_projection_import_audit_tables_are_registered_in_orm_metadata() -> None:
+    from app.db.base import Base, init_models
+
+    init_models(force=True)
+
+    assert "wms_oms_fulfillment_order_imports" in Base.metadata.tables
+    assert "wms_oms_fulfillment_component_imports" in Base.metadata.tables


### PR DESCRIPTION
## Summary

- add import audit tables for OMS fulfillment projection order imports
- add `/wms/outbound/orders/import-from-oms-projection`
- convert selected OMS fulfillment projection orders into WMS execution orders
- generate WMS `orders`, `order_address`, `order_lines`, `order_items`, and `order_fulfillment`
- keep projection tables read-only and idempotent via import audit tables
- register import audit tables in ORM metadata for test DB reset compatibility
- add API and CI boundary coverage

## Verification

- .venv/bin/alembic upgrade head
- .venv/bin/python3 -m compileall alembic/versions/737e3e8199df_add_wms_oms_fulfillment_order_import_.py app/integrations/oms/projection_models.py app/router_mount.py app/wms/outbound/contracts/order_import.py app/wms/outbound/routers/order_import.py app/wms/outbound/services/oms_projection_order_import_service.py tests/api/test_oms_projection_order_import_api.py tests/ci/test_wms_oms_projection_order_import_boundary.py
- .venv/bin/python3 -m pytest tests/api/test_oms_projection_order_import_api.py tests/api/test_order_outbound_view_api.py tests/api/test_order_outbound_submit_api.py tests/ci/test_wms_oms_projection_order_import_boundary.py tests/ci/test_wms_oms_legacy_runtime_retired.py tests/ci/test_wms_outbound_order_read_boundary.py