### PR TITLE
feat(system): add app manifest read endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -25,7 +25,7 @@ PYTEST_RUNNING = os.getenv("PYTEST_RUNNING") == "1"
 DUMP_ROUTES = (os.getenv("WMS_DUMP_ROUTES") == "1") and IS_DEV_ENV and (not PYTEST_RUNNING)
 
 app = FastAPI(
-    title="WMS-DU",
+    title="wms-api",
     version="1.1.0",
     docs_url="/docs",
     redoc_url="/redoc",
@@ -69,7 +69,7 @@ if DUMP_ROUTES:
 
 @app.get("/")
 async def root() -> Dict[str, Any]:
-    return {"name": "WMS-DU", "version": "1.1.0"}
+    return {"name": "wms-api", "version": "1.1.0"}
 
 
 @app.get("/ping")

--- a/app/router_mount.py
+++ b/app/router_mount.py
@@ -52,6 +52,7 @@ def mount_routers(app: FastAPI) -> None:
     from app.wms.ledger.routers.stock_ledger import router as stock_ledger_router
     from app.user.routers.user import router as user_router
     from app.wms.warehouses.routers.warehouses import router as warehouses_router
+    from app.wms.system.read_v1.routers import router as wms_system_read_v1_router
 
 
     from app.oms.router import router as oms_router
@@ -114,6 +115,7 @@ def mount_routers(app: FastAPI) -> None:
     app.include_router(pms_router)
 
     app.include_router(warehouses_router)
+    app.include_router(wms_system_read_v1_router)
 
     # PMS 相关：
     # - PMS export 读面先挂，避免与 owner /items/{id} 类路由冲突

--- a/app/wms/system/read_v1/__init__.py
+++ b/app/wms/system/read_v1/__init__.py
@@ -1,0 +1,4 @@
+# app/wms/system/read_v1/__init__.py
+from __future__ import annotations
+
+"""WMS system read-v1 self-description package."""

--- a/app/wms/system/read_v1/contracts/__init__.py
+++ b/app/wms/system/read_v1/contracts/__init__.py
@@ -1,0 +1,12 @@
+# app/wms/system/read_v1/contracts/__init__.py
+from __future__ import annotations
+
+from app.wms.system.read_v1.contracts.app_manifest import (
+    WmsSystemAppManifestBuildInfoOut,
+    WmsSystemAppManifestOut,
+)
+
+__all__ = [
+    "WmsSystemAppManifestBuildInfoOut",
+    "WmsSystemAppManifestOut",
+]

--- a/app/wms/system/read_v1/contracts/app_manifest.py
+++ b/app/wms/system/read_v1/contracts/app_manifest.py
@@ -1,0 +1,45 @@
+# app/wms/system/read_v1/contracts/app_manifest.py
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class WmsSystemAppManifestBuildInfoOut(_Base):
+    environment: str = Field(..., min_length=1)
+    git_sha: str | None = None
+    build_time: str | None = None
+
+
+class WmsSystemAppManifestOut(_Base):
+    app_code: Literal["wms"]
+    app_name: str = Field(..., min_length=1)
+    app_type: str = Field(..., min_length=1)
+    status: str = Field(..., min_length=1)
+    description: str = Field(..., min_length=1)
+
+    default_web_path: str = Field(..., min_length=1)
+    default_api_path: str = Field(..., min_length=1)
+    local_web_url: str = Field(..., min_length=1)
+    local_api_url: str = Field(..., min_length=1)
+
+    health_url: str = Field(..., min_length=1)
+    db_health_url: str | None = None
+    openapi_url: str = Field(..., min_length=1)
+    page_catalog_url: str = Field(..., min_length=1)
+    service_capabilities_url: str = Field(..., min_length=1)
+    service_dependencies_url: str = Field(..., min_length=1)
+
+    version: str = Field(..., min_length=1)
+    build_info: WmsSystemAppManifestBuildInfoOut
+
+
+__all__ = [
+    "WmsSystemAppManifestBuildInfoOut",
+    "WmsSystemAppManifestOut",
+]

--- a/app/wms/system/read_v1/routers/__init__.py
+++ b/app/wms/system/read_v1/routers/__init__.py
@@ -1,0 +1,6 @@
+# app/wms/system/read_v1/routers/__init__.py
+from __future__ import annotations
+
+from app.wms.system.read_v1.routers.app_manifest import router
+
+__all__ = ["router"]

--- a/app/wms/system/read_v1/routers/app_manifest.py
+++ b/app/wms/system/read_v1/routers/app_manifest.py
@@ -1,0 +1,30 @@
+# app/wms/system/read_v1/routers/app_manifest.py
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.wms.system.read_v1.contracts import WmsSystemAppManifestOut
+from app.wms.system.read_v1.services import build_wms_app_manifest
+
+router = APIRouter(prefix="/system/read/v1", tags=["system-read-v1"])
+
+
+@router.get(
+    "/app-manifest",
+    response_model=WmsSystemAppManifestOut,
+    summary="Get WMS app manifest",
+)
+async def get_wms_app_manifest() -> WmsSystemAppManifestOut:
+    """
+    Return WMS self-description defaults for ERP app registration sync.
+
+    Boundary:
+    - This endpoint does not register itself into ERP.
+    - This endpoint does not decide whether WMS is enabled, visible, or published in ERP.
+    - This endpoint exposes no secrets and does not read/write business data.
+    """
+
+    return build_wms_app_manifest()
+
+
+__all__ = ["router"]

--- a/app/wms/system/read_v1/services/__init__.py
+++ b/app/wms/system/read_v1/services/__init__.py
@@ -1,0 +1,12 @@
+# app/wms/system/read_v1/services/__init__.py
+from __future__ import annotations
+
+from app.wms.system.read_v1.services.app_manifest_service import (
+    WMS_APP_VERSION,
+    build_wms_app_manifest,
+)
+
+__all__ = [
+    "WMS_APP_VERSION",
+    "build_wms_app_manifest",
+]

--- a/app/wms/system/read_v1/services/app_manifest_service.py
+++ b/app/wms/system/read_v1/services/app_manifest_service.py
@@ -1,0 +1,53 @@
+# app/wms/system/read_v1/services/app_manifest_service.py
+from __future__ import annotations
+
+import os
+
+from app.wms.system.read_v1.contracts import (
+    WmsSystemAppManifestBuildInfoOut,
+    WmsSystemAppManifestOut,
+)
+
+WMS_APP_VERSION = "1.1.0"
+
+
+def _env_value(*names: str) -> str | None:
+    for name in names:
+        value = os.getenv(name)
+        if value is not None and value.strip():
+            return value.strip()
+    return None
+
+
+def build_wms_app_manifest() -> WmsSystemAppManifestOut:
+    version = _env_value("WMS_APP_VERSION", "APP_VERSION") or WMS_APP_VERSION
+
+    return WmsSystemAppManifestOut(
+        app_code="wms",
+        app_name="仓储管理",
+        app_type="business_system",
+        status="available",
+        description="WMS 仓储管理系统，负责库存、入库、出库、仓库与仓内作业等仓储域能力。",
+        default_web_path="/wms/",
+        default_api_path="/api/wms",
+        local_web_url=_env_value("WMS_LOCAL_WEB_URL") or "http://127.0.0.1:5173",
+        local_api_url=_env_value("WMS_LOCAL_API_URL") or "http://127.0.0.1:8000",
+        health_url="/healthz",
+        db_health_url=_env_value("WMS_DB_HEALTH_URL"),
+        openapi_url="/openapi.json",
+        page_catalog_url="/system/read/v1/page-catalog",
+        service_capabilities_url="/system/read/v1/service-capabilities",
+        service_dependencies_url="/system/read/v1/service-dependencies",
+        version=version,
+        build_info=WmsSystemAppManifestBuildInfoOut(
+            environment=_env_value("WMS_ENV", "ENV") or "dev",
+            git_sha=_env_value("WMS_GIT_SHA", "GIT_SHA", "COMMIT_SHA"),
+            build_time=_env_value("WMS_BUILD_TIME", "BUILD_TIME"),
+        ),
+    )
+
+
+__all__ = [
+    "WMS_APP_VERSION",
+    "build_wms_app_manifest",
+]

--- a/tests/api/test_wms_system_app_manifest_api.py
+++ b/tests/api/test_wms_system_app_manifest_api.py
@@ -1,0 +1,68 @@
+# tests/api/test_wms_system_app_manifest_api.py
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_wms_api_service_name_is_wms_api() -> None:
+    client = TestClient(app)
+
+    root_response = client.get("/")
+    assert root_response.status_code == 200, root_response.text
+    assert root_response.json()["name"] == "wms-api"
+    assert root_response.json()["version"] == "1.1.0"
+
+    openapi_response = client.get("/openapi.json")
+    assert openapi_response.status_code == 200, openapi_response.text
+    assert openapi_response.json()["info"]["title"] == "wms-api"
+    assert openapi_response.json()["info"]["version"] == "1.1.0"
+
+
+def test_wms_system_app_manifest_returns_self_description_defaults() -> None:
+    client = TestClient(app)
+
+    response = client.get("/system/read/v1/app-manifest")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    assert body["app_code"] == "wms"
+    assert body["app_name"] == "仓储管理"
+    assert body["app_type"] == "business_system"
+    assert body["status"] == "available"
+    assert body["default_web_path"] == "/wms/"
+    assert body["default_api_path"] == "/api/wms"
+    assert body["local_web_url"] == "http://127.0.0.1:5173"
+    assert body["local_api_url"] == "http://127.0.0.1:8000"
+    assert body["health_url"] == "/healthz"
+    assert body["db_health_url"] is None
+    assert body["openapi_url"] == "/openapi.json"
+    assert body["page_catalog_url"] == "/system/read/v1/page-catalog"
+    assert body["service_capabilities_url"] == "/system/read/v1/service-capabilities"
+    assert body["service_dependencies_url"] == "/system/read/v1/service-dependencies"
+    assert body["version"] == "1.1.0"
+
+    build_info = body["build_info"]
+    assert isinstance(build_info, dict)
+    assert isinstance(build_info["environment"], str)
+    assert build_info["environment"]
+    assert "git_sha" in build_info
+    assert "build_time" in build_info
+
+    assert "is_active" not in body
+    assert "is_visible" not in body
+    assert "is_published" not in body
+
+
+def test_wms_system_app_manifest_is_registered_in_openapi() -> None:
+    client = TestClient(app)
+
+    response = client.get("/openapi.json")
+
+    assert response.status_code == 200, response.text
+    paths = response.json()["paths"]
+
+    assert "/system/read/v1/app-manifest" in paths
+    assert "get" in paths["/system/read/v1/app-manifest"]


### PR DESCRIPTION
Adds WMS system read-v1 app manifest endpoint for ERP app registration sync.

Scope:
- Add GET /system/read/v1/app-manifest.
- Return WMS default self-description only.
- Rename API service title/root name from WMS-DU to wms-api.
- Do not write DB.
- Do not auto-register or auto-enable WMS in ERP.
- ERP remains responsible for enablement, visibility and publish state.

Validation:
- python3 -m compileall app/main.py app/wms/system/read_v1 app/router_mount.py tests/api/test_wms_system_app_manifest_api.py
- make test TESTS="tests/api/test_wms_system_app_manifest_api.py tests/api/test_no_duplicate_routes.py"