### PR TITLE
feat(auth): add WMS service permission execution tables

### DIFF
--- a/alembic/versions/20260516145000_wms_service_auth_tables.py
+++ b/alembic/versions/20260516145000_wms_service_auth_tables.py
@@ -1,0 +1,434 @@
+"""wms service auth execution tables
+
+Revision ID: 20260516145000_wms_svc_auth
+Revises: 20260515123000_retire_wms_procurement_nav
+Create Date: 2026-05-16 14:50:00.000000
+
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20260516145000_wms_svc_auth"
+down_revision: str | Sequence[str] | None = "20260515123000_retire_wms_procurement_nav"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "wms_service_clients",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("client_code", sa.String(length=64), nullable=False),
+        sa.Column("client_name", sa.String(length=128), nullable=False),
+        sa.Column("description", sa.String(length=255), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_wms_service_clients"),
+        sa.UniqueConstraint("client_code", name="uq_wms_service_clients_client_code"),
+        sa.CheckConstraint(
+            "btrim(client_code) <> ''",
+            name="ck_wms_service_clients_client_code_not_blank",
+        ),
+        sa.CheckConstraint(
+            "btrim(client_name) <> ''",
+            name="ck_wms_service_clients_client_name_not_blank",
+        ),
+    )
+
+    op.create_table(
+        "wms_service_capabilities",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("capability_code", sa.String(length=128), nullable=False),
+        sa.Column("capability_name", sa.String(length=128), nullable=False),
+        sa.Column("resource_code", sa.String(length=64), nullable=False),
+        sa.Column("description", sa.String(length=255), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_wms_service_capabilities"),
+        sa.UniqueConstraint(
+            "capability_code",
+            name="uq_wms_service_capabilities_capability_code",
+        ),
+        sa.CheckConstraint(
+            "btrim(capability_code) <> ''",
+            name="ck_wms_service_capabilities_capability_code_not_blank",
+        ),
+        sa.CheckConstraint(
+            "btrim(capability_name) <> ''",
+            name="ck_wms_service_capabilities_capability_name_not_blank",
+        ),
+        sa.CheckConstraint(
+            "btrim(resource_code) <> ''",
+            name="ck_wms_service_capabilities_resource_code_not_blank",
+        ),
+    )
+    op.create_index(
+        "ix_wms_service_capabilities_resource_code",
+        "wms_service_capabilities",
+        ["resource_code"],
+    )
+
+    op.create_table(
+        "wms_service_capability_routes",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("capability_code", sa.String(length=128), nullable=False),
+        sa.Column("http_method", sa.String(length=16), nullable=False),
+        sa.Column("route_path", sa.String(length=255), nullable=False),
+        sa.Column("route_name", sa.String(length=128), nullable=False),
+        sa.Column("auth_required", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["capability_code"],
+            ["wms_service_capabilities.capability_code"],
+            name="fk_wms_service_capability_routes_capability_code",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_wms_service_capability_routes"),
+        sa.UniqueConstraint(
+            "http_method",
+            "route_path",
+            name="uq_wms_service_capability_routes_method_path",
+        ),
+        sa.CheckConstraint(
+            "btrim(capability_code) <> ''",
+            name="ck_wms_service_capability_routes_capability_code_not_blank",
+        ),
+        sa.CheckConstraint(
+            "btrim(http_method) <> ''",
+            name="ck_wms_service_capability_routes_http_method_not_blank",
+        ),
+        sa.CheckConstraint(
+            "btrim(route_path) <> ''",
+            name="ck_wms_service_capability_routes_route_path_not_blank",
+        ),
+        sa.CheckConstraint(
+            "btrim(route_name) <> ''",
+            name="ck_wms_service_capability_routes_route_name_not_blank",
+        ),
+    )
+    op.create_index(
+        "ix_wms_service_capability_routes_capability_code",
+        "wms_service_capability_routes",
+        ["capability_code"],
+    )
+
+    op.create_table(
+        "wms_service_permissions",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("client_id", sa.Integer(), nullable=False),
+        sa.Column("capability_code", sa.String(length=128), nullable=False),
+        sa.Column("description", sa.String(length=255), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column(
+            "granted_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["client_id"],
+            ["wms_service_clients.id"],
+            name="fk_wms_service_permissions_client_id_wms_service_clients",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["capability_code"],
+            ["wms_service_capabilities.capability_code"],
+            name="fk_wms_service_permissions_capability_code",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_wms_service_permissions"),
+        sa.UniqueConstraint(
+            "client_id",
+            "capability_code",
+            name="uq_wms_service_permissions_client_capability",
+        ),
+        sa.CheckConstraint(
+            "btrim(capability_code) <> ''",
+            name="ck_wms_service_permissions_capability_code_not_blank",
+        ),
+    )
+    op.create_index(
+        "ix_wms_service_permissions_client_id",
+        "wms_service_permissions",
+        ["client_id"],
+    )
+    op.create_index(
+        "ix_wms_service_permissions_capability_code",
+        "wms_service_permissions",
+        ["capability_code"],
+    )
+
+    op.execute(
+        """
+        INSERT INTO wms_service_clients (
+          client_code,
+          client_name,
+          description,
+          is_active
+        )
+        VALUES
+          (
+            'procurement-service',
+            'Procurement Service',
+            'Procurement 调用 WMS 仓库和采购收货结果能力',
+            TRUE
+          ),
+          (
+            'logistics-service',
+            'Logistics Service',
+            'Logistics 调用 WMS 发货交接能力',
+            TRUE
+          ),
+          (
+            'oms-service',
+            'OMS Service',
+            'OMS 调用 WMS 能力的预留调用方',
+            TRUE
+          ),
+          (
+            'erp-service',
+            'ERP Service',
+            'ERP 调用 WMS 配置/治理能力的预留调用方',
+            TRUE
+          )
+        ON CONFLICT (client_code) DO UPDATE
+        SET
+          client_name = EXCLUDED.client_name,
+          description = EXCLUDED.description,
+          is_active = EXCLUDED.is_active
+        """
+    )
+
+    op.execute(
+        """
+        INSERT INTO wms_service_capabilities (
+          capability_code,
+          capability_name,
+          resource_code,
+          description,
+          is_active
+        )
+        VALUES
+          (
+            'wms.read.warehouses',
+            'Read WMS warehouses',
+            'warehouses',
+            '读取 WMS 仓库基础下拉能力',
+            TRUE
+          ),
+          (
+            'wms.read.procurement_receiving_results',
+            'Read WMS procurement receiving results',
+            'procurement_receiving_results',
+            '读取 WMS 写回给采购系统的收货结果',
+            TRUE
+          ),
+          (
+            'wms.read.shipping_handoffs',
+            'Read WMS shipping handoffs',
+            'shipping_handoffs',
+            '读取 WMS 给 Logistics 的待导入发货交接数据',
+            TRUE
+          ),
+          (
+            'wms.write.shipping_handoff_import_results',
+            'Write WMS shipping handoff import results',
+            'shipping_handoff_import_results',
+            'Logistics 回写导入发货交接结果',
+            TRUE
+          ),
+          (
+            'wms.write.shipping_handoff_shipping_results',
+            'Write WMS shipping handoff shipping results',
+            'shipping_handoff_shipping_results',
+            'Logistics 回写发货完成结果',
+            TRUE
+          )
+        ON CONFLICT (capability_code) DO UPDATE
+        SET
+          capability_name = EXCLUDED.capability_name,
+          resource_code = EXCLUDED.resource_code,
+          description = EXCLUDED.description,
+          is_active = EXCLUDED.is_active,
+          updated_at = CURRENT_TIMESTAMP
+        """
+    )
+
+    op.execute(
+        """
+        INSERT INTO wms_service_capability_routes (
+          capability_code,
+          http_method,
+          route_path,
+          route_name,
+          auth_required,
+          is_active
+        )
+        VALUES
+          (
+            'wms.read.warehouses',
+            'GET',
+            '/wms/read/v1/warehouses',
+            'list_wms_read_warehouses',
+            TRUE,
+            TRUE
+          ),
+          (
+            'wms.read.warehouses',
+            'GET',
+            '/wms/read/v1/warehouses/{warehouse_id}',
+            'get_wms_read_warehouse',
+            TRUE,
+            TRUE
+          ),
+          (
+            'wms.read.procurement_receiving_results',
+            'GET',
+            '/wms/inbound/procurement-receiving-results',
+            'list_procurement_receiving_results_endpoint',
+            TRUE,
+            TRUE
+          ),
+          (
+            'wms.read.procurement_receiving_results',
+            'GET',
+            '/wms/inbound/procurement-receiving-results/{event_id}',
+            'get_procurement_receiving_result_detail_endpoint',
+            TRUE,
+            TRUE
+          ),
+          (
+            'wms.read.shipping_handoffs',
+            'GET',
+            '/shipping-assist/handoffs/ready',
+            'list_shipping_assist_handoff_ready',
+            TRUE,
+            TRUE
+          ),
+          (
+            'wms.write.shipping_handoff_import_results',
+            'POST',
+            '/shipping-assist/handoffs/import-results',
+            'record_shipping_assist_handoff_import_result',
+            TRUE,
+            TRUE
+          ),
+          (
+            'wms.write.shipping_handoff_shipping_results',
+            'POST',
+            '/shipping-assist/handoffs/shipping-results',
+            'record_shipping_assist_handoff_shipping_result',
+            TRUE,
+            TRUE
+          )
+        ON CONFLICT (http_method, route_path) DO UPDATE
+        SET
+          capability_code = EXCLUDED.capability_code,
+          route_name = EXCLUDED.route_name,
+          auth_required = EXCLUDED.auth_required,
+          is_active = EXCLUDED.is_active
+        """
+    )
+
+    op.execute(
+        """
+        WITH desired_permissions AS (
+          SELECT
+            'procurement-service' AS client_code,
+            'wms.read.warehouses' AS capability_code,
+            'Procurement 读取 WMS 仓库下拉' AS description
+          UNION ALL
+          SELECT
+            'procurement-service',
+            'wms.read.procurement_receiving_results',
+            'Procurement 读取 WMS 采购收货结果'
+          UNION ALL
+          SELECT
+            'logistics-service',
+            'wms.read.shipping_handoffs',
+            'Logistics 拉取 WMS 待导入发货交接数据'
+          UNION ALL
+          SELECT
+            'logistics-service',
+            'wms.write.shipping_handoff_import_results',
+            'Logistics 回写发货交接导入结果'
+          UNION ALL
+          SELECT
+            'logistics-service',
+            'wms.write.shipping_handoff_shipping_results',
+            'Logistics 回写发货完成结果'
+        )
+        INSERT INTO wms_service_permissions (
+          client_id,
+          capability_code,
+          description,
+          is_active
+        )
+        SELECT
+          c.id,
+          p.capability_code,
+          p.description,
+          TRUE
+        FROM desired_permissions p
+        JOIN wms_service_clients c
+          ON c.client_code = p.client_code
+        ON CONFLICT (client_id, capability_code) DO UPDATE
+        SET
+          description = EXCLUDED.description,
+          is_active = EXCLUDED.is_active
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_wms_service_permissions_capability_code",
+        table_name="wms_service_permissions",
+    )
+    op.drop_index(
+        "ix_wms_service_permissions_client_id",
+        table_name="wms_service_permissions",
+    )
+    op.drop_table("wms_service_permissions")
+
+    op.drop_index(
+        "ix_wms_service_capability_routes_capability_code",
+        table_name="wms_service_capability_routes",
+    )
+    op.drop_table("wms_service_capability_routes")
+
+    op.drop_index(
+        "ix_wms_service_capabilities_resource_code",
+        table_name="wms_service_capabilities",
+    )
+    op.drop_table("wms_service_capabilities")
+
+    op.drop_table("wms_service_clients")

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -103,6 +103,7 @@ def init_models(
 
     # ✅ 显式加载链：只放 wms-api owner 模型；PMS owner ORM 不再进入 wms-api metadata。
     explicit_chain = [
+        "app.service_auth.models",
         "app.integrations.pms.projection_models",
         "app.integrations.oms.projection_models",
         "app.procurement.models.purchase_order",

--- a/app/service_auth/__init__.py
+++ b/app/service_auth/__init__.py
@@ -1,0 +1,4 @@
+# app/service_auth/__init__.py
+from __future__ import annotations
+
+"""WMS service-to-service authorization package."""

--- a/app/service_auth/models.py
+++ b/app/service_auth/models.py
@@ -1,0 +1,256 @@
+# app/service_auth/models.py
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.orm import relationship
+
+from app.db.base import Base
+
+
+class WmsServiceClient(Base):
+    """
+    WMS 本地系统间调用方。
+
+    Boundary:
+    - 这不是用户表。
+    - 这不是页面权限表。
+    - 这张表只表示“哪个系统服务可以调用 WMS”。
+    """
+
+    __tablename__ = "wms_service_clients"
+
+    __table_args__ = (
+        sa.PrimaryKeyConstraint("id", name="pk_wms_service_clients"),
+        sa.UniqueConstraint("client_code", name="uq_wms_service_clients_client_code"),
+        sa.CheckConstraint(
+            "btrim(client_code) <> ''",
+            name="ck_wms_service_clients_client_code_not_blank",
+        ),
+        sa.CheckConstraint(
+            "btrim(client_name) <> ''",
+            name="ck_wms_service_clients_client_name_not_blank",
+        ),
+    )
+
+    id = sa.Column(sa.Integer, autoincrement=True)
+    client_code = sa.Column(sa.String(64), nullable=False)
+    client_name = sa.Column(sa.String(128), nullable=False)
+    description = sa.Column(sa.String(255), nullable=True)
+    is_active = sa.Column(sa.Boolean, nullable=False, server_default=sa.text("true"))
+    created_at = sa.Column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("CURRENT_TIMESTAMP"),
+    )
+
+    permissions = relationship(
+        "WmsServicePermission",
+        back_populates="client",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+        lazy="selectin",
+    )
+
+
+class WmsServiceCapability(Base):
+    """
+    WMS 本地系统间调用能力目录。
+
+    Boundary:
+    - WMS 自己声明自己暴露哪些 capability。
+    - ERP 后续只能读取 WMS 声明的 capability，不猜测 WMS 能力。
+    - capability 是系统间调用授权的能力粒度，不是用户页面权限。
+    """
+
+    __tablename__ = "wms_service_capabilities"
+
+    __table_args__ = (
+        sa.PrimaryKeyConstraint("id", name="pk_wms_service_capabilities"),
+        sa.UniqueConstraint(
+            "capability_code",
+            name="uq_wms_service_capabilities_capability_code",
+        ),
+        sa.CheckConstraint(
+            "btrim(capability_code) <> ''",
+            name="ck_wms_service_capabilities_capability_code_not_blank",
+        ),
+        sa.CheckConstraint(
+            "btrim(capability_name) <> ''",
+            name="ck_wms_service_capabilities_capability_name_not_blank",
+        ),
+        sa.CheckConstraint(
+            "btrim(resource_code) <> ''",
+            name="ck_wms_service_capabilities_resource_code_not_blank",
+        ),
+        sa.Index("ix_wms_service_capabilities_resource_code", "resource_code"),
+    )
+
+    id = sa.Column(sa.Integer, autoincrement=True)
+    capability_code = sa.Column(sa.String(128), nullable=False)
+    capability_name = sa.Column(sa.String(128), nullable=False)
+    resource_code = sa.Column(sa.String(64), nullable=False)
+    description = sa.Column(sa.String(255), nullable=True)
+    is_active = sa.Column(sa.Boolean, nullable=False, server_default=sa.text("true"))
+    created_at = sa.Column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("CURRENT_TIMESTAMP"),
+    )
+    updated_at = sa.Column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("CURRENT_TIMESTAMP"),
+    )
+
+    permissions = relationship(
+        "WmsServicePermission",
+        back_populates="capability",
+        lazy="selectin",
+    )
+    routes = relationship(
+        "WmsServiceCapabilityRoute",
+        back_populates="capability",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+        lazy="selectin",
+    )
+
+
+class WmsServiceCapabilityRoute(Base):
+    """
+    WMS capability 与 API 路由的本地映射合同。
+
+    Boundary:
+    - 用于说明 WMS 哪些 route 归属于哪个 capability。
+    - route mapping 是 WMS 自己声明的执行合同，不由 ERP 猜测。
+    - auth_required 表示该路由是否应纳入 service permission 校验。
+    """
+
+    __tablename__ = "wms_service_capability_routes"
+
+    __table_args__ = (
+        sa.PrimaryKeyConstraint("id", name="pk_wms_service_capability_routes"),
+        sa.UniqueConstraint(
+            "http_method",
+            "route_path",
+            name="uq_wms_service_capability_routes_method_path",
+        ),
+        sa.CheckConstraint(
+            "btrim(capability_code) <> ''",
+            name="ck_wms_service_capability_routes_capability_code_not_blank",
+        ),
+        sa.CheckConstraint(
+            "btrim(http_method) <> ''",
+            name="ck_wms_service_capability_routes_http_method_not_blank",
+        ),
+        sa.CheckConstraint(
+            "btrim(route_path) <> ''",
+            name="ck_wms_service_capability_routes_route_path_not_blank",
+        ),
+        sa.CheckConstraint(
+            "btrim(route_name) <> ''",
+            name="ck_wms_service_capability_routes_route_name_not_blank",
+        ),
+        sa.Index("ix_wms_service_capability_routes_capability_code", "capability_code"),
+    )
+
+    id = sa.Column(sa.Integer, autoincrement=True)
+    capability_code = sa.Column(
+        sa.String(128),
+        sa.ForeignKey(
+            "wms_service_capabilities.capability_code",
+            name="fk_wms_service_capability_routes_capability_code",
+            ondelete="RESTRICT",
+        ),
+        nullable=False,
+    )
+    http_method = sa.Column(sa.String(16), nullable=False)
+    route_path = sa.Column(sa.String(255), nullable=False)
+    route_name = sa.Column(sa.String(128), nullable=False)
+    auth_required = sa.Column(sa.Boolean, nullable=False, server_default=sa.text("true"))
+    is_active = sa.Column(sa.Boolean, nullable=False, server_default=sa.text("true"))
+    created_at = sa.Column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("CURRENT_TIMESTAMP"),
+    )
+
+    capability = relationship(
+        "WmsServiceCapability",
+        back_populates="routes",
+        lazy="joined",
+    )
+
+
+class WmsServicePermission(Base):
+    """
+    WMS 本地系统间调用权限。
+
+    Boundary:
+    - capability_code 表示 WMS 暴露给其他系统的能力。
+    - 不复用 users / permissions / user_permissions。
+    - 运行时是否放行由 WMS 自己查这张表决定。
+    """
+
+    __tablename__ = "wms_service_permissions"
+
+    __table_args__ = (
+        sa.PrimaryKeyConstraint("id", name="pk_wms_service_permissions"),
+        sa.UniqueConstraint(
+            "client_id",
+            "capability_code",
+            name="uq_wms_service_permissions_client_capability",
+        ),
+        sa.CheckConstraint(
+            "btrim(capability_code) <> ''",
+            name="ck_wms_service_permissions_capability_code_not_blank",
+        ),
+        sa.Index("ix_wms_service_permissions_client_id", "client_id"),
+        sa.Index("ix_wms_service_permissions_capability_code", "capability_code"),
+    )
+
+    id = sa.Column(sa.Integer, autoincrement=True)
+    client_id = sa.Column(
+        sa.Integer,
+        sa.ForeignKey(
+            "wms_service_clients.id",
+            name="fk_wms_service_permissions_client_id_wms_service_clients",
+            ondelete="CASCADE",
+        ),
+        nullable=False,
+    )
+    capability_code = sa.Column(
+        sa.String(128),
+        sa.ForeignKey(
+            "wms_service_capabilities.capability_code",
+            name="fk_wms_service_permissions_capability_code",
+            ondelete="RESTRICT",
+        ),
+        nullable=False,
+    )
+    description = sa.Column(sa.String(255), nullable=True)
+    is_active = sa.Column(sa.Boolean, nullable=False, server_default=sa.text("true"))
+    granted_at = sa.Column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("CURRENT_TIMESTAMP"),
+    )
+
+    client = relationship(
+        "WmsServiceClient",
+        back_populates="permissions",
+        lazy="joined",
+    )
+    capability = relationship(
+        "WmsServiceCapability",
+        back_populates="permissions",
+        lazy="joined",
+    )
+
+
+__all__ = [
+    "WmsServiceCapability",
+    "WmsServiceCapabilityRoute",
+    "WmsServiceClient",
+    "WmsServicePermission",
+]

--- a/tests/ci/test_wms_service_auth_contract.py
+++ b/tests/ci/test_wms_service_auth_contract.py
@@ -1,0 +1,269 @@
+# tests/ci/test_wms_service_auth_contract.py
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.db.base import Base, init_models
+from app.service_auth.models import (
+    WmsServiceCapability,
+    WmsServiceCapabilityRoute,
+    WmsServiceClient,
+    WmsServicePermission,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+MIGRATION = ROOT / "alembic/versions/20260516145000_wms_service_auth_tables.py"
+
+EXPECTED_CLIENT_CODES = {
+    "procurement-service",
+    "logistics-service",
+    "oms-service",
+    "erp-service",
+}
+
+EXPECTED_CAPABILITY_CODES = {
+    "wms.read.warehouses",
+    "wms.read.procurement_receiving_results",
+    "wms.read.shipping_handoffs",
+    "wms.write.shipping_handoff_import_results",
+    "wms.write.shipping_handoff_shipping_results",
+}
+
+EXPECTED_ROUTE_MAPPINGS = {
+    ("GET", "/wms/read/v1/warehouses", "wms.read.warehouses"),
+    ("GET", "/wms/read/v1/warehouses/{warehouse_id}", "wms.read.warehouses"),
+    (
+        "GET",
+        "/wms/inbound/procurement-receiving-results",
+        "wms.read.procurement_receiving_results",
+    ),
+    (
+        "GET",
+        "/wms/inbound/procurement-receiving-results/{event_id}",
+        "wms.read.procurement_receiving_results",
+    ),
+    (
+        "GET",
+        "/shipping-assist/handoffs/ready",
+        "wms.read.shipping_handoffs",
+    ),
+    (
+        "POST",
+        "/shipping-assist/handoffs/import-results",
+        "wms.write.shipping_handoff_import_results",
+    ),
+    (
+        "POST",
+        "/shipping-assist/handoffs/shipping-results",
+        "wms.write.shipping_handoff_shipping_results",
+    ),
+}
+
+
+def _constraint_names(table_name: str) -> set[str]:
+    return {constraint.name for constraint in Base.metadata.tables[table_name].constraints}
+
+
+def test_wms_service_auth_models_are_registered_in_metadata() -> None:
+    init_models(force=True)
+
+    assert WmsServiceClient.__tablename__ == "wms_service_clients"
+    assert WmsServiceCapability.__tablename__ == "wms_service_capabilities"
+    assert WmsServiceCapabilityRoute.__tablename__ == "wms_service_capability_routes"
+    assert WmsServicePermission.__tablename__ == "wms_service_permissions"
+
+    assert "wms_service_clients" in Base.metadata.tables
+    assert "wms_service_capabilities" in Base.metadata.tables
+    assert "wms_service_capability_routes" in Base.metadata.tables
+    assert "wms_service_permissions" in Base.metadata.tables
+
+
+def test_wms_service_auth_model_is_loaded_by_db_base() -> None:
+    text = (ROOT / "app/db/base.py").read_text(encoding="utf-8")
+
+    assert '"app.service_auth.models"' in text
+
+
+def test_wms_service_clients_table_contract() -> None:
+    init_models(force=True)
+    table = Base.metadata.tables["wms_service_clients"]
+
+    assert {
+        "id",
+        "client_code",
+        "client_name",
+        "description",
+        "is_active",
+        "created_at",
+    } == set(table.c.keys())
+
+    assert table.c.client_code.type.length == 64
+    assert table.c.client_name.type.length == 128
+    assert table.c.description.type.length == 255
+    assert str(table.c.is_active.server_default.arg) == "true"
+    assert str(table.c.created_at.server_default.arg) == "CURRENT_TIMESTAMP"
+
+    constraint_names = _constraint_names("wms_service_clients")
+    assert "pk_wms_service_clients" in constraint_names
+    assert "uq_wms_service_clients_client_code" in constraint_names
+    assert "ck_wms_service_clients_client_code_not_blank" in constraint_names
+    assert "ck_wms_service_clients_client_name_not_blank" in constraint_names
+
+
+def test_wms_service_capabilities_table_contract() -> None:
+    init_models(force=True)
+    table = Base.metadata.tables["wms_service_capabilities"]
+
+    assert {
+        "id",
+        "capability_code",
+        "capability_name",
+        "resource_code",
+        "description",
+        "is_active",
+        "created_at",
+        "updated_at",
+    } == set(table.c.keys())
+
+    assert table.c.capability_code.type.length == 128
+    assert table.c.capability_name.type.length == 128
+    assert table.c.resource_code.type.length == 64
+    assert table.c.description.type.length == 255
+    assert str(table.c.is_active.server_default.arg) == "true"
+    assert str(table.c.created_at.server_default.arg) == "CURRENT_TIMESTAMP"
+    assert str(table.c.updated_at.server_default.arg) == "CURRENT_TIMESTAMP"
+
+    constraint_names = _constraint_names("wms_service_capabilities")
+    assert "pk_wms_service_capabilities" in constraint_names
+    assert "uq_wms_service_capabilities_capability_code" in constraint_names
+    assert "ck_wms_service_capabilities_capability_code_not_blank" in constraint_names
+    assert "ck_wms_service_capabilities_capability_name_not_blank" in constraint_names
+    assert "ck_wms_service_capabilities_resource_code_not_blank" in constraint_names
+
+    index_names = {index.name for index in table.indexes}
+    assert "ix_wms_service_capabilities_resource_code" in index_names
+
+
+def test_wms_service_capability_routes_table_contract() -> None:
+    init_models(force=True)
+    table = Base.metadata.tables["wms_service_capability_routes"]
+
+    assert {
+        "id",
+        "capability_code",
+        "http_method",
+        "route_path",
+        "route_name",
+        "auth_required",
+        "is_active",
+        "created_at",
+    } == set(table.c.keys())
+
+    assert table.c.capability_code.type.length == 128
+    assert table.c.http_method.type.length == 16
+    assert table.c.route_path.type.length == 255
+    assert table.c.route_name.type.length == 128
+    assert str(table.c.auth_required.server_default.arg) == "true"
+    assert str(table.c.is_active.server_default.arg) == "true"
+    assert str(table.c.created_at.server_default.arg) == "CURRENT_TIMESTAMP"
+
+    foreign_keys = list(table.c.capability_code.foreign_keys)
+    assert len(foreign_keys) == 1
+    assert foreign_keys[0].column.table.name == "wms_service_capabilities"
+    assert foreign_keys[0].column.name == "capability_code"
+    assert foreign_keys[0].ondelete == "RESTRICT"
+    assert foreign_keys[0].constraint.name == "fk_wms_service_capability_routes_capability_code"
+
+    constraint_names = _constraint_names("wms_service_capability_routes")
+    assert "pk_wms_service_capability_routes" in constraint_names
+    assert "uq_wms_service_capability_routes_method_path" in constraint_names
+    assert "ck_wms_service_capability_routes_capability_code_not_blank" in constraint_names
+    assert "ck_wms_service_capability_routes_http_method_not_blank" in constraint_names
+    assert "ck_wms_service_capability_routes_route_path_not_blank" in constraint_names
+    assert "ck_wms_service_capability_routes_route_name_not_blank" in constraint_names
+
+    index_names = {index.name for index in table.indexes}
+    assert "ix_wms_service_capability_routes_capability_code" in index_names
+
+
+def test_wms_service_permissions_table_contract() -> None:
+    init_models(force=True)
+    table = Base.metadata.tables["wms_service_permissions"]
+
+    assert {
+        "id",
+        "client_id",
+        "capability_code",
+        "description",
+        "is_active",
+        "granted_at",
+    } == set(table.c.keys())
+
+    assert table.c.capability_code.type.length == 128
+    assert table.c.description.type.length == 255
+    assert str(table.c.is_active.server_default.arg) == "true"
+    assert str(table.c.granted_at.server_default.arg) == "CURRENT_TIMESTAMP"
+
+    target_tables = {foreign_key.column.table.name for foreign_key in table.foreign_keys}
+    assert target_tables == {
+        "wms_service_clients",
+        "wms_service_capabilities",
+    }
+
+    capability_fks = [
+        foreign_key
+        for foreign_key in table.c.capability_code.foreign_keys
+        if foreign_key.column.table.name == "wms_service_capabilities"
+    ]
+    assert len(capability_fks) == 1
+    assert capability_fks[0].column.name == "capability_code"
+    assert capability_fks[0].ondelete == "RESTRICT"
+    assert capability_fks[0].constraint.name == "fk_wms_service_permissions_capability_code"
+
+    constraint_names = _constraint_names("wms_service_permissions")
+    assert "pk_wms_service_permissions" in constraint_names
+    assert "uq_wms_service_permissions_client_capability" in constraint_names
+    assert "ck_wms_service_permissions_capability_code_not_blank" in constraint_names
+
+    index_names = {index.name for index in table.indexes}
+    assert "ix_wms_service_permissions_client_id" in index_names
+    assert "ix_wms_service_permissions_capability_code" in index_names
+
+
+def test_wms_service_permissions_do_not_reuse_user_permission_tables() -> None:
+    init_models(force=True)
+    table = Base.metadata.tables["wms_service_permissions"]
+
+    assert "permission_id" not in table.c
+    assert "user_id" not in table.c
+
+
+def test_wms_service_auth_migration_contains_catalog_routes_and_seed_data() -> None:
+    text = MIGRATION.read_text(encoding="utf-8")
+
+    assert 'revision: str = "20260516145000_wms_svc_auth"' in text
+    assert (
+        'down_revision: str | Sequence[str] | None = '
+        '"20260515123000_retire_wms_procurement_nav"'
+    ) in text
+
+    assert '"wms_service_clients"' in text
+    assert '"wms_service_capabilities"' in text
+    assert '"wms_service_capability_routes"' in text
+    assert '"wms_service_permissions"' in text
+
+    assert "fk_wms_service_permissions_client_id_wms_service_clients" in text
+    assert "fk_wms_service_permissions_capability_code" in text
+    assert "fk_wms_service_capability_routes_capability_code" in text
+    assert "uq_wms_service_capability_routes_method_path" in text
+
+    for client_code in EXPECTED_CLIENT_CODES:
+        assert client_code in text
+
+    for capability_code in EXPECTED_CAPABILITY_CODES:
+        assert capability_code in text
+
+    for method, route_path, capability_code in EXPECTED_ROUTE_MAPPINGS:
+        assert method in text
+        assert route_path in text
+        assert capability_code in text


### PR DESCRIPTION
## Summary
- add WMS service-to-service clients table
- add WMS service capability catalog table
- add WMS service capability route mapping table
- add WMS service permission execution table
- seed initial Procurement and Logistics service permissions
- register WMS service auth models in ORM metadata
- add contract tests for WMS service auth schema and seed contract

## Validation
- python3 -m compileall app/db/base.py app/service_auth alembic/versions/20260516145000_wms_service_auth_tables.py tests/ci/test_wms_service_auth_contract.py
- make test TESTS="tests/ci/test_wms_service_auth_contract.py"
- make lint
- WMS dev DB alembic upgrade head
- WMS dev DB table/seed verification