### PR TITLE
feat(inbound): add procurement source options BFF

### DIFF
--- a/app/wms/inventory_adjustment/return_inbound/contracts/purchase_source_options.py
+++ b/app/wms/inventory_adjustment/return_inbound/contracts/purchase_source_options.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+InboundReceiptPurchaseSourceCompletionStatus = Literal[
+    "NOT_RECEIVED",
+    "PARTIAL",
+    "RECEIVED",
+]
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+        str_strip_whitespace=True,
+        populate_by_name=True,
+    )
+
+
+class InboundReceiptPurchaseSourceOptionOut(_Base):
+    po_id: Annotated[int, Field(ge=1, description="采购单 ID")]
+    po_no: Annotated[str, Field(min_length=1, max_length=64, description="采购单号")]
+
+    target_warehouse_id: Annotated[int, Field(ge=1, description="目标仓库 ID")]
+    target_warehouse_code_snapshot: Annotated[
+        str | None,
+        Field(default=None, max_length=64, description="目标仓库编码快照"),
+    ]
+    target_warehouse_name_snapshot: Annotated[
+        str | None,
+        Field(default=None, max_length=255, description="目标仓库名称快照"),
+    ]
+
+    supplier_id: Annotated[int, Field(ge=1, description="供应商 ID")]
+    supplier_code_snapshot: Annotated[
+        str,
+        Field(min_length=1, max_length=64, description="供应商编码快照"),
+    ]
+    supplier_name_snapshot: Annotated[
+        str,
+        Field(min_length=1, max_length=255, description="供应商名称快照"),
+    ]
+
+    purchase_time: datetime
+    order_status: Annotated[str, Field(min_length=1, max_length=32, description="采购单状态")]
+    completion_status: InboundReceiptPurchaseSourceCompletionStatus
+    last_received_at: datetime | None = Field(default=None, description="最近收货时间")
+
+
+class InboundReceiptPurchaseSourceOptionsOut(_Base):
+    items: list[InboundReceiptPurchaseSourceOptionOut] = Field(
+        default_factory=list,
+        description="可生成采购入库单的采购来源",
+    )
+
+
+__all__ = [
+    "InboundReceiptPurchaseSourceCompletionStatus",
+    "InboundReceiptPurchaseSourceOptionOut",
+    "InboundReceiptPurchaseSourceOptionsOut",
+]

--- a/app/wms/inventory_adjustment/return_inbound/routers/inbound_receipts.py
+++ b/app/wms/inventory_adjustment/return_inbound/routers/inbound_receipts.py
@@ -1,23 +1,24 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_session
+from app.integrations.procurement.http_client import ProcurementReadClientError
+from app.wms.inventory_adjustment.return_inbound.contracts.purchase_source_options import (
+    InboundReceiptPurchaseSourceOptionsOut,
+)
 from app.wms.inventory_adjustment.return_inbound.contracts.receipt_create_from_purchase import (
     InboundReceiptCreateFromPurchaseIn,
     InboundReceiptCreateFromPurchaseOut,
-)
-from app.wms.inventory_adjustment.return_inbound.contracts.receipt_create_manual import (
-    InboundReceiptCreateManualIn,
-    InboundReceiptCreateManualOut,
 )
 from app.wms.inventory_adjustment.return_inbound.contracts.receipt_create_from_return_order import (
     InboundReceiptCreateFromReturnOrderIn,
     InboundReceiptCreateFromReturnOrderOut,
 )
-from app.wms.inventory_adjustment.return_inbound.contracts.receipt_return_source import (
-    InboundReceiptReturnSourceOut,
+from app.wms.inventory_adjustment.return_inbound.contracts.receipt_create_manual import (
+    InboundReceiptCreateManualIn,
+    InboundReceiptCreateManualOut,
 )
 from app.wms.inventory_adjustment.return_inbound.contracts.receipt_read import (
     InboundReceiptListOut,
@@ -27,17 +28,20 @@ from app.wms.inventory_adjustment.return_inbound.contracts.receipt_read import (
 from app.wms.inventory_adjustment.return_inbound.contracts.receipt_release import (
     InboundReceiptReleaseOut,
 )
+from app.wms.inventory_adjustment.return_inbound.contracts.receipt_return_source import (
+    InboundReceiptReturnSourceOut,
+)
 from app.wms.inventory_adjustment.return_inbound.services.create_from_purchase_service import (
     create_inbound_receipt_from_purchase,
-)
-from app.wms.inventory_adjustment.return_inbound.services.create_manual_service import (
-    create_inbound_receipt_manual,
 )
 from app.wms.inventory_adjustment.return_inbound.services.create_from_return_order_service import (
     create_inbound_receipt_from_return_order,
 )
-from app.wms.inventory_adjustment.return_inbound.services.return_source_service import (
-    get_inbound_return_source,
+from app.wms.inventory_adjustment.return_inbound.services.create_manual_service import (
+    create_inbound_receipt_manual,
+)
+from app.wms.inventory_adjustment.return_inbound.services.purchase_source_options_service import (
+    list_inbound_receipt_purchase_source_options,
 )
 from app.wms.inventory_adjustment.return_inbound.services.read_service import (
     get_inbound_receipt,
@@ -45,8 +49,31 @@ from app.wms.inventory_adjustment.return_inbound.services.read_service import (
     list_inbound_receipts,
     release_inbound_receipt,
 )
+from app.wms.inventory_adjustment.return_inbound.services.return_source_service import (
+    get_inbound_return_source,
+)
 
 router = APIRouter(prefix="/inbound-receipts", tags=["inbound-receipts"])
+
+
+@router.get("/purchase-source-options", response_model=InboundReceiptPurchaseSourceOptionsOut)
+async def list_inbound_receipt_purchase_source_options_endpoint(
+    target_warehouse_id: int | None = Query(None, gt=0),
+    q: str | None = Query(None),
+    limit: int = Query(200, ge=1, le=500),
+) -> InboundReceiptPurchaseSourceOptionsOut:
+    try:
+        return await list_inbound_receipt_purchase_source_options(
+            target_warehouse_id=target_warehouse_id,
+            q=q,
+            limit=limit,
+        )
+    except ProcurementReadClientError as e:
+        raise HTTPException(status_code=502, detail=str(e)) from e
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
 
 
 @router.post("/from-purchase", response_model=InboundReceiptCreateFromPurchaseOut)

--- a/app/wms/inventory_adjustment/return_inbound/services/purchase_source_options_service.py
+++ b/app/wms/inventory_adjustment/return_inbound/services/purchase_source_options_service.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from app.integrations.procurement.contracts import (
+    ProcurementPurchaseOrderSourceOptionOut,
+)
+from app.integrations.procurement.factory import create_procurement_read_client
+from app.wms.inventory_adjustment.return_inbound.contracts.purchase_source_options import (
+    InboundReceiptPurchaseSourceOptionOut,
+    InboundReceiptPurchaseSourceOptionsOut,
+)
+
+
+async def list_inbound_receipt_purchase_source_options(
+    *,
+    target_warehouse_id: int | None = None,
+    q: str | None = None,
+    limit: int = 200,
+) -> InboundReceiptPurchaseSourceOptionsOut:
+    """List procurement purchase sources through procurement-api.
+
+    边界说明：
+    - WMS 只通过 procurement read API 读取采购来源。
+    - 本函数不创建 inbound_receipts。
+    - 本函数不读取 WMS 本地 purchase_orders owner 表。
+    """
+
+    client = create_procurement_read_client()
+    source_options = await client.list_purchase_order_source_options(
+        target_warehouse_id=target_warehouse_id,
+        q=q,
+        limit=limit,
+    )
+
+    return InboundReceiptPurchaseSourceOptionsOut(
+        items=[
+            _map_procurement_source_option(item)
+            for item in source_options.items
+        ]
+    )
+
+
+def _map_procurement_source_option(
+    item: ProcurementPurchaseOrderSourceOptionOut,
+) -> InboundReceiptPurchaseSourceOptionOut:
+    return InboundReceiptPurchaseSourceOptionOut.model_validate(
+        {
+            "po_id": item.po_id,
+            "po_no": item.po_no,
+            "target_warehouse_id": item.target_warehouse_id,
+            "target_warehouse_code_snapshot": item.target_warehouse_code_snapshot,
+            "target_warehouse_name_snapshot": item.target_warehouse_name_snapshot,
+            "supplier_id": item.supplier_id,
+            "supplier_code_snapshot": item.supplier_code_snapshot,
+            "supplier_name_snapshot": item.supplier_name_snapshot,
+            "purchase_time": item.purchase_time,
+            "order_status": item.order_status,
+            "completion_status": item.completion_status,
+            "last_received_at": item.last_received_at,
+        }
+    )
+
+
+__all__ = ["list_inbound_receipt_purchase_source_options"]

--- a/tests/api/test_inbound_receipt_purchase_source_options_api.py
+++ b/tests/api/test_inbound_receipt_purchase_source_options_api.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.integrations.procurement.http_client import ProcurementReadClientError
+from app.wms.inventory_adjustment.return_inbound.contracts.purchase_source_options import (
+    InboundReceiptPurchaseSourceOptionOut,
+    InboundReceiptPurchaseSourceOptionsOut,
+)
+from app.wms.inventory_adjustment.return_inbound.routers import inbound_receipts as router_module
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router_module.router)
+    return TestClient(app)
+
+
+def _source_options() -> InboundReceiptPurchaseSourceOptionsOut:
+    now = datetime.now(UTC)
+
+    return InboundReceiptPurchaseSourceOptionsOut(
+        items=[
+            InboundReceiptPurchaseSourceOptionOut(
+                po_id=1,
+                po_no="PO-1",
+                target_warehouse_id=2,
+                target_warehouse_code_snapshot="WH-2",
+                target_warehouse_name_snapshot="二号仓",
+                supplier_id=10,
+                supplier_code_snapshot="SUP-10",
+                supplier_name_snapshot="供应商快照",
+                purchase_time=now,
+                order_status="CREATED",
+                completion_status="PARTIAL",
+                last_received_at=now,
+            )
+        ]
+    )
+
+
+def test_purchase_source_options_route_returns_bff_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_list_source_options(
+        *,
+        target_warehouse_id: int | None = None,
+        q: str | None = None,
+        limit: int = 200,
+    ) -> InboundReceiptPurchaseSourceOptionsOut:
+        captured["target_warehouse_id"] = target_warehouse_id
+        captured["q"] = q
+        captured["limit"] = limit
+        return _source_options()
+
+    monkeypatch.setattr(
+        router_module,
+        "list_inbound_receipt_purchase_source_options",
+        fake_list_source_options,
+    )
+
+    response = _client().get(
+        "/inbound-receipts/purchase-source-options",
+        params={
+            "target_warehouse_id": 2,
+            "q": "SUP",
+            "limit": 20,
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+
+    assert captured == {
+        "target_warehouse_id": 2,
+        "q": "SUP",
+        "limit": 20,
+    }
+    assert body["items"][0]["po_id"] == 1
+    assert body["items"][0]["supplier_name_snapshot"] == "供应商快照"
+
+
+def test_purchase_source_options_route_is_not_captured_by_receipt_id_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_list_source_options(
+        *,
+        target_warehouse_id: int | None = None,
+        q: str | None = None,
+        limit: int = 200,
+    ) -> InboundReceiptPurchaseSourceOptionsOut:
+        return InboundReceiptPurchaseSourceOptionsOut(items=[])
+
+    monkeypatch.setattr(
+        router_module,
+        "list_inbound_receipt_purchase_source_options",
+        fake_list_source_options,
+    )
+
+    response = _client().get("/inbound-receipts/purchase-source-options")
+
+    assert response.status_code == 200
+    assert response.json() == {"items": []}
+
+
+def test_purchase_source_options_route_maps_procurement_error_to_502(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_list_source_options(
+        *,
+        target_warehouse_id: int | None = None,
+        q: str | None = None,
+        limit: int = 200,
+    ) -> InboundReceiptPurchaseSourceOptionsOut:
+        raise ProcurementReadClientError("upstream failed")
+
+    monkeypatch.setattr(
+        router_module,
+        "list_inbound_receipt_purchase_source_options",
+        fake_list_source_options,
+    )
+
+    response = _client().get("/inbound-receipts/purchase-source-options")
+
+    assert response.status_code == 502
+    assert response.json() == {"detail": "upstream failed"}

--- a/tests/services/test_inbound_receipt_purchase_source_options_service.py
+++ b/tests/services/test_inbound_receipt_purchase_source_options_service.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from app.integrations.procurement.contracts import (
+    ProcurementPurchaseOrderSourceOptionOut,
+    ProcurementPurchaseOrderSourceOptionsOut,
+)
+import app.wms.inventory_adjustment.return_inbound.services.purchase_source_options_service as service_module
+
+
+class FakeProcurementReadClient:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def list_purchase_order_source_options(
+        self,
+        *,
+        target_warehouse_id: int | None = None,
+        q: str | None = None,
+        limit: int = 200,
+    ) -> ProcurementPurchaseOrderSourceOptionsOut:
+        self.calls.append(
+            {
+                "target_warehouse_id": target_warehouse_id,
+                "q": q,
+                "limit": limit,
+            }
+        )
+        now = datetime.now(UTC)
+
+        return ProcurementPurchaseOrderSourceOptionsOut(
+            items=[
+                ProcurementPurchaseOrderSourceOptionOut(
+                    po_id=1,
+                    po_no="PO-1",
+                    target_warehouse_id=2,
+                    target_warehouse_code_snapshot="WH-2",
+                    target_warehouse_name_snapshot="二号仓",
+                    supplier_id=10,
+                    supplier_code_snapshot="SUP-10",
+                    supplier_name_snapshot="供应商快照",
+                    purchase_time=now,
+                    order_status="CREATED",
+                    completion_status="PARTIAL",
+                    last_received_at=now,
+                )
+            ]
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_purchase_source_options_maps_procurement_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_client = FakeProcurementReadClient()
+    monkeypatch.setattr(
+        service_module,
+        "create_procurement_read_client",
+        lambda: fake_client,
+    )
+
+    result = await service_module.list_inbound_receipt_purchase_source_options(
+        target_warehouse_id=2,
+        q="SUP",
+        limit=20,
+    )
+
+    assert fake_client.calls == [
+        {
+            "target_warehouse_id": 2,
+            "q": "SUP",
+            "limit": 20,
+        }
+    ]
+    assert len(result.items) == 1
+    assert result.items[0].po_id == 1
+    assert result.items[0].target_warehouse_id == 2
+    assert result.items[0].supplier_code_snapshot == "SUP-10"
+    assert result.items[0].supplier_name_snapshot == "供应商快照"
+    assert result.items[0].completion_status == "PARTIAL"


### PR DESCRIPTION
Adds WMS inbound receipt purchase-source-options BFF backed by procurement-api read client. Does not change from-purchase generation, database schema, frontend behavior, or WMS execution writes.