### PR TITLE
chore(dev): document WMS local port contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ WMS_TEST_DATABASE_URL=
 WMS_DATABASE_URL=postgresql+psycopg://wms:wms@127.0.0.1:5433/wms
 PMS_API_BASE_URL=http://127.0.0.1:8005
 OMS_API_BASE_URL=http://127.0.0.1:8010
+PROCUREMENT_API_BASE_URL=http://127.0.0.1:8015
 # Bearer token with oms.fulfillment.read scope for OMS fulfillment projection sync.
 OMS_API_TOKEN=
 PYTHONPATH=.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WMS-DU
 
-WMS-DU backend service for WMS / OMS / TMS / PMS.
+WMS-DU backend service for WMS execution, inventory, inbound, outbound, finance, and cross-system integration.
 
 当前后端目录清理原则：
 
@@ -11,7 +11,20 @@ WMS-DU backend service for WMS / OMS / TMS / PMS.
 - 不保留 alias / 双轨 / 兼容壳。
 - 前后端继续坚持刚性契约。
 
-后端常用入口：
+## Local dev ports
+
+| Component | Port | Purpose |
+| --- | ---: | --- |
+| wms-api | 8000 | FastAPI / Uvicorn HTTP service |
+| wms-web | 5173 | Vite dev server |
+| wms-db | 5433 | Shared local PostgreSQL host port |
+| pms-api upstream | 8005 | PMS HTTP API consumed by WMS |
+| oms-api upstream | 8010 | OMS HTTP API consumed by WMS |
+| procurement-api upstream | 8015 | Procurement HTTP API consumed by WMS |
+
+See `docs/dev-ports.md` for the full local port contract.
+
+## 后端常用入口
 
 - make alembic-check
 - make test TESTS="tests/api/test_no_duplicate_routes.py tests/api/test_user_api.py"
@@ -22,9 +35,9 @@ WMS-DU backend service for WMS / OMS / TMS / PMS.
 
 ---
 
-## Frontend (wms-web)
+## Frontend
 
-本仓库包含前端子工程（Vite + React + MSW）：
-- 开发启动：`pnpm dev`
-- Mock：MSW（`public/mockServiceWorker.js`），开发环境置 `VITE_USE_MSW=1`
-- 入口：`/src/router.tsx`，首页“库存快照 + 三大任务页（Inbound/Putaway/Outbound）+ 工具（Stock/Ledger）”
+WMS frontend is maintained in the independent `wms-web` repository:
+
+- local Vite port: `5173`
+- API base URL: `http://127.0.0.1:8000`

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -17,7 +17,7 @@ class AppSettings(BaseSettings):
     # 数据库 —— 这里强制要求必须从环境变量或 .env 文件读取
     DATABASE_URL: str = Field(
         default=...,
-        description="PostgreSQL 连接串，例如：postgresql+psycopg://wms:wms@127.0.0.1:5435/wms",
+        description="PostgreSQL 连接串，例如：postgresql+psycopg://wms:wms@127.0.0.1:5433/wms",
     )
     SQL_ECHO: bool = Field(default=False)
 

--- a/docs/dev-ports.md
+++ b/docs/dev-ports.md
@@ -1,0 +1,32 @@
+# WMS local development ports
+
+## Port contract
+
+| Component | Port | Purpose |
+| --- | ---: | --- |
+| wms-api | 8000 | FastAPI / Uvicorn HTTP service |
+| wms-web | 5173 | Vite dev server |
+| wms-db | 5433 | Shared local PostgreSQL host port |
+| pms-api upstream | 8005 | PMS HTTP API consumed by WMS |
+| oms-api upstream | 8010 | OMS HTTP API consumed by WMS |
+| procurement-api upstream | 8015 | Procurement HTTP API consumed by WMS |
+
+## Environment variables
+
+| Variable | Example | Meaning |
+| --- | --- | --- |
+| `WMS_DATABASE_URL` | `postgresql+psycopg://wms:wms@127.0.0.1:5433/wms` | WMS development database |
+| `WMS_TEST_DATABASE_URL` | `postgresql+psycopg://wms:wms@127.0.0.1:5433/wms_test` | WMS test database |
+| `PMS_API_BASE_URL` | `http://127.0.0.1:8005` | PMS API upstream |
+| `OMS_API_BASE_URL` | `http://127.0.0.1:8010` | OMS API upstream |
+| `PROCUREMENT_API_BASE_URL` | `http://127.0.0.1:8015` | Procurement API upstream |
+| `OMS_API_TOKEN` | empty by default | Bearer token with `oms.fulfillment.read` scope when syncing OMS fulfillment projection |
+
+## Rules
+
+- Local development PostgreSQL uses the shared host port `5433`.
+- Do not use `5433` for FastAPI. It is reserved for PostgreSQL.
+- Do not use `8000` for PostgreSQL. It is reserved for wms-api HTTP.
+- wms-web should call wms-api through `VITE_API_BASE_URL=http://127.0.0.1:8000`.
+- WMS must read Procurement purchase order sources through wms-api → procurement-api; wms-web must not call procurement-api directly.
+- If another local PostgreSQL container already owns `5433`, do not start another DB container from this repo.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,8 +61,8 @@ markers = [
     "sqlite: tests requiring SQLite behavior",
 ]
 env = [
-    "DATABASE_URL=postgresql+asyncpg://wms:wms@127.0.0.1:5432/wms",
-    "DATABASE_URL_TEST=postgresql+asyncpg://wms:wms@127.0.0.1:5432/wms_test",
+    "DATABASE_URL=postgresql+asyncpg://wms:wms@127.0.0.1:5433/wms",
+    "DATABASE_URL_TEST=postgresql+asyncpg://wms:wms@127.0.0.1:5433/wms_test",
     "ENABLE_DIAG=1",
     "JWT_SECRET=dev-temp-secret",
 ]


### PR DESCRIPTION
Adds WMS local development port documentation and aligns environment examples with the shared PostgreSQL port 5433. Keeps wms-api on 8000, wms-web on 5173, and upstream service ports unchanged.