### PR TITLE
refactor(inbound): stop local procurement completion sync

### DIFF
--- a/app/wms/inbound/services/inbound_commit_service.py
+++ b/app/wms/inbound/services/inbound_commit_service.py
@@ -9,9 +9,6 @@ from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.integrations.pms.factory import create_pms_read_client
-from app.procurement.services.purchase_order_completion_sync import (
-    sync_purchase_completion_for_inbound_event,
-)
 from app.wms.inbound.contracts.inbound_commit import (
     InboundCommitIn,
     InboundCommitOut,
@@ -372,13 +369,6 @@ async def commit_inbound(
         )
 
     await session.flush()
-
-    if str(payload.source_type) == "PURCHASE_ORDER":
-        await sync_purchase_completion_for_inbound_event(
-            session,
-            event_id=int(event.id),
-            occurred_at=payload.occurred_at,
-        )
 
     return InboundCommitOut(
         ok=True,

--- a/tests/api/test_inbound_commit_no_local_procurement_completion_sync.py
+++ b/tests/api/test_inbound_commit_no_local_procurement_completion_sync.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_inbound_commit_service_does_not_import_local_procurement_completion_sync() -> None:
+    text = Path("app/wms/inbound/services/inbound_commit_service.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "purchase_order_completion_sync" not in text
+    assert "sync_purchase_completion_for_inbound_event" not in text

--- a/tests/api/test_purchase_orders_completion_api.py
+++ b/tests/api/test_purchase_orders_completion_api.py
@@ -127,7 +127,7 @@ def _rows_for_po(rows: List[Dict[str, Any]], *, po_id: int) -> List[Dict[str, An
 
 
 @pytest.mark.asyncio
-async def test_purchase_orders_completion_list_returns_line_level_completion(
+async def test_purchase_orders_completion_list_is_not_updated_by_wms_inbound_commit(
     client: httpx.AsyncClient,
     session: AsyncSession,
 ) -> None:
@@ -158,22 +158,22 @@ async def test_purchase_orders_completion_list_returns_line_level_completion(
     assert str(line1["po_no"]) == po_no
     assert int(line1["item_id"]) == int(item_a)
     assert int(line1["qty_ordered_base"]) == 2
-    assert int(line1["qty_received_base"]) == 2
-    assert int(line1["qty_remaining_base"]) == 0
-    assert str(line1["line_completion_status"]) == "RECEIVED"
+    assert int(line1["qty_received_base"]) == 0
+    assert int(line1["qty_remaining_base"]) == 2
+    assert str(line1["line_completion_status"]) == "NOT_RECEIVED"
 
     line2 = rows_by_line_no[2]
     assert int(line2["po_id"]) == po_id
     assert str(line2["po_no"]) == po_no
     assert int(line2["item_id"]) == int(item_b)
     assert int(line2["qty_ordered_base"]) == 3
-    assert int(line2["qty_received_base"]) == 3
-    assert int(line2["qty_remaining_base"]) == 0
-    assert str(line2["line_completion_status"]) == "RECEIVED"
+    assert int(line2["qty_received_base"]) == 0
+    assert int(line2["qty_remaining_base"]) == 3
+    assert str(line2["line_completion_status"]) == "NOT_RECEIVED"
 
 
 @pytest.mark.asyncio
-async def test_purchase_orders_completion_detail_returns_summary_lines_and_events(
+async def test_purchase_orders_completion_detail_keeps_local_completion_static_after_wms_commit(
     client: httpx.AsyncClient,
     session: AsyncSession,
 ) -> None:
@@ -200,9 +200,9 @@ async def test_purchase_orders_completion_detail_returns_summary_lines_and_event
     assert int(summary["po_id"]) == po_id
     assert str(summary["po_no"]) == po_no
     assert int(summary["total_ordered_base"]) == 5
-    assert int(summary["total_received_base"]) == 5
-    assert int(summary["total_remaining_base"]) == 0
-    assert str(summary["completion_status"]) == "RECEIVED"
+    assert int(summary["total_received_base"]) == 0
+    assert int(summary["total_remaining_base"]) == 5
+    assert str(summary["completion_status"]) == "NOT_RECEIVED"
 
     lines = data.get("lines")
     assert isinstance(lines, list) and len(lines) == 2, data
@@ -211,16 +211,16 @@ async def test_purchase_orders_completion_detail_returns_summary_lines_and_event
     line1 = lines_by_line_no[1]
     assert int(line1["item_id"]) == int(item_a)
     assert int(line1["qty_ordered_base"]) == 2
-    assert int(line1["qty_received_base"]) == 2
-    assert int(line1["qty_remaining_base"]) == 0
-    assert str(line1["line_completion_status"]) == "RECEIVED"
+    assert int(line1["qty_received_base"]) == 0
+    assert int(line1["qty_remaining_base"]) == 2
+    assert str(line1["line_completion_status"]) == "NOT_RECEIVED"
 
     line2 = lines_by_line_no[2]
     assert int(line2["item_id"]) == int(item_b)
     assert int(line2["qty_ordered_base"]) == 3
-    assert int(line2["qty_received_base"]) == 3
-    assert int(line2["qty_remaining_base"]) == 0
-    assert str(line2["line_completion_status"]) == "RECEIVED"
+    assert int(line2["qty_received_base"]) == 0
+    assert int(line2["qty_remaining_base"]) == 3
+    assert str(line2["line_completion_status"]) == "NOT_RECEIVED"
 
     receipt_events = data.get("receipt_events")
     assert isinstance(receipt_events, list) and len(receipt_events) == 3, data


### PR DESCRIPTION
Stops WMS inbound commit from updating the legacy local procurement completion read model. WMS now only writes inbound event and inventory facts; procurement completion should be maintained by the procurement domain through a later event/read integration. Does not change from-purchase, frontend behavior, schema, or procurement-api.