### PR TITLE
feat(warehouses): expose WMS read-v1 warehouse contract

### DIFF
--- a/app/wms/warehouses/contracts/warehouse_read_v1.py
+++ b/app/wms/warehouses/contracts/warehouse_read_v1.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class WmsReadWarehouseOut(BaseModel):
+    """WMS warehouse read-v1 contract for cross-system consumers.
+
+    Boundary:
+    - WMS owns warehouse master data.
+    - Cross-system consumers only receive stable read fields.
+    - This contract intentionally does not expose management fields.
+    """
+
+    id: int = Field(ge=1)
+    code: str | None = Field(default=None, max_length=64)
+    name: str = Field(min_length=1, max_length=100)
+    active: bool
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class WmsReadWarehouseListOut(BaseModel):
+    items: list[WmsReadWarehouseOut] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+__all__ = [
+    "WmsReadWarehouseListOut",
+    "WmsReadWarehouseOut",
+]

--- a/app/wms/warehouses/routers/warehouses_read_v1.py
+++ b/app/wms/warehouses/routers/warehouses_read_v1.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.deps import get_async_session as get_session
+from app.wms.warehouses.contracts.warehouse_read_v1 import (
+    WmsReadWarehouseListOut,
+    WmsReadWarehouseOut,
+)
+
+
+def _row_to_read_warehouse(row: Mapping[str, Any]) -> WmsReadWarehouseOut:
+    return WmsReadWarehouseOut(
+        id=int(row["id"]),
+        code=str(row["code"]) if row.get("code") is not None else None,
+        name=str(row["name"]),
+        active=bool(row["active"]),
+    )
+
+
+def register(router: APIRouter) -> None:
+    @router.get(
+        "/wms/read/v1/warehouses",
+        response_model=WmsReadWarehouseListOut,
+        tags=["wms-read-v1"],
+    )
+    async def list_wms_read_warehouses(
+        active: bool | None = Query(
+            True,
+            description=(
+                "是否过滤启用仓库；默认只返回 active=true，用于跨系统下拉。"
+            ),
+        ),
+        limit: int = Query(200, ge=1, le=500),
+        session: AsyncSession = Depends(get_session),
+    ) -> WmsReadWarehouseListOut:
+        """List WMS warehouses for cross-system read contracts.
+
+        Boundary:
+        - No consumer system should read WMS DB directly.
+        - No management-only fields are exposed.
+        - Consumers should store scalar id + code/name snapshot when needed.
+        """
+
+        where_clause = ""
+        params: dict[str, Any] = {
+            "limit": int(limit),
+        }
+
+        if active is not None:
+            where_clause = "WHERE w.active = :active"
+            params["active"] = bool(active)
+
+        rows = (
+            await session.execute(
+                text(
+                    f"""
+                    SELECT
+                      w.id,
+                      w.code,
+                      w.name,
+                      w.active
+                    FROM warehouses AS w
+                    {where_clause}
+                    ORDER BY w.id
+                    LIMIT :limit
+                    """
+                ),
+                params,
+            )
+        ).mappings().all()
+
+        return WmsReadWarehouseListOut(
+            items=[_row_to_read_warehouse(row) for row in rows],
+        )
+
+    @router.get(
+        "/wms/read/v1/warehouses/{warehouse_id}",
+        response_model=WmsReadWarehouseOut,
+        tags=["wms-read-v1"],
+    )
+    async def get_wms_read_warehouse(
+        warehouse_id: int = Path(..., ge=1),
+        session: AsyncSession = Depends(get_session),
+    ) -> WmsReadWarehouseOut:
+        row = (
+            await session.execute(
+                text(
+                    """
+                    SELECT
+                      w.id,
+                      w.code,
+                      w.name,
+                      w.active
+                    FROM warehouses AS w
+                    WHERE w.id = :warehouse_id
+                    """
+                ),
+                {"warehouse_id": int(warehouse_id)},
+            )
+        ).mappings().first()
+
+        if row is None:
+            raise HTTPException(status_code=404, detail="warehouse not found")
+
+        return _row_to_read_warehouse(row)
+
+
+__all__ = ["register"]

--- a/app/wms/warehouses/routers/warehouses_routes.py
+++ b/app/wms/warehouses/routers/warehouses_routes.py
@@ -3,14 +3,21 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+from app.wms.warehouses.routers import warehouses_read_v1
 from app.wms.warehouses.routers import warehouses_routes_read
-from app.wms.warehouses.routers import warehouses_routes_write
 from app.wms.warehouses.routers import warehouses_routes_service_cities
 from app.wms.warehouses.routers import warehouses_routes_service_city_split_provinces
 from app.wms.warehouses.routers import warehouses_routes_service_provinces
+from app.wms.warehouses.routers import warehouses_routes_write
 
 
 def register(router: APIRouter) -> None:
+    # Cross-system read-v1 contract.
+    # This is intentionally separate from legacy/admin /warehouses routes,
+    # because system consumers such as procurement-api should not bind to
+    # user/page-management endpoints.
+    warehouses_read_v1.register(router)
+
     warehouses_routes_read.register(router)
     warehouses_routes_write.register(router)
 

--- a/tests/api/test_wms_read_v1_warehouses_api.py
+++ b/tests/api/test_wms_read_v1_warehouses_api.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+
+from app.wms.warehouses.routers import warehouses_read_v1 as router_module
+
+
+class FakeMappings:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[dict[str, Any]]:
+        return self._rows
+
+    def first(self) -> dict[str, Any] | None:
+        return self._rows[0] if self._rows else None
+
+
+class FakeResult:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    def mappings(self) -> FakeMappings:
+        return FakeMappings(self._rows)
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def execute(
+        self,
+        _stmt: object,
+        params: dict[str, Any] | None = None,
+    ) -> FakeResult:
+        normalized_params = dict(params or {})
+        self.calls.append(normalized_params)
+
+        if "warehouse_id" in normalized_params:
+            warehouse_id = int(normalized_params["warehouse_id"])
+            if warehouse_id == 404:
+                return FakeResult([])
+            return FakeResult(
+                [
+                    {
+                        "id": warehouse_id,
+                        "code": "WH-1",
+                        "name": "河北省固安第一仓库",
+                        "active": True,
+                    }
+                ]
+            )
+
+        active = normalized_params.get("active")
+        rows = [
+            {
+                "id": 1,
+                "code": "WH-1",
+                "name": "河北省固安第一仓库",
+                "active": True,
+            },
+            {
+                "id": 2,
+                "code": "WH-2",
+                "name": "河北第二仓库测试",
+                "active": True,
+            },
+        ]
+
+        if active is False:
+            rows = [
+                {
+                    "id": 9,
+                    "code": "WH-OFF",
+                    "name": "停用仓",
+                    "active": False,
+                }
+            ]
+
+        return FakeResult(rows)
+
+
+def _client(fake_session: FakeSession) -> TestClient:
+    app = FastAPI()
+    router = APIRouter()
+    router_module.register(router)
+    app.include_router(router)
+
+    async def override_session() -> AsyncGenerator[FakeSession]:
+        yield fake_session
+
+    app.dependency_overrides[router_module.get_session] = override_session
+    return TestClient(app)
+
+
+def test_list_wms_read_warehouses_defaults_to_active_true() -> None:
+    fake_session = FakeSession()
+    response = _client(fake_session).get("/wms/read/v1/warehouses")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "items": [
+            {
+                "id": 1,
+                "code": "WH-1",
+                "name": "河北省固安第一仓库",
+                "active": True,
+            },
+            {
+                "id": 2,
+                "code": "WH-2",
+                "name": "河北第二仓库测试",
+                "active": True,
+            },
+        ]
+    }
+    assert fake_session.calls[0]["active"] is True
+
+
+def test_list_wms_read_warehouses_can_query_inactive() -> None:
+    fake_session = FakeSession()
+    response = _client(fake_session).get("/wms/read/v1/warehouses?active=false")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "items": [
+            {
+                "id": 9,
+                "code": "WH-OFF",
+                "name": "停用仓",
+                "active": False,
+            }
+        ]
+    }
+    assert fake_session.calls[0]["active"] is False
+
+
+def test_get_wms_read_warehouse_returns_contract() -> None:
+    fake_session = FakeSession()
+    response = _client(fake_session).get("/wms/read/v1/warehouses/1")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "id": 1,
+        "code": "WH-1",
+        "name": "河北省固安第一仓库",
+        "active": True,
+    }
+
+
+def test_get_wms_read_warehouse_returns_404() -> None:
+    fake_session = FakeSession()
+    response = _client(fake_session).get("/wms/read/v1/warehouses/404")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "warehouse not found"}


### PR DESCRIPTION
Adds cross-system WMS read-v1 warehouse endpoints for procurement-api consumption. Keeps legacy /warehouses management routes unchanged. OpenAPI JSON is intentionally not included because current export causes unrelated large-scale reordering.