### PR TITLE
feat(system): add service capabilities read endpoint

### DIFF
--- a/app/wms/system/read_v1/contracts/__init__.py
+++ b/app/wms/system/read_v1/contracts/__init__.py
@@ -9,10 +9,18 @@ from app.wms.system.read_v1.contracts.page_catalog import (
     WmsSystemPageCatalogOut,
     WmsSystemPageCatalogPageOut,
 )
+from app.wms.system.read_v1.contracts.service_capabilities import (
+    WmsSystemServiceCapabilitiesOut,
+    WmsSystemServiceCapabilityOut,
+    WmsSystemServiceCapabilityRouteOut,
+)
 
 __all__ = [
     "WmsSystemAppManifestBuildInfoOut",
     "WmsSystemAppManifestOut",
     "WmsSystemPageCatalogOut",
     "WmsSystemPageCatalogPageOut",
+    "WmsSystemServiceCapabilitiesOut",
+    "WmsSystemServiceCapabilityOut",
+    "WmsSystemServiceCapabilityRouteOut",
 ]

--- a/app/wms/system/read_v1/contracts/service_capabilities.py
+++ b/app/wms/system/read_v1/contracts/service_capabilities.py
@@ -1,0 +1,44 @@
+# app/wms/system/read_v1/contracts/service_capabilities.py
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class WmsSystemServiceCapabilityRouteOut(_Base):
+    http_method: str = Field(..., min_length=1, max_length=16)
+    path: str = Field(..., min_length=1, max_length=255)
+    route_name: str = Field(..., min_length=1, max_length=128)
+    auth_required: bool
+    is_active: bool
+    source_created_at: datetime | None = None
+
+
+class WmsSystemServiceCapabilityOut(_Base):
+    capability_code: str = Field(..., min_length=1, max_length=128)
+    capability_name: str = Field(..., min_length=1, max_length=128)
+    resource_code: str = Field(..., min_length=1, max_length=64)
+    permission_code: str = Field(..., min_length=1, max_length=128)
+    description: str | None = Field(default=None, max_length=255)
+    is_active: bool
+    source_updated_at: datetime | None = None
+    routes: list[WmsSystemServiceCapabilityRouteOut] = Field(default_factory=list)
+
+
+class WmsSystemServiceCapabilitiesOut(_Base):
+    app_code: Literal["wms"]
+    app_name: str = Field(..., min_length=1)
+    capabilities: list[WmsSystemServiceCapabilityOut] = Field(default_factory=list)
+
+
+__all__ = [
+    "WmsSystemServiceCapabilitiesOut",
+    "WmsSystemServiceCapabilityOut",
+    "WmsSystemServiceCapabilityRouteOut",
+]

--- a/app/wms/system/read_v1/repos/__init__.py
+++ b/app/wms/system/read_v1/repos/__init__.py
@@ -6,9 +6,17 @@ from app.wms.system.read_v1.repos.page_catalog_repo import (
     PageCatalogRoutePrefixRow,
     WmsPageCatalogRepo,
 )
+from app.wms.system.read_v1.repos.service_capability_repo import (
+    ServiceCapabilityRouteRow,
+    ServiceCapabilityRow,
+    WmsServiceCapabilityReadRepo,
+)
 
 __all__ = [
     "PageCatalogPageRow",
     "PageCatalogRoutePrefixRow",
+    "ServiceCapabilityRouteRow",
+    "ServiceCapabilityRow",
     "WmsPageCatalogRepo",
+    "WmsServiceCapabilityReadRepo",
 ]

--- a/app/wms/system/read_v1/repos/service_capability_repo.py
+++ b/app/wms/system/read_v1/repos/service_capability_repo.py
@@ -1,0 +1,70 @@
+# app/wms/system/read_v1/repos/service_capability_repo.py
+from __future__ import annotations
+
+from app.wms.system.service_auth.models import (
+    WmsServiceCapability,
+    WmsServiceCapabilityRoute,
+)
+from sqlalchemy.orm import Session
+
+ServiceCapabilityRow = dict[str, object]
+ServiceCapabilityRouteRow = dict[str, object]
+
+
+class WmsServiceCapabilityReadRepo:
+    """
+    WMS service capability read repository.
+
+    Boundary:
+    - Read only WMS local service auth declaration tables.
+    - Do not read ERP tables.
+    - Do not infer capabilities from runtime routes.
+    - Do not write any table.
+    """
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def list_capability_rows(self) -> list[ServiceCapabilityRow]:
+        rows = (
+            self.db.query(
+                WmsServiceCapability.capability_code.label("capability_code"),
+                WmsServiceCapability.capability_name.label("capability_name"),
+                WmsServiceCapability.resource_code.label("resource_code"),
+                WmsServiceCapability.description.label("description"),
+                WmsServiceCapability.is_active.label("is_active"),
+                WmsServiceCapability.updated_at.label("source_updated_at"),
+            )
+            .order_by(WmsServiceCapability.capability_code.asc())
+            .all()
+        )
+
+        return [dict(row._mapping) for row in rows]
+
+    def list_route_rows(self) -> list[ServiceCapabilityRouteRow]:
+        rows = (
+            self.db.query(
+                WmsServiceCapabilityRoute.capability_code.label("capability_code"),
+                WmsServiceCapabilityRoute.http_method.label("http_method"),
+                WmsServiceCapabilityRoute.route_path.label("route_path"),
+                WmsServiceCapabilityRoute.route_name.label("route_name"),
+                WmsServiceCapabilityRoute.auth_required.label("auth_required"),
+                WmsServiceCapabilityRoute.is_active.label("is_active"),
+                WmsServiceCapabilityRoute.created_at.label("source_created_at"),
+            )
+            .order_by(
+                WmsServiceCapabilityRoute.capability_code.asc(),
+                WmsServiceCapabilityRoute.http_method.asc(),
+                WmsServiceCapabilityRoute.route_path.asc(),
+            )
+            .all()
+        )
+
+        return [dict(row._mapping) for row in rows]
+
+
+__all__ = [
+    "ServiceCapabilityRow",
+    "ServiceCapabilityRouteRow",
+    "WmsServiceCapabilityReadRepo",
+]

--- a/app/wms/system/read_v1/routers/__init__.py
+++ b/app/wms/system/read_v1/routers/__init__.py
@@ -5,9 +5,13 @@ from fastapi import APIRouter
 
 from app.wms.system.read_v1.routers.app_manifest import router as app_manifest_router
 from app.wms.system.read_v1.routers.page_catalog import router as page_catalog_router
+from app.wms.system.read_v1.routers.service_capabilities import (
+    router as service_capabilities_router,
+)
 
 router = APIRouter()
 router.include_router(app_manifest_router)
 router.include_router(page_catalog_router)
+router.include_router(service_capabilities_router)
 
 __all__ = ["router"]

--- a/app/wms/system/read_v1/routers/service_capabilities.py
+++ b/app/wms/system/read_v1/routers/service_capabilities.py
@@ -1,0 +1,38 @@
+# app/wms/system/read_v1/routers/service_capabilities.py
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.wms.system.read_v1.contracts import WmsSystemServiceCapabilitiesOut
+from app.wms.system.read_v1.repos import WmsServiceCapabilityReadRepo
+from app.wms.system.read_v1.services import WmsServiceCapabilityReadService
+
+router = APIRouter(prefix="/system/read/v1", tags=["system-read-v1"])
+
+
+@router.get(
+    "/service-capabilities",
+    response_model=WmsSystemServiceCapabilitiesOut,
+    summary="Get WMS service capabilities",
+)
+async def get_wms_service_capabilities(
+    db: Session = Depends(get_db),
+) -> WmsSystemServiceCapabilitiesOut:
+    """
+    Return WMS service capabilities for ERP system collaboration sync.
+
+    Boundary:
+    - WMS declares what WMS provides.
+    - ERP must not guess WMS capabilities.
+    - This endpoint is read-only.
+    - This endpoint does not expose approval, grant, written, or verified state.
+    """
+
+    return WmsServiceCapabilityReadService(
+        WmsServiceCapabilityReadRepo(db),
+    ).get_service_capabilities()
+
+
+__all__ = ["router"]

--- a/app/wms/system/read_v1/services/__init__.py
+++ b/app/wms/system/read_v1/services/__init__.py
@@ -10,11 +10,15 @@ from app.wms.system.read_v1.services.page_catalog_service import (
     WMS_APP_NAME,
     WmsPageCatalogService,
 )
+from app.wms.system.read_v1.services.service_capability_service import (
+    WmsServiceCapabilityReadService,
+)
 
 __all__ = [
     "WMS_APP_CODE",
     "WMS_APP_NAME",
     "WMS_APP_VERSION",
     "WmsPageCatalogService",
+    "WmsServiceCapabilityReadService",
     "build_wms_app_manifest",
 ]

--- a/app/wms/system/read_v1/services/service_capability_service.py
+++ b/app/wms/system/read_v1/services/service_capability_service.py
@@ -1,0 +1,156 @@
+# app/wms/system/read_v1/services/service_capability_service.py
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Mapping
+from datetime import datetime
+
+from app.wms.system.read_v1.contracts import (
+    WmsSystemServiceCapabilitiesOut,
+    WmsSystemServiceCapabilityOut,
+    WmsSystemServiceCapabilityRouteOut,
+)
+from app.wms.system.read_v1.repos import (
+    ServiceCapabilityRouteRow,
+    ServiceCapabilityRow,
+    WmsServiceCapabilityReadRepo,
+)
+
+WMS_APP_CODE = "wms"
+WMS_APP_NAME = "仓储管理"
+
+
+def _optional_str(value: object) -> str | None:
+    if value is None:
+        return None
+
+    text = str(value).strip()
+    return text or None
+
+
+def _required_str(value: object, *, field_name: str) -> str:
+    text = _optional_str(value)
+    if text is None:
+        raise ValueError(f"{field_name} is required")
+    return text
+
+
+def _bool_value(value: object, *, field_name: str) -> bool:
+    if isinstance(value, bool):
+        return value
+
+    raise ValueError(f"{field_name} must be boolean")
+
+
+def _datetime_or_none(value: object, *, field_name: str) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+
+    raise ValueError(f"{field_name} must be datetime")
+
+
+class WmsServiceCapabilityReadService:
+    """
+    Build WMS service capabilities declaration for ERP sync.
+
+    Boundary:
+    - WMS declares what WMS provides.
+    - ERP reads this declaration; ERP must not guess WMS capabilities.
+    - This service does not expose grants, approvals, written status, or verification status.
+    """
+
+    def __init__(self, repo: WmsServiceCapabilityReadRepo) -> None:
+        self.repo = repo
+
+    def get_service_capabilities(self) -> WmsSystemServiceCapabilitiesOut:
+        capability_rows = self.repo.list_capability_rows()
+        route_rows = self.repo.list_route_rows()
+        route_rows_by_capability = self._group_route_rows_by_capability(route_rows)
+
+        return WmsSystemServiceCapabilitiesOut(
+            app_code=WMS_APP_CODE,
+            app_name=WMS_APP_NAME,
+            capabilities=[
+                self._build_capability_out(
+                    row=row,
+                    route_rows_by_capability=route_rows_by_capability,
+                )
+                for row in capability_rows
+            ],
+        )
+
+    @staticmethod
+    def _group_route_rows_by_capability(
+        route_rows: list[ServiceCapabilityRouteRow],
+    ) -> dict[str, list[ServiceCapabilityRouteRow]]:
+        grouped: dict[str, list[ServiceCapabilityRouteRow]] = defaultdict(list)
+
+        for row in route_rows:
+            capability_code = _optional_str(row.get("capability_code"))
+            if capability_code is None:
+                continue
+            grouped[capability_code].append(row)
+
+        return dict(grouped)
+
+    def _build_capability_out(
+        self,
+        *,
+        row: ServiceCapabilityRow,
+        route_rows_by_capability: Mapping[str, list[ServiceCapabilityRouteRow]],
+    ) -> WmsSystemServiceCapabilityOut:
+        capability_code = _required_str(
+            row.get("capability_code"),
+            field_name="capability_code",
+        )
+
+        return WmsSystemServiceCapabilityOut(
+            capability_code=capability_code,
+            capability_name=_required_str(
+                row.get("capability_name"),
+                field_name="capability_name",
+            ),
+            resource_code=_required_str(
+                row.get("resource_code"),
+                field_name="resource_code",
+            ),
+            permission_code=capability_code,
+            description=_optional_str(row.get("description")),
+            is_active=_bool_value(row.get("is_active"), field_name="is_active"),
+            source_updated_at=_datetime_or_none(
+                row.get("source_updated_at"),
+                field_name="source_updated_at",
+            ),
+            routes=[
+                self._build_route_out(route_row)
+                for route_row in route_rows_by_capability.get(capability_code, [])
+            ],
+        )
+
+    @staticmethod
+    def _build_route_out(
+        row: ServiceCapabilityRouteRow,
+    ) -> WmsSystemServiceCapabilityRouteOut:
+        return WmsSystemServiceCapabilityRouteOut(
+            http_method=_required_str(row.get("http_method"), field_name="http_method"),
+            path=_required_str(row.get("route_path"), field_name="route_path"),
+            route_name=_required_str(row.get("route_name"), field_name="route_name"),
+            auth_required=_bool_value(
+                row.get("auth_required"),
+                field_name="auth_required",
+            ),
+            is_active=_bool_value(row.get("is_active"), field_name="is_active"),
+            source_created_at=_datetime_or_none(
+                row.get("source_created_at"),
+                field_name="source_created_at",
+            ),
+        )
+
+
+__all__ = [
+    "WMS_APP_CODE",
+    "WMS_APP_NAME",
+    "WmsServiceCapabilityReadService",
+]

--- a/tests/api/test_wms_system_service_capabilities_api.py
+++ b/tests/api/test_wms_system_service_capabilities_api.py
@@ -1,0 +1,96 @@
+# tests/api/test_wms_system_service_capabilities_api.py
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def _capability_by_code(capabilities: list[dict]) -> dict[str, dict]:
+    return {str(item["capability_code"]): item for item in capabilities}
+
+
+def test_wms_system_service_capabilities_returns_declared_capabilities() -> None:
+    client = TestClient(app)
+
+    response = client.get("/system/read/v1/service-capabilities")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    assert body["app_code"] == "wms"
+    assert body["app_name"] == "仓储管理"
+
+    capabilities = body["capabilities"]
+    assert isinstance(capabilities, list)
+    assert capabilities
+
+    by_code = _capability_by_code(capabilities)
+
+    warehouses = by_code["wms.read.warehouses"]
+    assert warehouses["capability_code"] == "wms.read.warehouses"
+    assert warehouses["capability_name"] == "Read WMS warehouses"
+    assert warehouses["resource_code"] == "warehouses"
+    assert warehouses["permission_code"] == "wms.read.warehouses"
+    assert warehouses["description"] == "读取 WMS 仓库基础下拉能力"
+    assert warehouses["is_active"] is True
+    assert warehouses["source_updated_at"] is not None
+
+    routes = warehouses["routes"]
+    assert isinstance(routes, list)
+    route_pairs = {(route["http_method"], route["path"]) for route in routes}
+    assert ("GET", "/wms/read/v1/warehouses") in route_pairs
+    assert ("GET", "/wms/read/v1/warehouses/{warehouse_id}") in route_pairs
+
+    for route in routes:
+        assert {"http_method", "path", "route_name", "auth_required", "is_active", "source_created_at"} <= set(route)
+        assert route["auth_required"] is True
+        assert route["is_active"] is True
+        assert route["source_created_at"] is not None
+
+    required_capability_keys = {
+        "capability_code",
+        "capability_name",
+        "resource_code",
+        "permission_code",
+        "description",
+        "is_active",
+        "source_updated_at",
+        "routes",
+    }
+    for capability in capabilities:
+        assert required_capability_keys <= set(capability)
+        assert capability["permission_code"] == capability["capability_code"]
+
+    assert "approved" not in warehouses
+    assert "written" not in warehouses
+    assert "verified" not in warehouses
+
+
+def test_wms_system_service_capabilities_include_write_capabilities() -> None:
+    client = TestClient(app)
+
+    response = client.get("/system/read/v1/service-capabilities")
+
+    assert response.status_code == 200, response.text
+    by_code = _capability_by_code(response.json()["capabilities"])
+
+    assert "wms.write.shipping_handoff_import_results" in by_code
+    assert "wms.write.shipping_handoff_shipping_results" in by_code
+
+    import_result = by_code["wms.write.shipping_handoff_import_results"]
+    route_pairs = {(route["http_method"], route["path"]) for route in import_result["routes"]}
+
+    assert ("POST", "/shipping-assist/handoffs/import-results") in route_pairs
+
+
+def test_wms_system_service_capabilities_is_registered_in_openapi() -> None:
+    client = TestClient(app)
+
+    response = client.get("/openapi.json")
+
+    assert response.status_code == 200, response.text
+    paths = response.json()["paths"]
+
+    assert "/system/read/v1/service-capabilities" in paths
+    assert "get" in paths["/system/read/v1/service-capabilities"]


### PR DESCRIPTION
Adds WMS system read-v1 service capabilities endpoint for ERP system collaboration sync.

Scope:
- Add GET /system/read/v1/service-capabilities.
- Read WMS service capability declarations and route mappings.
- Return capabilities with permission_code=capability_code and route metadata.
- Do not write DB.
- Do not infer capabilities from runtime routes.
- Do not expose approval/grant/written/verified state.

Validation:
- python3 -m compileall app/wms/system/read_v1 tests/api/test_wms_system_service_capabilities_api.py
- make test TESTS="tests/api/test_wms_system_service_capabilities_api.py tests/api/test_wms_system_page_catalog_api.py tests/api/test_wms_system_app_manifest_api.py tests/api/test_no_duplicate_routes.py tests/ci/test_wms_service_auth_contract.py"