### PR TITLE
refactor(inbound): replace event po line with source line

### DIFF
--- a/alembic/versions/20260513133000_inbound_event_lines_source_line_id.py
+++ b/alembic/versions/20260513133000_inbound_event_lines_source_line_id.py
@@ -1,0 +1,113 @@
+"""inbound_event_lines_source_line_id
+
+Revision ID: 20260513133000_source_line_id
+Revises: 737e3e8199df
+Create Date: 2026-05-13 13:30:00.000000
+
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260513133000_source_line_id"
+down_revision: str | Sequence[str] | None = "737e3e8199df"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Rename inbound_event_lines.po_line_id to source_line_id and retire local PO FK."""
+
+    op.execute("DROP INDEX IF EXISTS ix_inbound_event_lines_po_line_id;")
+    op.execute(
+        "ALTER TABLE inbound_event_lines "
+        "DROP CONSTRAINT IF EXISTS fk_inbound_event_lines_po_line;"
+    )
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1
+                  FROM information_schema.columns
+                 WHERE table_schema = 'public'
+                   AND table_name = 'inbound_event_lines'
+                   AND column_name = 'po_line_id'
+            )
+            AND NOT EXISTS (
+                SELECT 1
+                  FROM information_schema.columns
+                 WHERE table_schema = 'public'
+                   AND table_name = 'inbound_event_lines'
+                   AND column_name = 'source_line_id'
+            ) THEN
+                ALTER TABLE inbound_event_lines
+                RENAME COLUMN po_line_id TO source_line_id;
+            END IF;
+        END $$;
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_inbound_event_lines_source_line_id "
+        "ON inbound_event_lines (source_line_id);"
+    )
+    op.execute(
+        """
+        COMMENT ON COLUMN inbound_event_lines.source_line_id IS
+        '外部来源行 ID；采购来源时对应 procurement purchase_order_lines.id，不声明本地 FK';
+        """
+    )
+
+
+def downgrade() -> None:
+    """Restore inbound_event_lines.po_line_id and local PO FK."""
+
+    op.execute("DROP INDEX IF EXISTS ix_inbound_event_lines_source_line_id;")
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1
+                  FROM information_schema.columns
+                 WHERE table_schema = 'public'
+                   AND table_name = 'inbound_event_lines'
+                   AND column_name = 'source_line_id'
+            )
+            AND NOT EXISTS (
+                SELECT 1
+                  FROM information_schema.columns
+                 WHERE table_schema = 'public'
+                   AND table_name = 'inbound_event_lines'
+                   AND column_name = 'po_line_id'
+            ) THEN
+                ALTER TABLE inbound_event_lines
+                RENAME COLUMN source_line_id TO po_line_id;
+            END IF;
+        END $$;
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_inbound_event_lines_po_line_id "
+        "ON inbound_event_lines (po_line_id);"
+    )
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1
+                  FROM pg_constraint
+                 WHERE conname = 'fk_inbound_event_lines_po_line'
+            ) THEN
+                ALTER TABLE inbound_event_lines
+                ADD CONSTRAINT fk_inbound_event_lines_po_line
+                FOREIGN KEY (po_line_id)
+                REFERENCES purchase_order_lines(id)
+                ON DELETE SET NULL;
+            END IF;
+        END $$;
+        """
+    )

--- a/app/procurement/repos/purchase_order_completion_repo.py
+++ b/app/procurement/repos/purchase_order_completion_repo.py
@@ -165,7 +165,7 @@ async def load_po_completion_events(
           we.source_ref AS source_ref,
           we.occurred_at AS occurred_at,
 
-          iel.po_line_id AS po_line_id,
+          iel.source_line_id AS po_line_id,
           pol.line_no AS line_no,
           iel.item_id AS item_id,
 
@@ -177,7 +177,7 @@ async def load_po_completion_events(
         JOIN wms_events we
           ON we.id = iel.event_id
         JOIN purchase_order_lines pol
-          ON pol.id = iel.po_line_id
+          ON pol.id = iel.source_line_id
         WHERE pol.po_id = :po_id
           AND we.event_type = 'INBOUND'
           AND we.source_type = 'PURCHASE_ORDER'

--- a/app/procurement/repos/purchase_order_line_completion_repo.py
+++ b/app/procurement/repos/purchase_order_line_completion_repo.py
@@ -148,18 +148,18 @@ async def apply_completion_delta_for_event(
 
     要求：
     - 调用方应保证 event / inbound_event_lines 已 flush
-    - 仅采购来源 event line 才会带 po_line_id
+    - 仅采购来源 event line 才会带 source_line_id；本地 completion 仍映射为 po_line_id
     """
     sql = text(
         """
         WITH delta AS (
           SELECT
-            iel.po_line_id AS po_line_id,
+            iel.source_line_id AS po_line_id,
             SUM(iel.qty_base)::int AS add_qty
           FROM inbound_event_lines iel
           WHERE iel.event_id = :event_id
-            AND iel.po_line_id IS NOT NULL
-          GROUP BY iel.po_line_id
+            AND iel.source_line_id IS NOT NULL
+          GROUP BY iel.source_line_id
         )
         UPDATE purchase_order_line_completion plc
         SET

--- a/app/procurement/repos/purchase_order_update_repo.py
+++ b/app/procurement/repos/purchase_order_update_repo.py
@@ -67,7 +67,7 @@ async def has_po_committed_inbound_facts(
             SELECT 1
               FROM purchase_order_lines pol
               JOIN inbound_event_lines iel
-                ON iel.po_line_id = pol.id
+                ON iel.source_line_id = pol.id
               JOIN wms_events we
                 ON we.id = iel.event_id
              WHERE pol.po_id = :po_id

--- a/app/wms/inbound/contracts/inbound_commit.py
+++ b/app/wms/inbound/contracts/inbound_commit.py
@@ -31,7 +31,7 @@ class InboundCommitLineIn(_Base):
     设计原则：
     - 输入只接用户事实：商品/条码、包装单位、输入数量、批号/日期
     - 不接 qty_base，qty_base 由后端根据 PMS item_uoms.ratio_to_base 计算
-    - 采购来源时允许显式带 po_line_id；其他来源不需要 source_line_ref 这种泛字段
+    - 采购来源时允许显式带 source_line_id；其他来源不需要来源行引用
     """
 
     item_id: Annotated[int | None, Field(default=None, ge=1, description="商品 ID")]
@@ -44,7 +44,7 @@ class InboundCommitLineIn(_Base):
     production_date: date | None = Field(default=None, description="生产日期")
     expiry_date: date | None = Field(default=None, description="到期日期")
 
-    po_line_id: Annotated[int | None, Field(default=None, ge=1, description="采购来源时的采购单行 ID")]
+    source_line_id: Annotated[int | None, Field(default=None, ge=1, description="采购来源时的外部来源行 ID")]
     remark: Annotated[str | None, Field(default=None, max_length=255, description="行备注")]
 
     @model_validator(mode="after")
@@ -85,6 +85,17 @@ class InboundCommitIn(_Base):
 
     lines: Annotated[list[InboundCommitLineIn], Field(min_length=1, description="提交行")]
 
+    @model_validator(mode="after")
+    def _validate_purchase_source_lines_require_source_line_id(self) -> "InboundCommitIn":
+        if self.source_type != "PURCHASE_ORDER":
+            return self
+
+        for index, line in enumerate(self.lines, start=1):
+            if line.source_line_id is None:
+                raise ValueError(f"采购入库第 {index} 行必须提供 source_line_id")
+
+        return self
+
 
 class InboundCommitResultRow(_Base):
     """
@@ -106,7 +117,7 @@ class InboundCommitResultRow(_Base):
     lot_id: Annotated[int | None, Field(default=None, ge=1, description="实际落账 lot_id")]
     lot_code: Annotated[str | None, Field(default=None, max_length=128, description="实际落账 lot_code")]
 
-    po_line_id: Annotated[int | None, Field(default=None, ge=1, description="采购来源时的采购单行 ID")]
+    source_line_id: Annotated[int | None, Field(default=None, ge=1, description="采购来源时的外部来源行 ID")]
     remark: Annotated[str | None, Field(default=None, max_length=255, description="行备注")]
 
 

--- a/app/wms/inbound/contracts/inbound_event_read.py
+++ b/app/wms/inbound/contracts/inbound_event_read.py
@@ -54,7 +54,7 @@ class InboundEventLineOut(_Base):
     production_date: date | None = Field(default=None, description="生产日期")
     expiry_date: date | None = Field(default=None, description="到期日期")
 
-    po_line_id: Annotated[int | None, Field(default=None, ge=1, description="采购来源时的采购单行 ID")]
+    source_line_id: Annotated[int | None, Field(default=None, ge=1, description="采购来源时的外部来源行 ID")]
     remark: Annotated[str | None, Field(default=None, max_length=255, description="行备注")]
 
 

--- a/app/wms/inbound/models/inbound_event.py
+++ b/app/wms/inbound/models/inbound_event.py
@@ -214,10 +214,10 @@ class InboundEventLine(Base):
         nullable=True,
     )
 
-    po_line_id: Mapped[Optional[int]] = mapped_column(
+    source_line_id: Mapped[Optional[int]] = mapped_column(
         Integer,
-        ForeignKey("purchase_order_lines.id", name="fk_inbound_event_lines_po_line", ondelete="SET NULL"),
         nullable=True,
+        comment="外部来源行 ID；采购来源时对应 procurement purchase_order_lines.id，不声明本地 FK",
     )
 
     remark: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)

--- a/app/wms/inbound/services/inbound_commit_service.py
+++ b/app/wms/inbound/services/inbound_commit_service.py
@@ -44,7 +44,7 @@ class ResolvedCommitLine:
     production_date: date | None
     expiry_date: date | None
     lot_id: int | None
-    po_line_id: int | None
+    source_line_id: int | None
     remark: str | None
 
 
@@ -116,10 +116,10 @@ def _validate_source(payload: InboundCommitIn) -> None:
         if not _norm_text(payload.source_ref):
             raise HTTPException(status_code=400, detail="采购入库必须提供 source_ref")
         for idx, line in enumerate(payload.lines, start=1):
-            if line.po_line_id is None:
+            if line.source_line_id is None:
                 raise HTTPException(
                     status_code=400,
-                    detail=f"采购入库第 {idx} 行必须提供 po_line_id",
+                    detail=f"采购入库第 {idx} 行必须提供 source_line_id",
                 )
 
 
@@ -138,7 +138,7 @@ async def _resolve_line(
     lot_code_input = _norm_lot_code(getattr(line, "lot_code_input", None))
     production_date_in = getattr(line, "production_date", None)
     expiry_date_in = getattr(line, "expiry_date", None)
-    po_line_id = getattr(line, "po_line_id", None)
+    source_line_id = getattr(line, "source_line_id", None)
     remark = _norm_text(getattr(line, "remark", None))
 
     if qty_input <= 0:
@@ -242,7 +242,7 @@ async def _resolve_line(
     )
 
     if source_type != "PURCHASE_ORDER":
-        po_line_id = None
+        source_line_id = None
 
     return ResolvedCommitLine(
         line_no=int(line_no),
@@ -259,7 +259,7 @@ async def _resolve_line(
         production_date=resolved_production_date,
         expiry_date=resolved_expiry_date,
         lot_id=int(lot_id) if lot_id is not None else None,
-        po_line_id=int(po_line_id) if po_line_id is not None else None,
+        source_line_id=int(source_line_id) if source_line_id is not None else None,
         remark=remark,
     )
 
@@ -330,7 +330,7 @@ async def commit_inbound(
             production_date=line.production_date,
             expiry_date=line.expiry_date,
             lot_id=int(line.lot_id) if line.lot_id is not None else None,
-            po_line_id=int(line.po_line_id) if line.po_line_id is not None else None,
+            source_line_id=int(line.source_line_id) if line.source_line_id is not None else None,
             remark=line.remark,
         )
         session.add(event_line)
@@ -366,7 +366,7 @@ async def commit_inbound(
                 qty_base=int(line.qty_base),
                 lot_id=int(line.lot_id) if line.lot_id is not None else None,
                 lot_code=line.lot_code_input,
-                po_line_id=int(line.po_line_id) if line.po_line_id is not None else None,
+                source_line_id=int(line.source_line_id) if line.source_line_id is not None else None,
                 remark=line.remark,
             )
         )

--- a/app/wms/inbound/services/inbound_event_read_service.py
+++ b/app/wms/inbound/services/inbound_event_read_service.py
@@ -201,7 +201,7 @@ async def get_inbound_event_detail(
             lo.lot_code,
             iel.production_date,
             iel.expiry_date,
-            iel.po_line_id,
+            iel.source_line_id,
             iel.remark
           FROM inbound_event_lines AS iel
           LEFT JOIN lots AS lo

--- a/app/wms/inventory_adjustment/inbound_reversal/repos/inbound_reversal_repo.py
+++ b/app/wms/inventory_adjustment/inbound_reversal/repos/inbound_reversal_repo.py
@@ -257,7 +257,7 @@ async def list_inbound_event_lines_for_reversal(
                   production_date,
                   expiry_date,
                   lot_id,
-                  po_line_id,
+                  source_line_id,
                   remark
                 FROM inbound_event_lines
                 WHERE event_id = :event_id

--- a/app/wms/inventory_adjustment/inbound_reversal/services/inbound_reversal_service.py
+++ b/app/wms/inventory_adjustment/inbound_reversal/services/inbound_reversal_service.py
@@ -268,7 +268,7 @@ async def reverse_inbound_event(
             production_date=src["production_date"],
             expiry_date=src["expiry_date"],
             lot_id=int(lot_id),
-            po_line_id=(int(src["po_line_id"]) if src["po_line_id"] is not None else None),
+            source_line_id=(int(src["source_line_id"]) if src["source_line_id"] is not None else None),
             remark=_norm_text(src["remark"]),
         )
         session.add(event_line)

--- a/app/wms/inventory_adjustment/return_inbound/repos/inbound_operation_write_repo.py
+++ b/app/wms/inventory_adjustment/return_inbound/repos/inbound_operation_write_repo.py
@@ -467,7 +467,7 @@ async def submit_inbound_operation_repo(
             ).mappings().first()
 
             event_line_no += 1
-            po_line_id = (
+            source_line_id = (
                 int(task_line["source_line_id"])
                 if str(task["source_type"]) == "PURCHASE_ORDER" and task_line["source_line_id"] is not None
                 else None
@@ -492,7 +492,7 @@ async def submit_inbound_operation_repo(
                       production_date,
                       expiry_date,
                       lot_id,
-                      po_line_id,
+                      source_line_id,
                       remark
                     )
                     VALUES (
@@ -511,7 +511,7 @@ async def submit_inbound_operation_repo(
                       :production_date,
                       :expiry_date,
                       :lot_id,
-                      :po_line_id,
+                      :source_line_id,
                       :remark
                     )
                     """
@@ -532,7 +532,7 @@ async def submit_inbound_operation_repo(
                     "production_date": entry.production_date,
                     "expiry_date": entry.expiry_date,
                     "lot_id": int(lot_id) if lot_id is not None else None,
-                    "po_line_id": po_line_id,
+                    "source_line_id": source_line_id,
                     "remark": entry.remark,
                 },
             )

--- a/tests/api/test_inbound_commit_source_line_contract_api.py
+++ b/tests/api/test_inbound_commit_source_line_contract_api.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from app.wms.inbound.contracts.inbound_commit import InboundCommitIn, InboundCommitLineIn
+
+
+def test_purchase_inbound_commit_line_uses_source_line_id() -> None:
+    line = InboundCommitLineIn.model_validate(
+        {
+            "item_id": 3001,
+            "uom_id": 11,
+            "qty_input": 2,
+            "source_line_id": 7001,
+        }
+    )
+
+    assert line.source_line_id == 7001
+
+
+def test_purchase_inbound_commit_line_rejects_po_line_id_alias() -> None:
+    with pytest.raises(ValidationError):
+        InboundCommitLineIn.model_validate(
+            {
+                "item_id": 3001,
+                "uom_id": 11,
+                "qty_input": 2,
+                "po_line_id": 7001,
+            }
+        )
+
+
+def test_purchase_inbound_commit_requires_source_line_id_for_purchase_source() -> None:
+    with pytest.raises(ValidationError):
+        InboundCommitIn.model_validate(
+            {
+                "warehouse_id": 1,
+                "source_type": "PURCHASE_ORDER",
+                "source_ref": "PO-1",
+                "occurred_at": datetime.now(UTC).isoformat(),
+                "lines": [
+                    {
+                        "item_id": 3001,
+                        "uom_id": 11,
+                        "qty_input": 2,
+                    }
+                ],
+            }
+        )
+
+
+def test_manual_inbound_commit_does_not_require_source_line_id() -> None:
+    payload = InboundCommitIn.model_validate(
+        {
+            "warehouse_id": 1,
+            "source_type": "MANUAL",
+            "source_ref": None,
+            "occurred_at": datetime.now(UTC).isoformat(),
+            "lines": [
+                {
+                    "item_id": 3001,
+                    "uom_id": 11,
+                    "qty_input": 2,
+                }
+            ],
+        }
+    )
+
+    assert payload.lines[0].source_line_id is None

--- a/tests/api/test_purchase_order_detail_editability_api.py
+++ b/tests/api/test_purchase_order_detail_editability_api.py
@@ -83,7 +83,7 @@ async def _commit_purchase_inbound(
                 "item_id": int(line["item_id"]),
                 "uom_id": int(uom_id),
                 "qty_input": 1,
-                "po_line_id": int(line["id"]),
+                "source_line_id": int(line["id"]),
             },
         ],
     }

--- a/tests/api/test_purchase_order_update_api.py
+++ b/tests/api/test_purchase_order_update_api.py
@@ -90,13 +90,13 @@ async def _commit_purchase_inbound(
                 "item_id": int(by_line_no[1]["item_id"]),
                 "uom_id": int(uom_map[1]),
                 "qty_input": 1,
-                "po_line_id": int(by_line_no[1]["id"]),
+                "source_line_id": int(by_line_no[1]["id"]),
             },
             {
                 "item_id": int(by_line_no[2]["item_id"]),
                 "uom_id": int(uom_map[2]),
                 "qty_input": 3,
-                "po_line_id": int(by_line_no[2]["id"]),
+                "source_line_id": int(by_line_no[2]["id"]),
             },
         ],
     }

--- a/tests/api/test_purchase_orders_completion_api.py
+++ b/tests/api/test_purchase_orders_completion_api.py
@@ -92,19 +92,19 @@ async def _commit_purchase_inbound(
                 "item_id": int(by_line_no[1]["item_id"]),
                 "uom_id": int(uom_map[1]),
                 "qty_input": 1,
-                "po_line_id": int(by_line_no[1]["id"]),
+                "source_line_id": int(by_line_no[1]["id"]),
             },
             {
                 "item_id": int(by_line_no[1]["item_id"]),
                 "uom_id": int(uom_map[1]),
                 "qty_input": 1,
-                "po_line_id": int(by_line_no[1]["id"]),
+                "source_line_id": int(by_line_no[1]["id"]),
             },
             {
                 "item_id": int(by_line_no[2]["item_id"]),
                 "uom_id": int(uom_map[2]),
                 "qty_input": 3,
-                "po_line_id": int(by_line_no[2]["id"]),
+                "source_line_id": int(by_line_no[2]["id"]),
             },
         ],
     }


### PR DESCRIPTION
Renames inbound_event_lines.po_line_id to source_line_id and removes the local purchase_order_lines FK from WMS inbound event facts. Keeps legacy local procurement completion reads mapped to po_line_id while WMS event storage becomes source_line_id. Does not change from-purchase generation, frontend behavior, or procurement-api integration.