### PR TITLE
feat(outbound): expose OMS projection import candidates

### DIFF
--- a/app/wms/outbound/contracts/order_import.py
+++ b/app/wms/outbound/contracts/order_import.py
@@ -44,3 +44,48 @@ class OmsProjectionOrderImportOut(BaseModel):
     already_imported: int
     failed: int
     results: list[OmsProjectionOrderImportRowOut]
+
+
+class OmsProjectionOrderImportCandidateOut(BaseModel):
+    """
+    订单出库页专用：OMS fulfillment projection 待接入候选订单。
+
+    Boundary:
+    - 来源是 WMS 本地 OMS fulfillment projection。
+    - import_status 来自 WMS 导入审计表。
+    - 给订单出库页展示/导入使用，不回写 projection。
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    ready_order_id: str
+    platform: str
+    store_code: str
+    store_name: str | None = None
+    platform_order_no: str
+    platform_status: str | None = None
+
+    receiver_name: str | None = None
+    receiver_phone: str | None = None
+
+    ready_status: str
+    ready_at: str | None = None
+    synced_at: str | None = None
+
+    line_count: int = 0
+    component_count: int = 0
+    total_required_qty: str | None = None
+
+    import_status: str
+    imported_order_id: int | None = None
+    imported_at: str | None = None
+    can_import: bool = True
+
+
+class OmsProjectionOrderImportCandidatesOut(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    items: list[OmsProjectionOrderImportCandidateOut]
+    total: int
+    limit: int
+    offset: int

--- a/app/wms/outbound/routers/order_import.py
+++ b/app/wms/outbound/routers/order_import.py
@@ -1,20 +1,48 @@
 # app/wms/outbound/routers/order_import.py
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.deps import get_async_session as get_session
 from app.user.deps.auth import get_current_user
 from app.wms.outbound.contracts.order_import import (
+    OmsProjectionOrderImportCandidatesOut,
+    OmsProjectionOrderImportCandidateOut,
     OmsProjectionOrderImportIn,
     OmsProjectionOrderImportOut,
 )
 from app.wms.outbound.services.oms_projection_order_import_service import (
     import_orders_from_oms_projection,
+    list_oms_projection_import_candidates,
 )
 
 router = APIRouter(prefix="/wms/outbound", tags=["wms-outbound-order-import"])
+
+
+@router.get(
+    "/orders/oms-projection-candidates",
+    response_model=OmsProjectionOrderImportCandidatesOut,
+)
+async def list_wms_outbound_oms_projection_candidates(
+    q: str | None = Query(None),
+    limit: int = Query(20, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    session: AsyncSession = Depends(get_session),
+    _user=Depends(get_current_user),
+) -> OmsProjectionOrderImportCandidatesOut:
+    data = await list_oms_projection_import_candidates(
+        session,
+        q=q,
+        limit=int(limit),
+        offset=int(offset),
+    )
+    return OmsProjectionOrderImportCandidatesOut(
+        items=[OmsProjectionOrderImportCandidateOut(**item) for item in data["items"]],
+        total=int(data["total"]),
+        limit=int(data["limit"]),
+        offset=int(data["offset"]),
+    )
 
 
 @router.post(

--- a/app/wms/outbound/services/oms_projection_order_import_service.py
+++ b/app/wms/outbound/services/oms_projection_order_import_service.py
@@ -839,3 +839,120 @@ async def import_orders_from_oms_projection(
         failed=failed,
         results=results,
     )
+
+
+async def list_oms_projection_import_candidates(
+    session: AsyncSession,
+    *,
+    q: str | None,
+    limit: int,
+    offset: int,
+) -> dict[str, Any]:
+    query_text = str(q or "").strip()
+
+    where_sql = ""
+    params: dict[str, Any] = {
+        "limit": int(limit),
+        "offset": int(offset),
+    }
+
+    if query_text:
+        where_sql = """
+        WHERE (
+          p.ready_order_id ILIKE :q
+          OR p.platform ILIKE :q
+          OR p.store_code ILIKE :q
+          OR p.store_name ILIKE :q
+          OR p.platform_order_no ILIKE :q
+          OR p.receiver_name ILIKE :q
+          OR p.receiver_phone ILIKE :q
+        )
+        """
+        params["q"] = f"%{query_text}%"
+
+    total = int(
+        (
+            await session.execute(
+                text(
+                    f"""
+                    SELECT count(*)::bigint
+                    FROM wms_oms_fulfillment_order_projection AS p
+                    {where_sql}
+                    """
+                ),
+                params,
+            )
+        ).scalar_one()
+    )
+
+    rows = (
+        await session.execute(
+            text(
+                f"""
+                SELECT
+                  p.ready_order_id,
+                  p.platform,
+                  p.store_code,
+                  p.store_name,
+                  p.platform_order_no,
+                  p.platform_status,
+                  p.receiver_name,
+                  p.receiver_phone,
+                  p.ready_status,
+                  p.ready_at,
+                  p.synced_at,
+                  p.line_count,
+                  p.component_count,
+                  p.total_required_qty,
+                  i.order_id AS imported_order_id,
+                  i.import_status,
+                  i.imported_at
+                FROM wms_oms_fulfillment_order_projection AS p
+                LEFT JOIN wms_oms_fulfillment_order_imports AS i
+                  ON i.ready_order_id = p.ready_order_id
+                {where_sql}
+                ORDER BY
+                  CASE WHEN i.ready_order_id IS NULL THEN 0 ELSE 1 END ASC,
+                  p.source_updated_at DESC,
+                  p.ready_order_id ASC
+                LIMIT :limit
+                OFFSET :offset
+                """
+            ),
+            params,
+        )
+    ).mappings().all()
+
+    items: list[dict[str, Any]] = []
+    for row in rows:
+        imported_order_id = row.get("imported_order_id")
+        imported = imported_order_id is not None
+        items.append(
+            {
+                "ready_order_id": str(row["ready_order_id"]),
+                "platform": _platform_to_wms(row["platform"]),
+                "store_code": str(row["store_code"]),
+                "store_name": row.get("store_name"),
+                "platform_order_no": str(row["platform_order_no"]),
+                "platform_status": row.get("platform_status"),
+                "receiver_name": row.get("receiver_name"),
+                "receiver_phone": row.get("receiver_phone"),
+                "ready_status": str(row["ready_status"]),
+                "ready_at": str(row["ready_at"]) if row.get("ready_at") is not None else None,
+                "synced_at": str(row["synced_at"]) if row.get("synced_at") is not None else None,
+                "line_count": int(row.get("line_count") or 0),
+                "component_count": int(row.get("component_count") or 0),
+                "total_required_qty": str(row["total_required_qty"]) if row.get("total_required_qty") is not None else None,
+                "import_status": str(row.get("import_status") or "NOT_IMPORTED"),
+                "imported_order_id": int(imported_order_id) if imported_order_id is not None else None,
+                "imported_at": str(row["imported_at"]) if row.get("imported_at") is not None else None,
+                "can_import": not imported,
+            }
+        )
+
+    return {
+        "items": items,
+        "total": total,
+        "limit": int(limit),
+        "offset": int(offset),
+    }

--- a/tests/api/test_oms_projection_order_import_api.py
+++ b/tests/api/test_oms_projection_order_import_api.py
@@ -364,3 +364,47 @@ async def test_import_oms_projection_order_creates_wms_execution_order(
     assert duplicate_data["imported"] == 0
     assert duplicate_data["already_imported"] == 1
     assert duplicate_data["results"][0]["order_id"] == order_id
+
+
+async def test_list_oms_projection_import_candidates_marks_import_status(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    headers = await _login_admin_headers(client)
+    ready_order_id = await _seed_projection_order(session)
+
+    before = await client.get(
+        "/wms/outbound/orders/oms-projection-candidates",
+        headers=headers,
+        params={"q": ready_order_id, "limit": 20, "offset": 0},
+    )
+    assert before.status_code == 200, before.text
+    before_data = before.json()
+    assert before_data["total"] == 1
+    before_item = before_data["items"][0]
+    assert before_item["ready_order_id"] == ready_order_id
+    assert before_item["import_status"] == "NOT_IMPORTED"
+    assert before_item["imported_order_id"] is None
+    assert before_item["can_import"] is True
+
+    imported = await client.post(
+        "/wms/outbound/orders/import-from-oms-projection",
+        headers=headers,
+        json={"ready_order_ids": [ready_order_id], "dry_run": False},
+    )
+    assert imported.status_code == 200, imported.text
+    order_id = int(imported.json()["results"][0]["order_id"])
+
+    after = await client.get(
+        "/wms/outbound/orders/oms-projection-candidates",
+        headers=headers,
+        params={"q": ready_order_id, "limit": 20, "offset": 0},
+    )
+    assert after.status_code == 200, after.text
+    after_data = after.json()
+    assert after_data["total"] == 1
+    after_item = after_data["items"][0]
+    assert after_item["ready_order_id"] == ready_order_id
+    assert after_item["import_status"] == "IMPORTED"
+    assert int(after_item["imported_order_id"]) == order_id
+    assert after_item["can_import"] is False

--- a/tests/ci/test_wms_oms_projection_order_import_boundary.py
+++ b/tests/ci/test_wms_oms_projection_order_import_boundary.py
@@ -16,6 +16,7 @@ def test_oms_projection_import_route_lives_under_wms_outbound() -> None:
     paths = _runtime_paths()
 
     assert "/wms/outbound/orders/import-from-oms-projection" in paths
+    assert "/wms/outbound/orders/oms-projection-candidates" in paths
     assert all(not path.startswith("/oms/orders") for path in paths)
 
 
@@ -41,3 +42,13 @@ def test_oms_projection_import_audit_tables_are_registered_in_orm_metadata() -> 
 
     assert "wms_oms_fulfillment_order_imports" in Base.metadata.tables
     assert "wms_oms_fulfillment_component_imports" in Base.metadata.tables
+
+
+def test_oms_projection_import_candidate_service_uses_import_audit_left_join() -> None:
+    text = (
+        ROOT / "app/wms/outbound/services/oms_projection_order_import_service.py"
+    ).read_text(encoding="utf-8")
+
+    assert "LEFT JOIN wms_oms_fulfillment_order_imports" in text
+    assert "NOT_IMPORTED" in text
+    assert "imported_order_id" in text


### PR DESCRIPTION
## Summary

- add WMS outbound candidate endpoint for OMS fulfillment projection orders
- expose import status by joining projection rows with import audit rows
- keep order import workflow under `/wms/outbound`
- add API and CI boundary coverage

## Verification

- .venv/bin/python3 -m compileall app/wms/outbound/contracts/order_import.py app/wms/outbound/routers/order_import.py app/wms/outbound/services/oms_projection_order_import_service.py tests/api/test_oms_projection_order_import_api.py tests/ci/test_wms_oms_projection_order_import_boundary.py
- .venv/bin/python3 -m pytest tests/api/test_oms_projection_order_import_api.py tests/ci/test_wms_oms_projection_order_import_boundary.py