### PR TITLE
feat(auth): add WMS service permission runtime checks

### DIFF
--- a/app/service_auth/deps.py
+++ b/app/service_auth/deps.py
@@ -1,0 +1,65 @@
+# app/service_auth/deps.py
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from fastapi import Depends, Header, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.service_auth.services import WmsServicePermissionService
+
+WMS_SERVICE_CLIENT_HEADER = "X-Service-Client"
+
+
+def get_wms_service_permission_service(
+    db: Session = Depends(get_db),
+) -> WmsServicePermissionService:
+    return WmsServicePermissionService(db)
+
+
+def require_wms_service_capability(
+    capability_code: str,
+) -> Callable[[str | None, WmsServicePermissionService], None]:
+    """
+    Build a FastAPI dependency for WMS service-to-service capability checks.
+
+    Usage example:
+        Depends(require_wms_service_capability("wms.read.warehouses"))
+
+    Boundary:
+    - capability_code 由 WMS 路由自己声明，不能由调用方传入。
+    - 调用方只通过 X-Service-Client 声明自己是谁。
+    - 这不是用户权限校验。
+    """
+
+    normalized_capability_code = (capability_code or "").strip()
+
+    def dependency(
+        x_service_client: str | None = Header(default=None, alias=WMS_SERVICE_CLIENT_HEADER),
+        service: WmsServicePermissionService = Depends(get_wms_service_permission_service),
+    ) -> None:
+        client_code = (x_service_client or "").strip()
+        if not client_code:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="wms_service_client_required",
+            )
+
+        if not service.is_allowed(
+            client_code=client_code,
+            capability_code=normalized_capability_code,
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="wms_service_permission_denied",
+            )
+
+    return dependency
+
+
+__all__ = [
+    "WMS_SERVICE_CLIENT_HEADER",
+    "get_wms_service_permission_service",
+    "require_wms_service_capability",
+]

--- a/app/service_auth/services/__init__.py
+++ b/app/service_auth/services/__init__.py
@@ -1,0 +1,8 @@
+# app/service_auth/services/__init__.py
+from __future__ import annotations
+
+from app.service_auth.services.wms_service_permission_service import WmsServicePermissionService
+
+__all__ = [
+    "WmsServicePermissionService",
+]

--- a/app/service_auth/services/wms_service_permission_service.py
+++ b/app/service_auth/services/wms_service_permission_service.py
@@ -1,0 +1,54 @@
+# app/service_auth/services/wms_service_permission_service.py
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.service_auth.models import (
+    WmsServiceCapability,
+    WmsServiceClient,
+    WmsServicePermission,
+)
+
+
+class WmsServicePermissionService:
+    """
+    WMS 本地系统间调用权限校验服务。
+
+    Boundary:
+    - 只判断 service client 是否拥有某个 WMS capability。
+    - 不读取 users / permissions / user_permissions。
+    - 不负责 service client 身份认证；身份认证后续由网关、service token 或签名机制承接。
+    """
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    @staticmethod
+    def _normalize(value: str | None) -> str:
+        return (value or "").strip()
+
+    def is_allowed(self, *, client_code: str | None, capability_code: str | None) -> bool:
+        normalized_client_code = self._normalize(client_code)
+        normalized_capability_code = self._normalize(capability_code)
+
+        if not normalized_client_code or not normalized_capability_code:
+            return False
+
+        row = (
+            self.db.query(WmsServicePermission.id)
+            .join(WmsServiceClient, WmsServiceClient.id == WmsServicePermission.client_id)
+            .join(
+                WmsServiceCapability,
+                WmsServiceCapability.capability_code == WmsServicePermission.capability_code,
+            )
+            .filter(WmsServiceClient.client_code == normalized_client_code)
+            .filter(WmsServiceClient.is_active.is_(True))
+            .filter(WmsServiceCapability.is_active.is_(True))
+            .filter(WmsServicePermission.capability_code == normalized_capability_code)
+            .filter(WmsServicePermission.is_active.is_(True))
+            .first()
+        )
+        return row is not None
+
+
+__all__ = ["WmsServicePermissionService"]

--- a/tests/ci/test_wms_service_permission_runtime_contract.py
+++ b/tests/ci/test_wms_service_permission_runtime_contract.py
@@ -1,0 +1,193 @@
+# tests/ci/test_wms_service_permission_runtime_contract.py
+from __future__ import annotations
+
+from fastapi import HTTPException
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session
+
+from app.service_auth.deps import (
+    WMS_SERVICE_CLIENT_HEADER,
+    require_wms_service_capability,
+)
+from app.service_auth.models import (
+    WmsServiceCapability,
+    WmsServiceClient,
+    WmsServicePermission,
+)
+from app.service_auth.services import WmsServicePermissionService
+
+
+def _sqlite_session() -> Session:
+    engine = create_engine("sqlite:///:memory:")
+
+    @event.listens_for(engine, "connect")
+    def _register_sqlite_functions(dbapi_connection, _connection_record) -> None:
+        dbapi_connection.create_function(
+            "btrim",
+            1,
+            lambda value: "" if value is None else str(value).strip(),
+        )
+
+    WmsServiceCapability.__table__.create(engine)
+    WmsServiceClient.__table__.create(engine)
+    WmsServicePermission.__table__.create(engine)
+    return Session(bind=engine)
+
+
+def _seed_permission(
+    db: Session,
+    *,
+    client_code: str,
+    capability_code: str,
+    capability_active: bool = True,
+    client_active: bool = True,
+    permission_active: bool = True,
+) -> None:
+    capability = WmsServiceCapability(
+        capability_code=capability_code,
+        capability_name=f"{capability_code} name",
+        resource_code=capability_code.split(".")[-1],
+        is_active=capability_active,
+    )
+    db.add(capability)
+    db.flush()
+
+    client = WmsServiceClient(
+        client_code=client_code,
+        client_name=f"{client_code} name",
+        is_active=client_active,
+    )
+    db.add(client)
+    db.flush()
+
+    permission = WmsServicePermission(
+        client_id=int(client.id),
+        capability_code=capability_code,
+        is_active=permission_active,
+    )
+    db.add(permission)
+    db.commit()
+
+
+def test_wms_service_permission_service_allows_active_client_and_capability() -> None:
+    with _sqlite_session() as db:
+        _seed_permission(
+            db,
+            client_code="procurement-service",
+            capability_code="wms.read.warehouses",
+        )
+
+        service = WmsServicePermissionService(db)
+
+        assert service.is_allowed(
+            client_code=" procurement-service ",
+            capability_code=" wms.read.warehouses ",
+        )
+
+
+def test_wms_service_permission_service_rejects_missing_inactive_or_ungranted() -> None:
+    with _sqlite_session() as db:
+        _seed_permission(
+            db,
+            client_code="inactive-capability-client",
+            capability_code="wms.read.inactive_capability",
+            capability_active=False,
+        )
+        _seed_permission(
+            db,
+            client_code="inactive-client",
+            capability_code="wms.read.inactive_client",
+            client_active=False,
+        )
+        _seed_permission(
+            db,
+            client_code="inactive-permission",
+            capability_code="wms.read.inactive_permission",
+            permission_active=False,
+        )
+        _seed_permission(
+            db,
+            client_code="procurement-service",
+            capability_code="wms.read.warehouses",
+        )
+
+        service = WmsServicePermissionService(db)
+
+        assert not service.is_allowed(client_code=None, capability_code="wms.read.warehouses")
+        assert not service.is_allowed(client_code="procurement-service", capability_code=None)
+        assert not service.is_allowed(
+            client_code="unknown-service",
+            capability_code="wms.read.warehouses",
+        )
+        assert not service.is_allowed(
+            client_code="inactive-capability-client",
+            capability_code="wms.read.inactive_capability",
+        )
+        assert not service.is_allowed(
+            client_code="inactive-client",
+            capability_code="wms.read.inactive_client",
+        )
+        assert not service.is_allowed(
+            client_code="inactive-permission",
+            capability_code="wms.read.inactive_permission",
+        )
+        assert not service.is_allowed(
+            client_code="procurement-service",
+            capability_code="wms.read.shipping_handoffs",
+        )
+
+
+class FakePermissionService:
+    def __init__(self, *, allowed: bool) -> None:
+        self.allowed = allowed
+        self.calls: list[tuple[str | None, str | None]] = []
+
+    def is_allowed(self, *, client_code: str | None, capability_code: str | None) -> bool:
+        self.calls.append((client_code, capability_code))
+        return self.allowed
+
+
+def test_wms_service_permission_dependency_uses_service_client_header() -> None:
+    assert WMS_SERVICE_CLIENT_HEADER == "X-Service-Client"
+
+    dependency = require_wms_service_capability("wms.read.warehouses")
+    service = FakePermissionService(allowed=True)
+
+    dependency(
+        x_service_client="procurement-service",
+        service=service,  # type: ignore[arg-type]
+    )
+
+    assert service.calls == [("procurement-service", "wms.read.warehouses")]
+
+
+def test_wms_service_permission_dependency_rejects_missing_service_client_header() -> None:
+    dependency = require_wms_service_capability("wms.read.warehouses")
+    service = FakePermissionService(allowed=True)
+
+    try:
+        dependency(
+            x_service_client=None,
+            service=service,  # type: ignore[arg-type]
+        )
+    except HTTPException as exc:
+        assert exc.status_code == 401
+        assert exc.detail == "wms_service_client_required"
+    else:
+        raise AssertionError("missing X-Service-Client should be rejected")
+
+
+def test_wms_service_permission_dependency_rejects_denied_capability() -> None:
+    dependency = require_wms_service_capability("wms.read.shipping_handoffs")
+    service = FakePermissionService(allowed=False)
+
+    try:
+        dependency(
+            x_service_client="procurement-service",
+            service=service,  # type: ignore[arg-type]
+        )
+    except HTTPException as exc:
+        assert exc.status_code == 403
+        assert exc.detail == "wms_service_permission_denied"
+    else:
+        raise AssertionError("denied service permission should be rejected")


### PR DESCRIPTION
## Summary
- add WMS service-to-service permission checker
- add FastAPI dependency factory for WMS capability checks
- add runtime contract tests for service client header and allow/deny behavior

## Validation
- python3 -m compileall app/service_auth/deps.py app/service_auth/services tests/ci/test_wms_service_permission_runtime_contract.py
- make test TESTS="tests/ci/test_wms_service_auth_contract.py tests/ci/test_wms_service_permission_runtime_contract.py"
- make lint