### PR TITLE
refactor(inbound): use procurement WMS receiving source contract

### DIFF
--- a/app/integrations/procurement/http_client.py
+++ b/app/integrations/procurement/http_client.py
@@ -21,6 +21,8 @@ class HttpProcurementReadClient:
     - WMS 只读取 procurement-api read API。
     - 本 client 不写 procurement owner 数据。
     - 本 client 不创建 WMS 入库单。
+    - 采购入库来源必须使用 procurement-api 暴露给 WMS 的 receiving-sources 合同，
+      不再绑定采购管理页面的 purchase-orders 读模型路径。
     """
 
     def __init__(
@@ -54,7 +56,7 @@ class HttpProcurementReadClient:
             params["q"] = q.strip()
 
         payload = await self._get_json(
-            "/procurement/read/v1/purchase-orders/source-options",
+            "/procurement/read/v1/wms/receiving-sources",
             params=params,
         )
 
@@ -62,7 +64,7 @@ class HttpProcurementReadClient:
 
     async def get_purchase_order(self, po_id: int) -> ProcurementPurchaseOrderOut:
         payload = await self._get_json(
-            f"/procurement/read/v1/purchase-orders/{int(po_id)}",
+            f"/procurement/read/v1/wms/receiving-sources/{int(po_id)}",
             params=None,
         )
 

--- a/tests/services/test_procurement_integration_http_client.py
+++ b/tests/services/test_procurement_integration_http_client.py
@@ -64,8 +64,8 @@ async def test_list_purchase_order_source_options_calls_procurement_read_api() -
     )
 
     assert captured["url"] == (
-        "http://procurement.test/procurement/read/v1/purchase-orders/"
-        "source-options?limit=20&target_warehouse_id=2&q=SUP"
+        "http://procurement.test/procurement/read/v1/wms/"
+        "receiving-sources?limit=20&target_warehouse_id=2&q=SUP"
     )
     assert captured["params"] == {
         "limit": "20",
@@ -138,7 +138,7 @@ async def test_get_purchase_order_calls_procurement_read_api_and_parses_lines() 
 
     result = await client.get_purchase_order(7)
 
-    assert captured["url"] == "http://procurement.test/procurement/read/v1/purchase-orders/7"
+    assert captured["url"] == "http://procurement.test/procurement/read/v1/wms/receiving-sources/7"
     assert result.id == 7
     assert result.total_amount == Decimal("20.00")
     assert result.lines[0].qty_ordered_base == 24


### PR DESCRIPTION
Switches the WMS procurement read client from procurement purchase-order management routes to the explicit /procurement/read/v1/wms/receiving-sources contract. Keeps the WMS inbound receipt BFF unchanged.