### PR TITLE
feat(pms): send WMS service client header to PMS

### DIFF
--- a/app/integrations/pms/http_client.py
+++ b/app/integrations/pms/http_client.py
@@ -20,6 +20,7 @@ from typing import Any, NoReturn, TypeVar
 
 import httpx
 
+from app.integrations.pms.service_auth import pms_service_auth_headers
 from app.integrations.pms.contracts import (
     BarcodeProbeOut,
     ItemBasic,
@@ -99,7 +100,7 @@ class HttpPmsReadClient:
         self.base_url = _base_url(base_url)
         self.timeout = httpx.Timeout(timeout_seconds)
         self.transport = transport
-        self.headers = dict(headers or {})
+        self.headers = pms_service_auth_headers(headers)
 
     async def _request(
         self,

--- a/app/integrations/pms/projection_sync.py
+++ b/app/integrations/pms/projection_sync.py
@@ -22,6 +22,8 @@ from typing import Any, Literal
 
 import httpx
 from sqlalchemy import text
+
+from app.integrations.pms.service_auth import pms_service_auth_headers
 from sqlalchemy.ext.asyncio import AsyncSession
 
 ProjectionResource = Literal["items", "suppliers", "uoms", "sku-codes", "barcodes"]
@@ -605,6 +607,7 @@ async def sync_pms_read_projection_once(
 
     async with httpx.AsyncClient(
         base_url=_base_url(pms_api_base_url),
+        headers=pms_service_auth_headers(),
         timeout=httpx.Timeout(timeout_seconds),
         transport=transport,
     ) as client:

--- a/app/integrations/pms/service_auth.py
+++ b/app/integrations/pms/service_auth.py
@@ -1,0 +1,29 @@
+# app/integrations/pms/service_auth.py
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+PMS_SERVICE_CLIENT_HEADER = "X-Service-Client"
+PMS_SERVICE_CLIENT_CODE = "wms-service"
+
+
+def pms_service_auth_headers(headers: Mapping[str, str] | None = None) -> dict[str, str]:
+    """
+    Build WMS -> PMS service authorization headers.
+
+    Boundary:
+    - WMS calls PMS as the fixed service client: wms-service.
+    - This is system-to-system authorization metadata, not user authorization.
+    - Caller-supplied headers are preserved, but X-Service-Client is owned by WMS.
+    """
+
+    merged = dict(headers or {})
+    merged[PMS_SERVICE_CLIENT_HEADER] = PMS_SERVICE_CLIENT_CODE
+    return merged
+
+
+__all__ = [
+    "PMS_SERVICE_CLIENT_CODE",
+    "PMS_SERVICE_CLIENT_HEADER",
+    "pms_service_auth_headers",
+]

--- a/app/integrations/pms/sync_http_client.py
+++ b/app/integrations/pms/sync_http_client.py
@@ -20,6 +20,7 @@ from typing import Any, TypeVar
 import httpx
 
 from app.integrations.pms.contracts import PmsExportSkuCodeResolution
+from app.integrations.pms.service_auth import pms_service_auth_headers
 
 ModelT = TypeVar("ModelT")
 
@@ -50,7 +51,7 @@ class SyncHttpPmsReadClient:
         self.base_url = _base_url(base_url)
         self.timeout = httpx.Timeout(timeout_seconds)
         self.transport = transport
-        self.headers = dict(headers or {})
+        self.headers = pms_service_auth_headers(headers)
 
     def resolve_active_code_for_outbound_default(
         self,

--- a/tests/services/test_pms_integration_http_client.py
+++ b/tests/services/test_pms_integration_http_client.py
@@ -9,6 +9,10 @@ import pytest
 
 from app.integrations.pms.contracts import BarcodeProbeStatus
 from app.integrations.pms.http_client import HttpPmsReadClient
+from app.integrations.pms.service_auth import (
+    PMS_SERVICE_CLIENT_CODE,
+    PMS_SERVICE_CLIENT_HEADER,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -21,6 +25,7 @@ def _json(request: httpx.Request) -> dict[str, Any]:
 
 def _transport() -> httpx.MockTransport:
     def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers.get(PMS_SERVICE_CLIENT_HEADER) == PMS_SERVICE_CLIENT_CODE
         path = request.url.path
 
         if path == "/pms/read/v1/items/basic":

--- a/tests/services/test_pms_projection_sync.py
+++ b/tests/services/test_pms_projection_sync.py
@@ -12,6 +12,10 @@ from app.integrations.pms.projection_sync import (
     SYNC_VERSION,
     sync_pms_read_projection_once,
 )
+from app.integrations.pms.service_auth import (
+    PMS_SERVICE_CLIENT_CODE,
+    PMS_SERVICE_CLIENT_HEADER,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -27,12 +31,12 @@ async def _clear_projection_tables(session: AsyncSession) -> None:
         await session.execute(text(f"DELETE FROM {table_name}"))
 
 
-def _transport(calls: list[tuple[str, str]]) -> httpx.MockTransport:
+def _transport(calls: list[tuple[str, str, str | None]]) -> httpx.MockTransport:
     def handler(request: httpx.Request) -> httpx.Response:
         path = request.url.path
         offset = int(request.url.params.get("offset", 0))
         limit = int(request.url.params.get("limit", 500))
-        calls.append((path, str(request.url.query.decode("utf-8"))))
+        calls.append((path, str(request.url.query.decode("utf-8")), request.headers.get(PMS_SERVICE_CLIENT_HEADER)))
 
         if path == "/pms/read/v1/projection-feed/items":
             rows: list[dict[str, Any]] = [
@@ -199,7 +203,7 @@ def _transport(calls: list[tuple[str, str]]) -> httpx.MockTransport:
 async def test_sync_pms_read_projection_upserts_feed_rows(session: AsyncSession) -> None:
     await _clear_projection_tables(session)
 
-    calls: list[tuple[str, str]] = []
+    calls: list[tuple[str, str, str | None]] = []
     result = await sync_pms_read_projection_once(
         session,
         pms_api_base_url="http://pms-api.test",
@@ -312,7 +316,7 @@ async def test_sync_pms_read_projection_upserts_feed_rows(session: AsyncSession)
     assert barcode["active"] is True
     assert barcode["is_primary"] is True
 
-    called_paths = [path for path, _ in calls]
+    called_paths = [path for path, _query, _service_client in calls]
     assert called_paths == [
         "/pms/read/v1/projection-feed/items",
         "/pms/read/v1/projection-feed/items",
@@ -322,12 +326,13 @@ async def test_sync_pms_read_projection_upserts_feed_rows(session: AsyncSession)
         "/pms/read/v1/projection-feed/sku-codes",
         "/pms/read/v1/projection-feed/barcodes",
     ]
+    assert {service_client for _path, _query, service_client in calls} == {PMS_SERVICE_CLIENT_CODE}
 
 
 async def test_sync_pms_read_projection_can_limit_resources(session: AsyncSession) -> None:
     await _clear_projection_tables(session)
 
-    calls: list[tuple[str, str]] = []
+    calls: list[tuple[str, str, str | None]] = []
     result = await sync_pms_read_projection_once(
         session,
         pms_api_base_url="http://pms-api.test",
@@ -340,5 +345,6 @@ async def test_sync_pms_read_projection_can_limit_resources(session: AsyncSessio
     assert sorted(result.resources) == ["barcodes"]
     assert result.fetched == 1
 
-    called_paths = [path for path, _ in calls]
+    called_paths = [path for path, _query, _service_client in calls]
     assert called_paths == ["/pms/read/v1/projection-feed/barcodes"]
+    assert {service_client for _path, _query, service_client in calls} == {PMS_SERVICE_CLIENT_CODE}

--- a/tests/services/test_pms_service_auth_headers.py
+++ b/tests/services/test_pms_service_auth_headers.py
@@ -1,0 +1,57 @@
+# tests/services/test_pms_service_auth_headers.py
+from __future__ import annotations
+
+import httpx
+
+from app.integrations.pms.contracts import PmsExportSkuCodeResolution
+from app.integrations.pms.service_auth import (
+    PMS_SERVICE_CLIENT_CODE,
+    PMS_SERVICE_CLIENT_HEADER,
+    pms_service_auth_headers,
+)
+from app.integrations.pms.sync_http_client import SyncHttpPmsReadClient
+
+
+def test_pms_service_auth_headers_force_wms_service_client() -> None:
+    headers = pms_service_auth_headers(
+        {
+            "Authorization": "Bearer token",
+            PMS_SERVICE_CLIENT_HEADER: "wrong-service",
+        }
+    )
+
+    assert headers["Authorization"] == "Bearer token"
+    assert headers[PMS_SERVICE_CLIENT_HEADER] == PMS_SERVICE_CLIENT_CODE
+
+
+def test_sync_http_pms_read_client_sends_wms_service_client_header() -> None:
+    seen_headers: list[str | None] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_headers.append(request.headers.get(PMS_SERVICE_CLIENT_HEADER))
+        return httpx.Response(
+            200,
+            json={
+                "sku_code_id": 10,
+                "item_id": 1,
+                "sku_code": "SKU-0001",
+                "code_type": "PRIMARY",
+                "is_primary": True,
+                "item_sku": "SKU-0001",
+                "item_name": "笔记本",
+                "item_uom_id": 7,
+                "uom": "PCS",
+                "display_name": "件",
+                "uom_name": "件",
+                "ratio_to_base": 1,
+            },
+        )
+
+    client = SyncHttpPmsReadClient(
+        base_url="http://pms-api.test",
+        transport=httpx.MockTransport(handler),
+    )
+    result = client.resolve_active_code_for_outbound_default(code="SKU-0001")
+
+    assert isinstance(result, PmsExportSkuCodeResolution)
+    assert seen_headers == [PMS_SERVICE_CLIENT_CODE]


### PR DESCRIPTION
## Summary
- add WMS-owned PMS service auth header helper
- send X-Service-Client: wms-service for PMS projection sync
- send X-Service-Client: wms-service for async and sync PMS read clients
- add tests to freeze PMS service client header behavior

## Validation
- python3 -m compileall app/integrations/pms/service_auth.py app/integrations/pms/projection_sync.py app/integrations/pms/http_client.py app/integrations/pms/sync_http_client.py tests/services/test_pms_projection_sync.py tests/services/test_pms_integration_http_client.py tests/services/test_pms_service_auth_headers.py
- make test TESTS="tests/services/test_pms_projection_sync.py tests/services/test_pms_integration_http_client.py tests/services/test_pms_service_auth_headers.py tests/ci/test_wms_pms_projection_sync_boundary.py"
- make lint