### PR TITLE
fix(outbound): use OMS import snapshots when PMS display is unavailable

### DIFF
--- a/app/wms/outbound/repos/order_read_view_repo.py
+++ b/app/wms/outbound/repos/order_read_view_repo.py
@@ -10,6 +10,13 @@ from app.integrations.pms.contracts import PmsExportUom
 from app.integrations.pms.factory import create_pms_read_client
 
 
+def _clean_text(value: object | None) -> str | None:
+    if value is None:
+        return None
+    text_value = str(value).strip()
+    return text_value or None
+
+
 def _pick_base_uom(rows: list[PmsExportUom]) -> PmsExportUom | None:
     if not rows:
         return None
@@ -68,6 +75,38 @@ async def load_order_outbound_head(
     return row
 
 
+async def _load_pms_display_maps(
+    session: AsyncSession,
+    *,
+    item_ids: list[int],
+) -> tuple[dict[int, Any], dict[int, list[PmsExportUom]]]:
+    """
+    Try PMS read client for display enrichment.
+
+    PMS display enrichment must not be required for WMS outbound execution:
+    - imported OMS projection orders have local snapshots in
+      wms_oms_fulfillment_component_imports;
+    - dev/test environments may intentionally not configure PMS_API_BASE_URL;
+    - missing PMS display data should degrade to snapshots/nulls, not 500.
+    """
+
+    if not item_ids:
+        return {}, {}
+
+    try:
+        pms_client = create_pms_read_client(session=session)
+        item_map = await pms_client.get_item_basics(item_ids=item_ids)
+        uom_rows = await pms_client.list_uoms(item_ids=item_ids)
+    except Exception:
+        return {}, {}
+
+    uoms_by_item_id: dict[int, list[PmsExportUom]] = {}
+    for row in uom_rows:
+        uoms_by_item_id.setdefault(int(row.item_id), []).append(row)
+
+    return item_map, uoms_by_item_id
+
+
 async def load_order_outbound_lines(
     session: AsyncSession,
     *,
@@ -78,7 +117,8 @@ async def load_order_outbound_lines(
 
     Boundary:
     - 核心来源是 WMS 本地 order_lines。
-    - 商品展示字段通过 PMS read client / WMS PMS projection 获取。
+    - 商品展示字段优先通过 PMS read client / WMS PMS projection 获取。
+    - 对 OMS projection 导入订单，允许使用导入审计快照兜底。
     - 不直接 JOIN PMS owner 表。
     """
 
@@ -88,13 +128,19 @@ async def load_order_outbound_lines(
                 text(
                     """
                     SELECT
-                      id,
-                      order_id,
-                      item_id,
-                      req_qty
-                    FROM order_lines
-                    WHERE order_id = :oid
-                    ORDER BY id ASC
+                      ol.id,
+                      ol.order_id,
+                      ol.item_id,
+                      ol.req_qty,
+                      ci.sku_code_snapshot AS import_sku_code_snapshot,
+                      ci.item_name_snapshot AS import_item_name_snapshot,
+                      ci.resolved_item_uom_id AS import_uom_id,
+                      ci.uom_snapshot AS import_uom_snapshot
+                    FROM order_lines AS ol
+                    LEFT JOIN wms_oms_fulfillment_component_imports AS ci
+                      ON ci.order_line_id = ol.id
+                    WHERE ol.order_id = :oid
+                    ORDER BY ol.id ASC
                     """
                 ),
                 {"oid": int(order_id)},
@@ -113,13 +159,10 @@ async def load_order_outbound_lines(
         }
     )
 
-    pms_client = create_pms_read_client(session=session)
-    item_map = await pms_client.get_item_basics(item_ids=item_ids)
-    uom_rows = await pms_client.list_uoms(item_ids=item_ids)
-
-    uoms_by_item_id: Dict[int, List[PmsExportUom]] = {}
-    for row in uom_rows:
-        uoms_by_item_id.setdefault(int(row.item_id), []).append(row)
+    item_map, uoms_by_item_id = await _load_pms_display_maps(
+        session,
+        item_ids=item_ids,
+    )
 
     out: List[Dict[str, Any]] = []
     for row in lines:
@@ -127,14 +170,34 @@ async def load_order_outbound_lines(
         item = item_map.get(item_id)
         base_uom = _pick_base_uom(uoms_by_item_id.get(item_id, []))
 
+        import_uom_id = row.get("import_uom_id")
+        import_uom_id_int = int(import_uom_id) if import_uom_id is not None else None
+
         out.append(
             {
-                **row,
-                "item_sku": item.sku if item is not None else None,
-                "item_name": item.name if item is not None else None,
+                "id": row["id"],
+                "order_id": row["order_id"],
+                "item_id": row["item_id"],
+                "req_qty": row["req_qty"],
+                "item_sku": (
+                    item.sku
+                    if item is not None
+                    else _clean_text(row.get("import_sku_code_snapshot"))
+                ),
+                "item_name": (
+                    item.name
+                    if item is not None
+                    else _clean_text(row.get("import_item_name_snapshot"))
+                ),
                 "item_spec": item.spec if item is not None else None,
-                "base_uom_id": int(base_uom.id) if base_uom is not None else None,
-                "base_uom_name": base_uom.uom_name if base_uom is not None else None,
+                "base_uom_id": (
+                    int(base_uom.id) if base_uom is not None else import_uom_id_int
+                ),
+                "base_uom_name": (
+                    base_uom.uom_name
+                    if base_uom is not None
+                    else _clean_text(row.get("import_uom_snapshot"))
+                ),
             }
         )
 

--- a/tests/api/test_oms_projection_order_import_api.py
+++ b/tests/api/test_oms_projection_order_import_api.py
@@ -408,3 +408,41 @@ async def test_list_oms_projection_import_candidates_marks_import_status(
     assert after_item["import_status"] == "IMPORTED"
     assert int(after_item["imported_order_id"]) == order_id
     assert after_item["can_import"] is False
+
+
+async def test_imported_oms_projection_order_view_uses_import_snapshots_without_pms_config(
+    client: AsyncClient,
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PMS_API_BASE_URL", raising=False)
+
+    headers = await _login_admin_headers(client)
+    ready_order_id = await _seed_projection_order(session)
+
+    imported = await client.post(
+        "/wms/outbound/orders/import-from-oms-projection",
+        headers=headers,
+        json={"ready_order_ids": [ready_order_id], "dry_run": False},
+    )
+    assert imported.status_code == 200, imported.text
+    order_id = int(imported.json()["results"][0]["order_id"])
+
+    view = await client.get(
+        f"/wms/outbound/orders/{order_id}/view",
+        headers=headers,
+    )
+    assert view.status_code == 200, view.text
+
+    data = view.json()
+    assert data["ok"] is True
+    assert data["order"]["id"] == order_id
+    assert len(data["lines"]) == 2
+
+    sku_values = {line["item_sku"] for line in data["lines"]}
+    name_values = {line["item_name"] for line in data["lines"]}
+    uom_values = {line["base_uom_name"] for line in data["lines"]}
+
+    assert sku_values == {"UT-SKU-1", "UT-SKU-2"}
+    assert name_values == {"UT Import Item 1", "UT Import Item 2"}
+    assert uom_values == {"件"}


### PR DESCRIPTION
## Summary

- prevent `/wms/outbound/orders/{order_id}/view` from failing when PMS_API_BASE_URL is not configured
- use OMS projection import snapshots for imported WMS execution order line display
- keep PMS read enrichment as optional display data instead of a hard dependency
- add regression coverage for imported OMS projection orders

## Verification

- .venv/bin/python3 -m compileall app/wms/outbound/repos/order_read_view_repo.py tests/api/test_oms_projection_order_import_api.py
- .venv/bin/python3 -m pytest tests/api/test_oms_projection_order_import_api.py tests/api/test_order_outbound_view_api.py tests/api/test_order_outbound_submit_api.py tests/ci/test_wms_outbound_order_read_boundary.py