### PR TITLE
feat(system): add service dependencies read endpoint

### DIFF
--- a/app/wms/system/read_v1/contracts/__init__.py
+++ b/app/wms/system/read_v1/contracts/__init__.py
@@ -14,6 +14,11 @@ from app.wms.system.read_v1.contracts.service_capabilities import (
     WmsSystemServiceCapabilityOut,
     WmsSystemServiceCapabilityRouteOut,
 )
+from app.wms.system.read_v1.contracts.service_dependencies import (
+    WmsSystemServiceDependenciesOut,
+    WmsSystemServiceDependencyEndpointOut,
+    WmsSystemServiceDependencyOut,
+)
 
 __all__ = [
     "WmsSystemAppManifestBuildInfoOut",
@@ -23,4 +28,7 @@ __all__ = [
     "WmsSystemServiceCapabilitiesOut",
     "WmsSystemServiceCapabilityOut",
     "WmsSystemServiceCapabilityRouteOut",
+    "WmsSystemServiceDependenciesOut",
+    "WmsSystemServiceDependencyEndpointOut",
+    "WmsSystemServiceDependencyOut",
 ]

--- a/app/wms/system/read_v1/contracts/service_dependencies.py
+++ b/app/wms/system/read_v1/contracts/service_dependencies.py
@@ -1,0 +1,47 @@
+# app/wms/system/read_v1/contracts/service_dependencies.py
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class WmsSystemServiceDependencyEndpointOut(_Base):
+    http_method: str = Field(..., min_length=1, max_length=16)
+    path: str = Field(..., min_length=1, max_length=255)
+    purpose: str | None = Field(default=None, max_length=255)
+
+
+class WmsSystemServiceDependencyOut(_Base):
+    dependency_code: str = Field(..., min_length=1, max_length=128)
+    dependency_name: str = Field(..., min_length=1, max_length=128)
+
+    target_app_code: str = Field(..., min_length=1, max_length=64)
+    target_capability_code: str = Field(..., min_length=1, max_length=128)
+    required_permission_code: str = Field(..., min_length=1, max_length=128)
+
+    description: str | None = Field(default=None, max_length=255)
+    is_required: bool
+    is_active: bool
+
+    required_config_keys: list[str] = Field(default_factory=list)
+    source_modules: list[str] = Field(default_factory=list)
+    endpoints: list[WmsSystemServiceDependencyEndpointOut] = Field(default_factory=list)
+
+
+class WmsSystemServiceDependenciesOut(_Base):
+    app_code: Literal["wms"]
+    app_name: str = Field(..., min_length=1)
+    source_service_client_code: Literal["wms-service"]
+    dependencies: list[WmsSystemServiceDependencyOut] = Field(default_factory=list)
+
+
+__all__ = [
+    "WmsSystemServiceDependenciesOut",
+    "WmsSystemServiceDependencyEndpointOut",
+    "WmsSystemServiceDependencyOut",
+]

--- a/app/wms/system/read_v1/routers/__init__.py
+++ b/app/wms/system/read_v1/routers/__init__.py
@@ -8,10 +8,14 @@ from app.wms.system.read_v1.routers.page_catalog import router as page_catalog_r
 from app.wms.system.read_v1.routers.service_capabilities import (
     router as service_capabilities_router,
 )
+from app.wms.system.read_v1.routers.service_dependencies import (
+    router as service_dependencies_router,
+)
 
 router = APIRouter()
 router.include_router(app_manifest_router)
 router.include_router(page_catalog_router)
 router.include_router(service_capabilities_router)
+router.include_router(service_dependencies_router)
 
 __all__ = ["router"]

--- a/app/wms/system/read_v1/routers/service_dependencies.py
+++ b/app/wms/system/read_v1/routers/service_dependencies.py
@@ -1,0 +1,31 @@
+# app/wms/system/read_v1/routers/service_dependencies.py
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.wms.system.read_v1.contracts import WmsSystemServiceDependenciesOut
+from app.wms.system.read_v1.services import build_wms_service_dependencies
+
+router = APIRouter(prefix="/system/read/v1", tags=["system-read-v1"])
+
+
+@router.get(
+    "/service-dependencies",
+    response_model=WmsSystemServiceDependenciesOut,
+    summary="Get WMS service dependencies",
+)
+async def get_wms_service_dependencies() -> WmsSystemServiceDependenciesOut:
+    """
+    Return WMS declared outbound service dependencies for ERP collaboration sync.
+
+    Boundary:
+    - Declared dependency does not mean approved.
+    - Declared dependency does not mean permission has been written to target system.
+    - Declared dependency does not mean runtime verification has passed.
+    - ERP remains responsible for matching, approval, write-back, and verification state.
+    """
+
+    return build_wms_service_dependencies()
+
+
+__all__ = ["router"]

--- a/app/wms/system/read_v1/services/__init__.py
+++ b/app/wms/system/read_v1/services/__init__.py
@@ -13,12 +13,18 @@ from app.wms.system.read_v1.services.page_catalog_service import (
 from app.wms.system.read_v1.services.service_capability_service import (
     WmsServiceCapabilityReadService,
 )
+from app.wms.system.read_v1.services.service_dependencies_service import (
+    WMS_SERVICE_CLIENT_CODE,
+    build_wms_service_dependencies,
+)
 
 __all__ = [
     "WMS_APP_CODE",
     "WMS_APP_NAME",
     "WMS_APP_VERSION",
+    "WMS_SERVICE_CLIENT_CODE",
     "WmsPageCatalogService",
     "WmsServiceCapabilityReadService",
     "build_wms_app_manifest",
+    "build_wms_service_dependencies",
 ]

--- a/app/wms/system/read_v1/services/service_dependencies_service.py
+++ b/app/wms/system/read_v1/services/service_dependencies_service.py
@@ -1,0 +1,325 @@
+# app/wms/system/read_v1/services/service_dependencies_service.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.wms.system.read_v1.contracts import (
+    WmsSystemServiceDependenciesOut,
+    WmsSystemServiceDependencyEndpointOut,
+    WmsSystemServiceDependencyOut,
+)
+
+WMS_APP_CODE = "wms"
+WMS_APP_NAME = "仓储管理"
+WMS_SERVICE_CLIENT_CODE = "wms-service"
+
+
+@dataclass(frozen=True)
+class ServiceDependencyEndpoint:
+    http_method: str
+    path: str
+    purpose: str | None = None
+
+
+@dataclass(frozen=True)
+class ServiceDependency:
+    dependency_code: str
+    dependency_name: str
+    target_app_code: str
+    target_capability_code: str
+    description: str
+    is_required: bool
+    is_active: bool
+    required_config_keys: tuple[str, ...]
+    source_modules: tuple[str, ...]
+    endpoints: tuple[ServiceDependencyEndpoint, ...]
+
+
+WMS_SERVICE_DEPENDENCIES: tuple[ServiceDependency, ...] = (
+    ServiceDependency(
+        dependency_code="wms.depends_on.pms.projection_feed",
+        dependency_name="PMS projection feed",
+        target_app_code="pms",
+        target_capability_code="pms.read.projection_feed",
+        description="WMS 同步 PMS 当前态只读投影，用于商品、供应商、包装单位、SKU 编码与条码查询。",
+        is_required=True,
+        is_active=True,
+        required_config_keys=("PMS_API_BASE_URL",),
+        source_modules=(
+            "app.integrations.pms.projection_sync",
+            "scripts.pms.sync_projection",
+        ),
+        endpoints=(
+            ServiceDependencyEndpoint(
+                http_method="GET",
+                path="/pms/read/v1/projection-feed/items",
+                purpose="同步 PMS 商品投影。",
+            ),
+            ServiceDependencyEndpoint(
+                http_method="GET",
+                path="/pms/read/v1/projection-feed/suppliers",
+                purpose="同步 PMS 供应商投影。",
+            ),
+            ServiceDependencyEndpoint(
+                http_method="GET",
+                path="/pms/read/v1/projection-feed/uoms",
+                purpose="同步 PMS 包装单位投影。",
+            ),
+            ServiceDependencyEndpoint(
+                http_method="GET",
+                path="/pms/read/v1/projection-feed/sku-codes",
+                purpose="同步 PMS SKU 编码投影。",
+            ),
+            ServiceDependencyEndpoint(
+                http_method="GET",
+                path="/pms/read/v1/projection-feed/barcodes",
+                purpose="同步 PMS 条码投影。",
+            ),
+        ),
+    ),
+    ServiceDependency(
+        dependency_code="wms.depends_on.pms.item_read",
+        dependency_name="PMS item read",
+        target_app_code="pms",
+        target_capability_code="pms.read.items",
+        description="WMS 通过 PMS read-v1 读取商品基础信息、商品策略与报表元数据。",
+        is_required=True,
+        is_active=True,
+        required_config_keys=("PMS_API_BASE_URL",),
+        source_modules=("app.integrations.pms.http_client",),
+        endpoints=(
+            ServiceDependencyEndpoint(
+                http_method="GET",
+                path="/pms/read/v1/items/basic",
+                purpose="读取商品基础列表。",
+            ),
+            ServiceDependencyEndpoint(
+                http_method="POST",
+                path="/pms/read/v1/items/basic/batch",
+                purpose="批量读取商品基础信息。",
+            ),
+            ServiceDependencyEndpoint(
+                http_method="POST",
+                path="/pms/read/v1/items/policies/batch",
+                purpose="批量读取商品策略。",
+            ),
+            ServiceDependencyEndpoint(
+                http_method="GET",
+                path="/pms/read/v1/items/policy-by-sku",
+                purpose="按 SKU 读取商品策略。",
+            ),
+            ServiceDependencyEndpoint(
+                http_method="GET",
+                path="/pms/read/v1/items/report-search",
+                purpose="按关键字搜索报表商品 ID。",
+            ),
+            ServiceDependencyEndpoint(
+                http_method="POST",
+                path="/pms/read/v1/items/report-meta/batch",
+                purpose="批量读取报表商品元数据。",
+            ),
+        ),
+    ),
+    ServiceDependency(
+        dependency_code="wms.depends_on.pms.uom_read",
+        dependency_name="PMS UOM read",
+        target_app_code="pms",
+        target_capability_code="pms.read.uoms",
+        description="WMS 通过 PMS read-v1 读取包装单位及默认单位。",
+        is_required=True,
+        is_active=True,
+        required_config_keys=("PMS_API_BASE_URL",),
+        source_modules=("app.integrations.pms.http_client",),
+        endpoints=(
+            ServiceDependencyEndpoint(
+                http_method="POST",
+                path="/pms/read/v1/uoms/query",
+                purpose="查询包装单位。",
+            ),
+            ServiceDependencyEndpoint(
+                http_method="POST",
+                path="/pms/read/v1/items/uom-defaults/batch",
+                purpose="批量读取商品默认包装单位。",
+            ),
+        ),
+    ),
+    ServiceDependency(
+        dependency_code="wms.depends_on.pms.barcode_read",
+        dependency_name="PMS barcode read",
+        target_app_code="pms",
+        target_capability_code="pms.read.barcodes",
+        description="WMS 通过 PMS read-v1 读取、查询与探测条码。",
+        is_required=True,
+        is_active=True,
+        required_config_keys=("PMS_API_BASE_URL",),
+        source_modules=("app.integrations.pms.http_client",),
+        endpoints=(
+            ServiceDependencyEndpoint(
+                http_method="GET",
+                path="/pms/read/v1/barcodes/{barcode_id}",
+                purpose="按 ID 读取条码。",
+            ),
+            ServiceDependencyEndpoint(
+                http_method="POST",
+                path="/pms/read/v1/barcodes/query",
+                purpose="查询条码。",
+            ),
+            ServiceDependencyEndpoint(
+                http_method="POST",
+                path="/pms/read/v1/barcodes/probe",
+                purpose="条码探测。",
+            ),
+        ),
+    ),
+    ServiceDependency(
+        dependency_code="wms.depends_on.pms.sku_code_read",
+        dependency_name="PMS SKU code read",
+        target_app_code="pms",
+        target_capability_code="pms.read.sku_codes",
+        description="WMS 通过 PMS read-v1 读取 SKU 编码并解析出库默认编码。",
+        is_required=True,
+        is_active=True,
+        required_config_keys=("PMS_API_BASE_URL",),
+        source_modules=(
+            "app.integrations.pms.http_client",
+            "app.integrations.pms.sync_http_client",
+        ),
+        endpoints=(
+            ServiceDependencyEndpoint(
+                http_method="POST",
+                path="/pms/read/v1/sku-codes/query",
+                purpose="查询 SKU 编码。",
+            ),
+            ServiceDependencyEndpoint(
+                http_method="GET",
+                path="/pms/read/v1/sku-codes/resolve-outbound-default",
+                purpose="解析出库默认 SKU 编码。",
+            ),
+        ),
+    ),
+    ServiceDependency(
+        dependency_code="wms.depends_on.oms.fulfillment_ready_orders",
+        dependency_name="OMS fulfillment-ready orders",
+        target_app_code="oms",
+        target_capability_code="oms.read.fulfillment_ready_orders",
+        description="WMS 从 OMS 读取可履约订单，用于出库侧 OMS 履约投影同步。",
+        is_required=True,
+        is_active=True,
+        required_config_keys=("OMS_API_BASE_URL",),
+        source_modules=(
+            "app.integrations.oms.projection_sync",
+            "scripts.oms.sync_fulfillment_projection",
+        ),
+        endpoints=(
+            ServiceDependencyEndpoint(
+                http_method="GET",
+                path="/oms/read/v1/fulfillment-ready-orders",
+                purpose="读取 OMS 可履约订单列表。",
+            ),
+        ),
+    ),
+    ServiceDependency(
+        dependency_code="wms.depends_on.procurement.receiving_sources",
+        dependency_name="Procurement receiving sources",
+        target_app_code="procurement",
+        target_capability_code="procurement.read.wms_receiving_sources",
+        description="WMS 从 Procurement 读取采购入库来源，用于采购收货。",
+        is_required=True,
+        is_active=True,
+        required_config_keys=("PROCUREMENT_API_BASE_URL",),
+        source_modules=("app.integrations.procurement.http_client",),
+        endpoints=(
+            ServiceDependencyEndpoint(
+                http_method="GET",
+                path="/procurement/read/v1/wms/receiving-sources",
+                purpose="读取采购入库来源选项。",
+            ),
+            ServiceDependencyEndpoint(
+                http_method="GET",
+                path="/procurement/read/v1/wms/receiving-sources/{po_id}",
+                purpose="读取采购入库来源详情。",
+            ),
+        ),
+    ),
+    ServiceDependency(
+        dependency_code="wms.depends_on.logistics.shipping_record_facts",
+        dependency_name="Logistics shipping record facts",
+        target_app_code="logistics",
+        target_capability_code="logistics.read.shipping_record_facts",
+        description="WMS 从 Logistics 同步发货记录事实，用于 WMS 发货记录投影。",
+        is_required=True,
+        is_active=True,
+        required_config_keys=(
+            "LOGISTICS_API_BASE_URL",
+            "LOGISTICS_API_TOKEN",
+            "LOGISTICS_API_TIMEOUT_SECONDS",
+        ),
+        source_modules=(
+            "app.shipping_assist.records.sync.client",
+            "app.shipping_assist.records.sync.service",
+            "scripts.sync_logistics_shipping_records",
+        ),
+        endpoints=(
+            ServiceDependencyEndpoint(
+                http_method="GET",
+                path="/logistics/read/v1/shipping-record-facts",
+                purpose="读取 Logistics 发货记录事实。",
+            ),
+        ),
+    ),
+)
+
+
+def _endpoint_out(endpoint: ServiceDependencyEndpoint) -> WmsSystemServiceDependencyEndpointOut:
+    return WmsSystemServiceDependencyEndpointOut(
+        http_method=endpoint.http_method,
+        path=endpoint.path,
+        purpose=endpoint.purpose,
+    )
+
+
+def _dependency_out(dependency: ServiceDependency) -> WmsSystemServiceDependencyOut:
+    return WmsSystemServiceDependencyOut(
+        dependency_code=dependency.dependency_code,
+        dependency_name=dependency.dependency_name,
+        target_app_code=dependency.target_app_code,
+        target_capability_code=dependency.target_capability_code,
+        required_permission_code=dependency.target_capability_code,
+        description=dependency.description,
+        is_required=dependency.is_required,
+        is_active=dependency.is_active,
+        required_config_keys=list(dependency.required_config_keys),
+        source_modules=list(dependency.source_modules),
+        endpoints=[_endpoint_out(endpoint) for endpoint in dependency.endpoints],
+    )
+
+
+def build_wms_service_dependencies() -> WmsSystemServiceDependenciesOut:
+    """
+    Return WMS declared outbound service dependencies.
+
+    Boundary:
+    - This is only a declaration of what WMS needs.
+    - It is not ERP approval.
+    - It is not a grant.
+    - It is not a write-back result.
+    - It is not runtime verification.
+    """
+
+    return WmsSystemServiceDependenciesOut(
+        app_code=WMS_APP_CODE,
+        app_name=WMS_APP_NAME,
+        source_service_client_code=WMS_SERVICE_CLIENT_CODE,
+        dependencies=[_dependency_out(row) for row in WMS_SERVICE_DEPENDENCIES],
+    )
+
+
+__all__ = [
+    "WMS_APP_CODE",
+    "WMS_APP_NAME",
+    "WMS_SERVICE_CLIENT_CODE",
+    "WMS_SERVICE_DEPENDENCIES",
+    "ServiceDependency",
+    "ServiceDependencyEndpoint",
+    "build_wms_service_dependencies",
+]

--- a/tests/api/test_wms_system_service_dependencies_api.py
+++ b/tests/api/test_wms_system_service_dependencies_api.py
@@ -1,0 +1,131 @@
+# tests/api/test_wms_system_service_dependencies_api.py
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def _dependency_by_code(dependencies: list[dict]) -> dict[str, dict]:
+    return {str(item["dependency_code"]): item for item in dependencies}
+
+
+def test_wms_system_service_dependencies_returns_declared_dependencies() -> None:
+    client = TestClient(app)
+
+    response = client.get("/system/read/v1/service-dependencies")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    assert body["app_code"] == "wms"
+    assert body["app_name"] == "仓储管理"
+    assert body["source_service_client_code"] == "wms-service"
+
+    dependencies = body["dependencies"]
+    assert isinstance(dependencies, list)
+    assert dependencies
+
+    by_code = _dependency_by_code(dependencies)
+
+    pms_projection = by_code["wms.depends_on.pms.projection_feed"]
+    assert pms_projection["target_app_code"] == "pms"
+    assert pms_projection["target_capability_code"] == "pms.read.projection_feed"
+    assert pms_projection["required_permission_code"] == "pms.read.projection_feed"
+    assert pms_projection["is_required"] is True
+    assert pms_projection["is_active"] is True
+    assert "PMS_API_BASE_URL" in pms_projection["required_config_keys"]
+
+    pms_projection_paths = {
+        (endpoint["http_method"], endpoint["path"])
+        for endpoint in pms_projection["endpoints"]
+    }
+    assert ("GET", "/pms/read/v1/projection-feed/items") in pms_projection_paths
+    assert ("GET", "/pms/read/v1/projection-feed/suppliers") in pms_projection_paths
+    assert ("GET", "/pms/read/v1/projection-feed/uoms") in pms_projection_paths
+    assert ("GET", "/pms/read/v1/projection-feed/sku-codes") in pms_projection_paths
+    assert ("GET", "/pms/read/v1/projection-feed/barcodes") in pms_projection_paths
+
+    oms = by_code["wms.depends_on.oms.fulfillment_ready_orders"]
+    assert oms["target_app_code"] == "oms"
+    assert oms["target_capability_code"] == "oms.read.fulfillment_ready_orders"
+    assert "OMS_API_BASE_URL" in oms["required_config_keys"]
+    assert {
+        (endpoint["http_method"], endpoint["path"])
+        for endpoint in oms["endpoints"]
+    } == {("GET", "/oms/read/v1/fulfillment-ready-orders")}
+
+    procurement = by_code["wms.depends_on.procurement.receiving_sources"]
+    assert procurement["target_app_code"] == "procurement"
+    assert procurement["target_capability_code"] == "procurement.read.wms_receiving_sources"
+    assert "PROCUREMENT_API_BASE_URL" in procurement["required_config_keys"]
+
+    procurement_paths = {
+        (endpoint["http_method"], endpoint["path"])
+        for endpoint in procurement["endpoints"]
+    }
+    assert ("GET", "/procurement/read/v1/wms/receiving-sources") in procurement_paths
+    assert ("GET", "/procurement/read/v1/wms/receiving-sources/{po_id}") in procurement_paths
+
+    logistics = by_code["wms.depends_on.logistics.shipping_record_facts"]
+    assert logistics["target_app_code"] == "logistics"
+    assert logistics["target_capability_code"] == "logistics.read.shipping_record_facts"
+    assert "LOGISTICS_API_BASE_URL" in logistics["required_config_keys"]
+    assert "LOGISTICS_API_TOKEN" in logistics["required_config_keys"]
+
+    required_keys = {
+        "dependency_code",
+        "dependency_name",
+        "target_app_code",
+        "target_capability_code",
+        "required_permission_code",
+        "description",
+        "is_required",
+        "is_active",
+        "required_config_keys",
+        "source_modules",
+        "endpoints",
+    }
+    for dependency in dependencies:
+        assert required_keys <= set(dependency)
+        assert dependency["required_permission_code"] == dependency["target_capability_code"]
+        assert dependency["endpoints"]
+
+        assert "approved" not in dependency
+        assert "written" not in dependency
+        assert "verified" not in dependency
+        assert "granted" not in dependency
+
+
+def test_wms_system_service_dependencies_includes_pms_runtime_read_dependencies() -> None:
+    client = TestClient(app)
+
+    response = client.get("/system/read/v1/service-dependencies")
+
+    assert response.status_code == 200, response.text
+    by_code = _dependency_by_code(response.json()["dependencies"])
+
+    assert "wms.depends_on.pms.item_read" in by_code
+    assert "wms.depends_on.pms.uom_read" in by_code
+    assert "wms.depends_on.pms.barcode_read" in by_code
+    assert "wms.depends_on.pms.sku_code_read" in by_code
+
+    sku_code = by_code["wms.depends_on.pms.sku_code_read"]
+    sku_code_paths = {
+        (endpoint["http_method"], endpoint["path"])
+        for endpoint in sku_code["endpoints"]
+    }
+    assert ("POST", "/pms/read/v1/sku-codes/query") in sku_code_paths
+    assert ("GET", "/pms/read/v1/sku-codes/resolve-outbound-default") in sku_code_paths
+
+
+def test_wms_system_service_dependencies_is_registered_in_openapi() -> None:
+    client = TestClient(app)
+
+    response = client.get("/openapi.json")
+
+    assert response.status_code == 200, response.text
+    paths = response.json()["paths"]
+
+    assert "/system/read/v1/service-dependencies" in paths
+    assert "get" in paths["/system/read/v1/service-dependencies"]


### PR DESCRIPTION
Adds WMS system read-v1 service dependencies endpoint for ERP system collaboration sync.

Scope:
- Add GET /system/read/v1/service-dependencies.
- Declare WMS outbound dependencies on PMS, OMS, Procurement and Logistics.
- Return target capability codes, endpoint paths, required config key names and source modules.
- Do not write DB.
- Do not expose secrets, config values, grant status, approval state, write-back state or verification state.
- ERP remains responsible for matching dependencies to target capabilities and managing approval/write/verify workflow.

Validation:
- python3 -m compileall app/wms/system/read_v1 tests/api/test_wms_system_service_dependencies_api.py
- make test TESTS="tests/api/test_wms_system_service_dependencies_api.py tests/api/test_wms_system_service_capabilities_api.py tests/api/test_wms_system_page_catalog_api.py tests/api/test_wms_system_app_manifest_api.py tests/api/test_no_duplicate_routes.py"