### PR TITLE
feat(inbound): expose procurement receiving results

### DIFF
--- a/app/wms/inbound/contracts/procurement_receiving_result.py
+++ b/app/wms/inbound/contracts/procurement_receiving_result.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+ProcurementReceivingResultEventKind = Literal["COMMIT"]
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+        from_attributes=True,
+        str_strip_whitespace=True,
+    )
+
+
+class ProcurementReceivingResultLineOut(_Base):
+    wms_event_id: Annotated[int, Field(ge=1)]
+    wms_event_no: Annotated[str, Field(min_length=1, max_length=64)]
+    trace_id: Annotated[str, Field(min_length=1, max_length=128)]
+    event_kind: ProcurementReceivingResultEventKind
+    event_status: Annotated[str, Field(min_length=1, max_length=16)]
+    occurred_at: datetime
+
+    receipt_no: Annotated[str, Field(min_length=1, max_length=128)]
+    procurement_po_id: Annotated[int, Field(ge=1)]
+    procurement_po_no: Annotated[str, Field(min_length=1, max_length=128)]
+    wms_event_line_no: Annotated[int, Field(ge=1)]
+    procurement_po_line_id: Annotated[int, Field(ge=1)]
+
+    warehouse_id: Annotated[int, Field(ge=1)]
+    item_id: Annotated[int, Field(ge=1)]
+    qty_delta_base: int
+
+    lot_code_input: str | None = Field(default=None, max_length=128)
+    production_date: date | None = None
+    expiry_date: date | None = None
+    lot_id: int | None = Field(default=None, ge=1)
+
+
+class ProcurementReceivingResultsOut(_Base):
+    items: list[ProcurementReceivingResultLineOut] = Field(default_factory=list)
+    after_event_id: int = Field(ge=0)
+    next_after_event_id: int = Field(ge=0)
+    limit: int = Field(ge=1, le=200)
+    has_more: bool
+
+
+class ProcurementReceivingResultDetailOut(_Base):
+    event_id: Annotated[int, Field(ge=1)]
+    items: list[ProcurementReceivingResultLineOut] = Field(default_factory=list)
+
+
+__all__ = [
+    "ProcurementReceivingResultDetailOut",
+    "ProcurementReceivingResultLineOut",
+    "ProcurementReceivingResultsOut",
+]

--- a/app/wms/inbound/routers/inbound_events.py
+++ b/app/wms/inbound/routers/inbound_events.py
@@ -11,12 +11,64 @@ from app.wms.inbound.contracts.inbound_event_read import (
     InboundEventDetailOut,
     InboundEventListOut,
 )
+from app.wms.inbound.contracts.procurement_receiving_result import (
+    ProcurementReceivingResultDetailOut,
+    ProcurementReceivingResultsOut,
+)
 from app.wms.inbound.services.inbound_event_read_service import (
     get_inbound_event_detail,
     list_inbound_events,
 )
+from app.wms.inbound.services.procurement_receiving_result_service import (
+    get_procurement_receiving_result_detail,
+    list_procurement_receiving_results,
+)
 
 router = APIRouter(prefix="/wms/inbound", tags=["wms-inbound-events"])
+
+
+@router.get(
+    "/procurement-receiving-results",
+    response_model=ProcurementReceivingResultsOut,
+)
+async def list_procurement_receiving_results_endpoint(
+    after_event_id: int = Query(default=0, ge=0, description="只返回 event_id 大于该值的收货结果"),
+    limit: int = Query(default=50, ge=1, le=200, description="最多读取多少个 WMS event"),
+    procurement_po_id: int | None = Query(default=None, ge=1, description="采购系统采购单 ID"),
+    receipt_no: str | None = Query(default=None, description="WMS 入库单号"),
+    session: AsyncSession = Depends(get_session),
+) -> ProcurementReceivingResultsOut:
+    try:
+        return await list_procurement_receiving_results(
+            session,
+            after_event_id=after_event_id,
+            limit=limit,
+            procurement_po_id=procurement_po_id,
+            receipt_no=receipt_no,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+@router.get(
+    "/procurement-receiving-results/{event_id}",
+    response_model=ProcurementReceivingResultDetailOut,
+)
+async def get_procurement_receiving_result_detail_endpoint(
+    event_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> ProcurementReceivingResultDetailOut:
+    try:
+        return await get_procurement_receiving_result_detail(
+            session,
+            event_id=int(event_id),
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
 
 
 @router.get("/events", response_model=InboundEventListOut)

--- a/app/wms/inbound/services/procurement_receiving_result_service.py
+++ b/app/wms/inbound/services/procurement_receiving_result_service.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.wms.inbound.contracts.procurement_receiving_result import (
+    ProcurementReceivingResultDetailOut,
+    ProcurementReceivingResultLineOut,
+    ProcurementReceivingResultsOut,
+)
+
+
+def _normalize_limit(value: int | None) -> int:
+    if value is None:
+        return 50
+
+    return min(max(int(value), 1), 200)
+
+
+def _normalize_after_event_id(value: int | None) -> int:
+    if value is None:
+        return 0
+
+    return max(int(value), 0)
+
+
+def _map_row(row: dict[str, Any]) -> ProcurementReceivingResultLineOut:
+    return ProcurementReceivingResultLineOut.model_validate(
+        {
+            "wms_event_id": row["wms_event_id"],
+            "wms_event_no": row["wms_event_no"],
+            "trace_id": row["trace_id"],
+            "event_kind": row["event_kind"],
+            "event_status": row["event_status"],
+            "occurred_at": row["occurred_at"],
+            "receipt_no": row["receipt_no"],
+            "procurement_po_id": row["procurement_po_id"],
+            "procurement_po_no": row["procurement_po_no"],
+            "wms_event_line_no": row["wms_event_line_no"],
+            "procurement_po_line_id": row["procurement_po_line_id"],
+            "warehouse_id": row["warehouse_id"],
+            "item_id": row["item_id"],
+            "qty_delta_base": row["qty_delta_base"],
+            "lot_code_input": row["lot_code_input"],
+            "production_date": row["production_date"],
+            "expiry_date": row["expiry_date"],
+            "lot_id": row["lot_id"],
+        }
+    )
+
+
+async def list_procurement_receiving_results(
+    session: AsyncSession,
+    *,
+    after_event_id: int | None = 0,
+    limit: int | None = 50,
+    procurement_po_id: int | None = None,
+    receipt_no: str | None = None,
+) -> ProcurementReceivingResultsOut:
+    """List WMS inbound commit results for procurement consumption.
+
+    边界说明：
+    - 只读 WMS 入库事件事实。
+    - 不更新采购完成情况。
+    - 不暴露 WMS 本地旧 purchase_order_lines 语义。
+    - procurement_po_line_id 来自 inbound_event_lines.source_line_id。
+    """
+
+    limit_n = _normalize_limit(limit)
+    after_event_id_n = _normalize_after_event_id(after_event_id)
+
+    where_clauses = [
+        "e.event_type = 'INBOUND'",
+        "e.source_type = 'PURCHASE_ORDER'",
+        "e.event_kind = 'COMMIT'",
+        "e.status = 'COMMITTED'",
+        "e.id > :after_event_id",
+        "iel.source_line_id IS NOT NULL",
+        "r.source_doc_id IS NOT NULL",
+        "r.source_doc_no_snapshot IS NOT NULL",
+    ]
+    params: dict[str, Any] = {
+        "after_event_id": after_event_id_n,
+        "limit": limit_n,
+    }
+
+    if procurement_po_id is not None:
+        where_clauses.append("r.source_doc_id = :procurement_po_id")
+        params["procurement_po_id"] = int(procurement_po_id)
+
+    normalized_receipt_no = str(receipt_no or "").strip()
+    if normalized_receipt_no:
+        where_clauses.append("r.receipt_no = :receipt_no")
+        params["receipt_no"] = normalized_receipt_no
+
+    where_sql = " AND ".join(where_clauses)
+
+    sql = text(
+        f"""
+        WITH event_page AS (
+          SELECT e.id
+          FROM wms_events e
+          JOIN inbound_receipts r
+            ON r.receipt_no = e.source_ref
+           AND r.source_type = 'PURCHASE_ORDER'
+          JOIN inbound_event_lines iel
+            ON iel.event_id = e.id
+          WHERE {where_sql}
+          GROUP BY e.id
+          ORDER BY e.id ASC
+          LIMIT :limit
+        )
+        SELECT
+          e.id AS wms_event_id,
+          e.event_no AS wms_event_no,
+          e.trace_id AS trace_id,
+          e.event_kind AS event_kind,
+          e.status AS event_status,
+          e.occurred_at AS occurred_at,
+
+          r.receipt_no AS receipt_no,
+          r.source_doc_id AS procurement_po_id,
+          r.source_doc_no_snapshot AS procurement_po_no,
+
+          iel.line_no AS wms_event_line_no,
+          iel.source_line_id AS procurement_po_line_id,
+          e.warehouse_id AS warehouse_id,
+          iel.item_id AS item_id,
+          iel.qty_base AS qty_delta_base,
+          iel.lot_code_input AS lot_code_input,
+          iel.production_date AS production_date,
+          iel.expiry_date AS expiry_date,
+          iel.lot_id AS lot_id
+        FROM event_page ep
+        JOIN wms_events e
+          ON e.id = ep.id
+        JOIN inbound_receipts r
+          ON r.receipt_no = e.source_ref
+         AND r.source_type = 'PURCHASE_ORDER'
+        JOIN inbound_event_lines iel
+          ON iel.event_id = e.id
+        WHERE iel.source_line_id IS NOT NULL
+        ORDER BY e.id ASC, iel.line_no ASC, iel.id ASC
+        """
+    )
+
+    rows = [dict(row) for row in (await session.execute(sql, params)).mappings().all()]
+    items = [_map_row(row) for row in rows]
+    next_after_event_id = max((item.wms_event_id for item in items), default=after_event_id_n)
+
+    return ProcurementReceivingResultsOut(
+        items=items,
+        after_event_id=after_event_id_n,
+        next_after_event_id=next_after_event_id,
+        limit=limit_n,
+        has_more=len({item.wms_event_id for item in items}) >= limit_n,
+    )
+
+
+async def get_procurement_receiving_result_detail(
+    session: AsyncSession,
+    *,
+    event_id: int,
+) -> ProcurementReceivingResultDetailOut:
+    result = await list_procurement_receiving_results(
+        session,
+        after_event_id=int(event_id) - 1,
+        limit=1,
+    )
+
+    items = [item for item in result.items if item.wms_event_id == int(event_id)]
+
+    if not items:
+        raise HTTPException(
+            status_code=404,
+            detail=f"procurement_receiving_result_not_found:{int(event_id)}",
+        )
+
+    return ProcurementReceivingResultDetailOut(
+        event_id=int(event_id),
+        items=items,
+    )
+
+
+__all__ = [
+    "get_procurement_receiving_result_detail",
+    "list_procurement_receiving_results",
+]

--- a/tests/api/test_wms_procurement_receiving_results_api.py
+++ b/tests/api/test_wms_procurement_receiving_results_api.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.wms.inbound.contracts.procurement_receiving_result import (
+    ProcurementReceivingResultDetailOut,
+    ProcurementReceivingResultLineOut,
+    ProcurementReceivingResultsOut,
+)
+from app.wms.inbound.routers import inbound_events as router_module
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router_module.router)
+    return TestClient(app)
+
+
+def _line(event_id: int = 34) -> ProcurementReceivingResultLineOut:
+    return ProcurementReceivingResultLineOut(
+        wms_event_id=event_id,
+        wms_event_no="IE-20260513144401-FA957E19",
+        trace_id="IN-OP-1092a9a1243d4ae6ab40",
+        event_kind="COMMIT",
+        event_status="COMMITTED",
+        occurred_at=datetime.now(UTC),
+        receipt_no="IR-PO-1-20260513141447-A864B3",
+        procurement_po_id=1,
+        procurement_po_no="PO-LINK-0001",
+        wms_event_line_no=1,
+        procurement_po_line_id=1,
+        warehouse_id=2,
+        item_id=4002,
+        qty_delta_base=3,
+        lot_code_input="PO-LINK-LOT-0001",
+        production_date=None,
+        expiry_date=None,
+        lot_id=79,
+    )
+
+
+def test_procurement_receiving_results_route_returns_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_list_results(
+        _session: object,
+        *,
+        after_event_id: int | None = 0,
+        limit: int | None = 50,
+        procurement_po_id: int | None = None,
+        receipt_no: str | None = None,
+    ) -> ProcurementReceivingResultsOut:
+        captured["after_event_id"] = after_event_id
+        captured["limit"] = limit
+        captured["procurement_po_id"] = procurement_po_id
+        captured["receipt_no"] = receipt_no
+
+        return ProcurementReceivingResultsOut(
+            items=[_line()],
+            after_event_id=int(after_event_id or 0),
+            next_after_event_id=34,
+            limit=int(limit or 50),
+            has_more=False,
+        )
+
+    monkeypatch.setattr(
+        router_module,
+        "list_procurement_receiving_results",
+        fake_list_results,
+    )
+
+    response = _client().get(
+        "/wms/inbound/procurement-receiving-results",
+        params={
+            "after_event_id": 10,
+            "limit": 20,
+            "procurement_po_id": 1,
+            "receipt_no": "IR-PO-1-20260513141447-A864B3",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+
+    assert captured == {
+        "after_event_id": 10,
+        "limit": 20,
+        "procurement_po_id": 1,
+        "receipt_no": "IR-PO-1-20260513141447-A864B3",
+    }
+    assert body["items"][0]["procurement_po_id"] == 1
+    assert body["items"][0]["procurement_po_line_id"] == 1
+    assert body["items"][0]["qty_delta_base"] == 3
+    assert body["next_after_event_id"] == 34
+
+
+def test_procurement_receiving_result_detail_route_returns_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, int] = {}
+
+    async def fake_get_result_detail(
+        _session: object,
+        *,
+        event_id: int,
+    ) -> ProcurementReceivingResultDetailOut:
+        captured["event_id"] = event_id
+        return ProcurementReceivingResultDetailOut(
+            event_id=event_id,
+            items=[_line(event_id=event_id)],
+        )
+
+    monkeypatch.setattr(
+        router_module,
+        "get_procurement_receiving_result_detail",
+        fake_get_result_detail,
+    )
+
+    response = _client().get("/wms/inbound/procurement-receiving-results/34")
+
+    assert response.status_code == 200
+    body = response.json()
+
+    assert captured["event_id"] == 34
+    assert body["event_id"] == 34
+    assert body["items"][0]["receipt_no"] == "IR-PO-1-20260513141447-A864B3"


### PR DESCRIPTION
Adds a WMS read API for procurement to consume inbound receiving results. The API exposes committed purchase receiving event lines using procurement_po_id and procurement_po_line_id derived from WMS inbound receipts and inbound event source_line_id. This is read-only and does not update procurement completion or introduce projection.