### PR TITLE
feat(procurement): send WMS service client header to Procurement

### DIFF
--- a/app/integrations/procurement/http_client.py
+++ b/app/integrations/procurement/http_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 import httpx
@@ -7,6 +8,9 @@ import httpx
 from app.integrations.procurement.contracts import (
     ProcurementPurchaseOrderOut,
     ProcurementPurchaseOrderSourceOptionsOut,
+)
+from app.integrations.procurement.wms_procurement_service_auth import (
+    wms_to_procurement_service_auth_headers,
 )
 
 
@@ -21,6 +25,7 @@ class HttpProcurementReadClient:
     - WMS 只读取 procurement-api read API。
     - 本 client 不写 procurement owner 数据。
     - 本 client 不创建 WMS 入库单。
+    - 本 client 统一以 wms-service 身份调用 Procurement。
     - 采购入库来源必须使用 procurement-api 暴露给 WMS 的 receiving-sources 合同，
       不再绑定采购管理页面的 purchase-orders 读模型路径。
     """
@@ -31,6 +36,7 @@ class HttpProcurementReadClient:
         base_url: str,
         timeout_seconds: float = 10.0,
         transport: httpx.AsyncBaseTransport | None = None,
+        headers: Mapping[str, str] | None = None,
     ) -> None:
         normalized = (base_url or "").strip().rstrip("/")
         if not normalized:
@@ -39,6 +45,7 @@ class HttpProcurementReadClient:
         self._base_url = normalized
         self._timeout_seconds = float(timeout_seconds)
         self._transport = transport
+        self._headers = wms_to_procurement_service_auth_headers(headers)
 
     async def list_purchase_order_source_options(
         self,
@@ -80,6 +87,7 @@ class HttpProcurementReadClient:
 
         async with httpx.AsyncClient(
             transport=self._transport,
+            headers=self._headers,
             timeout=httpx.Timeout(self._timeout_seconds),
         ) as client:
             response = await client.get(url, params=params)

--- a/app/integrations/procurement/wms_procurement_service_auth.py
+++ b/app/integrations/procurement/wms_procurement_service_auth.py
@@ -1,0 +1,31 @@
+# app/integrations/procurement/wms_procurement_service_auth.py
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+PROCUREMENT_SERVICE_CLIENT_HEADER = "X-Service-Client"
+WMS_SERVICE_CLIENT_CODE = "wms-service"
+
+
+def wms_to_procurement_service_auth_headers(
+    headers: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """
+    Build WMS -> Procurement service authorization headers.
+
+    Boundary:
+    - WMS calls Procurement as the fixed service client: wms-service.
+    - This is system-to-system authorization metadata, not user authorization.
+    - Caller-supplied headers are preserved, but X-Service-Client is owned by WMS.
+    """
+
+    merged = dict(headers or {})
+    merged[PROCUREMENT_SERVICE_CLIENT_HEADER] = WMS_SERVICE_CLIENT_CODE
+    return merged
+
+
+__all__ = [
+    "PROCUREMENT_SERVICE_CLIENT_HEADER",
+    "WMS_SERVICE_CLIENT_CODE",
+    "wms_to_procurement_service_auth_headers",
+]

--- a/tests/services/test_procurement_integration_http_client.py
+++ b/tests/services/test_procurement_integration_http_client.py
@@ -12,6 +12,11 @@ from app.integrations.procurement.http_client import (
     HttpProcurementReadClient,
     ProcurementReadClientError,
 )
+from app.integrations.procurement.wms_procurement_service_auth import (
+    PROCUREMENT_SERVICE_CLIENT_HEADER,
+    WMS_SERVICE_CLIENT_CODE,
+    wms_to_procurement_service_auth_headers,
+)
 
 
 def _json_response(payload: object, status_code: int = 200) -> httpx.Response:
@@ -22,6 +27,18 @@ def _json_response(payload: object, status_code: int = 200) -> httpx.Response:
     )
 
 
+def test_wms_to_procurement_service_auth_headers_force_wms_service_client() -> None:
+    headers = wms_to_procurement_service_auth_headers(
+        {
+            "Authorization": "Bearer token",
+            PROCUREMENT_SERVICE_CLIENT_HEADER: "wrong-service",
+        }
+    )
+
+    assert headers["Authorization"] == "Bearer token"
+    assert headers[PROCUREMENT_SERVICE_CLIENT_HEADER] == WMS_SERVICE_CLIENT_CODE
+
+
 @pytest.mark.asyncio
 async def test_list_purchase_order_source_options_calls_procurement_read_api() -> None:
     captured: dict[str, object] = {}
@@ -30,6 +47,7 @@ async def test_list_purchase_order_source_options_calls_procurement_read_api() -
     async def handler(request: httpx.Request) -> httpx.Response:
         captured["url"] = str(request.url)
         captured["params"] = dict(request.url.params)
+        captured["service_client"] = request.headers.get(PROCUREMENT_SERVICE_CLIENT_HEADER)
 
         return _json_response(
             {
@@ -72,6 +90,7 @@ async def test_list_purchase_order_source_options_calls_procurement_read_api() -
         "target_warehouse_id": "2",
         "q": "SUP",
     }
+    assert captured["service_client"] == WMS_SERVICE_CLIENT_CODE
     assert result.items[0].po_id == 1
     assert result.items[0].supplier_name_snapshot == "供应商快照"
     assert result.items[0].completion_status == "PARTIAL"
@@ -84,6 +103,7 @@ async def test_get_purchase_order_calls_procurement_read_api_and_parses_lines() 
 
     async def handler(request: httpx.Request) -> httpx.Response:
         captured["url"] = str(request.url)
+        captured["service_client"] = str(request.headers.get(PROCUREMENT_SERVICE_CLIENT_HEADER))
 
         return _json_response(
             {
@@ -139,6 +159,7 @@ async def test_get_purchase_order_calls_procurement_read_api_and_parses_lines() 
     result = await client.get_purchase_order(7)
 
     assert captured["url"] == "http://procurement.test/procurement/read/v1/wms/receiving-sources/7"
+    assert captured["service_client"] == WMS_SERVICE_CLIENT_CODE
     assert result.id == 7
     assert result.total_amount == Decimal("20.00")
     assert result.lines[0].qty_ordered_base == 24
@@ -146,7 +167,10 @@ async def test_get_purchase_order_calls_procurement_read_api_and_parses_lines() 
 
 @pytest.mark.asyncio
 async def test_procurement_read_client_raises_on_error_status() -> None:
-    async def handler(_request: httpx.Request) -> httpx.Response:
+    captured: dict[str, str] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured["service_client"] = str(request.headers.get(PROCUREMENT_SERVICE_CLIENT_HEADER))
         return _json_response({"detail": "not found"}, status_code=404)
 
     client = HttpProcurementReadClient(
@@ -156,6 +180,8 @@ async def test_procurement_read_client_raises_on_error_status() -> None:
 
     with pytest.raises(ProcurementReadClientError):
         await client.get_purchase_order(404)
+
+    assert captured["service_client"] == WMS_SERVICE_CLIENT_CODE
 
 
 def test_factory_uses_explicit_base_url() -> None:


### PR DESCRIPTION
## Summary
- add WMS-owned Procurement service auth header helper
- send X-Service-Client: wms-service for Procurement receiving-source reads
- update Procurement integration HTTP client tests to freeze service client header behavior

## Validation
- python3 -m compileall app/integrations/procurement/wms_procurement_service_auth.py app/integrations/procurement/http_client.py tests/services/test_procurement_integration_http_client.py
- make test TESTS="tests/services/test_procurement_integration_http_client.py tests/services/test_inbound_receipt_purchase_source_options_service.py tests/services/test_inbound_receipt_from_purchase_procurement_client.py tests/api/test_inbound_receipt_purchase_source_options_api.py"
- make lint