### PR TITLE
feat(system): add WMS IAM snapshot read endpoint

### DIFF
--- a/alembic/versions/20260518135000_wms_iam_snapshot_read_v1.py
+++ b/alembic/versions/20260518135000_wms_iam_snapshot_read_v1.py
@@ -1,0 +1,123 @@
+"""add WMS IAM snapshot read-v1 capability
+
+Revision ID: 20260518135000_wms_iam_snapshot
+Revises: 20260516145000_wms_svc_auth
+Create Date: 2026-05-18 13:50:00.000000
+
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+
+revision: str = "20260518135000_wms_iam_snapshot"
+down_revision: str | Sequence[str] | None = "20260516145000_wms_svc_auth"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+IAM_SNAPSHOT_CAPABILITY_CODE = "wms.read.iam_snapshot"
+IAM_SNAPSHOT_ROUTE_PATH = "/system/read/v1/iam-snapshot"
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        INSERT INTO wms_service_capabilities (
+          capability_code,
+          capability_name,
+          resource_code,
+          description,
+          is_active
+        )
+        VALUES (
+          'wms.read.iam_snapshot',
+          'Read WMS IAM snapshot',
+          'iam_snapshot',
+          'ERP 读取 WMS 用户、权限和页面权限只读快照',
+          TRUE
+        )
+        ON CONFLICT (capability_code) DO UPDATE
+        SET
+          capability_name = EXCLUDED.capability_name,
+          resource_code = EXCLUDED.resource_code,
+          description = EXCLUDED.description,
+          is_active = EXCLUDED.is_active,
+          updated_at = CURRENT_TIMESTAMP
+        """
+    )
+
+    op.execute(
+        """
+        INSERT INTO wms_service_capability_routes (
+          capability_code,
+          http_method,
+          route_path,
+          route_name,
+          auth_required,
+          is_active
+        )
+        VALUES (
+          'wms.read.iam_snapshot',
+          'GET',
+          '/system/read/v1/iam-snapshot',
+          'get_wms_iam_snapshot',
+          TRUE,
+          TRUE
+        )
+        ON CONFLICT (http_method, route_path) DO UPDATE
+        SET
+          capability_code = EXCLUDED.capability_code,
+          route_name = EXCLUDED.route_name,
+          auth_required = EXCLUDED.auth_required,
+          is_active = EXCLUDED.is_active
+        """
+    )
+
+    op.execute(
+        """
+        INSERT INTO wms_service_permissions (
+          client_id,
+          capability_code,
+          description,
+          is_active
+        )
+        SELECT
+          c.id,
+          'wms.read.iam_snapshot',
+          'ERP 读取 WMS IAM 只读快照',
+          TRUE
+        FROM wms_service_clients c
+        WHERE c.client_code = 'erp-service'
+        ON CONFLICT (client_id, capability_code) DO UPDATE
+        SET
+          description = EXCLUDED.description,
+          is_active = EXCLUDED.is_active
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DELETE FROM wms_service_permissions
+        WHERE capability_code = 'wms.read.iam_snapshot'
+        """
+    )
+
+    op.execute(
+        """
+        DELETE FROM wms_service_capability_routes
+        WHERE http_method = 'GET'
+          AND route_path = '/system/read/v1/iam-snapshot'
+        """
+    )
+
+    op.execute(
+        """
+        DELETE FROM wms_service_capabilities
+        WHERE capability_code = 'wms.read.iam_snapshot'
+        """
+    )

--- a/app/wms/system/read_v1/contracts/__init__.py
+++ b/app/wms/system/read_v1/contracts/__init__.py
@@ -5,6 +5,14 @@ from app.wms.system.read_v1.contracts.app_manifest import (
     WmsSystemAppManifestBuildInfoOut,
     WmsSystemAppManifestOut,
 )
+from app.wms.system.read_v1.contracts.iam_snapshot import (
+    WmsSystemIamSnapshotOut,
+    WmsSystemIamSnapshotPageOut,
+    WmsSystemIamSnapshotPermissionOut,
+    WmsSystemIamSnapshotRoutePrefixOut,
+    WmsSystemIamSnapshotUserOut,
+    WmsSystemIamSnapshotUserPermissionOut,
+)
 from app.wms.system.read_v1.contracts.page_catalog import (
     WmsSystemPageCatalogOut,
     WmsSystemPageCatalogPageOut,
@@ -23,6 +31,12 @@ from app.wms.system.read_v1.contracts.service_dependencies import (
 __all__ = [
     "WmsSystemAppManifestBuildInfoOut",
     "WmsSystemAppManifestOut",
+    "WmsSystemIamSnapshotOut",
+    "WmsSystemIamSnapshotPageOut",
+    "WmsSystemIamSnapshotPermissionOut",
+    "WmsSystemIamSnapshotRoutePrefixOut",
+    "WmsSystemIamSnapshotUserOut",
+    "WmsSystemIamSnapshotUserPermissionOut",
     "WmsSystemPageCatalogOut",
     "WmsSystemPageCatalogPageOut",
     "WmsSystemServiceCapabilitiesOut",

--- a/app/wms/system/read_v1/contracts/iam_snapshot.py
+++ b/app/wms/system/read_v1/contracts/iam_snapshot.py
@@ -1,0 +1,76 @@
+# app/wms/system/read_v1/contracts/iam_snapshot.py
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class WmsSystemIamSnapshotUserOut(_Base):
+    user_id: int = Field(..., ge=1)
+    username: str = Field(..., min_length=1, max_length=64)
+    is_active: bool
+    full_name: str | None = Field(default=None, max_length=128)
+    phone: str | None = Field(default=None, max_length=32)
+    email: str | None = Field(default=None, max_length=255)
+
+
+class WmsSystemIamSnapshotPermissionOut(_Base):
+    permission_id: int = Field(..., ge=1)
+    permission_code: str = Field(..., min_length=1, max_length=128)
+
+
+class WmsSystemIamSnapshotUserPermissionOut(_Base):
+    user_id: int = Field(..., ge=1)
+    permission_id: int = Field(..., ge=1)
+    permission_code: str = Field(..., min_length=1, max_length=128)
+    granted_at: datetime
+
+
+class WmsSystemIamSnapshotPageOut(_Base):
+    page_code: str = Field(..., min_length=1, max_length=64)
+    page_name: str = Field(..., min_length=1, max_length=64)
+    parent_page_code: str | None = Field(default=None, max_length=64)
+    level: int = Field(..., ge=1, le=3)
+    domain_code: str = Field(..., min_length=1, max_length=32)
+    show_in_topbar: bool
+    show_in_sidebar: bool
+    inherit_permissions: bool
+    read_permission_code: str | None = Field(default=None, max_length=128)
+    write_permission_code: str | None = Field(default=None, max_length=128)
+    sort_order: int
+    is_active: bool
+
+
+class WmsSystemIamSnapshotRoutePrefixOut(_Base):
+    id: int = Field(..., ge=1)
+    page_code: str = Field(..., min_length=1, max_length=64)
+    route_prefix: str = Field(..., min_length=1, max_length=255)
+    sort_order: int
+    is_active: bool
+
+
+class WmsSystemIamSnapshotOut(_Base):
+    app_code: Literal["wms"]
+    app_name: str = Field(..., min_length=1)
+    snapshot_at: datetime
+    users: list[WmsSystemIamSnapshotUserOut] = Field(default_factory=list)
+    permissions: list[WmsSystemIamSnapshotPermissionOut] = Field(default_factory=list)
+    user_permissions: list[WmsSystemIamSnapshotUserPermissionOut] = Field(default_factory=list)
+    page_registry: list[WmsSystemIamSnapshotPageOut] = Field(default_factory=list)
+    page_route_prefixes: list[WmsSystemIamSnapshotRoutePrefixOut] = Field(default_factory=list)
+
+
+__all__ = [
+    "WmsSystemIamSnapshotOut",
+    "WmsSystemIamSnapshotPageOut",
+    "WmsSystemIamSnapshotPermissionOut",
+    "WmsSystemIamSnapshotRoutePrefixOut",
+    "WmsSystemIamSnapshotUserOut",
+    "WmsSystemIamSnapshotUserPermissionOut",
+]

--- a/app/wms/system/read_v1/repos/__init__.py
+++ b/app/wms/system/read_v1/repos/__init__.py
@@ -1,6 +1,14 @@
 # app/wms/system/read_v1/repos/__init__.py
 from __future__ import annotations
 
+from app.wms.system.read_v1.repos.iam_snapshot_repo import (
+    IamSnapshotPageRow,
+    IamSnapshotPermissionRow,
+    IamSnapshotRoutePrefixRow,
+    IamSnapshotUserPermissionRow,
+    IamSnapshotUserRow,
+    WmsIamSnapshotRepo,
+)
 from app.wms.system.read_v1.repos.page_catalog_repo import (
     PageCatalogPageRow,
     PageCatalogRoutePrefixRow,
@@ -13,10 +21,16 @@ from app.wms.system.read_v1.repos.service_capability_repo import (
 )
 
 __all__ = [
+    "IamSnapshotPageRow",
+    "IamSnapshotPermissionRow",
+    "IamSnapshotRoutePrefixRow",
+    "IamSnapshotUserPermissionRow",
+    "IamSnapshotUserRow",
     "PageCatalogPageRow",
     "PageCatalogRoutePrefixRow",
     "ServiceCapabilityRouteRow",
     "ServiceCapabilityRow",
+    "WmsIamSnapshotRepo",
     "WmsPageCatalogRepo",
     "WmsServiceCapabilityReadRepo",
 ]

--- a/app/wms/system/read_v1/repos/iam_snapshot_repo.py
+++ b/app/wms/system/read_v1/repos/iam_snapshot_repo.py
@@ -1,0 +1,130 @@
+# app/wms/system/read_v1/repos/iam_snapshot_repo.py
+from __future__ import annotations
+
+from sqlalchemy.orm import Session, aliased
+
+from app.user.models.page_registry import PageRegistry
+from app.user.models.page_route_prefix import PageRoutePrefix
+from app.user.models.permission import Permission
+from app.user.models.user import User, user_permissions
+
+IamSnapshotUserRow = dict[str, object]
+IamSnapshotPermissionRow = dict[str, object]
+IamSnapshotUserPermissionRow = dict[str, object]
+IamSnapshotPageRow = dict[str, object]
+IamSnapshotRoutePrefixRow = dict[str, object]
+
+
+class WmsIamSnapshotRepo:
+    """
+    WMS IAM snapshot read repository.
+
+    Boundary:
+    - Read only users / permissions / user_permissions / page_registry / page_route_prefixes.
+    - Never expose users.password_hash.
+    - Do not read wms_service_* tables; service auth is handled by route deps.
+    - Do not write any table.
+    """
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def list_user_rows(self) -> list[IamSnapshotUserRow]:
+        rows = (
+            self.db.query(
+                User.id.label("user_id"),
+                User.username.label("username"),
+                User.is_active.label("is_active"),
+                User.full_name.label("full_name"),
+                User.phone.label("phone"),
+                User.email.label("email"),
+            )
+            .order_by(User.id.asc())
+            .all()
+        )
+        return [dict(row._mapping) for row in rows]
+
+    def list_permission_rows(self) -> list[IamSnapshotPermissionRow]:
+        rows = (
+            self.db.query(
+                Permission.id.label("permission_id"),
+                Permission.name.label("permission_code"),
+            )
+            .order_by(Permission.id.asc())
+            .all()
+        )
+        return [dict(row._mapping) for row in rows]
+
+    def list_user_permission_rows(self) -> list[IamSnapshotUserPermissionRow]:
+        rows = (
+            self.db.query(
+                user_permissions.c.user_id.label("user_id"),
+                user_permissions.c.permission_id.label("permission_id"),
+                Permission.name.label("permission_code"),
+                user_permissions.c.granted_at.label("granted_at"),
+            )
+            .join(Permission, Permission.id == user_permissions.c.permission_id)
+            .order_by(
+                user_permissions.c.user_id.asc(),
+                Permission.name.asc(),
+                user_permissions.c.permission_id.asc(),
+            )
+            .all()
+        )
+        return [dict(row._mapping) for row in rows]
+
+    def list_page_rows(self) -> list[IamSnapshotPageRow]:
+        page = PageRegistry
+        read_permission = aliased(Permission)
+        write_permission = aliased(Permission)
+
+        rows = (
+            self.db.query(
+                page.code.label("page_code"),
+                page.name.label("page_name"),
+                page.parent_code.label("parent_page_code"),
+                page.level.label("level"),
+                page.domain_code.label("domain_code"),
+                page.show_in_topbar.label("show_in_topbar"),
+                page.show_in_sidebar.label("show_in_sidebar"),
+                page.inherit_permissions.label("inherit_permissions"),
+                read_permission.name.label("read_permission_code"),
+                write_permission.name.label("write_permission_code"),
+                page.sort_order.label("sort_order"),
+                page.is_active.label("is_active"),
+            )
+            .outerjoin(read_permission, read_permission.id == page.read_permission_id)
+            .outerjoin(write_permission, write_permission.id == page.write_permission_id)
+            .order_by(page.level.asc(), page.sort_order.asc(), page.code.asc())
+            .all()
+        )
+        return [dict(row._mapping) for row in rows]
+
+    def list_route_prefix_rows(self) -> list[IamSnapshotRoutePrefixRow]:
+        rows = (
+            self.db.query(
+                PageRoutePrefix.id.label("id"),
+                PageRoutePrefix.page_code.label("page_code"),
+                PageRoutePrefix.route_prefix.label("route_prefix"),
+                PageRoutePrefix.sort_order.label("sort_order"),
+                PageRoutePrefix.is_active.label("is_active"),
+            )
+            .order_by(
+                PageRoutePrefix.page_code.asc(),
+                PageRoutePrefix.is_active.desc(),
+                PageRoutePrefix.sort_order.asc(),
+                PageRoutePrefix.route_prefix.asc(),
+            )
+            .all()
+        )
+        return [dict(row._mapping) for row in rows]
+
+
+__all__ = [
+    "IamSnapshotPageRow",
+    "IamSnapshotPermissionRow",
+    "IamSnapshotRoutePrefixRow",
+    "IamSnapshotUserPermissionRow",
+    "IamSnapshotUserRow",
+    "WmsIamSnapshotRepo",
+]

--- a/app/wms/system/read_v1/routers/__init__.py
+++ b/app/wms/system/read_v1/routers/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from fastapi import APIRouter
 
 from app.wms.system.read_v1.routers.app_manifest import router as app_manifest_router
+from app.wms.system.read_v1.routers.iam_snapshot import router as iam_snapshot_router
 from app.wms.system.read_v1.routers.page_catalog import router as page_catalog_router
 from app.wms.system.read_v1.routers.service_capabilities import (
     router as service_capabilities_router,
@@ -17,5 +18,6 @@ router.include_router(app_manifest_router)
 router.include_router(page_catalog_router)
 router.include_router(service_capabilities_router)
 router.include_router(service_dependencies_router)
+router.include_router(iam_snapshot_router)
 
 __all__ = ["router"]

--- a/app/wms/system/read_v1/routers/iam_snapshot.py
+++ b/app/wms/system/read_v1/routers/iam_snapshot.py
@@ -1,0 +1,43 @@
+# app/wms/system/read_v1/routers/iam_snapshot.py
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.wms.system.read_v1.contracts import WmsSystemIamSnapshotOut
+from app.wms.system.read_v1.repos import WmsIamSnapshotRepo
+from app.wms.system.read_v1.services import WmsIamSnapshotService
+from app.wms.system.service_auth.deps import require_wms_service_capability
+
+router = APIRouter(prefix="/system/read/v1", tags=["system-read-v1"])
+
+require_wms_read_iam_snapshot = require_wms_service_capability(
+    "wms.read.iam_snapshot",
+)
+
+
+@router.get(
+    "/iam-snapshot",
+    response_model=WmsSystemIamSnapshotOut,
+    summary="Get WMS IAM snapshot",
+)
+async def get_wms_iam_snapshot(
+    _service_permission: None = Depends(require_wms_read_iam_snapshot),
+    db: Session = Depends(get_db),
+) -> WmsSystemIamSnapshotOut:
+    """
+    Return WMS users, user permissions, and page permission catalog for ERP projection sync.
+
+    Boundary:
+    - Only ERP service client should be granted this capability.
+    - This endpoint is read-only.
+    - This endpoint never exposes password_hash, tokens, or secrets.
+    - This endpoint does not write WMS permissions.
+    - This endpoint does not migrate permission execution to ERP.
+    """
+
+    return WmsIamSnapshotService(WmsIamSnapshotRepo(db)).get_iam_snapshot()
+
+
+__all__ = ["router"]

--- a/app/wms/system/read_v1/services/__init__.py
+++ b/app/wms/system/read_v1/services/__init__.py
@@ -5,6 +5,9 @@ from app.wms.system.read_v1.services.app_manifest_service import (
     WMS_APP_VERSION,
     build_wms_app_manifest,
 )
+from app.wms.system.read_v1.services.iam_snapshot_service import (
+    WmsIamSnapshotService,
+)
 from app.wms.system.read_v1.services.page_catalog_service import (
     WMS_APP_CODE,
     WMS_APP_NAME,
@@ -23,6 +26,7 @@ __all__ = [
     "WMS_APP_NAME",
     "WMS_APP_VERSION",
     "WMS_SERVICE_CLIENT_CODE",
+    "WmsIamSnapshotService",
     "WmsPageCatalogService",
     "WmsServiceCapabilityReadService",
     "build_wms_app_manifest",

--- a/app/wms/system/read_v1/services/iam_snapshot_service.py
+++ b/app/wms/system/read_v1/services/iam_snapshot_service.py
@@ -1,0 +1,181 @@
+# app/wms/system/read_v1/services/iam_snapshot_service.py
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.wms.system.read_v1.contracts import (
+    WmsSystemIamSnapshotOut,
+    WmsSystemIamSnapshotPageOut,
+    WmsSystemIamSnapshotPermissionOut,
+    WmsSystemIamSnapshotRoutePrefixOut,
+    WmsSystemIamSnapshotUserOut,
+    WmsSystemIamSnapshotUserPermissionOut,
+)
+from app.wms.system.read_v1.repos import (
+    IamSnapshotPageRow,
+    IamSnapshotPermissionRow,
+    IamSnapshotRoutePrefixRow,
+    IamSnapshotUserPermissionRow,
+    IamSnapshotUserRow,
+    WmsIamSnapshotRepo,
+)
+from app.wms.system.read_v1.services.page_catalog_service import WMS_APP_CODE, WMS_APP_NAME
+
+
+def _optional_str(value: object) -> str | None:
+    if value is None:
+        return None
+
+    text = str(value).strip()
+    return text or None
+
+
+def _required_str(value: object, *, field_name: str) -> str:
+    text = _optional_str(value)
+    if text is None:
+        raise ValueError(f"{field_name} is required")
+    return text
+
+
+def _int_value(value: object, *, field_name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{field_name} must be integer")
+
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be integer") from exc
+
+
+def _bool_value(value: object, *, field_name: str) -> bool:
+    if isinstance(value, bool):
+        return value
+
+    raise ValueError(f"{field_name} must be boolean")
+
+
+def _datetime_value(value: object, *, field_name: str) -> datetime:
+    if isinstance(value, datetime):
+        return value
+
+    raise ValueError(f"{field_name} must be datetime")
+
+
+class WmsIamSnapshotService:
+    """
+    Build WMS IAM snapshot for ERP projection sync.
+
+    Boundary:
+    - WMS remains the runtime permission source of truth.
+    - ERP gets a read-only projection input.
+    - This service never exposes password_hash.
+    - This service never writes WMS IAM tables.
+    """
+
+    def __init__(self, repo: WmsIamSnapshotRepo) -> None:
+        self.repo = repo
+
+    def get_iam_snapshot(self) -> WmsSystemIamSnapshotOut:
+        return WmsSystemIamSnapshotOut(
+            app_code=WMS_APP_CODE,
+            app_name=WMS_APP_NAME,
+            snapshot_at=datetime.now(timezone.utc),
+            users=[self._build_user_out(row) for row in self.repo.list_user_rows()],
+            permissions=[
+                self._build_permission_out(row)
+                for row in self.repo.list_permission_rows()
+            ],
+            user_permissions=[
+                self._build_user_permission_out(row)
+                for row in self.repo.list_user_permission_rows()
+            ],
+            page_registry=[
+                self._build_page_out(row)
+                for row in self.repo.list_page_rows()
+            ],
+            page_route_prefixes=[
+                self._build_route_prefix_out(row)
+                for row in self.repo.list_route_prefix_rows()
+            ],
+        )
+
+    @staticmethod
+    def _build_user_out(row: IamSnapshotUserRow) -> WmsSystemIamSnapshotUserOut:
+        return WmsSystemIamSnapshotUserOut(
+            user_id=_int_value(row.get("user_id"), field_name="user_id"),
+            username=_required_str(row.get("username"), field_name="username"),
+            is_active=_bool_value(row.get("is_active"), field_name="is_active"),
+            full_name=_optional_str(row.get("full_name")),
+            phone=_optional_str(row.get("phone")),
+            email=_optional_str(row.get("email")),
+        )
+
+    @staticmethod
+    def _build_permission_out(
+        row: IamSnapshotPermissionRow,
+    ) -> WmsSystemIamSnapshotPermissionOut:
+        return WmsSystemIamSnapshotPermissionOut(
+            permission_id=_int_value(row.get("permission_id"), field_name="permission_id"),
+            permission_code=_required_str(
+                row.get("permission_code"),
+                field_name="permission_code",
+            ),
+        )
+
+    @staticmethod
+    def _build_user_permission_out(
+        row: IamSnapshotUserPermissionRow,
+    ) -> WmsSystemIamSnapshotUserPermissionOut:
+        return WmsSystemIamSnapshotUserPermissionOut(
+            user_id=_int_value(row.get("user_id"), field_name="user_id"),
+            permission_id=_int_value(row.get("permission_id"), field_name="permission_id"),
+            permission_code=_required_str(
+                row.get("permission_code"),
+                field_name="permission_code",
+            ),
+            granted_at=_datetime_value(row.get("granted_at"), field_name="granted_at"),
+        )
+
+    @staticmethod
+    def _build_page_out(row: IamSnapshotPageRow) -> WmsSystemIamSnapshotPageOut:
+        return WmsSystemIamSnapshotPageOut(
+            page_code=_required_str(row.get("page_code"), field_name="page_code"),
+            page_name=_required_str(row.get("page_name"), field_name="page_name"),
+            parent_page_code=_optional_str(row.get("parent_page_code")),
+            level=_int_value(row.get("level"), field_name="level"),
+            domain_code=_required_str(row.get("domain_code"), field_name="domain_code"),
+            show_in_topbar=_bool_value(
+                row.get("show_in_topbar"),
+                field_name="show_in_topbar",
+            ),
+            show_in_sidebar=_bool_value(
+                row.get("show_in_sidebar"),
+                field_name="show_in_sidebar",
+            ),
+            inherit_permissions=_bool_value(
+                row.get("inherit_permissions"),
+                field_name="inherit_permissions",
+            ),
+            read_permission_code=_optional_str(row.get("read_permission_code")),
+            write_permission_code=_optional_str(row.get("write_permission_code")),
+            sort_order=_int_value(row.get("sort_order"), field_name="sort_order"),
+            is_active=_bool_value(row.get("is_active"), field_name="is_active"),
+        )
+
+    @staticmethod
+    def _build_route_prefix_out(
+        row: IamSnapshotRoutePrefixRow,
+    ) -> WmsSystemIamSnapshotRoutePrefixOut:
+        return WmsSystemIamSnapshotRoutePrefixOut(
+            id=_int_value(row.get("id"), field_name="id"),
+            page_code=_required_str(row.get("page_code"), field_name="page_code"),
+            route_prefix=_required_str(
+                row.get("route_prefix"),
+                field_name="route_prefix",
+            ),
+            sort_order=_int_value(row.get("sort_order"), field_name="sort_order"),
+            is_active=_bool_value(row.get("is_active"), field_name="is_active"),
+        )
+
+
+__all__ = ["WmsIamSnapshotService"]

--- a/tests/api/test_wms_system_iam_snapshot_api.py
+++ b/tests/api/test_wms_system_iam_snapshot_api.py
@@ -1,0 +1,114 @@
+# tests/api/test_wms_system_iam_snapshot_api.py
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def _by_code(items: list[dict], key: str) -> dict[str, dict]:
+    return {str(item[key]): item for item in items}
+
+
+def test_wms_system_iam_snapshot_requires_service_client_header() -> None:
+    client = TestClient(app)
+
+    response = client.get("/system/read/v1/iam-snapshot")
+
+    assert response.status_code == 401
+    assert "wms_service_client_required" in response.text
+
+
+def test_wms_system_iam_snapshot_rejects_ungranted_service_client() -> None:
+    client = TestClient(app)
+
+    response = client.get(
+        "/system/read/v1/iam-snapshot",
+        headers={"X-Service-Client": "logistics-service"},
+    )
+
+    assert response.status_code == 403
+    assert "wms_service_permission_denied" in response.text
+
+
+def test_wms_system_iam_snapshot_returns_safe_projection_for_erp() -> None:
+    client = TestClient(app)
+
+    response = client.get(
+        "/system/read/v1/iam-snapshot",
+        headers={"X-Service-Client": "erp-service"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    assert body["app_code"] == "wms"
+    assert body["app_name"] == "仓储管理"
+    assert body["snapshot_at"]
+
+    assert {"users", "permissions", "user_permissions"} <= set(body)
+    assert {"page_registry", "page_route_prefixes"} <= set(body)
+
+    users = body["users"]
+    permissions = body["permissions"]
+    pages = body["page_registry"]
+    route_prefixes = body["page_route_prefixes"]
+
+    assert isinstance(users, list)
+    assert isinstance(permissions, list)
+    assert isinstance(body["user_permissions"], list)
+    assert isinstance(pages, list)
+    assert isinstance(route_prefixes, list)
+
+    assert users
+    assert permissions
+    assert pages
+    assert route_prefixes
+
+    required_user_keys = {
+        "user_id",
+        "username",
+        "is_active",
+        "full_name",
+        "phone",
+        "email",
+    }
+    for user in users:
+        assert required_user_keys <= set(user)
+        assert "password_hash" not in user
+
+    permission_by_code = _by_code(permissions, "permission_code")
+    assert "page.wms.read" in permission_by_code
+    assert "page.wms.write" in permission_by_code
+
+    page_by_code = _by_code(pages, "page_code")
+    root = page_by_code["wms"]
+    assert root["page_name"] == "仓储管理"
+    assert root["read_permission_code"] == "page.wms.read"
+    assert root["write_permission_code"] == "page.wms.write"
+    assert root["is_active"] is True
+
+    admin_users = page_by_code["admin.users"]
+    assert admin_users["parent_page_code"] == "admin"
+    assert admin_users["inherit_permissions"] is True
+
+    route_by_prefix = _by_code(route_prefixes, "route_prefix")
+    assert "/admin/users" in route_by_prefix
+    assert "/inventory" in route_by_prefix
+
+    body_text = response.text
+    assert "password_hash" not in body_text
+    assert "token" not in body_text
+    assert "secret" not in body_text
+
+
+def test_wms_system_iam_snapshot_is_registered_in_openapi() -> None:
+    client = TestClient(app)
+
+    response = client.get("/openapi.json")
+
+    assert response.status_code == 200, response.text
+    paths = response.json()["paths"]
+
+    assert "/system/read/v1/iam-snapshot" in paths
+    assert "get" in paths["/system/read/v1/iam-snapshot"]


### PR DESCRIPTION
## Summary
- add service-gated WMS IAM snapshot read-v1 endpoint for ERP projection sync
- expose users, permissions, user_permissions, page_registry, and page_route_prefixes without password hashes or secrets
- seed wms.read.iam_snapshot capability, route mapping, and erp-service permission
- add API contract tests for 401/403/200 and OpenAPI registration

## Tests
- compileall app/wms/system/read_v1 alembic/versions/20260518135000_wms_iam_snapshot_read_v1.py tests/api/test_wms_system_iam_snapshot_api.py
- make alembic-check
- make test TESTS="tests/api/test_wms_system_iam_snapshot_api.py tests/api/test_wms_system_page_catalog_api.py tests/api/test_wms_system_service_capabilities_api.py tests/ci/test_wms_service_permission_runtime_contract.py"