### PR TITLE
feat(oms): send WMS service client header to OMS

### DIFF
--- a/app/integrations/oms/projection_sync.py
+++ b/app/integrations/oms/projection_sync.py
@@ -32,6 +32,7 @@ from app.integrations.oms.projection_contracts import (
     OmsFulfillmentReadyOrderIn,
     OmsFulfillmentReadyPlatform,
 )
+from app.integrations.oms.service_auth import oms_service_auth_headers
 
 SYNC_VERSION = "oms-read-v1-fulfillment-ready-orders"
 RESOURCE_PATH = "/oms/read/v1/fulfillment-ready-orders"
@@ -65,7 +66,7 @@ def _auth_headers(value: str | None = None) -> dict[str, str]:
     token = (value or os.getenv("OMS_API_TOKEN") or "").strip()
     if not token:
         raise RuntimeError("OMS_API_TOKEN is required for OMS fulfillment projection sync")
-    return {"Authorization": f"Bearer {token}"}
+    return oms_service_auth_headers({"Authorization": f"Bearer {token}"})
 
 
 def _safe_limit(value: int) -> int:

--- a/app/integrations/oms/service_auth.py
+++ b/app/integrations/oms/service_auth.py
@@ -1,0 +1,29 @@
+# app/integrations/oms/service_auth.py
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+OMS_SERVICE_CLIENT_HEADER = "X-Service-Client"
+WMS_SERVICE_CLIENT_CODE = "wms-service"
+
+
+def oms_service_auth_headers(headers: Mapping[str, str] | None = None) -> dict[str, str]:
+    """
+    Build service-to-service headers for WMS -> OMS calls.
+
+    Boundary:
+    - WMS calls OMS as the fixed service client: wms-service.
+    - Caller-supplied headers are preserved.
+    - X-Service-Client is owned by WMS and cannot be overridden by callers.
+    """
+
+    merged = dict(headers or {})
+    merged[OMS_SERVICE_CLIENT_HEADER] = WMS_SERVICE_CLIENT_CODE
+    return merged
+
+
+__all__ = [
+    "OMS_SERVICE_CLIENT_HEADER",
+    "WMS_SERVICE_CLIENT_CODE",
+    "oms_service_auth_headers",
+]

--- a/tests/ci/test_wms_oms_fulfillment_projection_sync_boundary.py
+++ b/tests/ci/test_wms_oms_fulfillment_projection_sync_boundary.py
@@ -54,3 +54,19 @@ def test_oms_fulfillment_projection_sync_has_local_make_target_and_token_contrac
     assert "OMS_API_TOKEN=" in env_example
     assert "oms-fulfillment-projection-sync" in test_mk
     assert "scripts/oms/sync_fulfillment_projection.py" in test_mk
+
+
+def test_oms_fulfillment_projection_sync_sends_wms_service_client_header() -> None:
+    sync_text = (ROOT / "app/integrations/oms/projection_sync.py").read_text(encoding="utf-8")
+    service_auth_text = (ROOT / "app/integrations/oms/service_auth.py").read_text(
+        encoding="utf-8"
+    )
+    test_text = (ROOT / "tests/services/test_oms_fulfillment_projection_sync.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "oms_service_auth_headers" in sync_text
+    assert "X-Service-Client" in service_auth_text
+    assert "wms-service" in service_auth_text
+    assert "OMS_SERVICE_CLIENT_HEADER" in test_text
+    assert "WMS_SERVICE_CLIENT_CODE" in test_text

--- a/tests/services/test_oms_fulfillment_projection_sync.py
+++ b/tests/services/test_oms_fulfillment_projection_sync.py
@@ -14,6 +14,10 @@ from app.integrations.oms.projection_sync import (
     OmsFulfillmentProjectionSyncError,
     sync_oms_fulfillment_projection_once,
 )
+from app.integrations.oms.service_auth import (
+    OMS_SERVICE_CLIENT_HEADER,
+    WMS_SERVICE_CLIENT_CODE,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -126,6 +130,7 @@ def _transport(
                 "path": request.url.path,
                 "params": dict(request.url.params),
                 "authorization": request.headers.get("authorization"),
+                "service_client": request.headers.get(OMS_SERVICE_CLIENT_HEADER),
             }
         )
         return httpx.Response(
@@ -259,6 +264,7 @@ async def test_sync_oms_fulfillment_projection_upserts_ready_orders(session: Asy
     ]
     assert [call["params"]["offset"] for call in calls] == ["0", "1"]
     assert all(call["authorization"] == "Bearer oms-token-001" for call in calls)
+    assert {call["service_client"] for call in calls} == {WMS_SERVICE_CLIENT_CODE}
 
 
 async def test_sync_oms_fulfillment_projection_replaces_stale_children(session: AsyncSession) -> None:

--- a/tests/services/test_oms_service_auth_headers.py
+++ b/tests/services/test_oms_service_auth_headers.py
@@ -1,0 +1,20 @@
+# tests/services/test_oms_service_auth_headers.py
+from __future__ import annotations
+
+from app.integrations.oms.service_auth import (
+    OMS_SERVICE_CLIENT_HEADER,
+    WMS_SERVICE_CLIENT_CODE,
+    oms_service_auth_headers,
+)
+
+
+def test_oms_service_auth_headers_force_wms_service_client() -> None:
+    headers = oms_service_auth_headers(
+        {
+            OMS_SERVICE_CLIENT_HEADER: "wrong-service",
+            "Authorization": "Bearer token",
+        }
+    )
+
+    assert headers["Authorization"] == "Bearer token"
+    assert headers[OMS_SERVICE_CLIENT_HEADER] == WMS_SERVICE_CLIENT_CODE


### PR DESCRIPTION
## Summary
- add WMS -> OMS service auth header helper
- send X-Service-Client: wms-service when syncing OMS fulfillment-ready read-v1 projection
- keep existing OMS_API_TOKEN/Authorization behavior unchanged in this PR
- add service auth header tests and boundary guard

## Validation
- python3 -m compileall app/integrations/oms/service_auth.py app/integrations/oms/projection_sync.py tests/services/test_oms_service_auth_headers.py tests/services/test_oms_fulfillment_projection_sync.py tests/ci/test_wms_oms_fulfillment_projection_sync_boundary.py
- make lint
- make test TESTS="tests/services/test_oms_service_auth_headers.py tests/services/test_oms_fulfillment_projection_sync.py tests/ci/test_wms_oms_fulfillment_projection_sync_boundary.py"