### PR TITLE
feat(auth): gate WMS service routes by service permissions

### DIFF
--- a/app/shipping_assist/handoffs/router.py
+++ b/app/shipping_assist/handoffs/router.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.deps import get_async_session as get_session
+from app.service_auth.deps import require_wms_service_capability
 from app.shipping_assist.handoffs.contracts import (
     ShippingHandoffListResponse,
     ShippingHandoffRow,
@@ -53,6 +54,16 @@ LogisticsStatus = Literal[
 ]
 
 router = APIRouter(prefix="/shipping-assist/handoffs", tags=["shipping-assist-handoffs"])
+
+require_wms_read_shipping_handoffs = require_wms_service_capability(
+    "wms.read.shipping_handoffs"
+)
+require_wms_write_shipping_handoff_import_results = require_wms_service_capability(
+    "wms.write.shipping_handoff_import_results"
+)
+require_wms_write_shipping_handoff_shipping_results = require_wms_service_capability(
+    "wms.write.shipping_handoff_shipping_results"
+)
 
 
 @router.get(
@@ -110,10 +121,8 @@ async def list_shipping_assist_handoff_ready(
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
     session: AsyncSession = Depends(get_session),
-    current_user: Any = Depends(get_current_user),
+    _service_permission: None = Depends(require_wms_read_shipping_handoffs),
 ) -> LogisticsReadyListOut:
-    del current_user
-
     total = await count_logistics_ready_records(
         session,
         source_doc_type=source_doc_type,
@@ -144,10 +153,8 @@ async def list_shipping_assist_handoff_ready(
 async def record_shipping_assist_handoff_import_result(
     payload: LogisticsImportResultIn,
     session: AsyncSession = Depends(get_session),
-    current_user: Any = Depends(get_current_user),
+    _service_permission: None = Depends(require_wms_write_shipping_handoff_import_results),
 ) -> LogisticsImportResultOut:
-    del current_user
-
     try:
         if payload.export_status == "EXPORTED":
             row = await apply_logistics_import_success(
@@ -188,10 +195,8 @@ async def record_shipping_assist_handoff_import_result(
 async def record_shipping_assist_handoff_shipping_result(
     payload: LogisticsShippingResultIn,
     session: AsyncSession = Depends(get_session),
-    current_user: Any = Depends(get_current_user),
+    _service_permission: None = Depends(require_wms_write_shipping_handoff_shipping_results),
 ) -> LogisticsShippingResultOut:
-    del current_user
-
     try:
         row = await apply_logistics_shipping_results(
             session,

--- a/app/wms/inbound/routers/inbound_events.py
+++ b/app/wms/inbound/routers/inbound_events.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_session
+from app.service_auth.deps import require_wms_service_capability
 from app.wms.inbound.contracts.inbound_event_read import (
     InboundEventDetailOut,
     InboundEventListOut,
@@ -26,6 +27,10 @@ from app.wms.inbound.services.procurement_receiving_result_service import (
 
 router = APIRouter(prefix="/wms/inbound", tags=["wms-inbound-events"])
 
+require_wms_read_procurement_receiving_results = require_wms_service_capability(
+    "wms.read.procurement_receiving_results"
+)
+
 
 @router.get(
     "/procurement-receiving-results",
@@ -37,6 +42,7 @@ async def list_procurement_receiving_results_endpoint(
     procurement_po_id: int | None = Query(default=None, ge=1, description="采购系统采购单 ID"),
     receipt_no: str | None = Query(default=None, description="WMS 入库单号"),
     session: AsyncSession = Depends(get_session),
+    _service_permission: None = Depends(require_wms_read_procurement_receiving_results),
 ) -> ProcurementReceivingResultsOut:
     try:
         return await list_procurement_receiving_results(
@@ -59,6 +65,7 @@ async def list_procurement_receiving_results_endpoint(
 async def get_procurement_receiving_result_detail_endpoint(
     event_id: int,
     session: AsyncSession = Depends(get_session),
+    _service_permission: None = Depends(require_wms_read_procurement_receiving_results),
 ) -> ProcurementReceivingResultDetailOut:
     try:
         return await get_procurement_receiving_result_detail(
@@ -115,4 +122,7 @@ async def get_inbound_event_detail_endpoint(
         raise HTTPException(status_code=400, detail=str(e)) from e
 
 
-__all__ = ["router"]
+__all__ = [
+    "require_wms_read_procurement_receiving_results",
+    "router",
+]

--- a/app/wms/warehouses/routers/warehouses_read_v1.py
+++ b/app/wms/warehouses/routers/warehouses_read_v1.py
@@ -8,10 +8,13 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.deps import get_async_session as get_session
+from app.service_auth.deps import require_wms_service_capability
 from app.wms.warehouses.contracts.warehouse_read_v1 import (
     WmsReadWarehouseListOut,
     WmsReadWarehouseOut,
 )
+
+require_wms_read_warehouses = require_wms_service_capability("wms.read.warehouses")
 
 
 def _row_to_read_warehouse(row: Mapping[str, Any]) -> WmsReadWarehouseOut:
@@ -38,6 +41,7 @@ def register(router: APIRouter) -> None:
         ),
         limit: int = Query(200, ge=1, le=500),
         session: AsyncSession = Depends(get_session),
+        _service_permission: None = Depends(require_wms_read_warehouses),
     ) -> WmsReadWarehouseListOut:
         """List WMS warehouses for cross-system read contracts.
 
@@ -87,6 +91,7 @@ def register(router: APIRouter) -> None:
     async def get_wms_read_warehouse(
         warehouse_id: int = Path(..., ge=1),
         session: AsyncSession = Depends(get_session),
+        _service_permission: None = Depends(require_wms_read_warehouses),
     ) -> WmsReadWarehouseOut:
         row = (
             await session.execute(
@@ -111,4 +116,4 @@ def register(router: APIRouter) -> None:
         return _row_to_read_warehouse(row)
 
 
-__all__ = ["register"]
+__all__ = ["register", "require_wms_read_warehouses"]

--- a/tests/api/test_shipping_assist_handoffs_import_results_api.py
+++ b/tests/api/test_shipping_assist_handoffs_import_results_api.py
@@ -8,14 +8,14 @@ from httpx import AsyncClient
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.service_auth.deps import WMS_SERVICE_CLIENT_HEADER
 pytestmark = pytest.mark.asyncio
 UTC = timezone.utc
 
 
 async def _login_admin_headers(client: AsyncClient) -> dict[str, str]:
-    r = await client.post("/users/login", json={"username": "admin", "password": "admin123"})
-    assert r.status_code == 200, r.text
-    return {"Authorization": f"Bearer {r.json()['access_token']}"}
+    _ = client
+    return {WMS_SERVICE_CLIENT_HEADER: "logistics-service"}
 
 
 async def _seed_export_record(

--- a/tests/api/test_shipping_assist_handoffs_ready_api.py
+++ b/tests/api/test_shipping_assist_handoffs_ready_api.py
@@ -9,6 +9,7 @@ from httpx import AsyncClient
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.service_auth.deps import WMS_SERVICE_CLIENT_HEADER
 from tests.services._helpers import ensure_store
 
 pytestmark = pytest.mark.asyncio
@@ -16,9 +17,8 @@ UTC = timezone.utc
 
 
 async def _login_admin_headers(client: AsyncClient) -> dict[str, str]:
-    r = await client.post("/users/login", json={"username": "admin", "password": "admin123"})
-    assert r.status_code == 200, r.text
-    return {"Authorization": f"Bearer {r.json()['access_token']}"}
+    _ = client
+    return {WMS_SERVICE_CLIENT_HEADER: "logistics-service"}
 
 
 async def _pick_any_item_id(session: AsyncSession) -> int:

--- a/tests/api/test_shipping_assist_handoffs_shipping_results_api.py
+++ b/tests/api/test_shipping_assist_handoffs_shipping_results_api.py
@@ -9,6 +9,7 @@ from httpx import AsyncClient
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.service_auth.deps import WMS_SERVICE_CLIENT_HEADER
 from tests.services._helpers import ensure_store
 
 pytestmark = pytest.mark.asyncio
@@ -16,9 +17,8 @@ UTC = timezone.utc
 
 
 async def _login_admin_headers(client: AsyncClient) -> dict[str, str]:
-    r = await client.post("/users/login", json={"username": "admin", "password": "admin123"})
-    assert r.status_code == 200, r.text
-    return {"Authorization": f"Bearer {r.json()['access_token']}"}
+    _ = client
+    return {WMS_SERVICE_CLIENT_HEADER: "logistics-service"}
 
 
 async def _ensure_warehouse(session: AsyncSession, warehouse_id: int = 1) -> int:

--- a/tests/api/test_wms_procurement_receiving_results_api.py
+++ b/tests/api/test_wms_procurement_receiving_results_api.py
@@ -6,6 +6,10 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from app.service_auth.deps import (
+    WMS_SERVICE_CLIENT_HEADER,
+    get_wms_service_permission_service,
+)
 from app.wms.inbound.contracts.procurement_receiving_result import (
     ProcurementReceivingResultDetailOut,
     ProcurementReceivingResultLineOut,
@@ -14,9 +18,26 @@ from app.wms.inbound.contracts.procurement_receiving_result import (
 from app.wms.inbound.routers import inbound_events as router_module
 
 
-def _client() -> TestClient:
+class FakePermissionService:
+    def __init__(self, *, allowed: bool = True) -> None:
+        self.allowed = allowed
+        self.calls: list[tuple[str | None, str | None]] = []
+
+    def is_allowed(self, *, client_code: str | None, capability_code: str | None) -> bool:
+        self.calls.append((client_code, capability_code))
+        return self.allowed
+
+
+def _headers(client_code: str = "procurement-service") -> dict[str, str]:
+    return {WMS_SERVICE_CLIENT_HEADER: client_code}
+
+
+def _client(fake_permission: FakePermissionService | None = None) -> TestClient:
     app = FastAPI()
     app.include_router(router_module.router)
+    app.dependency_overrides[get_wms_service_permission_service] = (
+        lambda: fake_permission or FakePermissionService()
+    )
     return TestClient(app)
 
 
@@ -77,6 +98,7 @@ def test_procurement_receiving_results_route_returns_contract(
 
     response = _client().get(
         "/wms/inbound/procurement-receiving-results",
+        headers=_headers(),
         params={
             "after_event_id": 10,
             "limit": 20,
@@ -122,7 +144,10 @@ def test_procurement_receiving_result_detail_route_returns_contract(
         fake_get_result_detail,
     )
 
-    response = _client().get("/wms/inbound/procurement-receiving-results/34")
+    response = _client().get(
+        "/wms/inbound/procurement-receiving-results/34",
+        headers=_headers(),
+    )
 
     assert response.status_code == 200
     body = response.json()
@@ -130,3 +155,20 @@ def test_procurement_receiving_result_detail_route_returns_contract(
     assert captured["event_id"] == 34
     assert body["event_id"] == 34
     assert body["items"][0]["receipt_no"] == "IR-PO-1-20260513141447-A864B3"
+
+
+def test_procurement_receiving_results_requires_service_client_header() -> None:
+    response = _client().get("/wms/inbound/procurement-receiving-results")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "wms_service_client_required"
+
+
+def test_procurement_receiving_results_rejects_denied_service_permission() -> None:
+    response = _client(FakePermissionService(allowed=False)).get(
+        "/wms/inbound/procurement-receiving-results",
+        headers=_headers(),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "wms_service_permission_denied"

--- a/tests/api/test_wms_read_v1_warehouses_api.py
+++ b/tests/api/test_wms_read_v1_warehouses_api.py
@@ -6,6 +6,10 @@ from typing import Any
 from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
 
+from app.service_auth.deps import (
+    WMS_SERVICE_CLIENT_HEADER,
+    get_wms_service_permission_service,
+)
 from app.wms.warehouses.routers import warehouses_read_v1 as router_module
 
 
@@ -84,7 +88,24 @@ class FakeSession:
         return FakeResult(rows)
 
 
-def _client(fake_session: FakeSession) -> TestClient:
+class FakePermissionService:
+    def __init__(self, *, allowed: bool = True) -> None:
+        self.allowed = allowed
+        self.calls: list[tuple[str | None, str | None]] = []
+
+    def is_allowed(self, *, client_code: str | None, capability_code: str | None) -> bool:
+        self.calls.append((client_code, capability_code))
+        return self.allowed
+
+
+def _headers(client_code: str = "procurement-service") -> dict[str, str]:
+    return {WMS_SERVICE_CLIENT_HEADER: client_code}
+
+
+def _client(
+    fake_session: FakeSession,
+    fake_permission: FakePermissionService | None = None,
+) -> TestClient:
     app = FastAPI()
     router = APIRouter()
     router_module.register(router)
@@ -93,13 +114,16 @@ def _client(fake_session: FakeSession) -> TestClient:
     async def override_session() -> AsyncGenerator[FakeSession]:
         yield fake_session
 
+    permission = fake_permission or FakePermissionService()
+
     app.dependency_overrides[router_module.get_session] = override_session
+    app.dependency_overrides[get_wms_service_permission_service] = lambda: permission
     return TestClient(app)
 
 
 def test_list_wms_read_warehouses_defaults_to_active_true() -> None:
     fake_session = FakeSession()
-    response = _client(fake_session).get("/wms/read/v1/warehouses")
+    response = _client(fake_session).get("/wms/read/v1/warehouses", headers=_headers())
 
     assert response.status_code == 200
     assert response.json() == {
@@ -123,7 +147,10 @@ def test_list_wms_read_warehouses_defaults_to_active_true() -> None:
 
 def test_list_wms_read_warehouses_can_query_inactive() -> None:
     fake_session = FakeSession()
-    response = _client(fake_session).get("/wms/read/v1/warehouses?active=false")
+    response = _client(fake_session).get(
+        "/wms/read/v1/warehouses?active=false",
+        headers=_headers(),
+    )
 
     assert response.status_code == 200
     assert response.json() == {
@@ -141,7 +168,7 @@ def test_list_wms_read_warehouses_can_query_inactive() -> None:
 
 def test_get_wms_read_warehouse_returns_contract() -> None:
     fake_session = FakeSession()
-    response = _client(fake_session).get("/wms/read/v1/warehouses/1")
+    response = _client(fake_session).get("/wms/read/v1/warehouses/1", headers=_headers())
 
     assert response.status_code == 200
     assert response.json() == {
@@ -154,7 +181,26 @@ def test_get_wms_read_warehouse_returns_contract() -> None:
 
 def test_get_wms_read_warehouse_returns_404() -> None:
     fake_session = FakeSession()
-    response = _client(fake_session).get("/wms/read/v1/warehouses/404")
+    response = _client(fake_session).get("/wms/read/v1/warehouses/404", headers=_headers())
 
     assert response.status_code == 404
     assert response.json() == {"detail": "warehouse not found"}
+
+
+def test_wms_read_warehouses_requires_service_client_header() -> None:
+    fake_session = FakeSession()
+    response = _client(fake_session).get("/wms/read/v1/warehouses")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "wms_service_client_required"
+
+
+def test_wms_read_warehouses_rejects_denied_service_permission() -> None:
+    fake_session = FakeSession()
+    response = _client(
+        fake_session,
+        fake_permission=FakePermissionService(allowed=False),
+    ).get("/wms/read/v1/warehouses", headers=_headers())
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "wms_service_permission_denied"


### PR DESCRIPTION
## Summary
- gate WMS warehouse read-v1 service routes with service permissions
- gate Procurement receiving result service routes with service permissions
- gate Logistics handoff machine routes with service permissions
- keep the human-facing shipping handoff list on user auth
- update route tests to use X-Service-Client

## Validation
- python3 -m compileall app/wms/warehouses/routers/warehouses_read_v1.py app/wms/inbound/routers/inbound_events.py app/shipping_assist/handoffs/router.py tests/api/test_wms_read_v1_warehouses_api.py tests/api/test_wms_procurement_receiving_results_api.py tests/api/test_shipping_assist_handoffs_ready_api.py tests/api/test_shipping_assist_handoffs_import_results_api.py tests/api/test_shipping_assist_handoffs_shipping_results_api.py
- make test TESTS="tests/api/test_wms_read_v1_warehouses_api.py tests/api/test_wms_procurement_receiving_results_api.py tests/api/test_shipping_assist_handoffs_ready_api.py tests/api/test_shipping_assist_handoffs_import_results_api.py tests/api/test_shipping_assist_handoffs_shipping_results_api.py tests/ci/test_wms_service_auth_contract.py tests/ci/test_wms_service_permission_runtime_contract.py"
- make lint