### PR TITLE
feat(system): add page catalog read endpoint

### DIFF
--- a/app/wms/system/read_v1/contracts/__init__.py
+++ b/app/wms/system/read_v1/contracts/__init__.py
@@ -5,8 +5,14 @@ from app.wms.system.read_v1.contracts.app_manifest import (
     WmsSystemAppManifestBuildInfoOut,
     WmsSystemAppManifestOut,
 )
+from app.wms.system.read_v1.contracts.page_catalog import (
+    WmsSystemPageCatalogOut,
+    WmsSystemPageCatalogPageOut,
+)
 
 __all__ = [
     "WmsSystemAppManifestBuildInfoOut",
     "WmsSystemAppManifestOut",
+    "WmsSystemPageCatalogOut",
+    "WmsSystemPageCatalogPageOut",
 ]

--- a/app/wms/system/read_v1/contracts/page_catalog.py
+++ b/app/wms/system/read_v1/contracts/page_catalog.py
@@ -1,0 +1,36 @@
+# app/wms/system/read_v1/contracts/page_catalog.py
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class WmsSystemPageCatalogPageOut(_Base):
+    page_code: str = Field(..., min_length=1, max_length=64)
+    page_name: str = Field(..., min_length=1, max_length=64)
+    route_path: str | None = Field(default=None, max_length=255)
+    parent_page_code: str | None = Field(default=None, max_length=64)
+    level: int = Field(..., ge=1, le=3)
+    read_permission_code: str | None = Field(default=None, max_length=128)
+    write_permission_code: str | None = Field(default=None, max_length=128)
+    is_active: bool
+    sort_order: int
+    source_updated_at: datetime | None = None
+
+
+class WmsSystemPageCatalogOut(_Base):
+    app_code: Literal["wms"]
+    app_name: str = Field(..., min_length=1)
+    pages: list[WmsSystemPageCatalogPageOut] = Field(default_factory=list)
+
+
+__all__ = [
+    "WmsSystemPageCatalogOut",
+    "WmsSystemPageCatalogPageOut",
+]

--- a/app/wms/system/read_v1/repos/__init__.py
+++ b/app/wms/system/read_v1/repos/__init__.py
@@ -1,0 +1,14 @@
+# app/wms/system/read_v1/repos/__init__.py
+from __future__ import annotations
+
+from app.wms.system.read_v1.repos.page_catalog_repo import (
+    PageCatalogPageRow,
+    PageCatalogRoutePrefixRow,
+    WmsPageCatalogRepo,
+)
+
+__all__ = [
+    "PageCatalogPageRow",
+    "PageCatalogRoutePrefixRow",
+    "WmsPageCatalogRepo",
+]

--- a/app/wms/system/read_v1/repos/page_catalog_repo.py
+++ b/app/wms/system/read_v1/repos/page_catalog_repo.py
@@ -1,0 +1,76 @@
+# app/wms/system/read_v1/repos/page_catalog_repo.py
+from __future__ import annotations
+
+from sqlalchemy.orm import Session, aliased
+
+from app.user.models.page_registry import PageRegistry
+from app.user.models.page_route_prefix import PageRoutePrefix
+from app.user.models.permission import Permission
+
+PageCatalogPageRow = dict[str, object]
+PageCatalogRoutePrefixRow = dict[str, object]
+
+
+class WmsPageCatalogRepo:
+    """
+    WMS page catalog read repository.
+
+    Boundary:
+    - Read only page_registry / page_route_prefixes / permissions.
+    - Do not read frontend routes.
+    - Do not write any table.
+    """
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def list_page_rows(self) -> list[PageCatalogPageRow]:
+        page = PageRegistry
+        self_read = aliased(Permission)
+        self_write = aliased(Permission)
+
+        rows = (
+            self.db.query(
+                page.code.label("page_code"),
+                page.name.label("page_name"),
+                page.parent_code.label("parent_page_code"),
+                page.level.label("level"),
+                page.sort_order.label("sort_order"),
+                page.is_active.label("is_active"),
+                page.inherit_permissions.label("inherit_permissions"),
+                self_read.name.label("self_read_permission_code"),
+                self_write.name.label("self_write_permission_code"),
+            )
+            .outerjoin(self_read, self_read.id == page.read_permission_id)
+            .outerjoin(self_write, self_write.id == page.write_permission_id)
+            .order_by(page.level.asc(), page.sort_order.asc(), page.code.asc())
+            .all()
+        )
+
+        return [dict(row._mapping) for row in rows]
+
+    def list_route_prefix_rows(self) -> list[PageCatalogRoutePrefixRow]:
+        rows = (
+            self.db.query(
+                PageRoutePrefix.page_code.label("page_code"),
+                PageRoutePrefix.route_prefix.label("route_prefix"),
+                PageRoutePrefix.sort_order.label("sort_order"),
+                PageRoutePrefix.is_active.label("is_active"),
+            )
+            .order_by(
+                PageRoutePrefix.page_code.asc(),
+                PageRoutePrefix.is_active.desc(),
+                PageRoutePrefix.sort_order.asc(),
+                PageRoutePrefix.route_prefix.asc(),
+            )
+            .all()
+        )
+
+        return [dict(row._mapping) for row in rows]
+
+
+__all__ = [
+    "PageCatalogPageRow",
+    "PageCatalogRoutePrefixRow",
+    "WmsPageCatalogRepo",
+]

--- a/app/wms/system/read_v1/routers/__init__.py
+++ b/app/wms/system/read_v1/routers/__init__.py
@@ -1,6 +1,13 @@
 # app/wms/system/read_v1/routers/__init__.py
 from __future__ import annotations
 
-from app.wms.system.read_v1.routers.app_manifest import router
+from fastapi import APIRouter
+
+from app.wms.system.read_v1.routers.app_manifest import router as app_manifest_router
+from app.wms.system.read_v1.routers.page_catalog import router as page_catalog_router
+
+router = APIRouter()
+router.include_router(app_manifest_router)
+router.include_router(page_catalog_router)
 
 __all__ = ["router"]

--- a/app/wms/system/read_v1/routers/page_catalog.py
+++ b/app/wms/system/read_v1/routers/page_catalog.py
@@ -1,0 +1,35 @@
+# app/wms/system/read_v1/routers/page_catalog.py
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.wms.system.read_v1.contracts import WmsSystemPageCatalogOut
+from app.wms.system.read_v1.repos import WmsPageCatalogRepo
+from app.wms.system.read_v1.services import WmsPageCatalogService
+
+router = APIRouter(prefix="/system/read/v1", tags=["system-read-v1"])
+
+
+@router.get(
+    "/page-catalog",
+    response_model=WmsSystemPageCatalogOut,
+    summary="Get WMS page catalog",
+)
+async def get_wms_page_catalog(
+    db: Session = Depends(get_db),
+) -> WmsSystemPageCatalogOut:
+    """
+    Return WMS page catalog for ERP page projection sync.
+
+    Boundary:
+    - This endpoint is read-only.
+    - ERP must not connect to WMS DB directly.
+    - ERP must not infer WMS pages from frontend routes.
+    """
+
+    return WmsPageCatalogService(WmsPageCatalogRepo(db)).get_page_catalog()
+
+
+__all__ = ["router"]

--- a/app/wms/system/read_v1/services/__init__.py
+++ b/app/wms/system/read_v1/services/__init__.py
@@ -5,8 +5,16 @@ from app.wms.system.read_v1.services.app_manifest_service import (
     WMS_APP_VERSION,
     build_wms_app_manifest,
 )
+from app.wms.system.read_v1.services.page_catalog_service import (
+    WMS_APP_CODE,
+    WMS_APP_NAME,
+    WmsPageCatalogService,
+)
 
 __all__ = [
+    "WMS_APP_CODE",
+    "WMS_APP_NAME",
     "WMS_APP_VERSION",
+    "WmsPageCatalogService",
     "build_wms_app_manifest",
 ]

--- a/app/wms/system/read_v1/services/page_catalog_service.py
+++ b/app/wms/system/read_v1/services/page_catalog_service.py
@@ -1,0 +1,223 @@
+# app/wms/system/read_v1/services/page_catalog_service.py
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Mapping
+
+from app.wms.system.read_v1.contracts import (
+    WmsSystemPageCatalogOut,
+    WmsSystemPageCatalogPageOut,
+)
+from app.wms.system.read_v1.repos import (
+    PageCatalogPageRow,
+    PageCatalogRoutePrefixRow,
+    WmsPageCatalogRepo,
+)
+
+WMS_APP_CODE = "wms"
+WMS_APP_NAME = "仓储管理"
+
+
+def _optional_str(value: object) -> str | None:
+    if value is None:
+        return None
+
+    text = str(value).strip()
+    return text or None
+
+
+def _required_str(value: object, *, field_name: str) -> str:
+    text = _optional_str(value)
+    if text is None:
+        raise ValueError(f"{field_name} is required")
+    return text
+
+
+def _int_value(value: object, *, field_name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{field_name} must be integer")
+
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be integer") from exc
+
+
+def _bool_value(value: object, *, field_name: str) -> bool:
+    if isinstance(value, bool):
+        return value
+
+    raise ValueError(f"{field_name} must be boolean")
+
+
+class WmsPageCatalogService:
+    """
+    Build WMS page catalog for ERP projection sync.
+
+    Boundary:
+    - WMS is the source of truth for its own page catalog.
+    - ERP must not connect to WMS DB directly.
+    - ERP must not infer WMS pages from frontend routes.
+    """
+
+    def __init__(self, repo: WmsPageCatalogRepo) -> None:
+        self.repo = repo
+
+    def get_page_catalog(self) -> WmsSystemPageCatalogOut:
+        page_rows = self.repo.list_page_rows()
+        route_rows = self.repo.list_route_prefix_rows()
+
+        rows_by_code = {
+            _required_str(row.get("page_code"), field_name="page_code"): row
+            for row in page_rows
+        }
+        route_rows_by_page = self._group_route_rows_by_page(route_rows)
+        permission_cache: dict[str, tuple[str | None, str | None]] = {}
+
+        pages = [
+            self._build_page_out(
+                row=row,
+                rows_by_code=rows_by_code,
+                route_rows_by_page=route_rows_by_page,
+                permission_cache=permission_cache,
+            )
+            for row in page_rows
+        ]
+
+        return WmsSystemPageCatalogOut(
+            app_code=WMS_APP_CODE,
+            app_name=WMS_APP_NAME,
+            pages=pages,
+        )
+
+    @staticmethod
+    def _group_route_rows_by_page(
+        route_rows: list[PageCatalogRoutePrefixRow],
+    ) -> dict[str, list[PageCatalogRoutePrefixRow]]:
+        grouped: dict[str, list[PageCatalogRoutePrefixRow]] = defaultdict(list)
+
+        for row in route_rows:
+            page_code = _optional_str(row.get("page_code"))
+            if page_code is None:
+                continue
+            grouped[page_code].append(row)
+
+        return dict(grouped)
+
+    def _build_page_out(
+        self,
+        *,
+        row: PageCatalogPageRow,
+        rows_by_code: Mapping[str, PageCatalogPageRow],
+        route_rows_by_page: Mapping[str, list[PageCatalogRoutePrefixRow]],
+        permission_cache: dict[str, tuple[str | None, str | None]],
+    ) -> WmsSystemPageCatalogPageOut:
+        page_code = _required_str(row.get("page_code"), field_name="page_code")
+        read_permission_code, write_permission_code = self._resolve_effective_permissions(
+            page_code=page_code,
+            rows_by_code=rows_by_code,
+            cache=permission_cache,
+        )
+
+        return WmsSystemPageCatalogPageOut(
+            page_code=page_code,
+            page_name=_required_str(row.get("page_name"), field_name="page_name"),
+            route_path=self._select_route_path(
+                route_rows_by_page.get(page_code, []),
+            ),
+            parent_page_code=_optional_str(row.get("parent_page_code")),
+            level=_int_value(row.get("level"), field_name="level"),
+            read_permission_code=read_permission_code,
+            write_permission_code=write_permission_code,
+            is_active=_bool_value(row.get("is_active"), field_name="is_active"),
+            sort_order=_int_value(row.get("sort_order"), field_name="sort_order"),
+            source_updated_at=None,
+        )
+
+    @classmethod
+    def _resolve_effective_permissions(
+        cls,
+        *,
+        page_code: str,
+        rows_by_code: Mapping[str, PageCatalogPageRow],
+        cache: dict[str, tuple[str | None, str | None]],
+        visiting: set[str] | None = None,
+    ) -> tuple[str | None, str | None]:
+        cached = cache.get(page_code)
+        if cached is not None:
+            return cached
+
+        row = rows_by_code.get(page_code)
+        if row is None:
+            result = (None, None)
+            cache[page_code] = result
+            return result
+
+        inherit_permissions = _bool_value(
+            row.get("inherit_permissions"),
+            field_name="inherit_permissions",
+        )
+        if not inherit_permissions:
+            result = (
+                _optional_str(row.get("self_read_permission_code")),
+                _optional_str(row.get("self_write_permission_code")),
+            )
+            cache[page_code] = result
+            return result
+
+        parent_page_code = _optional_str(row.get("parent_page_code"))
+        if parent_page_code is None:
+            result = (None, None)
+            cache[page_code] = result
+            return result
+
+        if visiting is None:
+            visiting = set()
+
+        if page_code in visiting:
+            result = (None, None)
+            cache[page_code] = result
+            return result
+
+        visiting.add(page_code)
+        result = cls._resolve_effective_permissions(
+            page_code=parent_page_code,
+            rows_by_code=rows_by_code,
+            cache=cache,
+            visiting=visiting,
+        )
+        visiting.remove(page_code)
+
+        cache[page_code] = result
+        return result
+
+    @staticmethod
+    def _select_route_path(
+        route_rows: list[PageCatalogRoutePrefixRow],
+    ) -> str | None:
+        if not route_rows:
+            return None
+
+        active_rows = [
+            row
+            for row in route_rows
+            if _bool_value(row.get("is_active"), field_name="route_is_active")
+        ]
+        candidates = active_rows or route_rows
+
+        selected = sorted(
+            candidates,
+            key=lambda item: (
+                _int_value(item.get("sort_order"), field_name="route_sort_order"),
+                _required_str(item.get("route_prefix"), field_name="route_prefix"),
+            ),
+        )[0]
+
+        return _required_str(selected.get("route_prefix"), field_name="route_prefix")
+
+
+__all__ = [
+    "WMS_APP_CODE",
+    "WMS_APP_NAME",
+    "WmsPageCatalogService",
+]

--- a/tests/api/test_wms_system_page_catalog_api.py
+++ b/tests/api/test_wms_system_page_catalog_api.py
@@ -1,0 +1,85 @@
+# tests/api/test_wms_system_page_catalog_api.py
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def _page_by_code(pages: list[dict]) -> dict[str, dict]:
+    return {str(page["page_code"]): page for page in pages}
+
+
+def test_wms_system_page_catalog_returns_standard_catalog() -> None:
+    client = TestClient(app)
+
+    response = client.get("/system/read/v1/page-catalog")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    assert body["app_code"] == "wms"
+    assert body["app_name"] == "仓储管理"
+
+    pages = body["pages"]
+    assert isinstance(pages, list)
+    assert pages
+
+    by_code = _page_by_code(pages)
+
+    root = by_code["wms"]
+    assert root["page_code"] == "wms"
+    assert root["page_name"] == "仓储管理"
+    assert root["route_path"] is None
+    assert root["parent_page_code"] is None
+    assert root["level"] == 1
+    assert root["read_permission_code"] == "page.wms.read"
+    assert root["write_permission_code"] == "page.wms.write"
+    assert root["is_active"] is True
+    assert root["sort_order"] == 20
+    assert root["source_updated_at"] is None
+
+    inventory = by_code["wms.inventory"]
+    assert inventory["page_name"] == "库存"
+    assert inventory["parent_page_code"] == "wms"
+    assert inventory["level"] == 2
+    assert inventory["read_permission_code"] == "page.wms.read"
+    assert inventory["write_permission_code"] == "page.wms.write"
+    assert inventory["is_active"] is True
+
+    main_inventory = by_code["wms.inventory.main"]
+    assert main_inventory["page_name"] == "即时库存"
+    assert main_inventory["route_path"] == "/inventory"
+    assert main_inventory["parent_page_code"] == "wms.inventory"
+    assert main_inventory["level"] == 3
+    assert main_inventory["read_permission_code"] == "page.wms.read"
+    assert main_inventory["write_permission_code"] == "page.wms.write"
+    assert main_inventory["is_active"] is True
+    assert main_inventory["sort_order"] == 10
+
+    required_keys = {
+        "page_code",
+        "page_name",
+        "route_path",
+        "parent_page_code",
+        "level",
+        "read_permission_code",
+        "write_permission_code",
+        "is_active",
+        "sort_order",
+        "source_updated_at",
+    }
+    for page in pages:
+        assert required_keys <= set(page.keys())
+
+
+def test_wms_system_page_catalog_is_registered_in_openapi() -> None:
+    client = TestClient(app)
+
+    response = client.get("/openapi.json")
+
+    assert response.status_code == 200, response.text
+    paths = response.json()["paths"]
+
+    assert "/system/read/v1/page-catalog" in paths
+    assert "get" in paths["/system/read/v1/page-catalog"]


### PR DESCRIPTION
Adds WMS system read-v1 page catalog endpoint for ERP page catalog projection sync.

Scope:
- Add GET /system/read/v1/page-catalog.
- Read WMS page_registry, page_route_prefixes and permissions.
- Return standard page catalog fields with effective read/write permissions.
- Keep source_updated_at null because WMS page_registry has no timestamp column.
- Do not write DB.
- Do not infer pages from frontend routes.
- Do not let ERP directly read WMS DB.

Validation:
- python3 -m compileall app/wms/system/read_v1 tests/api/test_wms_system_page_catalog_api.py
- make test TESTS="tests/api/test_wms_system_page_catalog_api.py tests/api/test_wms_system_app_manifest_api.py tests/api/test_no_duplicate_routes.py"