### PR TITLE
feat(system): add WMS service permission write endpoint

### DIFF
--- a/app/router_mount.py
+++ b/app/router_mount.py
@@ -53,7 +53,7 @@ def mount_routers(app: FastAPI) -> None:
     from app.user.routers.user import router as user_router
     from app.wms.warehouses.routers.warehouses import router as warehouses_router
     from app.wms.system.read_v1.routers import router as wms_system_read_v1_router
-
+    from app.wms.system.write_v1.routers import router as wms_system_write_v1_router
 
     from app.oms.router import router as oms_router
     from app.pms.router import router as pms_router
@@ -116,6 +116,7 @@ def mount_routers(app: FastAPI) -> None:
 
     app.include_router(warehouses_router)
     app.include_router(wms_system_read_v1_router)
+    app.include_router(wms_system_write_v1_router)
 
     # PMS 相关：
     # - PMS export 读面先挂，避免与 owner /items/{id} 类路由冲突
@@ -123,8 +124,6 @@ def mount_routers(app: FastAPI) -> None:
     # - /items/aggregate 先于 /items/{id}
     # - /partners/export/suppliers 仅保留跨模块只读出口；/partners/suppliers owner 写入口已退役
     app.include_router(partners_export_suppliers_read_router)
-
-
 
     app.include_router(shipping_assist_handoffs_router)
     app.include_router(tms_records_router)

--- a/app/wms/system/write_v1/contracts/__init__.py
+++ b/app/wms/system/write_v1/contracts/__init__.py
@@ -1,0 +1,14 @@
+# app/wms/system/write_v1/contracts/__init__.py
+from __future__ import annotations
+
+from app.wms.system.write_v1.contracts.service_permissions import (
+    WmsSystemServicePermissionApplyIn,
+    WmsSystemServicePermissionApplyOut,
+    WmsSystemServicePermissionVerifyOut,
+)
+
+__all__ = [
+    "WmsSystemServicePermissionApplyIn",
+    "WmsSystemServicePermissionApplyOut",
+    "WmsSystemServicePermissionVerifyOut",
+]

--- a/app/wms/system/write_v1/contracts/service_permissions.py
+++ b/app/wms/system/write_v1/contracts/service_permissions.py
@@ -1,0 +1,55 @@
+# app/wms/system/write_v1/contracts/service_permissions.py
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class WmsSystemServicePermissionApplyIn(_Base):
+    client_code: str = Field(..., min_length=1, max_length=64)
+    client_name: str = Field(..., min_length=1, max_length=128)
+    capability_code: str = Field(..., min_length=1, max_length=128)
+    description: str | None = Field(default=None, max_length=255)
+    is_active: bool
+
+
+class WmsSystemServicePermissionApplyOut(_Base):
+    app_code: Literal["wms"]
+    client_code: str
+    client_name: str
+    capability_code: str
+    description: str | None
+    is_active: bool
+    applied: bool
+    verified: bool
+    permission_id: int
+    granted_at: datetime
+
+
+class WmsSystemServicePermissionVerifyOut(_Base):
+    app_code: Literal["wms"]
+    client_code: str
+    capability_code: str
+    client_exists: bool
+    capability_exists: bool
+    permission_exists: bool
+    client_is_active: bool | None
+    capability_is_active: bool | None
+    permission_is_active: bool | None
+    description: str | None
+    verified: bool
+    permission_id: int | None
+    granted_at: datetime | None
+
+
+__all__ = [
+    "WmsSystemServicePermissionApplyIn",
+    "WmsSystemServicePermissionApplyOut",
+    "WmsSystemServicePermissionVerifyOut",
+]

--- a/app/wms/system/write_v1/repos/__init__.py
+++ b/app/wms/system/write_v1/repos/__init__.py
@@ -1,0 +1,12 @@
+# app/wms/system/write_v1/repos/__init__.py
+from __future__ import annotations
+
+from app.wms.system.write_v1.repos.service_permission_write_repo import (
+    WmsServicePermissionWriteRepo,
+    WmsServicePermissionWriteSaveError,
+)
+
+__all__ = [
+    "WmsServicePermissionWriteRepo",
+    "WmsServicePermissionWriteSaveError",
+]

--- a/app/wms/system/write_v1/repos/service_permission_write_repo.py
+++ b/app/wms/system/write_v1/repos/service_permission_write_repo.py
@@ -1,0 +1,83 @@
+# app/wms/system/write_v1/repos/service_permission_write_repo.py
+from __future__ import annotations
+
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from app.wms.system.service_auth.models import (
+    WmsServiceCapability,
+    WmsServiceClient,
+    WmsServicePermission,
+)
+
+
+class WmsServicePermissionWriteSaveError(RuntimeError):
+    pass
+
+
+class WmsServicePermissionWriteRepo:
+    """
+    WMS service permission write repository.
+
+    Boundary:
+    - Only reads/writes wms_service_clients and wms_service_permissions.
+    - Reads wms_service_capabilities only to validate target capability existence.
+    - Never reads users / permissions / user_permissions.
+    - Never writes ERP tables or other systems.
+    """
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def get_client_by_code(self, client_code: str) -> WmsServiceClient | None:
+        return (
+            self.db.query(WmsServiceClient)
+            .filter(WmsServiceClient.client_code == client_code)
+            .one_or_none()
+        )
+
+    def get_capability_by_code(self, capability_code: str) -> WmsServiceCapability | None:
+        return (
+            self.db.query(WmsServiceCapability)
+            .filter(WmsServiceCapability.capability_code == capability_code)
+            .one_or_none()
+        )
+
+    def get_permission(
+        self,
+        *,
+        client_id: int,
+        capability_code: str,
+    ) -> WmsServicePermission | None:
+        return (
+            self.db.query(WmsServicePermission)
+            .filter(WmsServicePermission.client_id == client_id)
+            .filter(WmsServicePermission.capability_code == capability_code)
+            .one_or_none()
+        )
+
+    def add(self, row: object) -> None:
+        self.db.add(row)
+
+    def flush(self) -> None:
+        try:
+            self.db.flush()
+        except SQLAlchemyError as exc:
+            self.db.rollback()
+            raise WmsServicePermissionWriteSaveError("wms_service_permission_write_flush_failed") from exc
+
+    def commit(self) -> None:
+        try:
+            self.db.commit()
+        except SQLAlchemyError as exc:
+            self.db.rollback()
+            raise WmsServicePermissionWriteSaveError("wms_service_permission_write_commit_failed") from exc
+
+    def refresh(self, row: object) -> None:
+        self.db.refresh(row)
+
+
+__all__ = [
+    "WmsServicePermissionWriteRepo",
+    "WmsServicePermissionWriteSaveError",
+]

--- a/app/wms/system/write_v1/routers/__init__.py
+++ b/app/wms/system/write_v1/routers/__init__.py
@@ -1,0 +1,13 @@
+# app/wms/system/write_v1/routers/__init__.py
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.wms.system.write_v1.routers.service_permissions import (
+    router as service_permissions_router,
+)
+
+router = APIRouter()
+router.include_router(service_permissions_router)
+
+__all__ = ["router"]

--- a/app/wms/system/write_v1/routers/service_permissions.py
+++ b/app/wms/system/write_v1/routers/service_permissions.py
@@ -1,0 +1,105 @@
+# app/wms/system/write_v1/routers/service_permissions.py
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.wms.system.service_auth.deps import WMS_SERVICE_CLIENT_HEADER
+from app.wms.system.write_v1.contracts import (
+    WmsSystemServicePermissionApplyIn,
+    WmsSystemServicePermissionApplyOut,
+    WmsSystemServicePermissionVerifyOut,
+)
+from app.wms.system.write_v1.repos import WmsServicePermissionWriteSaveError
+from app.wms.system.write_v1.services import (
+    WmsServicePermissionCapabilityNotFoundError,
+    WmsServicePermissionClientCodeReservedError,
+    WmsServicePermissionWriteService,
+)
+
+router = APIRouter(prefix="/system/write/v1", tags=["system-write-v1"])
+
+ERP_SERVICE_CLIENT_CODE = "erp-service"
+
+
+def require_erp_service_client(
+    x_service_client: str | None = Header(default=None, alias=WMS_SERVICE_CLIENT_HEADER),
+) -> None:
+    client_code = (x_service_client or "").strip()
+
+    if not client_code:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="wms_service_client_required",
+        )
+
+    if client_code != ERP_SERVICE_CLIENT_CODE:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="wms_service_permission_write_denied",
+        )
+
+
+@router.post(
+    "/service-permissions/apply",
+    response_model=WmsSystemServicePermissionApplyOut,
+    summary="Apply WMS service permission",
+)
+async def apply_wms_service_permission(
+    payload: WmsSystemServicePermissionApplyIn,
+    _erp_service_client: None = Depends(require_erp_service_client),
+    db: Session = Depends(get_db),
+) -> WmsSystemServicePermissionApplyOut:
+    """
+    Apply one WMS local service permission from ERP.
+
+    Boundary:
+    - Only X-Service-Client: erp-service may call this endpoint.
+    - Writes only wms_service_clients and wms_service_permissions.
+    - Does not write ERP tables.
+    - Does not write other systems.
+    - Does not read users / permissions / user_permissions.
+    """
+
+    try:
+        return WmsServicePermissionWriteService(db).apply_permission(payload)
+    except WmsServicePermissionCapabilityNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except WmsServicePermissionClientCodeReservedError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    except WmsServicePermissionWriteSaveError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(exc),
+        ) from exc
+
+
+@router.get(
+    "/service-permissions/verify",
+    response_model=WmsSystemServicePermissionVerifyOut,
+    summary="Verify WMS service permission",
+)
+async def verify_wms_service_permission(
+    client_code: str = Query(..., min_length=1, max_length=64),
+    capability_code: str = Query(..., min_length=1, max_length=128),
+    _erp_service_client: None = Depends(require_erp_service_client),
+    db: Session = Depends(get_db),
+) -> WmsSystemServicePermissionVerifyOut:
+    """
+    Verify one WMS local service permission for ERP.
+
+    Boundary:
+    - Only X-Service-Client: erp-service may call this endpoint.
+    - Reads only wms_service_clients, wms_service_capabilities, and wms_service_permissions.
+    - Does not write anything.
+    - Does not read users / permissions / user_permissions.
+    """
+
+    return WmsServicePermissionWriteService(db).verify_permission(
+        client_code=client_code,
+        capability_code=capability_code,
+    )
+
+
+__all__ = ["router"]

--- a/app/wms/system/write_v1/services/__init__.py
+++ b/app/wms/system/write_v1/services/__init__.py
@@ -1,0 +1,16 @@
+# app/wms/system/write_v1/services/__init__.py
+from __future__ import annotations
+
+from app.wms.system.write_v1.services.service_permission_write_service import (
+    WMS_APP_CODE,
+    WmsServicePermissionCapabilityNotFoundError,
+    WmsServicePermissionClientCodeReservedError,
+    WmsServicePermissionWriteService,
+)
+
+__all__ = [
+    "WMS_APP_CODE",
+    "WmsServicePermissionCapabilityNotFoundError",
+    "WmsServicePermissionClientCodeReservedError",
+    "WmsServicePermissionWriteService",
+]

--- a/app/wms/system/write_v1/services/service_permission_write_service.py
+++ b/app/wms/system/write_v1/services/service_permission_write_service.py
@@ -1,0 +1,190 @@
+# app/wms/system/write_v1/services/service_permission_write_service.py
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.wms.system.service_auth.models import (
+    WmsServiceCapability,
+    WmsServiceClient,
+    WmsServicePermission,
+)
+from app.wms.system.write_v1.contracts import (
+    WmsSystemServicePermissionApplyIn,
+    WmsSystemServicePermissionApplyOut,
+    WmsSystemServicePermissionVerifyOut,
+)
+from app.wms.system.write_v1.repos import WmsServicePermissionWriteRepo
+
+WMS_APP_CODE = "wms"
+
+
+class WmsServicePermissionCapabilityNotFoundError(ValueError):
+    pass
+
+
+class WmsServicePermissionClientCodeReservedError(ValueError):
+    pass
+
+
+def _strip(value: str | None) -> str:
+    return (value or "").strip()
+
+
+def _optional_strip(value: str | None) -> str | None:
+    text = _strip(value)
+    return text or None
+
+
+def _is_verified(
+    *,
+    client: WmsServiceClient | None,
+    capability: WmsServiceCapability | None,
+    permission: WmsServicePermission | None,
+) -> bool:
+    return bool(
+        client
+        and capability
+        and permission
+        and client.is_active
+        and capability.is_active
+        and permission.is_active
+    )
+
+
+class WmsServicePermissionWriteService:
+    """
+    Apply and verify WMS local service permissions for ERP.
+
+    Boundary:
+    - ERP calls this service through /system/write/v1.
+    - WMS remains the runtime permission source of truth.
+    - This service writes only WMS local service auth execution tables.
+    - This service never writes ERP and never reads user permission tables.
+    """
+
+    def __init__(
+        self,
+        db: Session,
+        repo: WmsServicePermissionWriteRepo | None = None,
+    ) -> None:
+        self.repo = repo or WmsServicePermissionWriteRepo(db)
+
+    def apply_permission(
+        self,
+        payload: WmsSystemServicePermissionApplyIn,
+    ) -> WmsSystemServicePermissionApplyOut:
+        client_code = _strip(payload.client_code)
+        client_name = _strip(payload.client_name)
+        capability_code = _strip(payload.capability_code)
+        description = _optional_strip(payload.description)
+
+        if client_code == "erp-service":
+            raise WmsServicePermissionClientCodeReservedError(
+                "erp_service_cannot_be_managed_as_target_client"
+            )
+
+        capability = self.repo.get_capability_by_code(capability_code)
+        if capability is None:
+            raise WmsServicePermissionCapabilityNotFoundError(
+                "wms_service_capability_not_found"
+            )
+
+        client = self.repo.get_client_by_code(client_code)
+        if client is None:
+            client = WmsServiceClient(
+                client_code=client_code,
+                client_name=client_name,
+                description="ERP managed service client",
+                is_active=True,
+            )
+            self.repo.add(client)
+            self.repo.flush()
+        else:
+            client.client_name = client_name
+            client.is_active = True
+            self.repo.flush()
+
+        permission = self.repo.get_permission(
+            client_id=int(client.id),
+            capability_code=capability_code,
+        )
+        if permission is None:
+            permission = WmsServicePermission(
+                client_id=int(client.id),
+                capability_code=capability_code,
+                description=description,
+                is_active=payload.is_active,
+            )
+            self.repo.add(permission)
+        else:
+            permission.description = description
+            permission.is_active = payload.is_active
+
+        self.repo.flush()
+        self.repo.commit()
+        self.repo.refresh(client)
+        self.repo.refresh(permission)
+
+        return WmsSystemServicePermissionApplyOut(
+            app_code=WMS_APP_CODE,
+            client_code=str(client.client_code),
+            client_name=str(client.client_name),
+            capability_code=str(permission.capability_code),
+            description=permission.description,
+            is_active=bool(permission.is_active),
+            applied=True,
+            verified=_is_verified(
+                client=client,
+                capability=capability,
+                permission=permission,
+            ),
+            permission_id=int(permission.id),
+            granted_at=permission.granted_at,
+        )
+
+    def verify_permission(
+        self,
+        *,
+        client_code: str,
+        capability_code: str,
+    ) -> WmsSystemServicePermissionVerifyOut:
+        normalized_client_code = _strip(client_code)
+        normalized_capability_code = _strip(capability_code)
+
+        client = self.repo.get_client_by_code(normalized_client_code)
+        capability = self.repo.get_capability_by_code(normalized_capability_code)
+        permission = None
+
+        if client is not None:
+            permission = self.repo.get_permission(
+                client_id=int(client.id),
+                capability_code=normalized_capability_code,
+            )
+
+        return WmsSystemServicePermissionVerifyOut(
+            app_code=WMS_APP_CODE,
+            client_code=normalized_client_code,
+            capability_code=normalized_capability_code,
+            client_exists=client is not None,
+            capability_exists=capability is not None,
+            permission_exists=permission is not None,
+            client_is_active=bool(client.is_active) if client is not None else None,
+            capability_is_active=bool(capability.is_active) if capability is not None else None,
+            permission_is_active=bool(permission.is_active) if permission is not None else None,
+            description=permission.description if permission is not None else None,
+            verified=_is_verified(
+                client=client,
+                capability=capability,
+                permission=permission,
+            ),
+            permission_id=int(permission.id) if permission is not None else None,
+            granted_at=permission.granted_at if permission is not None else None,
+        )
+
+
+__all__ = [
+    "WMS_APP_CODE",
+    "WmsServicePermissionCapabilityNotFoundError",
+    "WmsServicePermissionClientCodeReservedError",
+    "WmsServicePermissionWriteService",
+]

--- a/openapi/_current.json
+++ b/openapi/_current.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "WMS-DU",
+    "title": "wms-api",
     "version": "1.1.0"
   },
   "paths": {
@@ -735,6 +735,285 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/FulfillmentDebugOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/wms/outbound/orders/oms-projection-candidates": {
+      "get": {
+        "tags": [
+          "wms-outbound-order-import"
+        ],
+        "summary": "List Wms Outbound Oms Projection Candidates",
+        "operationId": "list_wms_outbound_oms_projection_candidates_wms_outbound_orders_oms_projection_candidates_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Q"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "default": 20,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OmsProjectionOrderImportCandidatesOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/wms/outbound/orders/import-from-oms-projection": {
+      "post": {
+        "tags": [
+          "wms-outbound-order-import"
+        ],
+        "summary": "Import Wms Orders From Oms Projection",
+        "operationId": "import_wms_orders_from_oms_projection_wms_outbound_orders_import_from_oms_projection_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OmsProjectionOrderImportIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OmsProjectionOrderImportOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/wms/outbound/orders/options": {
+      "get": {
+        "tags": [
+          "wms-outbound-order-read"
+        ],
+        "summary": "Get Wms Outbound Order Options",
+        "operationId": "get_wms_outbound_order_options_wms_outbound_orders_options_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Q"
+            }
+          },
+          {
+            "name": "platform",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Platform"
+            }
+          },
+          {
+            "name": "store_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Store Code"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "default": 20,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrderOutboundOptionsOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/wms/outbound/orders/{order_id}/view": {
+      "get": {
+        "tags": [
+          "wms-outbound-order-read"
+        ],
+        "summary": "Get Wms Outbound Order View",
+        "operationId": "get_wms_outbound_order_view_wms_outbound_orders__order_id__view_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "order_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Order Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrderOutboundViewResponse"
                 }
               }
             }
@@ -2726,6 +3005,84 @@
         }
       }
     },
+    "/inbound-receipts/purchase-source-options": {
+      "get": {
+        "tags": [
+          "inbound-receipts"
+        ],
+        "summary": "List Inbound Receipt Purchase Source Options Endpoint",
+        "operationId": "list_inbound_receipt_purchase_source_options_endpoint_inbound_receipts_purchase_source_options_get",
+        "parameters": [
+          {
+            "name": "target_warehouse_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "exclusiveMinimum": 0
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Target Warehouse Id"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Q"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "default": 200,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboundReceiptPurchaseSourceOptionsOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/inbound-receipts/from-purchase": {
       "post": {
         "tags": [
@@ -3197,6 +3554,177 @@
             "OAuth2PasswordBearer": []
           }
         ]
+      }
+    },
+    "/wms/inbound/procurement-receiving-results": {
+      "get": {
+        "tags": [
+          "wms-inbound-events"
+        ],
+        "summary": "List Procurement Receiving Results Endpoint",
+        "operationId": "list_procurement_receiving_results_endpoint_wms_inbound_procurement_receiving_results_get",
+        "parameters": [
+          {
+            "name": "after_event_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "只返回 event_id 大于该值的收货结果",
+              "default": 0,
+              "title": "After Event Id"
+            },
+            "description": "只返回 event_id 大于该值的收货结果"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "description": "最多读取多少个 WMS event",
+              "default": 50,
+              "title": "Limit"
+            },
+            "description": "最多读取多少个 WMS event"
+          },
+          {
+            "name": "procurement_po_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "采购系统采购单 ID",
+              "title": "Procurement Po Id"
+            },
+            "description": "采购系统采购单 ID"
+          },
+          {
+            "name": "receipt_no",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "WMS 入库单号",
+              "title": "Receipt No"
+            },
+            "description": "WMS 入库单号"
+          },
+          {
+            "name": "X-Service-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Service-Client"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcurementReceivingResultsOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/wms/inbound/procurement-receiving-results/{event_id}": {
+      "get": {
+        "tags": [
+          "wms-inbound-events"
+        ],
+        "summary": "Get Procurement Receiving Result Detail Endpoint",
+        "operationId": "get_procurement_receiving_result_detail_endpoint_wms_inbound_procurement_receiving_results__event_id__get",
+        "parameters": [
+          {
+            "name": "event_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Event Id"
+            }
+          },
+          {
+            "name": "X-Service-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Service-Client"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcurementReceivingResultDetailOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/wms/inbound/events": {
@@ -4287,1325 +4815,132 @@
         ]
       }
     },
-    "/oms/pdd/platform-order-mirrors/import": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Pdd Import Platform Order Mirror",
-        "operationId": "pdd_import_platform_order_mirror_oms_pdd_platform_order_mirrors_import_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlatformOrderMirrorImportIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderMirrorEnvelopeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/pdd/platform-order-mirrors/import-from-collector": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Pdd Import Platform Order Mirror From Collector Route",
-        "operationId": "pdd_import_platform_order_mirror_from_collector_route_oms_pdd_platform_order_mirrors_import_from_collector_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ImportPlatformOrderMirrorFromCollectorIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportPlatformOrderMirrorFromCollectorOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/pdd/platform-order-mirrors/sync-from-collector": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Pdd Sync Platform Order Mirrors From Collector Route",
-        "operationId": "pdd_sync_platform_order_mirrors_from_collector_route_oms_pdd_platform_order_mirrors_sync_from_collector_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SyncPlatformOrderMirrorsFromCollectorIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SyncPlatformOrderMirrorsFromCollectorOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/pdd/platform-order-mirrors": {
+    "/oms/fulfillment-projection/status": {
       "get": {
         "tags": [
           "OMS",
-          "oms-platform-order-mirrors"
+          "oms-fulfillment-projection"
         ],
-        "summary": "Pdd List Platform Order Mirror Rows",
-        "operationId": "pdd_list_platform_order_mirror_rows_oms_pdd_platform_order_mirrors_get",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 1000,
-              "minimum": 1,
-              "default": 200,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
-          }
-        ],
+        "summary": "Get Oms Fulfillment Projection Status",
+        "operationId": "get_oms_fulfillment_projection_status_oms_fulfillment_projection_status_get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderMirrorListOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/OmsProjectionStatusOut"
                 }
               }
             }
           }
-        }
-      }
-    },
-    "/oms/pdd/platform-order-mirrors/{mirror_id}": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Pdd Get Platform Order Mirror Row",
-        "operationId": "pdd_get_platform_order_mirror_row_oms_pdd_platform_order_mirrors__mirror_id__get",
-        "parameters": [
-          {
-            "name": "mirror_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Mirror Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderMirrorEnvelopeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/taobao/platform-order-mirrors/import": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Taobao Import Platform Order Mirror",
-        "operationId": "taobao_import_platform_order_mirror_oms_taobao_platform_order_mirrors_import_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlatformOrderMirrorImportIn"
-              }
-            }
-          },
-          "required": true
         },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderMirrorEnvelopeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
           }
-        }
+        ]
       }
     },
-    "/oms/taobao/platform-order-mirrors/import-from-collector": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Taobao Import Platform Order Mirror From Collector Route",
-        "operationId": "taobao_import_platform_order_mirror_from_collector_route_oms_taobao_platform_order_mirrors_import_from_collector_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ImportPlatformOrderMirrorFromCollectorIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportPlatformOrderMirrorFromCollectorOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/taobao/platform-order-mirrors/sync-from-collector": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Taobao Sync Platform Order Mirrors From Collector Route",
-        "operationId": "taobao_sync_platform_order_mirrors_from_collector_route_oms_taobao_platform_order_mirrors_sync_from_collector_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SyncPlatformOrderMirrorsFromCollectorIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SyncPlatformOrderMirrorsFromCollectorOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/taobao/platform-order-mirrors": {
+    "/oms/fulfillment-projection/sync-runs": {
       "get": {
         "tags": [
           "OMS",
-          "oms-platform-order-mirrors"
+          "oms-fulfillment-projection"
         ],
-        "summary": "Taobao List Platform Order Mirror Rows",
-        "operationId": "taobao_list_platform_order_mirror_rows_oms_taobao_platform_order_mirrors_get",
-        "parameters": [
+        "summary": "List Oms Fulfillment Projection Sync Runs",
+        "operationId": "list_oms_fulfillment_projection_sync_runs_oms_fulfillment_projection_sync_runs_get",
+        "security": [
           {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 1000,
-              "minimum": 1,
-              "default": 200,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
+            "OAuth2PasswordBearer": []
           }
         ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderMirrorListOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/taobao/platform-order-mirrors/{mirror_id}": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Taobao Get Platform Order Mirror Row",
-        "operationId": "taobao_get_platform_order_mirror_row_oms_taobao_platform_order_mirrors__mirror_id__get",
-        "parameters": [
-          {
-            "name": "mirror_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Mirror Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderMirrorEnvelopeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/jd/platform-order-mirrors/import": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Jd Import Platform Order Mirror",
-        "operationId": "jd_import_platform_order_mirror_oms_jd_platform_order_mirrors_import_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlatformOrderMirrorImportIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderMirrorEnvelopeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/jd/platform-order-mirrors/import-from-collector": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Jd Import Platform Order Mirror From Collector Route",
-        "operationId": "jd_import_platform_order_mirror_from_collector_route_oms_jd_platform_order_mirrors_import_from_collector_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ImportPlatformOrderMirrorFromCollectorIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportPlatformOrderMirrorFromCollectorOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/jd/platform-order-mirrors/sync-from-collector": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Jd Sync Platform Order Mirrors From Collector Route",
-        "operationId": "jd_sync_platform_order_mirrors_from_collector_route_oms_jd_platform_order_mirrors_sync_from_collector_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SyncPlatformOrderMirrorsFromCollectorIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SyncPlatformOrderMirrorsFromCollectorOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/jd/platform-order-mirrors": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Jd List Platform Order Mirror Rows",
-        "operationId": "jd_list_platform_order_mirror_rows_oms_jd_platform_order_mirrors_get",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 1000,
-              "minimum": 1,
-              "default": 200,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderMirrorListOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/jd/platform-order-mirrors/{mirror_id}": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Jd Get Platform Order Mirror Row",
-        "operationId": "jd_get_platform_order_mirror_row_oms_jd_platform_order_mirrors__mirror_id__get",
-        "parameters": [
-          {
-            "name": "mirror_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Mirror Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderMirrorEnvelopeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/pdd/code-mapping/code-options": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-code-mapping"
-        ],
-        "summary": "Pdd List Platform Code Mapping Code Options",
-        "operationId": "pdd_list_platform_code_mapping_code_options_oms_pdd_code_mapping_code_options_get",
-        "parameters": [
-          {
-            "name": "store_code",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 128
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Store Code"
-            }
-          },
-          {
-            "name": "merchant_code",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 128
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Merchant Code"
-            }
-          },
-          {
-            "name": "only_unbound",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Only Unbound"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 1000,
-              "minimum": 1,
-              "default": 200,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CodeMappingCodeOptionListOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/taobao/code-mapping/code-options": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-code-mapping"
-        ],
-        "summary": "Taobao List Platform Code Mapping Code Options",
-        "operationId": "taobao_list_platform_code_mapping_code_options_oms_taobao_code_mapping_code_options_get",
-        "parameters": [
-          {
-            "name": "store_code",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 128
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Store Code"
-            }
-          },
-          {
-            "name": "merchant_code",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 128
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Merchant Code"
-            }
-          },
-          {
-            "name": "only_unbound",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Only Unbound"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 1000,
-              "minimum": 1,
-              "default": 200,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CodeMappingCodeOptionListOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/jd/code-mapping/code-options": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-code-mapping"
-        ],
-        "summary": "Jd List Platform Code Mapping Code Options",
-        "operationId": "jd_list_platform_code_mapping_code_options_oms_jd_code_mapping_code_options_get",
-        "parameters": [
-          {
-            "name": "store_code",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 128
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Store Code"
-            }
-          },
-          {
-            "name": "merchant_code",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 128
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Merchant Code"
-            }
-          },
-          {
-            "name": "only_unbound",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Only Unbound"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 1000,
-              "minimum": 1,
-              "default": 200,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CodeMappingCodeOptionListOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/pdd/platform-order-mirrors/{mirror_id}/sku-resolution": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-order-sku-resolution"
-        ],
-        "summary": "Pdd Get Platform Order Sku Resolution",
-        "operationId": "pdd_get_platform_order_sku_resolution_oms_pdd_platform_order_mirrors__mirror_id__sku_resolution_get",
-        "parameters": [
-          {
-            "name": "mirror_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Mirror Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrderSkuResolutionOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/taobao/platform-order-mirrors/{mirror_id}/sku-resolution": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-order-sku-resolution"
-        ],
-        "summary": "Taobao Get Platform Order Sku Resolution",
-        "operationId": "taobao_get_platform_order_sku_resolution_oms_taobao_platform_order_mirrors__mirror_id__sku_resolution_get",
-        "parameters": [
-          {
-            "name": "mirror_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Mirror Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrderSkuResolutionOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/jd/platform-order-mirrors/{mirror_id}/sku-resolution": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-order-sku-resolution"
-        ],
-        "summary": "Jd Get Platform Order Sku Resolution",
-        "operationId": "jd_get_platform_order_sku_resolution_oms_jd_platform_order_mirrors__mirror_id__sku_resolution_get",
-        "parameters": [
-          {
-            "name": "mirror_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Mirror Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrderSkuResolutionOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/platform-orders/ingest": {
-      "post": {
-        "tags": [
-          "OMS",
-          "platform-orders"
-        ],
-        "summary": "平台订单接入（Phase N+2）：填写码 → FSKU → Items → /orders",
-        "operationId": "ingest_platform_order_oms_platform_orders_ingest_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlatformOrderIngestIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderIngestOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/platform-orders/confirm-and-create": {
-      "post": {
-        "tags": [
-          "OMS",
-          "platform-orders"
-        ],
-        "summary": "当单执行：人工确认选货后生成内部订单（不写任何映射；人工决策写入证据表）",
-        "operationId": "confirm_and_create_platform_order_oms_platform_orders_confirm_and_create_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlatformOrderConfirmCreateIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderConfirmCreateOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/platform-orders/replay": {
-      "post": {
-        "tags": [
-          "OMS",
-          "platform-orders"
-        ],
-        "summary": "平台订单事实重放解码：从 platform_order_lines 读取事实，复用 resolver + /orders ingest 主线幂等生成订单",
-        "operationId": "replay_platform_order_oms_platform_orders_replay_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlatformOrderReplayIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderReplayOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/platform-orders/resolve-preview": {
-      "post": {
-        "tags": [
-          "OMS",
-          "platform-orders"
-        ],
-        "summary": "平台订单事实只读解析预览：读取 platform_order_lines 并展开到 FSKU/SKU，不建单",
-        "description": "只读解析预览。\n\n边界：\n- 读取 platform_order_lines；\n- 复用 resolver 展开 FSKU / item；\n- 返回 resolved / unresolved / item_qty_map；\n- 不写 platform_order_lines；\n- 不建 orders/order_items；\n- 不触碰 finance。",
-        "operationId": "preview_platform_order_resolve_oms_platform_orders_resolve_preview_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlatformOrderResolvePreviewIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderResolvePreviewOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/platform-orders/manual-decisions/latest": {
-      "get": {
-        "tags": [
-          "OMS",
-          "platform-orders"
-        ],
-        "summary": "读取最近的人工救火批次（platform_order_manual_decisions），用于治理证据回流（不写绑定）",
-        "operationId": "list_latest_manual_decisions_oms_platform_orders_manual_decisions_latest_get",
         "parameters": [
           {
             "name": "platform",
             "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "pdd",
+                    "taobao",
+                    "jd"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Platform"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 20,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OmsProjectionSyncRunsOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/fulfillment-projection/projections/{resource}": {
+      "get": {
+        "tags": [
+          "OMS",
+          "oms-fulfillment-projection"
+        ],
+        "summary": "List Oms Fulfillment Projection Rows",
+        "operationId": "list_oms_fulfillment_projection_rows_oms_fulfillment_projection_projections__resource__get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "resource",
+            "in": "path",
             "required": true,
             "schema": {
+              "enum": [
+                "orders",
+                "lines",
+                "components"
+              ],
               "type": "string",
-              "description": "平台（如 DEMO/PDD/TB），大小写不敏感",
-              "title": "Platform"
-            },
-            "description": "平台（如 DEMO/PDD/TB），大小写不敏感"
-          },
-          {
-            "name": "store_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "description": "内部店铺 store_id（stores.id）",
-              "title": "Store Id"
-            },
-            "description": "内部店铺 store_id（stores.id）"
+              "title": "Resource"
+            }
           },
           {
             "name": "limit",
@@ -5613,9 +4948,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "maximum": 200,
+              "maximum": 500,
               "minimum": 1,
-              "default": 20,
+              "default": 50,
               "title": "Limit"
             }
           },
@@ -5629,6 +4964,22 @@
               "default": 0,
               "title": "Offset"
             }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Q"
+            }
           }
         ],
         "responses": {
@@ -5637,7 +4988,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ManualDecisionOrdersOut"
+                  "$ref": "#/components/schemas/OmsProjectionListOut"
                 }
               }
             }
@@ -5655,15 +5006,14 @@
         }
       }
     },
-    "/oms/stores": {
-      "get": {
+    "/oms/fulfillment-projection/projections/fulfillment-ready-orders/sync": {
+      "post": {
         "tags": [
           "OMS",
-          "stores"
+          "oms-fulfillment-projection"
         ],
-        "summary": "List Stores",
-        "description": "店铺列表（基础信息，不含仓绑定）。\n\n权限：config.store.read\n\n✅ 合同：\n- 支持 platform/q/limit/offset\n- 返回结构保持：{ ok: true, data: [...] }",
-        "operationId": "list_stores_oms_stores_get",
+        "summary": "Sync Oms Fulfillment Ready Orders",
+        "operationId": "sync_oms_fulfillment_ready_orders_oms_fulfillment_projection_projections_fulfillment_ready_orders_sync_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -5677,34 +5027,102 @@
             "schema": {
               "anyOf": [
                 {
+                  "enum": [
+                    "pdd",
+                    "taobao",
+                    "jd"
+                  ],
                   "type": "string"
                 },
                 {
                   "type": "null"
                 }
               ],
-              "description": "平台过滤（如 PDD/TB/DEMO），大小写不敏感",
               "title": "Platform"
-            },
-            "description": "平台过滤（如 PDD/TB/DEMO），大小写不敏感"
+            }
           },
           {
-            "name": "q",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
               "anyOf": [
                 {
-                  "type": "string"
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 128
                 },
                 {
                   "type": "null"
                 }
               ],
-              "description": "模糊搜索：store_name / store_code / id",
-              "title": "Q"
-            },
-            "description": "模糊搜索：store_name / store_code / id"
+              "title": "Store Code"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "default": 200,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OmsProjectionSyncOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/fulfillment-projection/projections/{resource}/check": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-fulfillment-projection"
+        ],
+        "summary": "Check Oms Fulfillment Projection Resource",
+        "operationId": "check_oms_fulfillment_projection_resource_oms_fulfillment_projection_projections__resource__check_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "resource",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "enum": [
+                "orders",
+                "lines",
+                "components"
+              ],
+              "type": "string",
+              "title": "Resource"
+            }
           },
           {
             "name": "limit",
@@ -5717,17 +5135,6 @@
               "default": 200,
               "title": "Limit"
             }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
           }
         ],
         "responses": {
@@ -5736,53 +5143,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/StoreListOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Create Or Get Store",
-        "description": "店铺建档 / 补录（幂等）。\n\n权限：config.store.write\n\n✅ 合同收敛：\n- store_type 的唯一真相为 platform_test_stores（code='DEFAULT'）\n- 创建时可选择 TEST/PROD：\n  * TEST：写入/更新 platform_test_stores（绑定 store_id）\n  * PROD：确保该 store_id 不在 platform_test_stores（删除绑定）",
-        "operationId": "create_or_get_store_oms_stores_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StoreCreateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StoreCreateOut"
+                  "$ref": "#/components/schemas/OmsProjectionCheckOut"
                 }
               }
             }
@@ -5800,123 +5161,41 @@
         }
       }
     },
-    "/oms/stores/{store_id}": {
-      "patch": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Update Store",
-        "description": "更新店铺基础信息（name / active / route_mode / email / 联系人 / 电话）。\n\n权限：config.store.write",
-        "operationId": "update_store_oms_stores__store_id__patch",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StoreUpdateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StoreUpdateOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
+    "/pms/projections/status": {
       "get": {
         "tags": [
-          "OMS",
-          "stores"
+          "pms",
+          "pms-projections"
         ],
-        "summary": "Get Store Detail",
-        "description": "店铺详情（含绑定仓列表）。\n权限：config.store.read",
-        "operationId": "get_store_detail_oms_stores__store_id__get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
+        "summary": "Get Pms Projection Sync Status",
+        "operationId": "get_pms_projection_sync_status_pms_projections_status_get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/StoreDetailOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/PmsProjectionStatusOut"
                 }
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
       }
     },
-    "/oms/stores/{store_id}/default-warehouse": {
+    "/pms/projections/sync-runs": {
       "get": {
         "tags": [
-          "OMS",
-          "stores"
+          "pms",
+          "pms-projections"
         ],
-        "summary": "Get Default Warehouse",
-        "description": "解析默认仓（若无绑定返回 null）。\n权限：config.store.read",
-        "operationId": "get_default_warehouse_oms_stores__store_id__default_warehouse_get",
+        "summary": "List Pms Projection Sync Runs",
+        "operationId": "list_pms_projection_sync_runs_pms_projections_sync_runs_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -5924,1005 +5203,27 @@
         ],
         "parameters": [
           {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DefaultWarehouseOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/warehouses/bind": {
-      "post": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Bind Store Warehouse",
-        "description": "店 ↔ 仓 绑定（幂等）。\n权限：config.store.write\n\n约束：\n- 若 is_default=true，会保证该店铺“唯一默认仓”\n- 若 is_top 为 null，由后端按 is_default 推导（由 StoreService.bind_warehouse 负责）",
-        "operationId": "bind_store_warehouse_oms_stores__store_id__warehouses_bind_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BindWarehouseIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BindWarehouseOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/warehouses/{warehouse_id}": {
-      "patch": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Update Binding",
-        "description": "更新绑定关系（is_default / priority / is_top）。\n权限：config.store.write\n\n✅ 强约束：当 is_default=true 时，必须保证“唯一默认仓”。\n实现方式：调用 StoreService.set_default_warehouse（清空同店其它 default，再置当前为 default）。",
-        "operationId": "update_binding_oms_stores__store_id__warehouses__warehouse_id__patch",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          },
-          {
-            "name": "warehouse_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Warehouse Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BindingUpdateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BindingUpdateOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Delete Binding",
-        "description": "解除店 ↔ 仓 绑定关系。\n权限：config.store.write",
-        "operationId": "delete_binding_oms_stores__store_id__warehouses__warehouse_id__delete",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          },
-          {
-            "name": "warehouse_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Warehouse Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BindingDeleteOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/routes/provinces": {
-      "get": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "List Province Routes",
-        "operationId": "list_province_routes_oms_stores__store_id__routes_provinces_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProvinceRouteListOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Create Province Route",
-        "operationId": "create_province_route_oms_stores__store_id__routes_provinces_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ProvinceRouteCreateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProvinceRouteWriteOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/routes/provinces/{route_id}": {
-      "patch": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Update Province Route",
-        "operationId": "update_province_route_oms_stores__store_id__routes_provinces__route_id__patch",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          },
-          {
-            "name": "route_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Route Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ProvinceRouteUpdateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProvinceRouteWriteOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Delete Province Route",
-        "operationId": "delete_province_route_oms_stores__store_id__routes_provinces__route_id__delete",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          },
-          {
-            "name": "route_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Route Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProvinceRouteWriteOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/routing/health": {
-      "get": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Routing Health",
-        "operationId": "routing_health_oms_stores__store_id__routing_health_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RoutingHealthOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/order-sim/merchant-lines": {
-      "get": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Get Order Sim Merchant Lines",
-        "operationId": "get_order_sim_merchant_lines_oms_stores__store_id__order_sim_merchant_lines_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrderSimMerchantLinesGetOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Put Order Sim Merchant Lines",
-        "operationId": "put_order_sim_merchant_lines_oms_stores__store_id__order_sim_merchant_lines_put",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/OrderSimMerchantLinesPutIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrderSimMerchantLinesPutOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/order-sim/filled-code-options": {
-      "get": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Get Order Sim Filled Code Options",
-        "operationId": "get_order_sim_filled_code_options_oms_stores__store_id__order_sim_filled_code_options_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrderSimFilledCodeOptionsOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/order-sim/cart": {
-      "get": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Get Order Sim Cart",
-        "operationId": "get_order_sim_cart_oms_stores__store_id__order_sim_cart_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrderSimCartGetOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Put Order Sim Cart",
-        "operationId": "put_order_sim_cart_oms_stores__store_id__order_sim_cart_put",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/OrderSimCartPutIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrderSimCartPutOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/order-sim/preview-order": {
-      "post": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Preview Order Sim Order",
-        "operationId": "preview_order_sim_order_oms_stores__store_id__order_sim_preview_order_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/OrderSimPreviewOrderIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrderSimPreviewOrderOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/order-sim/generate-order": {
-      "post": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Generate Order Sim Order",
-        "operationId": "generate_order_sim_order_oms_stores__store_id__order_sim_generate_order_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/OrderSimGenerateOrderIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrderSimGenerateOrderOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/fskus": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-fsku",
-          "oms-fsku",
-          "oms-fsku"
-        ],
-        "summary": "Create",
-        "operationId": "create_oms_fskus_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FskuCreateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FskuDetailOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-fsku",
-          "oms-fsku",
-          "oms-fsku"
-        ],
-        "summary": "List ",
-        "operationId": "list__oms_fskus_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "query",
+            "name": "resource",
             "in": "query",
             "required": false,
             "schema": {
               "anyOf": [
                 {
+                  "enum": [
+                    "items",
+                    "suppliers",
+                    "uoms",
+                    "sku-codes",
+                    "barcodes"
+                  ],
                   "type": "string"
                 },
                 {
                   "type": "null"
                 }
               ],
-              "description": "按 name/code/expression 模糊搜索",
-              "title": "Query"
-            },
-            "description": "按 name/code/expression 模糊搜索"
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "draft/published/retired",
-              "title": "Status"
-            },
-            "description": "draft/published/retired"
-          },
-          {
-            "name": "store_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer",
-                  "minimum": 1
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "保留查询上下文；OMS FSKU 主数据不按店铺过滤",
-              "title": "Store Id"
-            },
-            "description": "保留查询上下文；OMS FSKU 主数据不按店铺过滤"
+              "title": "Resource"
+            }
           },
           {
             "name": "limit",
@@ -6930,7 +5231,74 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "maximum": 200,
+              "maximum": 100,
+              "minimum": 1,
+              "default": 20,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PmsProjectionSyncRunsOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/projections/{resource}": {
+      "get": {
+        "tags": [
+          "pms",
+          "pms-projections"
+        ],
+        "summary": "List Pms Projection Rows",
+        "operationId": "list_pms_projection_rows_pms_projections__resource__get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "resource",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "enum": [
+                "items",
+                "suppliers",
+                "uoms",
+                "sku-codes",
+                "barcodes"
+              ],
+              "type": "string",
+              "title": "Resource"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
               "minimum": 1,
               "default": 50,
               "title": "Limit"
@@ -6946,610 +5314,7 @@
               "default": 0,
               "title": "Offset"
             }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FskuListOut"
-                }
-              }
-            }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/fskus/{fsku_id}": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-fsku",
-          "oms-fsku",
-          "oms-fsku"
-        ],
-        "summary": "Detail",
-        "operationId": "detail_oms_fskus__fsku_id__get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "fsku_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Fsku Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FskuDetailOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "OMS",
-          "oms-fsku",
-          "oms-fsku",
-          "oms-fsku"
-        ],
-        "summary": "Patch Fsku",
-        "operationId": "patch_fsku_oms_fskus__fsku_id__patch",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "fsku_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Fsku Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FskuNameUpdateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FskuDetailOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/fskus/{fsku_id}/expression": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-fsku",
-          "oms-fsku",
-          "oms-fsku"
-        ],
-        "summary": "Replace Expression",
-        "operationId": "replace_expression_oms_fskus__fsku_id__expression_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "fsku_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Fsku Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FskuExpressionReplaceIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FskuDetailOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/fskus/{fsku_id}/publish": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-fsku",
-          "oms-fsku",
-          "oms-fsku"
-        ],
-        "summary": "Publish",
-        "operationId": "publish_oms_fskus__fsku_id__publish_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "fsku_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Fsku Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FskuDetailOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/fskus/{fsku_id}/retire": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-fsku",
-          "oms-fsku",
-          "oms-fsku"
-        ],
-        "summary": "Retire",
-        "operationId": "retire_oms_fskus__fsku_id__retire_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "fsku_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Fsku Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FskuDetailOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/fskus/{fsku_id}/unretire": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-fsku",
-          "oms-fsku",
-          "oms-fsku"
-        ],
-        "summary": "Unretire",
-        "operationId": "unretire_oms_fskus__fsku_id__unretire_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "fsku_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Fsku Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FskuDetailOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/platform-code-mappings": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-fsku",
-          "platform-code-mappings"
-        ],
-        "summary": "列表：平台订单行身份 → published OMS FSKU 映射",
-        "operationId": "list_platform_code_mappings_oms_platform_code_mappings_get",
-        "parameters": [
-          {
-            "name": "platform",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 32
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Platform"
-            }
-          },
-          {
-            "name": "store_code",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 128
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Store Code"
-            }
-          },
-          {
-            "name": "identity_kind",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 32
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Identity Kind"
-            }
-          },
-          {
-            "name": "identity_value",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 256
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Identity Value"
-            }
-          },
-          {
-            "name": "fsku_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer",
-                  "minimum": 1
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Fsku Id"
-            }
-          },
-          {
-            "name": "fsku_code",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 128
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Fsku Code"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 200,
-              "minimum": 1,
-              "default": 50,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformCodeMappingListOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/platform-code-mappings/bind": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-fsku",
-          "platform-code-mappings"
-        ],
-        "summary": "新增/覆盖：平台订单行身份 → published OMS FSKU",
-        "operationId": "bind_platform_code_mapping_oms_platform_code_mappings_bind_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlatformCodeMappingBindIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformCodeMappingOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/platform-code-mappings/delete": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-fsku",
-          "platform-code-mappings"
-        ],
-        "summary": "删除：平台订单行身份 → OMS FSKU 映射",
-        "operationId": "delete_platform_code_mapping_oms_platform_code_mappings_delete_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlatformCodeMappingDeleteIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformCodeMappingOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/orders/outbound-options": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-order-outbound-options"
-        ],
-        "summary": "Get Order Outbound Options",
-        "operationId": "get_order_outbound_options_oms_orders_outbound_options_get",
-        "parameters": [
           {
             "name": "q",
             "in": "query",
@@ -7565,61 +5330,6 @@
               ],
               "title": "Q"
             }
-          },
-          {
-            "name": "platform",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Platform"
-            }
-          },
-          {
-            "name": "store_code",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Store Code"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 200,
-              "minimum": 1,
-              "default": 20,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
           }
         ],
         "responses": {
@@ -7628,7 +5338,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/OrderOutboundOptionsOut"
+                  "$ref": "#/components/schemas/PmsProjectionListOut"
                 }
               }
             }
@@ -7646,22 +5356,34 @@
         }
       }
     },
-    "/oms/orders/{order_id}/outbound-view": {
-      "get": {
+    "/pms/projections/{resource}/sync": {
+      "post": {
         "tags": [
-          "OMS",
-          "oms-order-outbound-view"
+          "pms",
+          "pms-projections"
         ],
-        "summary": "Get Order Outbound View",
-        "operationId": "get_order_outbound_view_oms_orders__order_id__outbound_view_get",
+        "summary": "Sync Pms Projection Resource",
+        "operationId": "sync_pms_projection_resource_pms_projections__resource__sync_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
         "parameters": [
           {
-            "name": "order_id",
+            "name": "resource",
             "in": "path",
             "required": true,
             "schema": {
-              "type": "integer",
-              "title": "Order Id"
+              "enum": [
+                "items",
+                "suppliers",
+                "uoms",
+                "sku-codes",
+                "barcodes"
+              ],
+              "type": "string",
+              "title": "Resource"
             }
           }
         ],
@@ -7671,7 +5393,216 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/OrderOutboundViewResponse"
+                  "$ref": "#/components/schemas/PmsProjectionSyncOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/projections/{resource}/check": {
+      "post": {
+        "tags": [
+          "pms",
+          "pms-projections"
+        ],
+        "summary": "Check Pms Projection Resource",
+        "operationId": "check_pms_projection_resource_pms_projections__resource__check_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "resource",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "enum": [
+                "items",
+                "suppliers",
+                "uoms",
+                "sku-codes",
+                "barcodes"
+              ],
+              "type": "string",
+              "title": "Resource"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "default": 200,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PmsProjectionCheckOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/wms/read/v1/warehouses": {
+      "get": {
+        "tags": [
+          "warehouses",
+          "wms-read-v1"
+        ],
+        "summary": "List Wms Read Warehouses",
+        "description": "List WMS warehouses for cross-system read contracts.\n\nBoundary:\n- No consumer system should read WMS DB directly.\n- No management-only fields are exposed.\n- Consumers should store scalar id + code/name snapshot when needed.",
+        "operationId": "list_wms_read_warehouses_wms_read_v1_warehouses_get",
+        "parameters": [
+          {
+            "name": "active",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "是否过滤启用仓库；默认只返回 active=true，用于跨系统下拉。",
+              "default": true,
+              "title": "Active"
+            },
+            "description": "是否过滤启用仓库；默认只返回 active=true，用于跨系统下拉。"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "default": 200,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "X-Service-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Service-Client"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WmsReadWarehouseListOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/wms/read/v1/warehouses/{warehouse_id}": {
+      "get": {
+        "tags": [
+          "warehouses",
+          "wms-read-v1"
+        ],
+        "summary": "Get Wms Read Warehouse",
+        "operationId": "get_wms_read_warehouse_wms_read_v1_warehouses__warehouse_id__get",
+        "parameters": [
+          {
+            "name": "warehouse_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "title": "Warehouse Id"
+            }
+          },
+          {
+            "name": "X-Service-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Service-Client"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WmsReadWarehouseOut"
                 }
               }
             }
@@ -8179,111 +6110,21 @@
         }
       }
     },
-    "/pms/export/items": {
+    "/system/read/v1/app-manifest": {
       "get": {
         "tags": [
-          "pms-export-items"
+          "system-read-v1"
         ],
-        "summary": "List Export Items",
-        "operationId": "list_export_items_pms_export_items_get",
-        "parameters": [
-          {
-            "name": "supplier_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer",
-                  "minimum": 1
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "按供应商过滤",
-              "title": "Supplier Id"
-            },
-            "description": "按供应商过滤"
-          },
-          {
-            "name": "enabled",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "按启用状态过滤",
-              "title": "Enabled"
-            },
-            "description": "按启用状态过滤"
-          },
-          {
-            "name": "q",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "关键词搜索（sku/name）",
-              "title": "Q"
-            },
-            "description": "关键词搜索（sku/name）"
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer",
-                  "maximum": 200,
-                  "minimum": 1
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "限制返回条数（默认 50，最大 200）",
-              "title": "Limit"
-            },
-            "description": "限制返回条数（默认 50，最大 200）"
-          }
-        ],
+        "summary": "Get WMS app manifest",
+        "description": "Return WMS self-description defaults for ERP app registration sync.\n\nBoundary:\n- This endpoint does not register itself into ERP.\n- This endpoint does not decide whether WMS is enabled, visible, or published in ERP.\n- This endpoint exposes no secrets and does not read/write business data.",
+        "operationId": "get_wms_app_manifest_system_read_v1_app_manifest_get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ItemBasic"
-                  },
-                  "title": "Response List Export Items Pms Export Items Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/WmsSystemAppManifestOut"
                 }
               }
             }
@@ -8291,41 +6132,21 @@
         }
       }
     },
-    "/pms/export/items/{item_id}": {
+    "/system/read/v1/page-catalog": {
       "get": {
         "tags": [
-          "pms-export-items"
+          "system-read-v1"
         ],
-        "summary": "Get Export Item By Id",
-        "operationId": "get_export_item_by_id_pms_export_items__item_id__get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
+        "summary": "Get WMS page catalog",
+        "description": "Return WMS page catalog for ERP page projection sync.\n\nBoundary:\n- This endpoint is read-only.\n- ERP must not connect to WMS DB directly.\n- ERP must not infer WMS pages from frontend routes.",
+        "operationId": "get_wms_page_catalog_system_read_v1_page_catalog_get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ItemBasic"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/WmsSystemPageCatalogOut"
                 }
               }
             }
@@ -8333,66 +6154,21 @@
         }
       }
     },
-    "/pms/export/uoms": {
+    "/system/read/v1/service-capabilities": {
       "get": {
         "tags": [
-          "pms-export-uoms"
+          "system-read-v1"
         ],
-        "summary": "List Export Uoms",
-        "operationId": "list_export_uoms_pms_export_uoms_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              },
-              "description": "可重复：item_id=1&item_id=2",
-              "default": [],
-              "title": "Item Id"
-            },
-            "description": "可重复：item_id=1&item_id=2"
-          },
-          {
-            "name": "item_uom_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              },
-              "description": "可重复：item_uom_id=1&item_uom_id=2",
-              "default": [],
-              "title": "Item Uom Id"
-            },
-            "description": "可重复：item_uom_id=1&item_uom_id=2"
-          }
-        ],
+        "summary": "Get WMS service capabilities",
+        "description": "Return WMS service capabilities for ERP system collaboration sync.\n\nBoundary:\n- WMS declares what WMS provides.\n- ERP must not guess WMS capabilities.\n- This endpoint is read-only.\n- This endpoint does not expose approval, grant, written, or verified state.",
+        "operationId": "get_wms_service_capabilities_system_read_v1_service_capabilities_get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/PmsExportUom"
-                  },
-                  "title": "Response List Export Uoms Pms Export Uoms Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/WmsSystemServiceCapabilitiesOut"
                 }
               }
             }
@@ -8400,41 +6176,21 @@
         }
       }
     },
-    "/pms/export/uoms/{item_uom_id}": {
+    "/system/read/v1/service-dependencies": {
       "get": {
         "tags": [
-          "pms-export-uoms"
+          "system-read-v1"
         ],
-        "summary": "Get Export Uom",
-        "operationId": "get_export_uom_pms_export_uoms__item_uom_id__get",
-        "parameters": [
-          {
-            "name": "item_uom_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Uom Id"
-            }
-          }
-        ],
+        "summary": "Get WMS service dependencies",
+        "description": "Return WMS declared outbound service dependencies for ERP collaboration sync.\n\nBoundary:\n- Declared dependency does not mean approved.\n- Declared dependency does not mean permission has been written to target system.\n- Declared dependency does not mean runtime verification has passed.\n- ERP remains responsible for matching, approval, write-back, and verification state.",
+        "operationId": "get_wms_service_dependencies_system_read_v1_service_dependencies_get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PmsExportUom"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/WmsSystemServiceDependenciesOut"
                 }
               }
             }
@@ -8442,93 +6198,18 @@
         }
       }
     },
-    "/pms/export/items/{item_id}/uoms": {
+    "/system/read/v1/iam-snapshot": {
       "get": {
         "tags": [
-          "pms-export-uoms"
+          "system-read-v1"
         ],
-        "summary": "List Export Item Uoms",
-        "operationId": "list_export_item_uoms_pms_export_items__item_id__uoms_get",
+        "summary": "Get WMS IAM snapshot",
+        "description": "Return WMS users, user permissions, and page permission catalog for ERP projection sync.\n\nBoundary:\n- Only ERP service client should be granted this capability.\n- This endpoint is read-only.\n- This endpoint never exposes password_hash, tokens, or secrets.\n- This endpoint does not write WMS permissions.\n- This endpoint does not migrate permission execution to ERP.",
+        "operationId": "get_wms_iam_snapshot_system_read_v1_iam_snapshot_get",
         "parameters": [
           {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/PmsExportUom"
-                  },
-                  "title": "Response List Export Item Uoms Pms Export Items  Item Id  Uoms Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/export/sku-codes": {
-      "get": {
-        "tags": [
-          "pms-export-sku-codes"
-        ],
-        "summary": "List Export Sku Codes",
-        "operationId": "list_export_sku_codes_pms_export_sku_codes_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              },
-              "description": "可重复：item_id=1&item_id=2",
-              "default": [],
-              "title": "Item Id"
-            },
-            "description": "可重复：item_id=1&item_id=2"
-          },
-          {
-            "name": "sku_code_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              },
-              "description": "可重复：sku_code_id=1&sku_code_id=2",
-              "default": [],
-              "title": "Sku Code Id"
-            },
-            "description": "可重复：sku_code_id=1&sku_code_id=2"
-          },
-          {
-            "name": "code",
-            "in": "query",
+            "name": "X-Service-Client",
+            "in": "header",
             "required": false,
             "schema": {
               "anyOf": [
@@ -8539,41 +6220,8 @@
                   "type": "null"
                 }
               ],
-              "description": "精确 SKU code，大小写不敏感",
-              "title": "Code"
-            },
-            "description": "精确 SKU code，大小写不敏感"
-          },
-          {
-            "name": "active",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "默认只返回 active=true；传空则不过滤",
-              "default": true,
-              "title": "Active"
-            },
-            "description": "默认只返回 active=true；传空则不过滤"
-          },
-          {
-            "name": "primary_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "true 时只返回主编码",
-              "default": false,
-              "title": "Primary Only"
-            },
-            "description": "true 时只返回主编码"
+              "title": "X-Service-Client"
+            }
           }
         ],
         "responses": {
@@ -8582,11 +6230,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/PmsExportSkuCode"
-                  },
-                  "title": "Response List Export Sku Codes Pms Export Sku Codes Get"
+                  "$ref": "#/components/schemas/WmsSystemIamSnapshotOut"
                 }
               }
             }
@@ -8604,433 +6248,41 @@
         }
       }
     },
-    "/pms/export/sku-codes/resolve": {
-      "get": {
-        "tags": [
-          "pms-export-sku-codes"
-        ],
-        "summary": "Resolve Export Sku Code",
-        "operationId": "resolve_export_sku_code_pms_export_sku_codes_resolve_get",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "description": "SKU code，大小写不敏感",
-              "title": "Code"
-            },
-            "description": "SKU code，大小写不敏感"
-          },
-          {
-            "name": "enabled_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "默认只解析 enabled=true 的商品",
-              "default": true,
-              "title": "Enabled Only"
-            },
-            "description": "默认只解析 enabled=true 的商品"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsExportSkuCodeResolution"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/export/sku-codes/{sku_code_id}": {
-      "get": {
-        "tags": [
-          "pms-export-sku-codes"
-        ],
-        "summary": "Get Export Sku Code",
-        "operationId": "get_export_sku_code_pms_export_sku_codes__sku_code_id__get",
-        "parameters": [
-          {
-            "name": "sku_code_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Sku Code Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsExportSkuCode"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/export/items/{item_id}/sku-codes": {
-      "get": {
-        "tags": [
-          "pms-export-sku-codes"
-        ],
-        "summary": "List Export Item Sku Codes",
-        "operationId": "list_export_item_sku_codes_pms_export_items__item_id__sku_codes_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          },
-          {
-            "name": "active",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "默认只返回 active=true；传空则不过滤",
-              "default": true,
-              "title": "Active"
-            },
-            "description": "默认只返回 active=true；传空则不过滤"
-          },
-          {
-            "name": "primary_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "true 时只返回主编码",
-              "default": false,
-              "title": "Primary Only"
-            },
-            "description": "true 时只返回主编码"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/PmsExportSkuCode"
-                  },
-                  "title": "Response List Export Item Sku Codes Pms Export Items  Item Id  Sku Codes Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/export/barcodes": {
-      "get": {
-        "tags": [
-          "pms-export-barcodes"
-        ],
-        "summary": "List Export Barcodes",
-        "operationId": "list_export_barcodes_pms_export_barcodes_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              },
-              "description": "可重复：item_id=1&item_id=2",
-              "default": [],
-              "title": "Item Id"
-            },
-            "description": "可重复：item_id=1&item_id=2"
-          },
-          {
-            "name": "item_uom_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              },
-              "description": "可重复：item_uom_id=1&item_uom_id=2",
-              "default": [],
-              "title": "Item Uom Id"
-            },
-            "description": "可重复：item_uom_id=1&item_uom_id=2"
-          },
-          {
-            "name": "barcode",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "精确条码查询",
-              "title": "Barcode"
-            },
-            "description": "精确条码查询"
-          },
-          {
-            "name": "active",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "默认只返回 active=true；传空则不过滤",
-              "default": true,
-              "title": "Active"
-            },
-            "description": "默认只返回 active=true；传空则不过滤"
-          },
-          {
-            "name": "primary_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "true 时只返回主条码",
-              "default": false,
-              "title": "Primary Only"
-            },
-            "description": "true 时只返回主条码"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/PmsExportBarcode"
-                  },
-                  "title": "Response List Export Barcodes Pms Export Barcodes Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/export/barcodes/{barcode_id}": {
-      "get": {
-        "tags": [
-          "pms-export-barcodes"
-        ],
-        "summary": "Get Export Barcode",
-        "operationId": "get_export_barcode_pms_export_barcodes__barcode_id__get",
-        "parameters": [
-          {
-            "name": "barcode_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Barcode Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsExportBarcode"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/export/items/{item_id}/barcodes": {
-      "get": {
-        "tags": [
-          "pms-export-barcodes"
-        ],
-        "summary": "List Export Item Barcodes",
-        "operationId": "list_export_item_barcodes_pms_export_items__item_id__barcodes_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          },
-          {
-            "name": "active",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "默认只返回 active=true；传空则不过滤",
-              "default": true,
-              "title": "Active"
-            },
-            "description": "默认只返回 active=true；传空则不过滤"
-          },
-          {
-            "name": "primary_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "true 时只返回主条码",
-              "default": false,
-              "title": "Primary Only"
-            },
-            "description": "true 时只返回主条码"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/PmsExportBarcode"
-                  },
-                  "title": "Response List Export Item Barcodes Pms Export Items  Item Id  Barcodes Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/export/items/barcode-probe": {
+    "/system/write/v1/service-permissions/apply": {
       "post": {
         "tags": [
-          "pms-export-items"
+          "system-write-v1"
         ],
-        "summary": "Probe Barcode",
-        "operationId": "probe_barcode_pms_export_items_barcode_probe_post",
+        "summary": "Apply WMS service permission",
+        "description": "Apply one WMS local service permission from ERP.\n\nBoundary:\n- Only X-Service-Client: erp-service may call this endpoint.\n- Writes only wms_service_clients and wms_service_permissions.\n- Does not write ERP tables.\n- Does not write other systems.\n- Does not read users / permissions / user_permissions.",
+        "operationId": "apply_wms_service_permission_system_write_v1_service_permissions_apply_post",
+        "parameters": [
+          {
+            "name": "X-Service-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Service-Client"
+            }
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/BarcodeProbeIn"
+                "$ref": "#/components/schemas/WmsSystemServicePermissionApplyIn"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -9038,7 +6290,79 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BarcodeProbeOut"
+                  "$ref": "#/components/schemas/WmsSystemServicePermissionApplyOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/system/write/v1/service-permissions/verify": {
+      "get": {
+        "tags": [
+          "system-write-v1"
+        ],
+        "summary": "Verify WMS service permission",
+        "description": "Verify one WMS local service permission for ERP.\n\nBoundary:\n- Only X-Service-Client: erp-service may call this endpoint.\n- Reads only wms_service_clients, wms_service_capabilities, and wms_service_permissions.\n- Does not write anything.\n- Does not read users / permissions / user_permissions.",
+        "operationId": "verify_wms_service_permission_system_write_v1_service_permissions_verify_get",
+        "parameters": [
+          {
+            "name": "client_code",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 64,
+              "title": "Client Code"
+            }
+          },
+          {
+            "name": "capability_code",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128,
+              "title": "Capability Code"
+            }
+          },
+          {
+            "name": "X-Service-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Service-Client"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WmsSystemServicePermissionVerifyOut"
                 }
               }
             }
@@ -9114,3278 +6438,6 @@
                   },
                   "title": "Response List Public Suppliers Partners Export Suppliers Get"
                 }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/items/{item_id}/aggregate": {
-      "get": {
-        "tags": [
-          "items-owner-aggregate"
-        ],
-        "summary": "Get Item Aggregate",
-        "operationId": "get_item_aggregate_items__item_id__aggregate_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAggregateOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "items-owner-aggregate"
-        ],
-        "summary": "Replace Item Aggregate",
-        "operationId": "replace_item_aggregate_items__item_id__aggregate_put",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemAggregatePayload"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAggregateOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/items/aggregate": {
-      "post": {
-        "tags": [
-          "items-owner-aggregate"
-        ],
-        "summary": "Create Item Aggregate",
-        "operationId": "create_item_aggregate_items_aggregate_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemAggregatePayload"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAggregateOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/items/list-rows": {
-      "get": {
-        "tags": [
-          "items-list"
-        ],
-        "summary": "List Item Rows",
-        "operationId": "list_item_rows_items_list_rows_get",
-        "parameters": [
-          {
-            "name": "enabled",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "true=有效商品；false=无效商品；不传=全部",
-              "title": "Enabled"
-            },
-            "description": "true=有效商品；false=无效商品；不传=全部"
-          },
-          {
-            "name": "supplier_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer",
-                  "minimum": 1
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "按供应商过滤",
-              "title": "Supplier Id"
-            },
-            "description": "按供应商过滤"
-          },
-          {
-            "name": "q",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "关键词搜索 SKU / 名称 / 规格 / 品牌 / 分类 / 供应商 / 主条码",
-              "title": "Q"
-            },
-            "description": "关键词搜索 SKU / 名称 / 规格 / 品牌 / 分类 / 供应商 / 主条码"
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 500,
-              "minimum": 1,
-              "default": 200,
-              "title": "Limit"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ItemListRowOut"
-                  },
-                  "title": "Response List Item Rows Items List Rows Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/items/{item_id}/list-detail": {
-      "get": {
-        "tags": [
-          "items-list"
-        ],
-        "summary": "Get Item List Detail",
-        "operationId": "get_item_list_detail_items__item_id__list_detail_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemListDetailOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/items": {
-      "post": {
-        "tags": [
-          "items"
-        ],
-        "summary": "Create Item",
-        "operationId": "create_item_items_post",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemCreate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "tags": [
-          "items"
-        ],
-        "summary": "Get All Items",
-        "operationId": "get_all_items_items_get",
-        "parameters": [
-          {
-            "name": "supplier_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer",
-                  "minimum": 1
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "按供应商过滤（采购单创建/收货用）",
-              "title": "Supplier Id"
-            },
-            "description": "按供应商过滤（采购单创建/收货用）"
-          },
-          {
-            "name": "enabled",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "按启用状态过滤（enabled=true 只取启用商品）",
-              "title": "Enabled"
-            },
-            "description": "按启用状态过滤（enabled=true 只取启用商品）"
-          },
-          {
-            "name": "q",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "关键词搜索（命中 sku/name/primary_barcode/id；大小写不敏感）",
-              "title": "Q"
-            },
-            "description": "关键词搜索（命中 sku/name/primary_barcode/id；大小写不敏感）"
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer",
-                  "maximum": 200,
-                  "minimum": 1
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "限制返回条数（默认 50，最大 200）",
-              "title": "Limit"
-            },
-            "description": "限制返回条数（默认 50，最大 200）"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ItemOut"
-                  },
-                  "title": "Response Get All Items Items Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/items/sku/{sku}": {
-      "get": {
-        "tags": [
-          "items"
-        ],
-        "summary": "Get Item By Sku",
-        "operationId": "get_item_by_sku_items_sku__sku__get",
-        "parameters": [
-          {
-            "name": "sku",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Sku"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/items/{id}": {
-      "get": {
-        "tags": [
-          "items"
-        ],
-        "summary": "Get Item By Id",
-        "operationId": "get_item_by_id_items__id__get",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "items"
-        ],
-        "summary": "Update Item",
-        "operationId": "update_item_items__id__patch",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/brands": {
-      "get": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "List Pms Brands",
-        "operationId": "list_pms_brands_pms_brands_get",
-        "parameters": [
-          {
-            "name": "active_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Active Only"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListOut_PmsBrandOut_"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Create Pms Brand",
-        "operationId": "create_pms_brand_pms_brands_post",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PmsBrandCreate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsBrandOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/brands/{brand_id}": {
-      "patch": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Update Pms Brand",
-        "operationId": "update_pms_brand_pms_brands__brand_id__patch",
-        "parameters": [
-          {
-            "name": "brand_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Brand Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PmsBrandUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsBrandOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/brands/{brand_id}/enable": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Enable Pms Brand",
-        "operationId": "enable_pms_brand_pms_brands__brand_id__enable_post",
-        "parameters": [
-          {
-            "name": "brand_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Brand Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsBrandOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/brands/{brand_id}/disable": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Disable Pms Brand",
-        "operationId": "disable_pms_brand_pms_brands__brand_id__disable_post",
-        "parameters": [
-          {
-            "name": "brand_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Brand Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsBrandOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/brands/{brand_id}/lock": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Lock Pms Brand",
-        "operationId": "lock_pms_brand_pms_brands__brand_id__lock_post",
-        "parameters": [
-          {
-            "name": "brand_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Brand Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsBrandOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/brands/{brand_id}/unlock": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Unlock Pms Brand",
-        "operationId": "unlock_pms_brand_pms_brands__brand_id__unlock_post",
-        "parameters": [
-          {
-            "name": "brand_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Brand Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsBrandOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/categories": {
-      "get": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "List Pms Categories",
-        "operationId": "list_pms_categories_pms_categories_get",
-        "parameters": [
-          {
-            "name": "product_kind",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Product Kind"
-            }
-          },
-          {
-            "name": "active_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Active Only"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListOut_PmsCategoryOut_"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Create Pms Category",
-        "operationId": "create_pms_category_pms_categories_post",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PmsCategoryCreate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsCategoryOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/categories/{category_id}": {
-      "patch": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Update Pms Category",
-        "operationId": "update_pms_category_pms_categories__category_id__patch",
-        "parameters": [
-          {
-            "name": "category_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Category Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PmsCategoryUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsCategoryOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/categories/{category_id}/enable": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Enable Pms Category",
-        "operationId": "enable_pms_category_pms_categories__category_id__enable_post",
-        "parameters": [
-          {
-            "name": "category_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Category Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsCategoryOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/categories/{category_id}/disable": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Disable Pms Category",
-        "operationId": "disable_pms_category_pms_categories__category_id__disable_post",
-        "parameters": [
-          {
-            "name": "category_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Category Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsCategoryOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/categories/{category_id}/lock": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Lock Pms Category",
-        "operationId": "lock_pms_category_pms_categories__category_id__lock_post",
-        "parameters": [
-          {
-            "name": "category_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Category Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsCategoryOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/categories/{category_id}/unlock": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Unlock Pms Category",
-        "operationId": "unlock_pms_category_pms_categories__category_id__unlock_post",
-        "parameters": [
-          {
-            "name": "category_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Category Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsCategoryOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/item-attribute-defs": {
-      "get": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "List Item Attribute Defs",
-        "operationId": "list_item_attribute_defs_pms_item_attribute_defs_get",
-        "parameters": [
-          {
-            "name": "product_kind",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Product Kind"
-            }
-          },
-          {
-            "name": "active_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Active Only"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListOut_ItemAttributeDefOut_"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Create Item Attribute Def",
-        "operationId": "create_item_attribute_def_pms_item_attribute_defs_post",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemAttributeDefCreate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAttributeDefOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/item-attribute-defs/{attribute_def_id}": {
-      "patch": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Update Item Attribute Def",
-        "operationId": "update_item_attribute_def_pms_item_attribute_defs__attribute_def_id__patch",
-        "parameters": [
-          {
-            "name": "attribute_def_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Attribute Def Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemAttributeDefUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAttributeDefOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/item-attribute-defs/{attribute_def_id}/enable": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Enable Item Attribute Def",
-        "operationId": "enable_item_attribute_def_pms_item_attribute_defs__attribute_def_id__enable_post",
-        "parameters": [
-          {
-            "name": "attribute_def_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Attribute Def Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAttributeDefOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/item-attribute-defs/{attribute_def_id}/disable": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Disable Item Attribute Def",
-        "operationId": "disable_item_attribute_def_pms_item_attribute_defs__attribute_def_id__disable_post",
-        "parameters": [
-          {
-            "name": "attribute_def_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Attribute Def Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAttributeDefOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/item-attribute-defs/{attribute_def_id}/lock": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Lock Item Attribute Def",
-        "operationId": "lock_item_attribute_def_pms_item_attribute_defs__attribute_def_id__lock_post",
-        "parameters": [
-          {
-            "name": "attribute_def_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Attribute Def Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAttributeDefOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/item-attribute-defs/{attribute_def_id}/unlock": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Unlock Item Attribute Def",
-        "operationId": "unlock_item_attribute_def_pms_item_attribute_defs__attribute_def_id__unlock_post",
-        "parameters": [
-          {
-            "name": "attribute_def_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Attribute Def Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAttributeDefOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/item-attribute-defs/{attribute_def_id}/options": {
-      "get": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "List Item Attribute Options",
-        "operationId": "list_item_attribute_options_pms_item_attribute_defs__attribute_def_id__options_get",
-        "parameters": [
-          {
-            "name": "attribute_def_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Attribute Def Id"
-            }
-          },
-          {
-            "name": "active_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Active Only"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListOut_ItemAttributeOptionOut_"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Create Item Attribute Option",
-        "operationId": "create_item_attribute_option_pms_item_attribute_defs__attribute_def_id__options_post",
-        "parameters": [
-          {
-            "name": "attribute_def_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Attribute Def Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemAttributeOptionCreate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAttributeOptionOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/item-attribute-options/{option_id}": {
-      "patch": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Update Item Attribute Option",
-        "operationId": "update_item_attribute_option_pms_item_attribute_options__option_id__patch",
-        "parameters": [
-          {
-            "name": "option_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Option Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemAttributeOptionUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAttributeOptionOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/item-attribute-options/{option_id}/lock": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Lock Item Attribute Option",
-        "operationId": "lock_item_attribute_option_pms_item_attribute_options__option_id__lock_post",
-        "parameters": [
-          {
-            "name": "option_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Option Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAttributeOptionOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/item-attribute-options/{option_id}/unlock": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Unlock Item Attribute Option",
-        "operationId": "unlock_item_attribute_option_pms_item_attribute_options__option_id__unlock_post",
-        "parameters": [
-          {
-            "name": "option_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Option Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAttributeOptionOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/item-attribute-options/{option_id}/enable": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Enable Item Attribute Option",
-        "operationId": "enable_item_attribute_option_pms_item_attribute_options__option_id__enable_post",
-        "parameters": [
-          {
-            "name": "option_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Option Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAttributeOptionOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/item-attribute-options/{option_id}/disable": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Disable Item Attribute Option",
-        "operationId": "disable_item_attribute_option_pms_item_attribute_options__option_id__disable_post",
-        "parameters": [
-          {
-            "name": "option_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Option Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAttributeOptionOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/items/{item_id}/attributes": {
-      "get": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "List Item Attribute Values",
-        "operationId": "list_item_attribute_values_items__item_id__attributes_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListOut_ItemAttributeValueOut_"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Replace Item Attribute Values",
-        "operationId": "replace_item_attribute_values_items__item_id__attributes_put",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemAttributeValuesReplaceIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListOut_ItemAttributeValueOut_"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/items/{item_id}/sku-codes": {
-      "get": {
-        "tags": [
-          "item-sku-codes"
-        ],
-        "summary": "List Item Sku Codes",
-        "operationId": "list_item_sku_codes_items__item_id__sku_codes_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ItemSkuCodeOut"
-                  },
-                  "title": "Response List Item Sku Codes Items  Item Id  Sku Codes Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "item-sku-codes"
-        ],
-        "summary": "Create Item Sku Code",
-        "operationId": "create_item_sku_code_items__item_id__sku_codes_post",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemSkuCodeCreate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemSkuCodeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/items/{item_id}/sku-codes/{code_id}/disable": {
-      "post": {
-        "tags": [
-          "item-sku-codes"
-        ],
-        "summary": "Disable Item Sku Code",
-        "operationId": "disable_item_sku_code_items__item_id__sku_codes__code_id__disable_post",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          },
-          {
-            "name": "code_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Code Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemSkuCodeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/items/{item_id}/sku-codes/{code_id}/enable": {
-      "post": {
-        "tags": [
-          "item-sku-codes"
-        ],
-        "summary": "Enable Item Sku Code",
-        "operationId": "enable_item_sku_code_items__item_id__sku_codes__code_id__enable_post",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          },
-          {
-            "name": "code_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Code Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemSkuCodeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/items/{item_id}/sku-codes/change-primary": {
-      "post": {
-        "tags": [
-          "item-sku-codes"
-        ],
-        "summary": "Change Primary Item Sku Code",
-        "operationId": "change_primary_item_sku_code_items__item_id__sku_codes_change_primary_post",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemSkuCodeChangePrimary"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemSkuCodeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/sku-coding/generate": {
-      "post": {
-        "tags": [
-          "pms-sku-coding"
-        ],
-        "summary": "Generate Sku",
-        "operationId": "generate_sku_pms_sku_coding_generate_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SkuGenerateIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SkuGenerateOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/sku-coding/items/{item_id}/generate": {
-      "post": {
-        "tags": [
-          "pms-sku-coding"
-        ],
-        "summary": "Generate Sku From Item",
-        "operationId": "generate_sku_from_item_pms_sku_coding_items__item_id__generate_post",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SkuGenerateOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/item-barcodes": {
-      "post": {
-        "tags": [
-          "item-barcodes"
-        ],
-        "summary": "Create Barcode",
-        "operationId": "create_barcode_item_barcodes_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemBarcodeCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemBarcodeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/item-barcodes/by-items": {
-      "get": {
-        "tags": [
-          "item-barcodes"
-        ],
-        "summary": "List Barcodes For Items",
-        "operationId": "list_barcodes_for_items_item_barcodes_by_items_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              },
-              "description": "item_id 可重复：item_id=1&item_id=2",
-              "title": "Item Id"
-            },
-            "description": "item_id 可重复：item_id=1&item_id=2"
-          },
-          {
-            "name": "active_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "默认只返回 active=true",
-              "default": true,
-              "title": "Active Only"
-            },
-            "description": "默认只返回 active=true"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ItemBarcodeOut"
-                  },
-                  "title": "Response List Barcodes For Items Item Barcodes By Items Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/item-barcodes/item/{item_id}/rows": {
-      "get": {
-        "tags": [
-          "item-barcodes"
-        ],
-        "summary": "List Barcode Rows For Item",
-        "description": "Owner 读模型：\n- 返回“一个商品、一个单位、一行条码”的复合结果\n- 供 PMS 商品条码页直接渲染当前商品条码表",
-        "operationId": "list_barcode_rows_for_item_item_barcodes_item__item_id__rows_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          },
-          {
-            "name": "active_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "true 时仅返回 active=true 的条码行",
-              "default": false,
-              "title": "Active Only"
-            },
-            "description": "true 时仅返回 active=true 的条码行"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ItemBarcodeCompositeRow"
-                  },
-                  "title": "Response List Barcode Rows For Item Item Barcodes Item  Item Id  Rows Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/item-barcodes/item/{item_id}": {
-      "get": {
-        "tags": [
-          "item-barcodes"
-        ],
-        "summary": "List Barcodes For Item",
-        "operationId": "list_barcodes_for_item_item_barcodes_item__item_id__get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ItemBarcodeOut"
-                  },
-                  "title": "Response List Barcodes For Item Item Barcodes Item  Item Id  Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/item-barcodes/{id}/set-primary": {
-      "post": {
-        "tags": [
-          "item-barcodes"
-        ],
-        "summary": "Set Primary",
-        "operationId": "set_primary_item_barcodes__id__set_primary_post",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemBarcodeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/item-barcodes/{id}": {
-      "patch": {
-        "tags": [
-          "item-barcodes"
-        ],
-        "summary": "Update Barcode",
-        "operationId": "update_barcode_item_barcodes__id__patch",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemBarcodeUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemBarcodeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "item-barcodes"
-        ],
-        "summary": "Delete Barcode",
-        "operationId": "delete_barcode_item_barcodes__id__delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Id"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/item-uoms": {
-      "post": {
-        "tags": [
-          "item-uoms"
-        ],
-        "summary": "Create Item Uom Route",
-        "operationId": "create_item_uom_route_item_uoms_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemUomCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemUomOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/item-uoms/item/{item_id}": {
-      "get": {
-        "tags": [
-          "item-uoms"
-        ],
-        "summary": "List Item Uoms",
-        "operationId": "list_item_uoms_item_uoms_item__item_id__get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ItemUomOut"
-                  },
-                  "title": "Response List Item Uoms Item Uoms Item  Item Id  Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/item-uoms/item/{item_id}/rows": {
-      "get": {
-        "tags": [
-          "item-uoms"
-        ],
-        "summary": "List Item Uom Rows For Item",
-        "operationId": "list_item_uom_rows_for_item_item_uoms_item__item_id__rows_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          },
-          {
-            "name": "active_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "true 时仅挂 active=true 的条码；无条码包装仍返回",
-              "default": false,
-              "title": "Active Only"
-            },
-            "description": "true 时仅挂 active=true 的条码；无条码包装仍返回"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ItemUomBarcodeRowOut"
-                  },
-                  "title": "Response List Item Uom Rows For Item Item Uoms Item  Item Id  Rows Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/item-uoms/by-items": {
-      "get": {
-        "tags": [
-          "item-uoms"
-        ],
-        "summary": "List Item Uoms For Items",
-        "operationId": "list_item_uoms_for_items_item_uoms_by_items_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              },
-              "default": [],
-              "title": "Item Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ItemUomOut"
-                  },
-                  "title": "Response List Item Uoms For Items Item Uoms By Items Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/item-uoms/rows/by-items": {
-      "get": {
-        "tags": [
-          "item-uoms"
-        ],
-        "summary": "List Item Uom Rows For Items",
-        "operationId": "list_item_uom_rows_for_items_item_uoms_rows_by_items_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              },
-              "default": [],
-              "title": "Item Id"
-            }
-          },
-          {
-            "name": "active_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "true 时仅挂 active=true 的条码；无条码包装仍返回",
-              "default": false,
-              "title": "Active Only"
-            },
-            "description": "true 时仅挂 active=true 的条码；无条码包装仍返回"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ItemUomBarcodeRowOut"
-                  },
-                  "title": "Response List Item Uom Rows For Items Item Uoms Rows By Items Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/item-uoms/{id}": {
-      "patch": {
-        "tags": [
-          "item-uoms"
-        ],
-        "summary": "Update Item Uom Route",
-        "operationId": "update_item_uom_route_item_uoms__id__patch",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemUomUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemUomOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "item-uoms"
-        ],
-        "summary": "Delete Item Uom Route",
-        "operationId": "delete_item_uom_route_item_uoms__id__delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/partners/suppliers": {
-      "get": {
-        "tags": [
-          "suppliers"
-        ],
-        "summary": "List Suppliers",
-        "operationId": "list_suppliers_partners_suppliers_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "active",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "active=true 仅返回合作中供应商（owner 页面使用）",
-              "title": "Active"
-            },
-            "description": "active=true 仅返回合作中供应商（owner 页面使用）"
-          },
-          {
-            "name": "q",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "名称/编码/联系人/电话/邮箱/微信 模糊搜索",
-              "title": "Q"
-            },
-            "description": "名称/编码/联系人/电话/邮箱/微信 模糊搜索"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/SupplierOut"
-                  },
-                  "title": "Response List Suppliers Partners Suppliers Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "suppliers"
-        ],
-        "summary": "Create Supplier",
-        "operationId": "create_supplier_partners_suppliers_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SupplierCreateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SupplierOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/partners/suppliers/{supplier_id}": {
-      "patch": {
-        "tags": [
-          "suppliers"
-        ],
-        "summary": "Update Supplier",
-        "operationId": "update_supplier_partners_suppliers__supplier_id__patch",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "supplier_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Supplier Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SupplierUpdateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SupplierOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/partners/suppliers/{supplier_id}/contacts": {
-      "post": {
-        "tags": [
-          "supplier-contacts"
-        ],
-        "summary": "Supplier Create Contact",
-        "operationId": "supplier_create_contact_partners_suppliers__supplier_id__contacts_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "supplier_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Supplier Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SupplierContactCreateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SupplierContactOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/partners/supplier-contacts/{contact_id}": {
-      "patch": {
-        "tags": [
-          "supplier-contacts"
-        ],
-        "summary": "Supplier Update Contact",
-        "operationId": "supplier_update_contact_partners_supplier_contacts__contact_id__patch",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "contact_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Contact Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SupplierContactUpdateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SupplierContactOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "supplier-contacts"
-        ],
-        "summary": "Supplier Delete Contact",
-        "operationId": "supplier_delete_contact_partners_supplier_contacts__contact_id__delete",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "contact_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Contact Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
               }
             }
           },
@@ -12589,11 +6641,6 @@
         ],
         "summary": "独立 Logistics 拉取待导入交接数据",
         "operationId": "list_shipping_assist_handoff_ready_shipping_assist_handoffs_ready_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
         "parameters": [
           {
             "name": "source_doc_type",
@@ -12661,6 +6708,22 @@
               "default": 0,
               "title": "Offset"
             }
+          },
+          {
+            "name": "X-Service-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Service-Client"
+            }
           }
         ],
         "responses": {
@@ -12694,15 +6757,33 @@
         ],
         "summary": "独立 Logistics 导入结果回写",
         "operationId": "record_shipping_assist_handoff_import_result_shipping_assist_handoffs_import_results_post",
+        "parameters": [
+          {
+            "name": "X-Service-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Service-Client"
+            }
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/LogisticsImportResultIn"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -12725,12 +6806,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
+        }
       }
     },
     "/shipping-assist/handoffs/shipping-results": {
@@ -12740,15 +6816,33 @@
         ],
         "summary": "独立 Logistics 发货完成结果回写",
         "operationId": "record_shipping_assist_handoff_shipping_result_shipping_assist_handoffs_shipping_results_post",
+        "parameters": [
+          {
+            "name": "X-Service-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Service-Client"
+            }
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/LogisticsShippingResultIn"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -12771,12 +6865,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
+        }
       }
     },
     "/shipping-assist/records": {
@@ -16019,951 +10108,6 @@
   },
   "components": {
     "schemas": {
-      "AggregateBarcodeInput": {
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Id"
-          },
-          "barcode": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Barcode"
-          },
-          "symbology": {
-            "type": "string",
-            "enum": [
-              "EAN13",
-              "UPC",
-              "UPC12",
-              "EAN8",
-              "GS1",
-              "CUSTOM"
-            ],
-            "title": "Symbology",
-            "default": "CUSTOM"
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active",
-            "default": true
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary",
-            "default": false
-          },
-          "bind_uom_key": {
-            "type": "string",
-            "maxLength": 64,
-            "minLength": 1,
-            "title": "Bind Uom Key"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "barcode",
-          "bind_uom_key"
-        ],
-        "title": "AggregateBarcodeInput"
-      },
-      "AggregateBarcodeOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "item_uom_id": {
-            "type": "integer",
-            "title": "Item Uom Id"
-          },
-          "barcode": {
-            "type": "string",
-            "title": "Barcode"
-          },
-          "symbology": {
-            "type": "string",
-            "title": "Symbology"
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active"
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary"
-          },
-          "created_at": {
-            "anyOf": [
-              {},
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {},
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "id",
-          "item_id",
-          "item_uom_id",
-          "barcode",
-          "symbology",
-          "active",
-          "is_primary"
-        ],
-        "title": "AggregateBarcodeOut"
-      },
-      "AggregateItemInput": {
-        "properties": {
-          "sku": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Sku"
-          },
-          "name": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Name"
-          },
-          "spec": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spec"
-          },
-          "brand_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Brand Id"
-          },
-          "category_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Category Id"
-          },
-          "enabled": {
-            "type": "boolean",
-            "title": "Enabled",
-            "default": true
-          },
-          "supplier_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Supplier Id"
-          },
-          "lot_source_policy": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "INTERNAL_ONLY",
-                  "SUPPLIER_ONLY"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Lot Source Policy"
-          },
-          "expiry_policy": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "NONE",
-                  "REQUIRED"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Expiry Policy"
-          },
-          "derivation_allowed": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Derivation Allowed"
-          },
-          "uom_governance_enabled": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Uom Governance Enabled"
-          },
-          "shelf_life_value": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "exclusiveMinimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Shelf Life Value"
-          },
-          "shelf_life_unit": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "DAY",
-                  "WEEK",
-                  "MONTH",
-                  "YEAR"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Shelf Life Unit"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "sku",
-          "name"
-        ],
-        "title": "AggregateItemInput"
-      },
-      "AggregateUomInput": {
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Id"
-          },
-          "uom_key": {
-            "type": "string",
-            "maxLength": 64,
-            "minLength": 1,
-            "title": "Uom Key"
-          },
-          "uom": {
-            "type": "string",
-            "maxLength": 16,
-            "minLength": 1,
-            "title": "Uom"
-          },
-          "ratio_to_base": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Ratio To Base"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 32
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "net_weight_kg": {
-            "anyOf": [
-              {
-                "type": "number",
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Weight Kg"
-          },
-          "is_base": {
-            "type": "boolean",
-            "title": "Is Base",
-            "default": false
-          },
-          "is_purchase_default": {
-            "type": "boolean",
-            "title": "Is Purchase Default",
-            "default": false
-          },
-          "is_inbound_default": {
-            "type": "boolean",
-            "title": "Is Inbound Default",
-            "default": false
-          },
-          "is_outbound_default": {
-            "type": "boolean",
-            "title": "Is Outbound Default",
-            "default": false
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "uom_key",
-          "uom",
-          "ratio_to_base"
-        ],
-        "title": "AggregateUomInput"
-      },
-      "BarcodeProbeError": {
-        "properties": {
-          "stage": {
-            "type": "string",
-            "title": "Stage"
-          },
-          "error": {
-            "type": "string",
-            "title": "Error"
-          }
-        },
-        "type": "object",
-        "required": [
-          "stage",
-          "error"
-        ],
-        "title": "BarcodeProbeError"
-      },
-      "BarcodeProbeIn": {
-        "properties": {
-          "barcode": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Barcode"
-          }
-        },
-        "type": "object",
-        "required": [
-          "barcode"
-        ],
-        "title": "BarcodeProbeIn"
-      },
-      "BarcodeProbeOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok"
-          },
-          "status": {
-            "$ref": "#/components/schemas/BarcodeProbeStatus"
-          },
-          "barcode": {
-            "type": "string",
-            "title": "Barcode"
-          },
-          "item_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Item Id"
-          },
-          "item_uom_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Item Uom Id"
-          },
-          "ratio_to_base": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Ratio To Base"
-          },
-          "symbology": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Symbology"
-          },
-          "active": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Active"
-          },
-          "item_basic": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ItemBasic"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "errors": {
-            "items": {
-              "$ref": "#/components/schemas/BarcodeProbeError"
-            },
-            "type": "array",
-            "title": "Errors"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ok",
-          "status",
-          "barcode"
-        ],
-        "title": "BarcodeProbeOut"
-      },
-      "BarcodeProbeStatus": {
-        "type": "string",
-        "enum": [
-          "BOUND",
-          "UNBOUND",
-          "ERROR"
-        ],
-        "title": "BarcodeProbeStatus"
-      },
-      "BindWarehouseIn": {
-        "properties": {
-          "warehouse_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Warehouse Id"
-          },
-          "is_default": {
-            "type": "boolean",
-            "title": "Is Default",
-            "default": false
-          },
-          "priority": {
-            "type": "integer",
-            "maximum": 100000.0,
-            "minimum": 0.0,
-            "title": "Priority",
-            "default": 100
-          },
-          "is_top": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Top",
-            "description": "是否主仓；若为 null，由后端按 is_default 推导"
-          }
-        },
-        "type": "object",
-        "required": [
-          "warehouse_id"
-        ],
-        "title": "BindWarehouseIn"
-      },
-      "BindWarehouseOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "BindWarehouseOut"
-      },
-      "BindingDeleteOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "BindingDeleteOut"
-      },
-      "BindingUpdateIn": {
-        "properties": {
-          "is_default": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Default"
-          },
-          "priority": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "maximum": 100000.0,
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Priority"
-          },
-          "is_top": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Top"
-          }
-        },
-        "type": "object",
-        "title": "BindingUpdateIn"
-      },
-      "BindingUpdateOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "BindingUpdateOut"
-      },
-      "CartLineItemIn": {
-        "properties": {
-          "row_no": {
-            "type": "integer",
-            "maximum": 6.0,
-            "minimum": 1.0,
-            "title": "Row No"
-          },
-          "checked": {
-            "type": "boolean",
-            "title": "Checked",
-            "default": false
-          },
-          "qty": {
-            "type": "integer",
-            "title": "Qty",
-            "default": 0
-          },
-          "receiver_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Name"
-          },
-          "receiver_phone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Phone"
-          },
-          "province": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Province"
-          },
-          "city": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "City"
-          },
-          "district": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "District"
-          },
-          "detail": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Detail"
-          },
-          "zipcode": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Zipcode"
-          },
-          "if_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "If Version"
-          }
-        },
-        "type": "object",
-        "required": [
-          "row_no"
-        ],
-        "title": "CartLineItemIn"
-      },
-      "CodeMappingCodeOptionListDataOut": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/CodeMappingCodeOptionOut"
-            },
-            "type": "array",
-            "title": "Items"
-          },
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          },
-          "limit": {
-            "type": "integer",
-            "title": "Limit"
-          },
-          "offset": {
-            "type": "integer",
-            "title": "Offset"
-          }
-        },
-        "type": "object",
-        "required": [
-          "total",
-          "limit",
-          "offset"
-        ],
-        "title": "CodeMappingCodeOptionListDataOut"
-      },
-      "CodeMappingCodeOptionListOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "$ref": "#/components/schemas/CodeMappingCodeOptionListDataOut"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "CodeMappingCodeOptionListOut"
-      },
-      "CodeMappingCodeOptionOut": {
-        "properties": {
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "store_code": {
-            "type": "string",
-            "title": "Store Code"
-          },
-          "merchant_code": {
-            "type": "string",
-            "title": "Merchant Code"
-          },
-          "latest_title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Latest Title"
-          },
-          "platform_item_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Item Id"
-          },
-          "platform_sku_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Sku Id"
-          },
-          "latest_platform_order_no": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Latest Platform Order No"
-          },
-          "latest_synced_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Latest Synced At"
-          },
-          "orders_count": {
-            "type": "integer",
-            "title": "Orders Count"
-          },
-          "is_bound": {
-            "type": "boolean",
-            "title": "Is Bound"
-          },
-          "binding_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Binding Id"
-          },
-          "fsku_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fsku Id"
-          },
-          "fsku_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fsku Code"
-          },
-          "fsku_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fsku Name"
-          },
-          "fsku_status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fsku Status"
-          },
-          "binding_updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Binding Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "platform",
-          "store_code",
-          "merchant_code",
-          "orders_count",
-          "is_bound"
-        ],
-        "title": "CodeMappingCodeOptionOut"
-      },
       "CountDocCreateIn": {
         "properties": {
           "warehouse_id": {
@@ -17802,34 +10946,6 @@
         ],
         "title": "DailyPurchaseReportItem"
       },
-      "DefaultWarehouseOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "additionalProperties": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "DefaultWarehouseOut"
-      },
       "ExplainAnchor": {
         "properties": {
           "ref": {
@@ -18605,422 +11721,6 @@
         ],
         "title": "FinanceOverviewSummary"
       },
-      "FskuComponentOut": {
-        "properties": {
-          "component_sku_code": {
-            "type": "string",
-            "title": "Component Sku Code"
-          },
-          "qty_per_fsku": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Qty Per Fsku"
-          },
-          "alloc_unit_price": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Alloc Unit Price"
-          },
-          "resolved_item_id": {
-            "type": "integer",
-            "title": "Resolved Item Id"
-          },
-          "resolved_item_sku_code_id": {
-            "type": "integer",
-            "title": "Resolved Item Sku Code Id"
-          },
-          "resolved_item_uom_id": {
-            "type": "integer",
-            "title": "Resolved Item Uom Id"
-          },
-          "sku_code_snapshot": {
-            "type": "string",
-            "title": "Sku Code Snapshot"
-          },
-          "item_name_snapshot": {
-            "type": "string",
-            "title": "Item Name Snapshot"
-          },
-          "uom_snapshot": {
-            "type": "string",
-            "title": "Uom Snapshot"
-          },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order"
-          }
-        },
-        "type": "object",
-        "required": [
-          "component_sku_code",
-          "qty_per_fsku",
-          "alloc_unit_price",
-          "resolved_item_id",
-          "resolved_item_sku_code_id",
-          "resolved_item_uom_id",
-          "sku_code_snapshot",
-          "item_name_snapshot",
-          "uom_snapshot",
-          "sort_order"
-        ],
-        "title": "FskuComponentOut"
-      },
-      "FskuCreateIn": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "maxLength": 200,
-            "minLength": 1,
-            "title": "Name"
-          },
-          "code": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Code"
-          },
-          "shape": {
-            "type": "string",
-            "enum": [
-              "single",
-              "bundle"
-            ],
-            "title": "Shape",
-            "default": "bundle"
-          },
-          "fsku_expr": {
-            "type": "string",
-            "maxLength": 2000,
-            "minLength": 1,
-            "title": "Fsku Expr"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "name",
-          "fsku_expr"
-        ],
-        "title": "FskuCreateIn"
-      },
-      "FskuDetailOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "code": {
-            "type": "string",
-            "title": "Code"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "shape": {
-            "type": "string",
-            "enum": [
-              "single",
-              "bundle"
-            ],
-            "title": "Shape"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "draft",
-              "published",
-              "retired"
-            ],
-            "title": "Status"
-          },
-          "fsku_expr": {
-            "type": "string",
-            "title": "Fsku Expr"
-          },
-          "normalized_expr": {
-            "type": "string",
-            "title": "Normalized Expr"
-          },
-          "expr_type": {
-            "type": "string",
-            "enum": [
-              "DIRECT",
-              "SEGMENT_GROUP"
-            ],
-            "title": "Expr Type"
-          },
-          "component_count": {
-            "type": "integer",
-            "title": "Component Count"
-          },
-          "published_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Published At"
-          },
-          "retired_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Retired At"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Updated At"
-          },
-          "components": {
-            "items": {
-              "$ref": "#/components/schemas/FskuComponentOut"
-            },
-            "type": "array",
-            "title": "Components"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "code",
-          "name",
-          "shape",
-          "status",
-          "fsku_expr",
-          "normalized_expr",
-          "expr_type",
-          "component_count",
-          "published_at",
-          "retired_at",
-          "created_at",
-          "updated_at",
-          "components"
-        ],
-        "title": "FskuDetailOut"
-      },
-      "FskuExpressionReplaceIn": {
-        "properties": {
-          "fsku_expr": {
-            "type": "string",
-            "maxLength": 2000,
-            "minLength": 1,
-            "title": "Fsku Expr"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "fsku_expr"
-        ],
-        "title": "FskuExpressionReplaceIn"
-      },
-      "FskuListItem": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "code": {
-            "type": "string",
-            "title": "Code"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "shape": {
-            "type": "string",
-            "enum": [
-              "single",
-              "bundle"
-            ],
-            "title": "Shape"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "draft",
-              "published",
-              "retired"
-            ],
-            "title": "Status"
-          },
-          "fsku_expr": {
-            "type": "string",
-            "title": "Fsku Expr"
-          },
-          "normalized_expr": {
-            "type": "string",
-            "title": "Normalized Expr"
-          },
-          "expr_type": {
-            "type": "string",
-            "enum": [
-              "DIRECT",
-              "SEGMENT_GROUP"
-            ],
-            "title": "Expr Type"
-          },
-          "component_count": {
-            "type": "integer",
-            "title": "Component Count"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Updated At"
-          },
-          "published_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Published At"
-          },
-          "retired_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Retired At"
-          },
-          "components_summary": {
-            "type": "string",
-            "title": "Components Summary"
-          },
-          "components_summary_name": {
-            "type": "string",
-            "title": "Components Summary Name"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "code",
-          "name",
-          "shape",
-          "status",
-          "fsku_expr",
-          "normalized_expr",
-          "expr_type",
-          "component_count",
-          "updated_at",
-          "published_at",
-          "retired_at",
-          "components_summary",
-          "components_summary_name"
-        ],
-        "title": "FskuListItem"
-      },
-      "FskuListOut": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/FskuListItem"
-            },
-            "type": "array",
-            "title": "Items"
-          },
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          },
-          "limit": {
-            "type": "integer",
-            "title": "Limit"
-          },
-          "offset": {
-            "type": "integer",
-            "title": "Offset"
-          }
-        },
-        "type": "object",
-        "required": [
-          "items",
-          "total",
-          "limit",
-          "offset"
-        ],
-        "title": "FskuListOut"
-      },
-      "FskuLiteOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "code": {
-            "type": "string",
-            "title": "Code"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "status": {
-            "type": "string",
-            "title": "Status"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "code",
-          "name",
-          "status"
-        ],
-        "title": "FskuLiteOut"
-      },
-      "FskuNameUpdateIn": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "maxLength": 200,
-            "minLength": 1,
-            "title": "Name"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "title": "FskuNameUpdateIn"
-      },
       "FulfillmentDebugAddress": {
         "properties": {
           "province": {
@@ -19191,53 +11891,6 @@
         "type": "object",
         "title": "HTTPValidationError"
       },
-      "ImportPlatformOrderMirrorFromCollectorIn": {
-        "properties": {
-          "collector_order_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Collector Order Id"
-          }
-        },
-        "type": "object",
-        "required": [
-          "collector_order_id"
-        ],
-        "title": "ImportPlatformOrderMirrorFromCollectorIn"
-      },
-      "ImportPlatformOrderMirrorFromCollectorOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "imported": {
-            "type": "boolean",
-            "title": "Imported",
-            "default": true
-          },
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "collector_order_id": {
-            "type": "integer",
-            "title": "Collector Order Id"
-          },
-          "mirror_id": {
-            "type": "integer",
-            "title": "Mirror Id"
-          }
-        },
-        "type": "object",
-        "required": [
-          "platform",
-          "collector_order_id",
-          "mirror_id"
-        ],
-        "title": "ImportPlatformOrderMirrorFromCollectorOut"
-      },
       "InboundCommitIn": {
         "properties": {
           "warehouse_id": {
@@ -19398,7 +12051,7 @@
             "title": "Expiry Date",
             "description": "到期日期"
           },
-          "po_line_id": {
+          "source_line_id": {
             "anyOf": [
               {
                 "type": "integer",
@@ -19408,8 +12061,8 @@
                 "type": "null"
               }
             ],
-            "title": "Po Line Id",
-            "description": "采购来源时的采购单行 ID"
+            "title": "Source Line Id",
+            "description": "采购来源时的外部来源行 ID"
           },
           "remark": {
             "anyOf": [
@@ -19431,7 +12084,7 @@
           "qty_input"
         ],
         "title": "InboundCommitLineIn",
-        "description": "一层式入库提交行输入。\n\n设计原则：\n- 输入只接用户事实：商品/条码、包装单位、输入数量、批号/日期\n- 不接 qty_base，qty_base 由后端根据 PMS item_uoms.ratio_to_base 计算\n- 采购来源时允许显式带 po_line_id；其他来源不需要 source_line_ref 这种泛字段"
+        "description": "一层式入库提交行输入。\n\n设计原则：\n- 输入只接用户事实：商品/条码、包装单位、输入数量、批号/日期\n- 不接 qty_base，qty_base 由后端根据 PMS item_uoms.ratio_to_base 计算\n- 采购来源时允许显式带 source_line_id；其他来源不需要来源行引用"
       },
       "InboundCommitOut": {
         "properties": {
@@ -19597,7 +12250,7 @@
             "title": "Lot Code",
             "description": "实际落账 lot_code"
           },
-          "po_line_id": {
+          "source_line_id": {
             "anyOf": [
               {
                 "type": "integer",
@@ -19607,8 +12260,8 @@
                 "type": "null"
               }
             ],
-            "title": "Po Line Id",
-            "description": "采购来源时的采购单行 ID"
+            "title": "Source Line Id",
+            "description": "采购来源时的外部来源行 ID"
           },
           "remark": {
             "anyOf": [
@@ -19814,7 +12467,7 @@
             "title": "Expiry Date",
             "description": "到期日期"
           },
-          "po_line_id": {
+          "source_line_id": {
             "anyOf": [
               {
                 "type": "integer",
@@ -19824,8 +12477,8 @@
                 "type": "null"
               }
             ],
-            "title": "Po Line Id",
-            "description": "采购来源时的采购单行 ID"
+            "title": "Source Line Id",
+            "description": "采购来源时的外部来源行 ID"
           },
           "remark": {
             "anyOf": [
@@ -21071,6 +13724,138 @@
           "receipt_no"
         ],
         "title": "InboundReceiptProgressOut"
+      },
+      "InboundReceiptPurchaseSourceOptionOut": {
+        "properties": {
+          "po_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Po Id",
+            "description": "采购单 ID"
+          },
+          "po_no": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Po No",
+            "description": "采购单号"
+          },
+          "target_warehouse_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Target Warehouse Id",
+            "description": "目标仓库 ID"
+          },
+          "target_warehouse_code_snapshot": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 64
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Warehouse Code Snapshot",
+            "description": "目标仓库编码快照"
+          },
+          "target_warehouse_name_snapshot": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Warehouse Name Snapshot",
+            "description": "目标仓库名称快照"
+          },
+          "supplier_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Supplier Id",
+            "description": "供应商 ID"
+          },
+          "supplier_code_snapshot": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Supplier Code Snapshot",
+            "description": "供应商编码快照"
+          },
+          "supplier_name_snapshot": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Supplier Name Snapshot",
+            "description": "供应商名称快照"
+          },
+          "purchase_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Purchase Time"
+          },
+          "order_status": {
+            "type": "string",
+            "maxLength": 32,
+            "minLength": 1,
+            "title": "Order Status",
+            "description": "采购单状态"
+          },
+          "completion_status": {
+            "type": "string",
+            "enum": [
+              "NOT_RECEIVED",
+              "PARTIAL",
+              "RECEIVED"
+            ],
+            "title": "Completion Status"
+          },
+          "last_received_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Received At",
+            "description": "最近收货时间"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "po_id",
+          "po_no",
+          "target_warehouse_id",
+          "supplier_id",
+          "supplier_code_snapshot",
+          "supplier_name_snapshot",
+          "purchase_time",
+          "order_status",
+          "completion_status"
+        ],
+        "title": "InboundReceiptPurchaseSourceOptionOut"
+      },
+      "InboundReceiptPurchaseSourceOptionsOut": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/InboundReceiptPurchaseSourceOptionOut"
+            },
+            "type": "array",
+            "title": "Items",
+            "description": "可生成采购入库单的采购来源"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "InboundReceiptPurchaseSourceOptionsOut"
       },
       "InboundReceiptReadOut": {
         "properties": {
@@ -24064,2231 +16849,6 @@
         ],
         "title": "InventoryWarehouseOption"
       },
-      "ItemAggregateOut": {
-        "properties": {
-          "item": {
-            "$ref": "#/components/schemas/ItemOut"
-          },
-          "uoms": {
-            "items": {
-              "$ref": "#/components/schemas/ItemUomOut"
-            },
-            "type": "array",
-            "title": "Uoms"
-          },
-          "barcodes": {
-            "items": {
-              "$ref": "#/components/schemas/AggregateBarcodeOut"
-            },
-            "type": "array",
-            "title": "Barcodes"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "item",
-          "uoms",
-          "barcodes"
-        ],
-        "title": "ItemAggregateOut"
-      },
-      "ItemAggregatePayload": {
-        "properties": {
-          "item": {
-            "$ref": "#/components/schemas/AggregateItemInput"
-          },
-          "uoms": {
-            "items": {
-              "$ref": "#/components/schemas/AggregateUomInput"
-            },
-            "type": "array",
-            "title": "Uoms"
-          },
-          "barcodes": {
-            "items": {
-              "$ref": "#/components/schemas/AggregateBarcodeInput"
-            },
-            "type": "array",
-            "title": "Barcodes"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "item",
-          "uoms",
-          "barcodes"
-        ],
-        "title": "ItemAggregatePayload"
-      },
-      "ItemAttributeDefCreate": {
-        "properties": {
-          "code": {
-            "type": "string",
-            "maxLength": 64,
-            "minLength": 1,
-            "title": "Code"
-          },
-          "name_cn": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Name Cn"
-          },
-          "name_en": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name En"
-          },
-          "product_kind": {
-            "type": "string",
-            "enum": [
-              "FOOD",
-              "SUPPLY",
-              "OTHER",
-              "COMMON"
-            ],
-            "title": "Product Kind"
-          },
-          "value_type": {
-            "type": "string",
-            "enum": [
-              "TEXT",
-              "NUMBER",
-              "OPTION",
-              "BOOL"
-            ],
-            "title": "Value Type"
-          },
-          "selection_mode": {
-            "type": "string",
-            "enum": [
-              "SINGLE",
-              "MULTI"
-            ],
-            "title": "Selection Mode",
-            "default": "SINGLE"
-          },
-          "unit": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 16
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Unit"
-          },
-          "is_item_required": {
-            "type": "boolean",
-            "title": "Is Item Required",
-            "default": false
-          },
-          "is_sku_required": {
-            "type": "boolean",
-            "title": "Is Sku Required",
-            "default": false
-          },
-          "is_sku_segment": {
-            "type": "boolean",
-            "title": "Is Sku Segment",
-            "default": false
-          },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order",
-            "default": 0
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 500
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          }
-        },
-        "type": "object",
-        "required": [
-          "code",
-          "name_cn",
-          "product_kind",
-          "value_type"
-        ],
-        "title": "ItemAttributeDefCreate"
-      },
-      "ItemAttributeDefOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "code": {
-            "type": "string",
-            "title": "Code"
-          },
-          "name_cn": {
-            "type": "string",
-            "title": "Name Cn"
-          },
-          "name_en": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name En"
-          },
-          "product_kind": {
-            "type": "string",
-            "title": "Product Kind"
-          },
-          "value_type": {
-            "type": "string",
-            "title": "Value Type"
-          },
-          "selection_mode": {
-            "type": "string",
-            "title": "Selection Mode"
-          },
-          "unit": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Unit"
-          },
-          "is_item_required": {
-            "type": "boolean",
-            "title": "Is Item Required"
-          },
-          "is_sku_required": {
-            "type": "boolean",
-            "title": "Is Sku Required"
-          },
-          "is_sku_segment": {
-            "type": "boolean",
-            "title": "Is Sku Segment"
-          },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
-          },
-          "is_locked": {
-            "type": "boolean",
-            "title": "Is Locked"
-          },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order"
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "code",
-          "name_cn",
-          "product_kind",
-          "value_type",
-          "selection_mode",
-          "is_item_required",
-          "is_sku_required",
-          "is_sku_segment",
-          "is_active",
-          "is_locked",
-          "sort_order"
-        ],
-        "title": "ItemAttributeDefOut"
-      },
-      "ItemAttributeDefUpdate": {
-        "properties": {
-          "name_cn": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name Cn"
-          },
-          "name_en": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name En"
-          },
-          "selection_mode": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "SINGLE",
-                  "MULTI"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Selection Mode"
-          },
-          "unit": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 16
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Unit"
-          },
-          "is_item_required": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Item Required"
-          },
-          "is_sku_required": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Sku Required"
-          },
-          "is_sku_segment": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Sku Segment"
-          },
-          "sort_order": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sort Order"
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 500
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          }
-        },
-        "type": "object",
-        "title": "ItemAttributeDefUpdate"
-      },
-      "ItemAttributeOptionCreate": {
-        "properties": {
-          "option_code": {
-            "type": "string",
-            "maxLength": 64,
-            "minLength": 1,
-            "title": "Option Code"
-          },
-          "option_name": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Option Name"
-          },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order",
-            "default": 0
-          }
-        },
-        "type": "object",
-        "required": [
-          "option_code",
-          "option_name"
-        ],
-        "title": "ItemAttributeOptionCreate"
-      },
-      "ItemAttributeOptionOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "attribute_def_id": {
-            "type": "integer",
-            "title": "Attribute Def Id"
-          },
-          "option_code": {
-            "type": "string",
-            "title": "Option Code"
-          },
-          "option_name": {
-            "type": "string",
-            "title": "Option Name"
-          },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
-          },
-          "is_locked": {
-            "type": "boolean",
-            "title": "Is Locked"
-          },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "attribute_def_id",
-          "option_code",
-          "option_name",
-          "is_active",
-          "is_locked",
-          "sort_order"
-        ],
-        "title": "ItemAttributeOptionOut"
-      },
-      "ItemAttributeOptionUpdate": {
-        "properties": {
-          "option_name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Option Name"
-          },
-          "sort_order": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sort Order"
-          }
-        },
-        "type": "object",
-        "title": "ItemAttributeOptionUpdate"
-      },
-      "ItemAttributeValueIn": {
-        "properties": {
-          "attribute_def_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Attribute Def Id"
-          },
-          "value_text": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Text"
-          },
-          "value_number": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Number"
-          },
-          "value_bool": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Bool"
-          },
-          "value_option_ids": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "integer",
-                  "minimum": 1.0
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Option Ids"
-          }
-        },
-        "type": "object",
-        "required": [
-          "attribute_def_id"
-        ],
-        "title": "ItemAttributeValueIn"
-      },
-      "ItemAttributeValueOut": {
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Id"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "attribute_def_id": {
-            "type": "integer",
-            "title": "Attribute Def Id"
-          },
-          "value_text": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Text"
-          },
-          "value_number": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Number"
-          },
-          "value_bool": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Bool"
-          },
-          "value_option_ids": {
-            "items": {
-              "type": "integer"
-            },
-            "type": "array",
-            "title": "Value Option Ids"
-          },
-          "value_option_code_snapshots": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Value Option Code Snapshots"
-          },
-          "value_unit_snapshot": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Unit Snapshot"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "item_id",
-          "attribute_def_id"
-        ],
-        "title": "ItemAttributeValueOut"
-      },
-      "ItemAttributeValuesReplaceIn": {
-        "properties": {
-          "values": {
-            "items": {
-              "$ref": "#/components/schemas/ItemAttributeValueIn"
-            },
-            "type": "array",
-            "title": "Values"
-          }
-        },
-        "type": "object",
-        "title": "ItemAttributeValuesReplaceIn"
-      },
-      "ItemBarcodeCompositeRow": {
-        "properties": {
-          "sku": {
-            "type": "string",
-            "title": "Sku"
-          },
-          "item_name": {
-            "type": "string",
-            "title": "Item Name"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "item_uom_id": {
-            "type": "integer",
-            "title": "Item Uom Id"
-          },
-          "uom": {
-            "type": "string",
-            "title": "Uom"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "ratio_to_base": {
-            "type": "integer",
-            "title": "Ratio To Base"
-          },
-          "net_weight_kg": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Weight Kg"
-          },
-          "is_base": {
-            "type": "boolean",
-            "title": "Is Base"
-          },
-          "is_purchase_default": {
-            "type": "boolean",
-            "title": "Is Purchase Default"
-          },
-          "is_inbound_default": {
-            "type": "boolean",
-            "title": "Is Inbound Default"
-          },
-          "is_outbound_default": {
-            "type": "boolean",
-            "title": "Is Outbound Default"
-          },
-          "barcode_id": {
-            "type": "integer",
-            "title": "Barcode Id"
-          },
-          "barcode": {
-            "type": "string",
-            "title": "Barcode"
-          },
-          "symbology": {
-            "type": "string",
-            "title": "Symbology"
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary"
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "sku",
-          "item_name",
-          "item_id",
-          "item_uom_id",
-          "uom",
-          "display_name",
-          "ratio_to_base",
-          "net_weight_kg",
-          "is_base",
-          "is_purchase_default",
-          "is_inbound_default",
-          "is_outbound_default",
-          "barcode_id",
-          "barcode",
-          "symbology",
-          "is_primary",
-          "active",
-          "updated_at"
-        ],
-        "title": "ItemBarcodeCompositeRow",
-        "description": "商品条码页 owner 复合只读行：\n- 继承 item_uoms owner 复合读模型，包装字段以 item_uoms 合同为唯一来源\n- 当前接口只返回已绑定条码的行，因此条码字段在这里收紧为必填"
-      },
-      "ItemBarcodeCreate": {
-        "properties": {
-          "item_uom_id": {
-            "type": "integer",
-            "title": "Item Uom Id"
-          },
-          "barcode": {
-            "type": "string",
-            "title": "Barcode"
-          },
-          "symbology": {
-            "type": "string",
-            "title": "Symbology",
-            "default": "CUSTOM"
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active",
-            "default": true
-          }
-        },
-        "type": "object",
-        "required": [
-          "item_uom_id",
-          "barcode"
-        ],
-        "title": "ItemBarcodeCreate"
-      },
-      "ItemBarcodeOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "item_uom_id": {
-            "type": "integer",
-            "title": "Item Uom Id"
-          },
-          "barcode": {
-            "type": "string",
-            "title": "Barcode"
-          },
-          "symbology": {
-            "type": "string",
-            "title": "Symbology"
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active"
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "item_id",
-          "item_uom_id",
-          "barcode",
-          "symbology",
-          "active",
-          "is_primary"
-        ],
-        "title": "ItemBarcodeOut"
-      },
-      "ItemBarcodeUpdate": {
-        "properties": {
-          "item_uom_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Item Uom Id"
-          },
-          "barcode": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Barcode"
-          },
-          "symbology": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Symbology"
-          },
-          "active": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Active"
-          },
-          "is_primary": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Primary"
-          }
-        },
-        "type": "object",
-        "title": "ItemBarcodeUpdate",
-        "description": "PATCH 更新条码：可用于改绑包装 / 改条码 / 改码制 / 切主条码"
-      },
-      "ItemBasic": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "exclusiveMinimum": 0.0,
-            "title": "Id"
-          },
-          "sku": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Sku"
-          },
-          "name": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Name"
-          },
-          "spec": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spec"
-          },
-          "enabled": {
-            "type": "boolean",
-            "title": "Enabled",
-            "default": true
-          },
-          "supplier_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Supplier Id"
-          },
-          "brand": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 64
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Brand"
-          },
-          "category": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 64
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Category"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "sku",
-          "name"
-        ],
-        "title": "ItemBasic",
-        "description": "PMS 对外最小商品读模型。\n\n说明：\n- 这是跨域 public read surface，不承载 owner 内部兼容输入语义\n- 只暴露 items 主表稳定需要的最小读取字段\n- 不承载条码 / 单位 / 净重等跨子表事实"
-      },
-      "ItemCompletenessOut": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "enum": [
-              "COMPLETE",
-              "WARNING",
-              "BLOCKED"
-            ],
-            "title": "Status"
-          },
-          "is_complete": {
-            "type": "boolean",
-            "title": "Is Complete"
-          },
-          "product_kind": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "FOOD",
-                  "SUPPLY",
-                  "OTHER"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Product Kind"
-          },
-          "has_brand": {
-            "type": "boolean",
-            "title": "Has Brand",
-            "default": false
-          },
-          "has_active_leaf_category": {
-            "type": "boolean",
-            "title": "Has Active Leaf Category",
-            "default": false
-          },
-          "has_base_uom": {
-            "type": "boolean",
-            "title": "Has Base Uom",
-            "default": false
-          },
-          "has_active_primary_barcode": {
-            "type": "boolean",
-            "title": "Has Active Primary Barcode",
-            "default": false
-          },
-          "has_active_primary_sku": {
-            "type": "boolean",
-            "title": "Has Active Primary Sku",
-            "default": false
-          },
-          "item_required_attributes_complete": {
-            "type": "boolean",
-            "title": "Item Required Attributes Complete",
-            "default": true
-          },
-          "sku_required_attributes_complete": {
-            "type": "boolean",
-            "title": "Sku Required Attributes Complete",
-            "default": true
-          },
-          "sku_segment_attributes_present": {
-            "type": "boolean",
-            "title": "Sku Segment Attributes Present",
-            "default": true
-          },
-          "sku_generation_applicable": {
-            "type": "boolean",
-            "title": "Sku Generation Applicable",
-            "default": false
-          },
-          "can_generate_sku": {
-            "type": "boolean",
-            "title": "Can Generate Sku",
-            "default": false
-          },
-          "missing_item_required_attribute_codes": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Missing Item Required Attribute Codes"
-          },
-          "missing_sku_required_attribute_codes": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Missing Sku Required Attribute Codes"
-          },
-          "missing_sku_segment_attribute_codes": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Missing Sku Segment Attribute Codes"
-          },
-          "missing_items": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Missing Items"
-          },
-          "blocking_items": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Blocking Items"
-          },
-          "warnings": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Warnings"
-          }
-        },
-        "type": "object",
-        "required": [
-          "status",
-          "is_complete"
-        ],
-        "title": "ItemCompletenessOut",
-        "description": "PMS 商品完整度 owner read model。\n\n定位：\n- 后端统一计算商品完整度\n- 前端列表、详情、编辑流程只消费这个合同\n- 不让前端根据多个数组自行拼完整度判断"
-      },
-      "ItemCreate": {
-        "properties": {
-          "sku": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Sku"
-          },
-          "name": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Name"
-          },
-          "spec": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spec"
-          },
-          "brand_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Brand Id"
-          },
-          "category_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Category Id"
-          },
-          "enabled": {
-            "type": "boolean",
-            "title": "Enabled",
-            "default": true
-          },
-          "supplier_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Supplier Id"
-          },
-          "lot_source_policy": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "INTERNAL_ONLY",
-                  "SUPPLIER_ONLY"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Lot Source Policy"
-          },
-          "expiry_policy": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "NONE",
-                  "REQUIRED"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Expiry Policy"
-          },
-          "derivation_allowed": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Derivation Allowed"
-          },
-          "uom_governance_enabled": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Uom Governance Enabled"
-          },
-          "shelf_life_value": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "exclusiveMinimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Shelf Life Value"
-          },
-          "shelf_life_unit": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "DAY",
-                  "WEEK",
-                  "MONTH",
-                  "YEAR"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Shelf Life Unit"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "sku",
-          "name"
-        ],
-        "title": "ItemCreate",
-        "description": "Create Item（SKU 由调用方显式输入）：\n- 必须传 sku；SKU 编码页只负责生成候选 SKU，最终由商品创建合同写入 items.sku\n- brand/category 不再接受自由文本；请传 brand_id/category_id\n- 不接受 barcode 输入；主条码请走 /item-barcodes\n- 不接受 weight_kg 输入；基础包装净重请走 item_uoms（base uom）\n\nPhase M-3：\n- items.case_ratio/case_uom 已删除；包装单位请走 item_uoms"
-      },
-      "ItemListAttributeOut": {
-        "properties": {
-          "attribute_def_id": {
-            "type": "integer",
-            "title": "Attribute Def Id"
-          },
-          "code": {
-            "type": "string",
-            "title": "Code"
-          },
-          "name_cn": {
-            "type": "string",
-            "title": "Name Cn"
-          },
-          "value_type": {
-            "type": "string",
-            "title": "Value Type"
-          },
-          "selection_mode": {
-            "type": "string",
-            "title": "Selection Mode"
-          },
-          "unit": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Unit"
-          },
-          "is_item_required": {
-            "type": "boolean",
-            "title": "Is Item Required"
-          },
-          "is_sku_required": {
-            "type": "boolean",
-            "title": "Is Sku Required"
-          },
-          "is_sku_segment": {
-            "type": "boolean",
-            "title": "Is Sku Segment"
-          },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order"
-          },
-          "value_text": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Text"
-          },
-          "value_number": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Number"
-          },
-          "value_bool": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Bool"
-          },
-          "value_option_ids": {
-            "items": {
-              "type": "integer"
-            },
-            "type": "array",
-            "title": "Value Option Ids"
-          },
-          "value_option_code_snapshots": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Value Option Code Snapshots"
-          },
-          "value_option_names": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Value Option Names"
-          },
-          "value_unit_snapshot": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Unit Snapshot"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "attribute_def_id",
-          "code",
-          "name_cn",
-          "value_type",
-          "selection_mode",
-          "is_item_required",
-          "is_sku_required",
-          "is_sku_segment",
-          "sort_order"
-        ],
-        "title": "ItemListAttributeOut"
-      },
-      "ItemListBarcodeOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "item_uom_id": {
-            "type": "integer",
-            "title": "Item Uom Id"
-          },
-          "uom": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Uom"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "barcode": {
-            "type": "string",
-            "title": "Barcode"
-          },
-          "symbology": {
-            "type": "string",
-            "title": "Symbology"
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active"
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "item_id",
-          "item_uom_id",
-          "barcode",
-          "symbology",
-          "active",
-          "is_primary"
-        ],
-        "title": "ItemListBarcodeOut"
-      },
-      "ItemListDetailOut": {
-        "properties": {
-          "row": {
-            "$ref": "#/components/schemas/ItemListRowOut"
-          },
-          "uoms": {
-            "items": {
-              "$ref": "#/components/schemas/ItemListUomOut"
-            },
-            "type": "array",
-            "title": "Uoms"
-          },
-          "barcodes": {
-            "items": {
-              "$ref": "#/components/schemas/ItemListBarcodeOut"
-            },
-            "type": "array",
-            "title": "Barcodes"
-          },
-          "sku_codes": {
-            "items": {
-              "$ref": "#/components/schemas/ItemListSkuCodeOut"
-            },
-            "type": "array",
-            "title": "Sku Codes"
-          },
-          "attributes": {
-            "items": {
-              "$ref": "#/components/schemas/ItemListAttributeOut"
-            },
-            "type": "array",
-            "title": "Attributes"
-          }
-        },
-        "type": "object",
-        "required": [
-          "row",
-          "uoms",
-          "barcodes",
-          "sku_codes",
-          "attributes"
-        ],
-        "title": "ItemListDetailOut",
-        "description": "PMS 商品列表详情读模型。\n\n定位：\n- 只读展示合同\n- 给商品列表页“详情展开”使用\n- row 复用 ItemListRowOut，确保列表摘要与详情头部一致"
-      },
-      "ItemListRowOut": {
-        "properties": {
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "sku": {
-            "type": "string",
-            "title": "Sku"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "spec": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spec"
-          },
-          "enabled": {
-            "type": "boolean",
-            "title": "Enabled"
-          },
-          "brand": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Brand"
-          },
-          "category": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Category"
-          },
-          "supplier_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Supplier Name"
-          },
-          "primary_barcode": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Primary Barcode"
-          },
-          "base_uom": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Base Uom"
-          },
-          "base_net_weight_kg": {
-            "anyOf": [
-              {
-                "type": "number",
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Base Net Weight Kg"
-          },
-          "purchase_uom": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Purchase Uom"
-          },
-          "purchase_ratio_to_base": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "minimum": 1.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Purchase Ratio To Base"
-          },
-          "lot_source_policy": {
-            "type": "string",
-            "title": "Lot Source Policy"
-          },
-          "expiry_policy": {
-            "type": "string",
-            "title": "Expiry Policy"
-          },
-          "shelf_life_value": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Shelf Life Value"
-          },
-          "shelf_life_unit": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Shelf Life Unit"
-          },
-          "uom_count": {
-            "type": "integer",
-            "minimum": 0.0,
-            "title": "Uom Count",
-            "default": 0
-          },
-          "barcode_count": {
-            "type": "integer",
-            "minimum": 0.0,
-            "title": "Barcode Count",
-            "default": 0
-          },
-          "sku_code_count": {
-            "type": "integer",
-            "minimum": 0.0,
-            "title": "Sku Code Count",
-            "default": 0
-          },
-          "attribute_count": {
-            "type": "integer",
-            "minimum": 0.0,
-            "title": "Attribute Count",
-            "default": 0
-          },
-          "completeness": {
-            "$ref": "#/components/schemas/ItemCompletenessOut"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "item_id",
-          "sku",
-          "name",
-          "enabled",
-          "lot_source_policy",
-          "expiry_policy",
-          "completeness"
-        ],
-        "title": "ItemListRowOut",
-        "description": "PMS 商品列表页专用 owner 读模型。\n\n定位：\n- 一行 = 一个商品的完整列表摘要\n- 只服务商品主数据总览页\n- 不承载写入语义\n- 不让前端再自行拼 item_uoms / item_barcodes / item_sku_codes / item_attribute_values"
-      },
-      "ItemListSkuCodeOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "code": {
-            "type": "string",
-            "title": "Code"
-          },
-          "code_type": {
-            "type": "string",
-            "title": "Code Type"
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary"
-          },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
-          },
-          "effective_from": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Effective From"
-          },
-          "effective_to": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Effective To"
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "item_id",
-          "code",
-          "code_type",
-          "is_primary",
-          "is_active"
-        ],
-        "title": "ItemListSkuCodeOut"
-      },
-      "ItemListUomOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "uom": {
-            "type": "string",
-            "title": "Uom"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "ratio_to_base": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Ratio To Base"
-          },
-          "net_weight_kg": {
-            "anyOf": [
-              {
-                "type": "number",
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Weight Kg"
-          },
-          "is_base": {
-            "type": "boolean",
-            "title": "Is Base"
-          },
-          "is_purchase_default": {
-            "type": "boolean",
-            "title": "Is Purchase Default"
-          },
-          "is_inbound_default": {
-            "type": "boolean",
-            "title": "Is Inbound Default"
-          },
-          "is_outbound_default": {
-            "type": "boolean",
-            "title": "Is Outbound Default"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "item_id",
-          "uom",
-          "ratio_to_base",
-          "is_base",
-          "is_purchase_default",
-          "is_inbound_default",
-          "is_outbound_default"
-        ],
-        "title": "ItemListUomOut"
-      },
-      "ItemOut": {
-        "properties": {
-          "sku": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Sku"
-          },
-          "name": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Name"
-          },
-          "spec": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spec"
-          },
-          "barcode": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 64
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Barcode"
-          },
-          "primary_barcode": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 64
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Primary Barcode"
-          },
-          "brand_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Brand Id"
-          },
-          "category_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Category Id"
-          },
-          "brand": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Brand"
-          },
-          "category": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Category"
-          },
-          "enabled": {
-            "type": "boolean",
-            "title": "Enabled",
-            "default": true
-          },
-          "supplier_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Supplier Id"
-          },
-          "lot_source_policy": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "INTERNAL_ONLY",
-                  "SUPPLIER_ONLY"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Lot Source Policy"
-          },
-          "expiry_policy": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "NONE",
-                  "REQUIRED"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Expiry Policy"
-          },
-          "derivation_allowed": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Derivation Allowed"
-          },
-          "uom_governance_enabled": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Uom Governance Enabled"
-          },
-          "shelf_life_value": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "exclusiveMinimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Shelf Life Value"
-          },
-          "shelf_life_unit": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "DAY",
-                  "WEEK",
-                  "MONTH",
-                  "YEAR"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Shelf Life Unit"
-          },
-          "weight_kg": {
-            "anyOf": [
-              {
-                "type": "number",
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Weight Kg"
-          },
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "supplier_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Supplier Name"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          },
-          "requires_batch": {
-            "type": "boolean",
-            "title": "Requires Batch",
-            "default": true
-          },
-          "requires_dates": {
-            "type": "boolean",
-            "title": "Requires Dates",
-            "default": true
-          }
-        },
-        "type": "object",
-        "required": [
-          "sku",
-          "name",
-          "id"
-        ],
-        "title": "ItemOut"
-      },
       "ItemPurchaseReportItem": {
         "properties": {
           "item_id": {
@@ -26513,735 +17073,6 @@
           "planned_line_amount"
         ],
         "title": "ItemPurchaseReportLineItem"
-      },
-      "ItemSkuCodeChangePrimary": {
-        "properties": {
-          "code": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Code"
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "code"
-        ],
-        "title": "ItemSkuCodeChangePrimary"
-      },
-      "ItemSkuCodeCreate": {
-        "properties": {
-          "code": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Code"
-          },
-          "code_type": {
-            "type": "string",
-            "enum": [
-              "PRIMARY",
-              "ALIAS",
-              "LEGACY",
-              "MANUAL"
-            ],
-            "title": "Code Type",
-            "default": "ALIAS"
-          },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active",
-            "default": true
-          },
-          "effective_from": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Effective From"
-          },
-          "effective_to": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Effective To"
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "code"
-        ],
-        "title": "ItemSkuCodeCreate"
-      },
-      "ItemSkuCodeOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "code": {
-            "type": "string",
-            "title": "Code"
-          },
-          "code_type": {
-            "type": "string",
-            "enum": [
-              "PRIMARY",
-              "ALIAS",
-              "LEGACY",
-              "MANUAL"
-            ],
-            "title": "Code Type"
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary"
-          },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
-          },
-          "effective_from": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Effective From"
-          },
-          "effective_to": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Effective To"
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "item_id",
-          "code",
-          "code_type",
-          "is_primary",
-          "is_active"
-        ],
-        "title": "ItemSkuCodeOut"
-      },
-      "ItemUomBarcodeRowOut": {
-        "properties": {
-          "sku": {
-            "type": "string",
-            "title": "Sku"
-          },
-          "item_name": {
-            "type": "string",
-            "title": "Item Name"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "item_uom_id": {
-            "type": "integer",
-            "title": "Item Uom Id"
-          },
-          "uom": {
-            "type": "string",
-            "title": "Uom"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "ratio_to_base": {
-            "type": "integer",
-            "title": "Ratio To Base"
-          },
-          "net_weight_kg": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Weight Kg"
-          },
-          "is_base": {
-            "type": "boolean",
-            "title": "Is Base"
-          },
-          "is_purchase_default": {
-            "type": "boolean",
-            "title": "Is Purchase Default"
-          },
-          "is_inbound_default": {
-            "type": "boolean",
-            "title": "Is Inbound Default"
-          },
-          "is_outbound_default": {
-            "type": "boolean",
-            "title": "Is Outbound Default"
-          },
-          "barcode_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Barcode Id"
-          },
-          "barcode": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Barcode"
-          },
-          "symbology": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Symbology"
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary",
-            "default": false
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active",
-            "default": false
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "sku",
-          "item_name",
-          "item_id",
-          "item_uom_id",
-          "uom",
-          "display_name",
-          "ratio_to_base",
-          "net_weight_kg",
-          "is_base",
-          "is_purchase_default",
-          "is_inbound_default",
-          "is_outbound_default",
-          "updated_at"
-        ],
-        "title": "ItemUomBarcodeRowOut",
-        "description": "owner 复合读模型：\n- 一行 = 一个商品 + 一个包装 + 零/一条码\n- 主权归 item_uoms，不归 item_barcodes"
-      },
-      "ItemUomCreate": {
-        "properties": {
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "uom": {
-            "type": "string",
-            "maxLength": 16,
-            "minLength": 1,
-            "title": "Uom"
-          },
-          "ratio_to_base": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Ratio To Base"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 32
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "net_weight_kg": {
-            "anyOf": [
-              {
-                "type": "number",
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Weight Kg"
-          },
-          "is_base": {
-            "type": "boolean",
-            "title": "Is Base",
-            "default": false
-          },
-          "is_purchase_default": {
-            "type": "boolean",
-            "title": "Is Purchase Default",
-            "default": false
-          },
-          "is_inbound_default": {
-            "type": "boolean",
-            "title": "Is Inbound Default",
-            "default": false
-          },
-          "is_outbound_default": {
-            "type": "boolean",
-            "title": "Is Outbound Default",
-            "default": false
-          }
-        },
-        "type": "object",
-        "required": [
-          "item_id",
-          "uom",
-          "ratio_to_base"
-        ],
-        "title": "ItemUomCreate"
-      },
-      "ItemUomOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "uom": {
-            "type": "string",
-            "title": "Uom"
-          },
-          "ratio_to_base": {
-            "type": "integer",
-            "title": "Ratio To Base"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "net_weight_kg": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Weight Kg"
-          },
-          "is_base": {
-            "type": "boolean",
-            "title": "Is Base"
-          },
-          "is_purchase_default": {
-            "type": "boolean",
-            "title": "Is Purchase Default"
-          },
-          "is_inbound_default": {
-            "type": "boolean",
-            "title": "Is Inbound Default"
-          },
-          "is_outbound_default": {
-            "type": "boolean",
-            "title": "Is Outbound Default"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "item_id",
-          "uom",
-          "ratio_to_base",
-          "display_name",
-          "net_weight_kg",
-          "is_base",
-          "is_purchase_default",
-          "is_inbound_default",
-          "is_outbound_default"
-        ],
-        "title": "ItemUomOut"
-      },
-      "ItemUomUpdate": {
-        "properties": {
-          "uom": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 16,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Uom"
-          },
-          "ratio_to_base": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "minimum": 1.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Ratio To Base"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 32
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "net_weight_kg": {
-            "anyOf": [
-              {
-                "type": "number",
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Weight Kg"
-          },
-          "is_base": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Base"
-          },
-          "is_purchase_default": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Purchase Default"
-          },
-          "is_inbound_default": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Inbound Default"
-          },
-          "is_outbound_default": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Outbound Default"
-          }
-        },
-        "type": "object",
-        "title": "ItemUomUpdate"
-      },
-      "ItemUpdate": {
-        "properties": {
-          "name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          },
-          "spec": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spec"
-          },
-          "brand_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Brand Id"
-          },
-          "category_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Category Id"
-          },
-          "enabled": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Enabled"
-          },
-          "supplier_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Supplier Id"
-          },
-          "lot_source_policy": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "INTERNAL_ONLY",
-                  "SUPPLIER_ONLY"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Lot Source Policy"
-          },
-          "expiry_policy": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "NONE",
-                  "REQUIRED"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Expiry Policy"
-          },
-          "derivation_allowed": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Derivation Allowed"
-          },
-          "uom_governance_enabled": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Uom Governance Enabled"
-          },
-          "shelf_life_value": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "exclusiveMinimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Shelf Life Value"
-          },
-          "shelf_life_unit": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "DAY",
-                  "WEEK",
-                  "MONTH",
-                  "YEAR"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Shelf Life Unit"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "title": "ItemUpdate",
-        "description": "Patch Item：\n\n- 不开放 sku 变更\n- brand/category 不再接受自由文本；请传 brand_id/category_id\n- 不接受 barcode / has_shelf_life\n- 不接受 weight_kg；基础包装净重请改 item_uoms\n- nullable 字段支持显式传 null 清空"
       },
       "LedgerDateViolationRow": {
         "properties": {
@@ -27831,111 +17662,6 @@
           "net_delta"
         ],
         "title": "LedgerSummary"
-      },
-      "ListOut_ItemAttributeDefOut_": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/ItemAttributeDefOut"
-            },
-            "type": "array",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "ListOut[ItemAttributeDefOut]"
-      },
-      "ListOut_ItemAttributeOptionOut_": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/ItemAttributeOptionOut"
-            },
-            "type": "array",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "ListOut[ItemAttributeOptionOut]"
-      },
-      "ListOut_ItemAttributeValueOut_": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/ItemAttributeValueOut"
-            },
-            "type": "array",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "ListOut[ItemAttributeValueOut]"
-      },
-      "ListOut_PmsBrandOut_": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/PmsBrandOut"
-            },
-            "type": "array",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "ListOut[PmsBrandOut]"
-      },
-      "ListOut_PmsCategoryOut_": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/PmsCategoryOut"
-            },
-            "type": "array",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "ListOut[PmsCategoryOut]"
       },
       "LogisticsImportResultIn": {
         "properties": {
@@ -28955,221 +18681,6 @@
         ],
         "title": "ManualAssignResponse"
       },
-      "ManualDecisionLineOut": {
-        "properties": {
-          "line_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Line Key"
-          },
-          "line_no": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Line No"
-          },
-          "locator_kind": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Locator Kind",
-            "description": "对外定位类型（推荐）：FILLED_CODE / LINE_NO"
-          },
-          "locator_value": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Locator Value",
-            "description": "对外定位值（推荐）"
-          },
-          "filled_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Filled Code",
-            "description": "商家后台填写码（对外语义字段）"
-          },
-          "fact_qty": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fact Qty"
-          },
-          "item_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Item Id"
-          },
-          "qty": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Qty"
-          },
-          "note": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Note"
-          }
-        },
-        "type": "object",
-        "title": "ManualDecisionLineOut",
-        "description": "人工救火明细行（证据表读侧输出）。\n\nPhase N+4：line_key（内部幂等锚点）与 locator（对外定位语义）分层。"
-      },
-      "ManualDecisionOrderOut": {
-        "properties": {
-          "batch_id": {
-            "type": "string",
-            "title": "Batch Id",
-            "description": "治理事实批次 id（platform_order_manual_decisions.batch_id）"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At",
-            "description": "该批次最新写入时间（MAX(created_at)）"
-          },
-          "order_id": {
-            "type": "integer",
-            "title": "Order Id"
-          },
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "store_code": {
-            "type": "string",
-            "title": "Store Code"
-          },
-          "ext_order_no": {
-            "type": "string",
-            "title": "Ext Order No"
-          },
-          "ref": {
-            "type": "string",
-            "title": "Ref"
-          },
-          "store_id": {
-            "type": "integer",
-            "title": "Store Id"
-          },
-          "manual_reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Manual Reason"
-          },
-          "risk_flags": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Risk Flags"
-          },
-          "manual_decisions": {
-            "items": {
-              "$ref": "#/components/schemas/ManualDecisionLineOut"
-            },
-            "type": "array",
-            "title": "Manual Decisions"
-          }
-        },
-        "type": "object",
-        "required": [
-          "batch_id",
-          "created_at",
-          "order_id",
-          "platform",
-          "store_code",
-          "ext_order_no",
-          "ref",
-          "store_id"
-        ],
-        "title": "ManualDecisionOrderOut"
-      },
-      "ManualDecisionOrdersOut": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/ManualDecisionOrderOut"
-            },
-            "type": "array",
-            "title": "Items"
-          },
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          },
-          "limit": {
-            "type": "integer",
-            "title": "Limit"
-          },
-          "offset": {
-            "type": "integer",
-            "title": "Offset"
-          }
-        },
-        "type": "object",
-        "required": [
-          "total",
-          "limit",
-          "offset"
-        ],
-        "title": "ManualDecisionOrdersOut"
-      },
       "ManualOutboundDocCreateIn": {
         "properties": {
           "warehouse_id": {
@@ -29787,66 +19298,6 @@
         "type": "object",
         "title": "MarkPrintedIn"
       },
-      "MerchantLineItemIn": {
-        "properties": {
-          "row_no": {
-            "type": "integer",
-            "maximum": 6.0,
-            "minimum": 1.0,
-            "title": "Row No"
-          },
-          "filled_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Filled Code"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title"
-          },
-          "spec": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spec"
-          },
-          "if_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "If Version",
-            "description": "可选乐观锁版本；不传则强制覆盖"
-          }
-        },
-        "type": "object",
-        "required": [
-          "row_no"
-        ],
-        "title": "MerchantLineItemIn"
-      },
       "MetaPlatformItem": {
         "properties": {
           "platform": {
@@ -30073,6 +19524,799 @@
         ],
         "title": "NavigationRoutePrefixOut"
       },
+      "OmsProjectionCheckIssueOut": {
+        "properties": {
+          "issue_type": {
+            "type": "string",
+            "title": "Issue Type"
+          },
+          "resource": {
+            "type": "string",
+            "enum": [
+              "orders",
+              "lines",
+              "components"
+            ],
+            "title": "Resource"
+          },
+          "source_id": {
+            "type": "string",
+            "title": "Source Id"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "ready_order_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ready Order Id"
+          },
+          "ready_line_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ready Line Id"
+          },
+          "ready_component_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ready Component Id"
+          },
+          "expected_value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected Value"
+          },
+          "actual_value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Actual Value"
+          }
+        },
+        "type": "object",
+        "required": [
+          "issue_type",
+          "resource",
+          "source_id",
+          "message"
+        ],
+        "title": "OmsProjectionCheckIssueOut"
+      },
+      "OmsProjectionCheckOut": {
+        "properties": {
+          "resource": {
+            "type": "string",
+            "enum": [
+              "orders",
+              "lines",
+              "components"
+            ],
+            "title": "Resource"
+          },
+          "ok": {
+            "type": "boolean",
+            "title": "Ok"
+          },
+          "issue_count": {
+            "type": "integer",
+            "title": "Issue Count"
+          },
+          "issues": {
+            "items": {
+              "$ref": "#/components/schemas/OmsProjectionCheckIssueOut"
+            },
+            "type": "array",
+            "title": "Issues"
+          }
+        },
+        "type": "object",
+        "required": [
+          "resource",
+          "ok",
+          "issue_count"
+        ],
+        "title": "OmsProjectionCheckOut"
+      },
+      "OmsProjectionListOut": {
+        "properties": {
+          "resource": {
+            "type": "string",
+            "enum": [
+              "orders",
+              "lines",
+              "components"
+            ],
+            "title": "Resource"
+          },
+          "table_name": {
+            "type": "string",
+            "title": "Table Name"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "columns": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Columns"
+          },
+          "rows": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Rows"
+          }
+        },
+        "type": "object",
+        "required": [
+          "resource",
+          "table_name",
+          "limit",
+          "offset",
+          "total"
+        ],
+        "title": "OmsProjectionListOut"
+      },
+      "OmsProjectionOrderImportCandidateOut": {
+        "properties": {
+          "ready_order_id": {
+            "type": "string",
+            "title": "Ready Order Id"
+          },
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "store_code": {
+            "type": "string",
+            "title": "Store Code"
+          },
+          "store_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Store Name"
+          },
+          "platform_order_no": {
+            "type": "string",
+            "title": "Platform Order No"
+          },
+          "platform_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform Status"
+          },
+          "receiver_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Receiver Name"
+          },
+          "receiver_phone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Receiver Phone"
+          },
+          "ready_status": {
+            "type": "string",
+            "title": "Ready Status"
+          },
+          "ready_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ready At"
+          },
+          "synced_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Synced At"
+          },
+          "line_count": {
+            "type": "integer",
+            "title": "Line Count",
+            "default": 0
+          },
+          "component_count": {
+            "type": "integer",
+            "title": "Component Count",
+            "default": 0
+          },
+          "total_required_qty": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Required Qty"
+          },
+          "import_status": {
+            "type": "string",
+            "title": "Import Status"
+          },
+          "imported_order_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Imported Order Id"
+          },
+          "imported_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Imported At"
+          },
+          "can_import": {
+            "type": "boolean",
+            "title": "Can Import",
+            "default": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "ready_order_id",
+          "platform",
+          "store_code",
+          "platform_order_no",
+          "ready_status",
+          "import_status"
+        ],
+        "title": "OmsProjectionOrderImportCandidateOut",
+        "description": "订单出库页专用：OMS fulfillment projection 待接入候选订单。\n\nBoundary:\n- 来源是 WMS 本地 OMS fulfillment projection。\n- import_status 来自 WMS 导入审计表。\n- 给订单出库页展示/导入使用，不回写 projection。"
+      },
+      "OmsProjectionOrderImportCandidatesOut": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/OmsProjectionOrderImportCandidateOut"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "OmsProjectionOrderImportCandidatesOut"
+      },
+      "OmsProjectionOrderImportIn": {
+        "properties": {
+          "ready_order_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "maxItems": 200,
+            "minItems": 1,
+            "title": "Ready Order Ids"
+          },
+          "dry_run": {
+            "type": "boolean",
+            "title": "Dry Run",
+            "default": false
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "ready_order_ids"
+        ],
+        "title": "OmsProjectionOrderImportIn",
+        "description": "从 WMS 本地 OMS fulfillment projection 手动导入 WMS 执行订单。\n\nBoundary:\n- 输入是 ready_order_id。\n- 来源只允许 wms_oms_fulfillment_* projection。\n- 输出写入 WMS 执行 facts：orders / order_address / order_items / order_lines / order_fulfillment。\n- 不写回 projection 表。"
+      },
+      "OmsProjectionOrderImportOut": {
+        "properties": {
+          "dry_run": {
+            "type": "boolean",
+            "title": "Dry Run"
+          },
+          "requested": {
+            "type": "integer",
+            "title": "Requested"
+          },
+          "imported": {
+            "type": "integer",
+            "title": "Imported"
+          },
+          "already_imported": {
+            "type": "integer",
+            "title": "Already Imported"
+          },
+          "failed": {
+            "type": "integer",
+            "title": "Failed"
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/OmsProjectionOrderImportRowOut"
+            },
+            "type": "array",
+            "title": "Results"
+          }
+        },
+        "type": "object",
+        "required": [
+          "dry_run",
+          "requested",
+          "imported",
+          "already_imported",
+          "failed",
+          "results"
+        ],
+        "title": "OmsProjectionOrderImportOut"
+      },
+      "OmsProjectionOrderImportRowOut": {
+        "properties": {
+          "ready_order_id": {
+            "type": "string",
+            "title": "Ready Order Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "order_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Order Id"
+          },
+          "platform": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform"
+          },
+          "store_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Store Code"
+          },
+          "platform_order_no": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform Order No"
+          },
+          "order_line_count": {
+            "type": "integer",
+            "title": "Order Line Count",
+            "default": 0
+          },
+          "component_count": {
+            "type": "integer",
+            "title": "Component Count",
+            "default": 0
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ready_order_id",
+          "status"
+        ],
+        "title": "OmsProjectionOrderImportRowOut"
+      },
+      "OmsProjectionResourceStatusOut": {
+        "properties": {
+          "resource": {
+            "type": "string",
+            "enum": [
+              "orders",
+              "lines",
+              "components"
+            ],
+            "title": "Resource"
+          },
+          "table_name": {
+            "type": "string",
+            "title": "Table Name"
+          },
+          "row_count": {
+            "type": "integer",
+            "title": "Row Count"
+          },
+          "max_synced_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Synced At"
+          },
+          "last_sync_run": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OmsProjectionSyncRunOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "resource",
+          "table_name",
+          "row_count"
+        ],
+        "title": "OmsProjectionResourceStatusOut"
+      },
+      "OmsProjectionStatusOut": {
+        "properties": {
+          "oms_api_base_url_configured": {
+            "type": "boolean",
+            "title": "Oms Api Base Url Configured"
+          },
+          "resources": {
+            "items": {
+              "$ref": "#/components/schemas/OmsProjectionResourceStatusOut"
+            },
+            "type": "array",
+            "title": "Resources"
+          }
+        },
+        "type": "object",
+        "required": [
+          "oms_api_base_url_configured"
+        ],
+        "title": "OmsProjectionStatusOut"
+      },
+      "OmsProjectionSyncOut": {
+        "properties": {
+          "run": {
+            "$ref": "#/components/schemas/OmsProjectionSyncRunOut"
+          }
+        },
+        "type": "object",
+        "required": [
+          "run"
+        ],
+        "title": "OmsProjectionSyncOut"
+      },
+      "OmsProjectionSyncRunOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "resource": {
+            "type": "string",
+            "const": "fulfillment-ready-orders",
+            "title": "Resource"
+          },
+          "platform": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "pdd",
+                  "taobao",
+                  "jd"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform"
+          },
+          "store_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Store Code"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "RUNNING",
+              "SUCCESS",
+              "FAILED"
+            ],
+            "title": "Status"
+          },
+          "fetched": {
+            "type": "integer",
+            "title": "Fetched",
+            "default": 0
+          },
+          "upserted_orders": {
+            "type": "integer",
+            "title": "Upserted Orders",
+            "default": 0
+          },
+          "upserted_lines": {
+            "type": "integer",
+            "title": "Upserted Lines",
+            "default": 0
+          },
+          "upserted_components": {
+            "type": "integer",
+            "title": "Upserted Components",
+            "default": 0
+          },
+          "pages": {
+            "type": "integer",
+            "title": "Pages",
+            "default": 0
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Started At"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finished At"
+          },
+          "duration_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration Ms"
+          },
+          "error_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Message"
+          },
+          "triggered_by_user_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Triggered By User Id"
+          },
+          "oms_api_base_url_snapshot": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Oms Api Base Url Snapshot"
+          },
+          "sync_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sync Version"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "resource",
+          "status",
+          "started_at"
+        ],
+        "title": "OmsProjectionSyncRunOut"
+      },
+      "OmsProjectionSyncRunsOut": {
+        "properties": {
+          "resource": {
+            "anyOf": [
+              {
+                "type": "string",
+                "const": "fulfillment-ready-orders"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resource"
+          },
+          "platform": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "pdd",
+                  "taobao",
+                  "jd"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "runs": {
+            "items": {
+              "$ref": "#/components/schemas/OmsProjectionSyncRunOut"
+            },
+            "type": "array",
+            "title": "Runs"
+          }
+        },
+        "type": "object",
+        "required": [
+          "limit"
+        ],
+        "title": "OmsProjectionSyncRunsOut"
+      },
       "OrderOutboundOptionOut": {
         "properties": {
           "id": {
@@ -30128,7 +20372,7 @@
           "created_at"
         ],
         "title": "OrderOutboundOptionOut",
-        "description": "订单出库页专用：订单选择器列表项（来源真相 = orders）\n\n说明：\n- 只返回“选单”需要的最小头字段\n- 不掺执行仓 / 履约阶段 / 平台 ledger 明细"
+        "description": "WMS 订单出库页专用：订单选择器列表项。\n\nBoundary:\n- 路由归属 WMS outbound。\n- 来源仍是 WMS 本地执行订单 facts：orders / order_lines。\n- 不读取 OMS owner 表，不挂在 /oms/orders。"
       },
       "OrderOutboundOptionsOut": {
         "properties": {
@@ -30159,7 +20403,7 @@
           "offset"
         ],
         "title": "OrderOutboundOptionsOut",
-        "description": "订单出库页专用：订单选择器列表响应"
+        "description": "WMS 订单出库页专用：订单选择器列表响应。"
       },
       "OrderOutboundSubmitIn": {
         "properties": {
@@ -30379,7 +20623,7 @@
           "req_qty"
         ],
         "title": "OrderOutboundViewLineOut",
-        "description": "订单出库页专用：订单行只读模型（来源真相 = order_lines + item display）\n\n说明：\n- 核心真相仍然是 order_lines\n- 为作业页补充商品展示字段：sku / name / spec / base_uom\n- 不掺平台 ledger / 执行上下文 / lot 分配结果"
+        "description": "WMS 订单出库页专用：订单行只读模型。\n\nBoundary:\n- 核心来源是 WMS 本地 order_lines。\n- 商品展示字段通过 PMS read client / WMS PMS projection 获取。\n- 不直接 JOIN PMS owner 表。"
       },
       "OrderOutboundViewOrderOut": {
         "properties": {
@@ -30483,7 +20727,7 @@
           "created_at"
         ],
         "title": "OrderOutboundViewOrderOut",
-        "description": "订单出库页专用：订单头只读模型（来源真相 = orders）\n\n说明：\n- 这里只表达真实订单头字段\n- 不掺执行仓 / 履约阶段 / 出库状态投影\n- order_fulfillment 后续若要展示，单独做 execution_context，不混入这里"
+        "description": "WMS 订单出库页专用：订单头只读模型。\n\nBoundary:\n- 路由归属 WMS outbound。\n- 来源仍是 WMS 本地执行订单 facts：orders。\n- 不读取 OMS owner 表，不挂在 /oms/orders。"
       },
       "OrderOutboundViewResponse": {
         "properties": {
@@ -30508,7 +20752,7 @@
           "order"
         ],
         "title": "OrderOutboundViewResponse",
-        "description": "订单出库页专用：只读聚合响应\n\n结构：\n- order: 订单头（orders）\n- lines: 订单行（order_lines + display）"
+        "description": "WMS 订单出库页专用：只读聚合响应。"
       },
       "OrderSalesDailyRow": {
         "properties": {
@@ -31024,613 +21268,6 @@
           "revenue"
         ],
         "title": "OrderSalesSummary"
-      },
-      "OrderSimCartGetOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok"
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ok",
-          "data"
-        ],
-        "title": "OrderSimCartGetOut"
-      },
-      "OrderSimCartPutIn": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/CartLineItemIn"
-            },
-            "type": "array",
-            "title": "Items"
-          }
-        },
-        "type": "object",
-        "title": "OrderSimCartPutIn"
-      },
-      "OrderSimCartPutOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok"
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ok",
-          "data"
-        ],
-        "title": "OrderSimCartPutOut"
-      },
-      "OrderSimFilledCodeOptionOut": {
-        "properties": {
-          "filled_code": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Filled Code",
-            "description": "商家后台填写码（merchant_code / filled_code）"
-          },
-          "suggested_title": {
-            "type": "string",
-            "title": "Suggested Title",
-            "description": "下拉选中后默认带出的标题（可编辑）"
-          },
-          "components_summary": {
-            "type": "string",
-            "title": "Components Summary",
-            "description": "FSKU components 摘要（spec 只读展示，不参与解析）"
-          }
-        },
-        "type": "object",
-        "required": [
-          "filled_code",
-          "suggested_title",
-          "components_summary"
-        ],
-        "title": "OrderSimFilledCodeOptionOut"
-      },
-      "OrderSimFilledCodeOptionsData": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/OrderSimFilledCodeOptionOut"
-            },
-            "type": "array",
-            "title": "Items"
-          }
-        },
-        "type": "object",
-        "title": "OrderSimFilledCodeOptionsData"
-      },
-      "OrderSimFilledCodeOptionsOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok"
-          },
-          "data": {
-            "$ref": "#/components/schemas/OrderSimFilledCodeOptionsData"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ok",
-          "data"
-        ],
-        "title": "OrderSimFilledCodeOptionsOut"
-      },
-      "OrderSimGenerateOrderIn": {
-        "properties": {
-          "idempotency_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Idempotency Key",
-            "description": "可选：用于 ext_order_no 幂等锚点（同 key → 同 ext_order_no）"
-          }
-        },
-        "type": "object",
-        "title": "OrderSimGenerateOrderIn"
-      },
-      "OrderSimGenerateOrderOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok"
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ok",
-          "data"
-        ],
-        "title": "OrderSimGenerateOrderOut"
-      },
-      "OrderSimMerchantLinesGetOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok"
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ok",
-          "data"
-        ],
-        "title": "OrderSimMerchantLinesGetOut"
-      },
-      "OrderSimMerchantLinesPutIn": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/MerchantLineItemIn"
-            },
-            "type": "array",
-            "title": "Items"
-          }
-        },
-        "type": "object",
-        "title": "OrderSimMerchantLinesPutIn"
-      },
-      "OrderSimMerchantLinesPutOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok"
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ok",
-          "data"
-        ],
-        "title": "OrderSimMerchantLinesPutOut"
-      },
-      "OrderSimPreviewOrderIn": {
-        "properties": {
-          "idempotency_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Idempotency Key",
-            "description": "可选：用于 preview 的 ext_order_no（与 generate-order 对齐）"
-          }
-        },
-        "type": "object",
-        "title": "OrderSimPreviewOrderIn"
-      },
-      "OrderSimPreviewOrderOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok"
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ok",
-          "data"
-        ],
-        "title": "OrderSimPreviewOrderOut"
-      },
-      "OrderSkuResolutionComponentOut": {
-        "properties": {
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "item_sku_code_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Item Sku Code Id"
-          },
-          "item_uom_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Item Uom Id"
-          },
-          "sku_code": {
-            "type": "string",
-            "title": "Sku Code"
-          },
-          "item_name": {
-            "type": "string",
-            "title": "Item Name"
-          },
-          "uom": {
-            "type": "string",
-            "title": "Uom"
-          },
-          "qty": {
-            "type": "string",
-            "title": "Qty"
-          },
-          "alloc_unit_price": {
-            "type": "string",
-            "title": "Alloc Unit Price"
-          },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order"
-          }
-        },
-        "type": "object",
-        "required": [
-          "item_id",
-          "sku_code",
-          "item_name",
-          "uom",
-          "qty",
-          "alloc_unit_price",
-          "sort_order"
-        ],
-        "title": "OrderSkuResolutionComponentOut"
-      },
-      "OrderSkuResolutionDataOut": {
-        "properties": {
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "mirror_id": {
-            "type": "integer",
-            "title": "Mirror Id"
-          },
-          "platform_order_no": {
-            "type": "string",
-            "title": "Platform Order No"
-          },
-          "store_code": {
-            "type": "string",
-            "title": "Store Code"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "resolved",
-              "needs_mapping"
-            ],
-            "title": "Status"
-          },
-          "lines": {
-            "items": {
-              "$ref": "#/components/schemas/OrderSkuResolutionLineOut"
-            },
-            "type": "array",
-            "title": "Lines"
-          }
-        },
-        "type": "object",
-        "required": [
-          "platform",
-          "mirror_id",
-          "platform_order_no",
-          "store_code",
-          "status"
-        ],
-        "title": "OrderSkuResolutionDataOut"
-      },
-      "OrderSkuResolutionLineOut": {
-        "properties": {
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "mirror_id": {
-            "type": "integer",
-            "title": "Mirror Id"
-          },
-          "line_id": {
-            "type": "integer",
-            "title": "Line Id"
-          },
-          "collector_order_id": {
-            "type": "integer",
-            "title": "Collector Order Id"
-          },
-          "collector_line_id": {
-            "type": "integer",
-            "title": "Collector Line Id"
-          },
-          "store_code": {
-            "type": "string",
-            "title": "Store Code"
-          },
-          "platform_order_no": {
-            "type": "string",
-            "title": "Platform Order No"
-          },
-          "merchant_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Merchant Code"
-          },
-          "platform_item_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Item Id"
-          },
-          "platform_sku_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Sku Id"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title"
-          },
-          "quantity": {
-            "type": "string",
-            "title": "Quantity"
-          },
-          "line_amount": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Line Amount"
-          },
-          "resolution_status": {
-            "type": "string",
-            "enum": [
-              "resolved",
-              "needs_mapping"
-            ],
-            "title": "Resolution Status"
-          },
-          "resolution_source": {
-            "type": "string",
-            "enum": [
-              "direct_fsku_code",
-              "code_mapping",
-              "unresolved"
-            ],
-            "title": "Resolution Source"
-          },
-          "resolved_identity_kind": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "merchant_code",
-                  "platform_sku_id",
-                  "platform_item_sku"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Resolved Identity Kind"
-          },
-          "resolved_identity_value": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Resolved Identity Value"
-          },
-          "fsku_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fsku Id"
-          },
-          "fsku_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fsku Code"
-          },
-          "fsku_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fsku Name"
-          },
-          "unresolved_reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Unresolved Reason"
-          },
-          "next_actions": {
-            "items": {
-              "$ref": "#/components/schemas/OrderSkuResolutionNextActionOut"
-            },
-            "type": "array",
-            "title": "Next Actions"
-          },
-          "components": {
-            "items": {
-              "$ref": "#/components/schemas/OrderSkuResolutionComponentOut"
-            },
-            "type": "array",
-            "title": "Components"
-          }
-        },
-        "type": "object",
-        "required": [
-          "platform",
-          "mirror_id",
-          "line_id",
-          "collector_order_id",
-          "collector_line_id",
-          "store_code",
-          "platform_order_no",
-          "quantity",
-          "resolution_status",
-          "resolution_source"
-        ],
-        "title": "OrderSkuResolutionLineOut"
-      },
-      "OrderSkuResolutionNextActionOut": {
-        "properties": {
-          "action": {
-            "type": "string",
-            "title": "Action"
-          },
-          "label": {
-            "type": "string",
-            "title": "Label"
-          },
-          "route_path": {
-            "type": "string",
-            "title": "Route Path"
-          },
-          "payload": {
-            "additionalProperties": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "type": "object",
-            "title": "Payload"
-          }
-        },
-        "type": "object",
-        "required": [
-          "action",
-          "label",
-          "route_path"
-        ],
-        "title": "OrderSkuResolutionNextActionOut"
-      },
-      "OrderSkuResolutionOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "$ref": "#/components/schemas/OrderSkuResolutionDataOut"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "OrderSkuResolutionOut"
       },
       "OrdersDailyStatsModel": {
         "properties": {
@@ -32826,114 +22463,138 @@
         ],
         "title": "PermissionMatrixRowOut"
       },
-      "PlatformCodeMappingBindIn": {
+      "PmsProjectionCheckIssueOut": {
         "properties": {
-          "platform": {
+          "issue_type": {
             "type": "string",
-            "maxLength": 32,
-            "minLength": 1,
-            "title": "Platform"
+            "title": "Issue Type"
           },
-          "store_code": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Store Code"
-          },
-          "identity_kind": {
+          "resource": {
             "type": "string",
             "enum": [
-              "merchant_code",
-              "platform_sku_id",
-              "platform_item_sku"
+              "items",
+              "suppliers",
+              "uoms",
+              "sku-codes",
+              "barcodes"
             ],
-            "title": "Identity Kind"
+            "title": "Resource"
           },
-          "identity_value": {
+          "source_id": {
             "type": "string",
-            "maxLength": 256,
-            "minLength": 1,
-            "title": "Identity Value"
+            "title": "Source Id"
           },
-          "fsku_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Fsku Id"
+          "message": {
+            "type": "string",
+            "title": "Message"
           },
-          "reason": {
+          "item_id": {
             "anyOf": [
               {
-                "type": "string",
-                "maxLength": 500
+                "type": "integer"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Reason"
+            "title": "Item Id"
+          },
+          "item_uom_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Item Uom Id"
+          },
+          "supplier_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Supplier Id"
+          },
+          "projection_item_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Projection Item Id"
           }
         },
         "type": "object",
         "required": [
-          "platform",
-          "store_code",
-          "identity_kind",
-          "identity_value",
-          "fsku_id"
+          "issue_type",
+          "resource",
+          "source_id",
+          "message"
         ],
-        "title": "PlatformCodeMappingBindIn"
+        "title": "PmsProjectionCheckIssueOut"
       },
-      "PlatformCodeMappingDeleteIn": {
+      "PmsProjectionCheckOut": {
         "properties": {
-          "platform": {
-            "type": "string",
-            "maxLength": 32,
-            "minLength": 1,
-            "title": "Platform"
-          },
-          "store_code": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Store Code"
-          },
-          "identity_kind": {
+          "resource": {
             "type": "string",
             "enum": [
-              "merchant_code",
-              "platform_sku_id",
-              "platform_item_sku"
+              "items",
+              "suppliers",
+              "uoms",
+              "sku-codes",
+              "barcodes"
             ],
-            "title": "Identity Kind"
+            "title": "Resource"
           },
-          "identity_value": {
-            "type": "string",
-            "maxLength": 256,
-            "minLength": 1,
-            "title": "Identity Value"
+          "ok": {
+            "type": "boolean",
+            "title": "Ok"
+          },
+          "issue_count": {
+            "type": "integer",
+            "title": "Issue Count"
+          },
+          "issues": {
+            "items": {
+              "$ref": "#/components/schemas/PmsProjectionCheckIssueOut"
+            },
+            "type": "array",
+            "title": "Issues"
           }
         },
         "type": "object",
         "required": [
-          "platform",
-          "store_code",
-          "identity_kind",
-          "identity_value"
+          "resource",
+          "ok",
+          "issue_count"
         ],
-        "title": "PlatformCodeMappingDeleteIn"
+        "title": "PmsProjectionCheckOut"
       },
-      "PlatformCodeMappingListDataOut": {
+      "PmsProjectionListOut": {
         "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/PlatformCodeMappingRowOut"
-            },
-            "type": "array",
-            "title": "Items"
+          "resource": {
+            "type": "string",
+            "enum": [
+              "items",
+              "suppliers",
+              "uoms",
+              "sku-codes",
+              "barcodes"
+            ],
+            "title": "Resource"
           },
-          "total": {
-            "type": "integer",
-            "title": "Total"
+          "table_name": {
+            "type": "string",
+            "title": "Table Name"
           },
           "limit": {
             "type": "integer",
@@ -32942,503 +22603,173 @@
           "offset": {
             "type": "integer",
             "title": "Offset"
-          }
-        },
-        "type": "object",
-        "required": [
-          "items",
-          "total",
-          "limit",
-          "offset"
-        ],
-        "title": "PlatformCodeMappingListDataOut"
-      },
-      "PlatformCodeMappingListOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
           },
-          "data": {
-            "$ref": "#/components/schemas/PlatformCodeMappingListDataOut"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "PlatformCodeMappingListOut"
-      },
-      "PlatformCodeMappingOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "$ref": "#/components/schemas/PlatformCodeMappingRowOut"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "PlatformCodeMappingOut"
-      },
-      "PlatformCodeMappingRowOut": {
-        "properties": {
-          "id": {
+          "total": {
             "type": "integer",
-            "title": "Id"
+            "title": "Total"
           },
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "store_code": {
-            "type": "string",
-            "title": "Store Code"
-          },
-          "store": {
-            "$ref": "#/components/schemas/StoreLiteOut"
-          },
-          "identity_kind": {
-            "type": "string",
-            "enum": [
-              "merchant_code",
-              "platform_sku_id",
-              "platform_item_sku"
-            ],
-            "title": "Identity Kind"
-          },
-          "identity_value": {
-            "type": "string",
-            "title": "Identity Value"
-          },
-          "fsku_id": {
-            "type": "integer",
-            "title": "Fsku Id"
-          },
-          "fsku": {
-            "$ref": "#/components/schemas/FskuLiteOut"
-          },
-          "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Reason"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "platform",
-          "store_code",
-          "store",
-          "identity_kind",
-          "identity_value",
-          "fsku_id",
-          "fsku",
-          "reason",
-          "created_at",
-          "updated_at"
-        ],
-        "title": "PlatformCodeMappingRowOut"
-      },
-      "PlatformOrderConfirmCreateDecisionIn": {
-        "properties": {
-          "line_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Line Key"
-          },
-          "line_no": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Line No"
-          },
-          "locator_kind": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Locator Kind",
-            "description": "对外定位类型（推荐）：FILLED_CODE / LINE_NO"
-          },
-          "locator_value": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Locator Value",
-            "description": "对外定位值（推荐）：当 FILLED_CODE 时为 filled_code；当 LINE_NO 时为 line_no 文本"
-          },
-          "filled_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Filled Code",
-            "description": "商家后台填写码（推荐；唯一语义字段）"
-          },
-          "platform_sku_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Sku Id",
-            "description": "已废弃：出现即报错（请使用 filled_code）"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "qty": {
-            "type": "integer",
-            "title": "Qty"
-          },
-          "note": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Note"
-          }
-        },
-        "type": "object",
-        "required": [
-          "item_id",
-          "qty"
-        ],
-        "title": "PlatformOrderConfirmCreateDecisionIn",
-        "description": "Phase N+4 · 人工决策输入（单行）\n\n说明：\n- filled_code 是“填写码”唯一语义字段\n- line_key 是内部幂等锚点（不推荐外部使用）\n- locator_kind/locator_value 是对外定位语义（推荐）\n  * FILLED_CODE + filled_code\n  * LINE_NO + str(line_no)"
-      },
-      "PlatformOrderConfirmCreateDecisionOut": {
-        "properties": {
-          "filled_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Filled Code",
-            "description": "商家后台填写码（唯一语义字段）"
-          },
-          "locator_kind": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Locator Kind",
-            "description": "对外定位类型（推荐）：FILLED_CODE / LINE_NO"
-          },
-          "locator_value": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Locator Value",
-            "description": "对外定位值（推荐）"
-          },
-          "line_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Line Key"
-          },
-          "line_no": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Line No"
-          },
-          "item_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Item Id"
-          },
-          "qty": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Qty"
-          },
-          "fact_qty": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fact Qty"
-          },
-          "note": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Note"
-          }
-        },
-        "type": "object",
-        "title": "PlatformOrderConfirmCreateDecisionOut",
-        "description": "Phase N+4 · 人工决策明细（输出）\n\n说明：\n- filled_code 为唯一语义字段\n- locator_kind/value 为推荐定位语义（与 line_key 分层）"
-      },
-      "PlatformOrderConfirmCreateIn": {
-        "properties": {
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "store_id": {
-            "type": "integer",
-            "title": "Store Id"
-          },
-          "ext_order_no": {
-            "type": "string",
-            "title": "Ext Order No"
-          },
-          "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Reason"
-          },
-          "decisions": {
-            "items": {
-              "$ref": "#/components/schemas/PlatformOrderConfirmCreateDecisionIn"
-            },
-            "type": "array",
-            "title": "Decisions",
-            "description": "人工决策行列表"
-          }
-        },
-        "type": "object",
-        "required": [
-          "platform",
-          "store_id",
-          "ext_order_no"
-        ],
-        "title": "PlatformOrderConfirmCreateIn",
-        "description": "Phase N+4 · 当单执行（人工确认后创建订单）\n\n解析语义：\n- 决策行优先使用 locator（locator_kind/value）\n- 其次使用 filled_code / line_no\n- line_key 仅作为旧链路兼容"
-      },
-      "PlatformOrderConfirmCreateOut": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Id"
-          },
-          "ref": {
-            "type": "string",
-            "title": "Ref"
-          },
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "store_id": {
-            "type": "integer",
-            "title": "Store Id"
-          },
-          "ext_order_no": {
-            "type": "string",
-            "title": "Ext Order No"
-          },
-          "manual_override": {
-            "type": "boolean",
-            "title": "Manual Override"
-          },
-          "manual_reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Manual Reason"
-          },
-          "manual_batch_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Manual Batch Id"
-          },
-          "decisions": {
-            "items": {
-              "$ref": "#/components/schemas/PlatformOrderConfirmCreateDecisionOut"
-            },
-            "type": "array",
-            "title": "Decisions"
-          },
-          "risk_flags": {
+          "columns": {
             "items": {
               "type": "string"
             },
             "type": "array",
-            "title": "Risk Flags"
+            "title": "Columns"
           },
-          "facts_n": {
-            "type": "integer",
-            "title": "Facts N"
-          },
-          "fulfillment_status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fulfillment Status"
-          },
-          "blocked_reasons": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Blocked Reasons"
+          "rows": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Rows"
           }
         },
         "type": "object",
         "required": [
-          "status",
-          "id",
-          "ref",
-          "platform",
-          "store_id",
-          "ext_order_no",
-          "manual_override",
-          "facts_n"
+          "resource",
+          "table_name",
+          "limit",
+          "offset",
+          "total"
         ],
-        "title": "PlatformOrderConfirmCreateOut"
+        "title": "PmsProjectionListOut"
       },
-      "PlatformOrderIngestIn": {
+      "PmsProjectionResourceStatusOut": {
         "properties": {
-          "platform": {
+          "resource": {
             "type": "string",
-            "maxLength": 32,
-            "minLength": 1,
-            "title": "Platform"
+            "enum": [
+              "items",
+              "suppliers",
+              "uoms",
+              "sku-codes",
+              "barcodes"
+            ],
+            "title": "Resource"
           },
-          "store_id": {
+          "table_name": {
+            "type": "string",
+            "title": "Table Name"
+          },
+          "row_count": {
+            "type": "integer",
+            "title": "Row Count"
+          },
+          "max_synced_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Synced At"
+          },
+          "last_sync_run": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PmsProjectionSyncRunOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "resource",
+          "table_name",
+          "row_count"
+        ],
+        "title": "PmsProjectionResourceStatusOut"
+      },
+      "PmsProjectionStatusOut": {
+        "properties": {
+          "pms_api_base_url_configured": {
+            "type": "boolean",
+            "title": "Pms Api Base Url Configured"
+          },
+          "resources": {
+            "items": {
+              "$ref": "#/components/schemas/PmsProjectionResourceStatusOut"
+            },
+            "type": "array",
+            "title": "Resources"
+          }
+        },
+        "type": "object",
+        "required": [
+          "pms_api_base_url_configured"
+        ],
+        "title": "PmsProjectionStatusOut"
+      },
+      "PmsProjectionSyncOut": {
+        "properties": {
+          "run": {
+            "$ref": "#/components/schemas/PmsProjectionSyncRunOut"
+          }
+        },
+        "type": "object",
+        "required": [
+          "run"
+        ],
+        "title": "PmsProjectionSyncOut"
+      },
+      "PmsProjectionSyncRunOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "resource": {
+            "type": "string",
+            "title": "Resource"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "RUNNING",
+              "SUCCESS",
+              "FAILED"
+            ],
+            "title": "Status"
+          },
+          "fetched": {
+            "type": "integer",
+            "title": "Fetched",
+            "default": 0
+          },
+          "upserted": {
+            "type": "integer",
+            "title": "Upserted",
+            "default": 0
+          },
+          "pages": {
+            "type": "integer",
+            "title": "Pages",
+            "default": 0
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Started At"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finished At"
+          },
+          "duration_ms": {
             "anyOf": [
               {
                 "type": "integer"
@@ -33447,2322 +22778,235 @@
                 "type": "null"
               }
             ],
-            "title": "Store Id"
+            "title": "Duration Ms"
           },
-          "store_code": {
+          "error_message": {
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Store Code"
+            "title": "Error Message"
           },
-          "ext_order_no": {
+          "triggered_by_user_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Triggered By User Id"
+          },
+          "pms_api_base_url_snapshot": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pms Api Base Url Snapshot"
+          },
+          "sync_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sync Version"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "resource",
+          "status",
+          "started_at"
+        ],
+        "title": "PmsProjectionSyncRunOut"
+      },
+      "PmsProjectionSyncRunsOut": {
+        "properties": {
+          "resource": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "items",
+                  "suppliers",
+                  "uoms",
+                  "sku-codes",
+                  "barcodes"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resource"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "runs": {
+            "items": {
+              "$ref": "#/components/schemas/PmsProjectionSyncRunOut"
+            },
+            "type": "array",
+            "title": "Runs"
+          }
+        },
+        "type": "object",
+        "required": [
+          "limit"
+        ],
+        "title": "PmsProjectionSyncRunsOut"
+      },
+      "ProcurementReceivingResultDetailOut": {
+        "properties": {
+          "event_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Event Id"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ProcurementReceivingResultLineOut"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "event_id"
+        ],
+        "title": "ProcurementReceivingResultDetailOut"
+      },
+      "ProcurementReceivingResultLineOut": {
+        "properties": {
+          "wms_event_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Wms Event Id"
+          },
+          "wms_event_no": {
             "type": "string",
+            "maxLength": 64,
             "minLength": 1,
-            "title": "Ext Order No"
+            "title": "Wms Event No"
+          },
+          "trace_id": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Trace Id"
+          },
+          "event_kind": {
+            "type": "string",
+            "const": "COMMIT",
+            "title": "Event Kind"
+          },
+          "event_status": {
+            "type": "string",
+            "maxLength": 16,
+            "minLength": 1,
+            "title": "Event Status"
           },
           "occurred_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "string",
+            "format": "date-time",
             "title": "Occurred At"
           },
-          "buyer_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Buyer Name"
-          },
-          "buyer_phone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Buyer Phone"
-          },
-          "receiver_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Name"
-          },
-          "receiver_phone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Phone"
-          },
-          "province": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Province"
-          },
-          "city": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "City"
-          },
-          "district": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "District"
-          },
-          "detail": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Detail"
-          },
-          "zipcode": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Zipcode"
-          },
-          "lines": {
-            "items": {
-              "$ref": "#/components/schemas/PlatformOrderLineIn"
-            },
-            "type": "array",
-            "title": "Lines",
-            "description": "订单行列表（可含 legacy 形态行）"
-          },
-          "store_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Store Name"
-          },
-          "raw_payload": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Raw Payload"
-          }
-        },
-        "type": "object",
-        "required": [
-          "platform",
-          "ext_order_no"
-        ],
-        "title": "PlatformOrderIngestIn",
-        "description": "Phase N+2 · 平台订单接入（宽进严出）"
-      },
-      "PlatformOrderIngestOut": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Id"
-          },
-          "ref": {
-            "type": "string",
-            "title": "Ref"
-          },
-          "store_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Store Id"
-          },
-          "resolved": {
-            "items": {
-              "$ref": "#/components/schemas/PlatformOrderLineResult"
-            },
-            "type": "array",
-            "title": "Resolved"
-          },
-          "unresolved": {
-            "items": {
-              "$ref": "#/components/schemas/PlatformOrderLineResult"
-            },
-            "type": "array",
-            "title": "Unresolved"
-          },
-          "facts_written": {
-            "type": "integer",
-            "title": "Facts Written"
-          },
-          "fulfillment_status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fulfillment Status"
-          },
-          "blocked_reasons": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Blocked Reasons"
-          },
-          "allow_manual_continue": {
-            "type": "boolean",
-            "title": "Allow Manual Continue",
-            "default": false
-          },
-          "risk_flags": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Risk Flags"
-          },
-          "risk_level": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Risk Level"
-          },
-          "risk_reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Risk Reason"
-          },
-          "reason_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Reason Code",
-            "description": "单一主因（OK / CODE_NOT_BOUND / MISSING_FILLED_CODE / ROUTING_BLOCKED 等）"
-          },
-          "next_actions": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "type": "array",
-            "title": "Next Actions",
-            "description": "面向操作者的下一步动作建议（可执行）"
-          }
-        },
-        "type": "object",
-        "required": [
-          "status",
-          "id",
-          "ref",
-          "store_id",
-          "facts_written"
-        ],
-        "title": "PlatformOrderIngestOut",
-        "description": "Phase D · 证据结构化输出（顶层）\n\n- reason_code：单一主因（稳定治理锚点）\n- next_actions：面向操作者的全局动作建议（可执行）"
-      },
-      "PlatformOrderLineIn": {
-        "properties": {
-          "filled_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Filled Code",
-            "description": "商家后台填写码（Phase N+2 推荐字段）"
-          },
-          "qty": {
-            "type": "integer",
-            "exclusiveMinimum": 0.0,
-            "title": "Qty",
-            "description": "数量（>0）",
-            "default": 1
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title",
-            "description": "商品标题（可选）"
-          },
-          "spec": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spec",
-            "description": "规格描述（可选）"
-          },
-          "extras": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Extras",
-            "description": "行级扩展字段"
-          }
-        },
-        "type": "object",
-        "title": "PlatformOrderLineIn",
-        "description": "Phase N+2 · 平台订单行输入\n\n说明：\n- filled_code 为推荐字段（Phase N+2 语义）\n- 二者均可缺失，是否可执行由 resolver 判定（而非 schema 阶段）"
-      },
-      "PlatformOrderLineResult": {
-        "properties": {
-          "filled_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Filled Code"
-          },
-          "qty": {
-            "type": "integer",
-            "title": "Qty"
-          },
-          "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Reason"
-          },
-          "hint": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Hint"
-          },
-          "fsku_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fsku Id"
-          },
-          "expanded_items": {
-            "anyOf": [
-              {
-                "items": {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Expanded Items"
-          },
-          "risk_flags": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Risk Flags"
-          },
-          "risk_level": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Risk Level"
-          },
-          "risk_reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Risk Reason"
-          },
-          "next_actions": {
-            "anyOf": [
-              {
-                "items": {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Next Actions"
-          }
-        },
-        "type": "object",
-        "required": [
-          "qty"
-        ],
-        "title": "PlatformOrderLineResult",
-        "description": "行级解析结果（Phase N+2 输出）"
-      },
-      "PlatformOrderMirrorEnvelopeOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "$ref": "#/components/schemas/PlatformOrderMirrorOut"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "PlatformOrderMirrorEnvelopeOut"
-      },
-      "PlatformOrderMirrorImportIn": {
-        "properties": {
-          "collector_order_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Collector Order Id"
-          },
-          "collector_store_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Collector Store Id"
-          },
-          "collector_store_code": {
+          "receipt_no": {
             "type": "string",
             "maxLength": 128,
             "minLength": 1,
-            "title": "Collector Store Code"
+            "title": "Receipt No"
           },
-          "collector_store_name": {
-            "type": "string",
-            "maxLength": 255,
-            "minLength": 1,
-            "title": "Collector Store Name"
+          "procurement_po_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Procurement Po Id"
           },
-          "platform": {
-            "type": "string",
-            "enum": [
-              "pdd",
-              "taobao",
-              "jd"
-            ],
-            "title": "Platform"
-          },
-          "platform_order_no": {
+          "procurement_po_no": {
             "type": "string",
             "maxLength": 128,
             "minLength": 1,
-            "title": "Platform Order No"
+            "title": "Procurement Po No"
           },
-          "platform_status": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 64
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Status"
-          },
-          "source_updated_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source Updated At"
-          },
-          "pulled_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pulled At"
-          },
-          "last_synced_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Synced At"
-          },
-          "receiver": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Receiver"
-          },
-          "amounts": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Amounts"
-          },
-          "platform_fields": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Platform Fields"
-          },
-          "raw_refs": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Raw Refs"
-          },
-          "lines": {
-            "items": {
-              "$ref": "#/components/schemas/PlatformOrderMirrorLineImportIn"
-            },
-            "type": "array",
-            "title": "Lines"
-          }
-        },
-        "type": "object",
-        "required": [
-          "collector_order_id",
-          "collector_store_id",
-          "collector_store_code",
-          "collector_store_name",
-          "platform",
-          "platform_order_no"
-        ],
-        "title": "PlatformOrderMirrorImportIn"
-      },
-      "PlatformOrderMirrorLineImportIn": {
-        "properties": {
-          "collector_line_id": {
+          "wms_event_line_no": {
             "type": "integer",
             "minimum": 1.0,
-            "title": "Collector Line Id"
+            "title": "Wms Event Line No"
           },
-          "collector_order_id": {
+          "procurement_po_line_id": {
             "type": "integer",
             "minimum": 1.0,
-            "title": "Collector Order Id"
-          },
-          "platform_order_no": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Platform Order No"
-          },
-          "merchant_sku": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Merchant Sku"
-          },
-          "platform_item_id": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Item Id"
-          },
-          "platform_sku_id": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Sku Id"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title"
-          },
-          "quantity": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              }
-            ],
-            "title": "Quantity",
-            "default": "0"
-          },
-          "unit_price": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Unit Price"
-          },
-          "line_amount": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Line Amount"
-          },
-          "platform_fields": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Platform Fields"
-          },
-          "raw_item_payload": {
-            "title": "Raw Item Payload"
-          }
-        },
-        "type": "object",
-        "required": [
-          "collector_line_id",
-          "collector_order_id",
-          "platform_order_no"
-        ],
-        "title": "PlatformOrderMirrorLineImportIn"
-      },
-      "PlatformOrderMirrorLineOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "collector_line_id": {
-            "type": "integer",
-            "title": "Collector Line Id"
-          },
-          "collector_order_id": {
-            "type": "integer",
-            "title": "Collector Order Id"
-          },
-          "platform_order_no": {
-            "type": "string",
-            "title": "Platform Order No"
-          },
-          "merchant_sku": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Merchant Sku"
-          },
-          "platform_item_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Item Id"
-          },
-          "platform_sku_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Sku Id"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title"
-          },
-          "quantity": {
-            "type": "string",
-            "title": "Quantity"
-          },
-          "unit_price": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Unit Price"
-          },
-          "line_amount": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Line Amount"
-          },
-          "platform_fields": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Platform Fields"
-          },
-          "raw_item_payload": {
-            "title": "Raw Item Payload"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "collector_line_id",
-          "collector_order_id",
-          "platform_order_no",
-          "quantity"
-        ],
-        "title": "PlatformOrderMirrorLineOut"
-      },
-      "PlatformOrderMirrorListOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/PlatformOrderMirrorOut"
-            },
-            "type": "array",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "PlatformOrderMirrorListOut"
-      },
-      "PlatformOrderMirrorOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "collector_order_id": {
-            "type": "integer",
-            "title": "Collector Order Id"
-          },
-          "collector_store_id": {
-            "type": "integer",
-            "title": "Collector Store Id"
-          },
-          "collector_store_code": {
-            "type": "string",
-            "title": "Collector Store Code"
-          },
-          "collector_store_name": {
-            "type": "string",
-            "title": "Collector Store Name"
-          },
-          "wms_store_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Wms Store Id"
-          },
-          "platform": {
-            "type": "string",
-            "enum": [
-              "pdd",
-              "taobao",
-              "jd"
-            ],
-            "title": "Platform"
-          },
-          "platform_order_no": {
-            "type": "string",
-            "title": "Platform Order No"
-          },
-          "platform_status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Status"
-          },
-          "import_status": {
-            "type": "string",
-            "title": "Import Status"
-          },
-          "mirror_status": {
-            "type": "string",
-            "title": "Mirror Status"
-          },
-          "source_updated_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source Updated At"
-          },
-          "pulled_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pulled At"
-          },
-          "collector_last_synced_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Collector Last Synced At"
-          },
-          "imported_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Imported At"
-          },
-          "last_synced_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Synced At"
-          },
-          "receiver": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Receiver"
-          },
-          "amounts": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Amounts"
-          },
-          "platform_fields": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Platform Fields"
-          },
-          "raw_refs": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Raw Refs"
-          },
-          "lines": {
-            "items": {
-              "$ref": "#/components/schemas/PlatformOrderMirrorLineOut"
-            },
-            "type": "array",
-            "title": "Lines"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "collector_order_id",
-          "collector_store_id",
-          "collector_store_code",
-          "collector_store_name",
-          "platform",
-          "platform_order_no",
-          "import_status",
-          "mirror_status"
-        ],
-        "title": "PlatformOrderMirrorOut"
-      },
-      "PlatformOrderReplayIn": {
-        "properties": {
-          "platform": {
-            "type": "string",
-            "maxLength": 32,
-            "minLength": 1,
-            "title": "Platform"
-          },
-          "store_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Store Id"
-          },
-          "ext_order_no": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Ext Order No"
-          }
-        },
-        "type": "object",
-        "required": [
-          "platform",
-          "store_id",
-          "ext_order_no"
-        ],
-        "title": "PlatformOrderReplayIn",
-        "description": "平台订单事实重放解码（内部治理接口）：\n- 入参只接收 store_id（stores.id）\n- 读取 platform_order_lines 事实行\n- 复用 resolver + OrderService.ingest 主线幂等"
-      },
-      "PlatformOrderReplayOut": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Id"
-          },
-          "ref": {
-            "type": "string",
-            "title": "Ref"
-          },
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "store_id": {
-            "type": "integer",
-            "title": "Store Id"
-          },
-          "ext_order_no": {
-            "type": "string",
-            "title": "Ext Order No"
-          },
-          "facts_n": {
-            "type": "integer",
-            "title": "Facts N",
-            "default": 0
-          },
-          "resolved": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "type": "array",
-            "title": "Resolved"
-          },
-          "unresolved": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "type": "array",
-            "title": "Unresolved"
-          },
-          "fulfillment_status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fulfillment Status"
-          },
-          "blocked_reasons": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Blocked Reasons"
-          }
-        },
-        "type": "object",
-        "required": [
-          "status",
-          "ref",
-          "platform",
-          "store_id",
-          "ext_order_no"
-        ],
-        "title": "PlatformOrderReplayOut"
-      },
-      "PlatformOrderResolvePreviewFactLineOut": {
-        "properties": {
-          "line_no": {
-            "type": "integer",
-            "title": "Line No"
-          },
-          "line_key": {
-            "type": "string",
-            "title": "Line Key"
-          },
-          "locator_kind": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Locator Kind"
-          },
-          "locator_value": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Locator Value"
-          },
-          "filled_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Filled Code"
-          },
-          "qty": {
-            "type": "integer",
-            "title": "Qty"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title"
-          },
-          "spec": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spec"
-          },
-          "extras": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Extras"
-          }
-        },
-        "type": "object",
-        "required": [
-          "line_no",
-          "line_key",
-          "qty"
-        ],
-        "title": "PlatformOrderResolvePreviewFactLineOut"
-      },
-      "PlatformOrderResolvePreviewIn": {
-        "properties": {
-          "platform": {
-            "type": "string",
-            "maxLength": 50,
-            "minLength": 1,
-            "title": "Platform"
-          },
-          "store_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Store Id"
-          },
-          "ext_order_no": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Ext Order No"
-          }
-        },
-        "type": "object",
-        "required": [
-          "platform",
-          "store_id",
-          "ext_order_no"
-        ],
-        "title": "PlatformOrderResolvePreviewIn"
-      },
-      "PlatformOrderResolvePreviewItemQtyOut": {
-        "properties": {
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "qty": {
-            "type": "integer",
-            "title": "Qty"
-          },
-          "sku": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sku"
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          }
-        },
-        "type": "object",
-        "required": [
-          "item_id",
-          "qty"
-        ],
-        "title": "PlatformOrderResolvePreviewItemQtyOut"
-      },
-      "PlatformOrderResolvePreviewOut": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "ref": {
-            "type": "string",
-            "title": "Ref"
-          },
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "store_id": {
-            "type": "integer",
-            "title": "Store Id"
-          },
-          "ext_order_no": {
-            "type": "string",
-            "title": "Ext Order No"
-          },
-          "facts_n": {
-            "type": "integer",
-            "title": "Facts N"
-          },
-          "fact_lines": {
-            "items": {
-              "$ref": "#/components/schemas/PlatformOrderResolvePreviewFactLineOut"
-            },
-            "type": "array",
-            "title": "Fact Lines"
-          },
-          "resolved": {
-            "items": {
-              "$ref": "#/components/schemas/PlatformOrderResolvePreviewResolvedLineOut"
-            },
-            "type": "array",
-            "title": "Resolved"
-          },
-          "unresolved": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "type": "array",
-            "title": "Unresolved"
-          },
-          "item_qty_map": {
-            "additionalProperties": {
-              "type": "integer"
-            },
-            "type": "object",
-            "title": "Item Qty Map"
-          },
-          "item_qty_items": {
-            "items": {
-              "$ref": "#/components/schemas/PlatformOrderResolvePreviewItemQtyOut"
-            },
-            "type": "array",
-            "title": "Item Qty Items"
-          }
-        },
-        "type": "object",
-        "required": [
-          "status",
-          "ref",
-          "platform",
-          "store_id",
-          "ext_order_no",
-          "facts_n",
-          "fact_lines",
-          "resolved",
-          "unresolved",
-          "item_qty_map",
-          "item_qty_items"
-        ],
-        "title": "PlatformOrderResolvePreviewOut"
-      },
-      "PlatformOrderResolvePreviewResolvedLineOut": {
-        "properties": {
-          "filled_code": {
-            "type": "string",
-            "title": "Filled Code"
-          },
-          "qty": {
-            "type": "integer",
-            "title": "Qty"
-          },
-          "fsku_id": {
-            "type": "integer",
-            "title": "Fsku Id"
-          },
-          "expanded_items": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "type": "array",
-            "title": "Expanded Items"
-          }
-        },
-        "type": "object",
-        "required": [
-          "filled_code",
-          "qty",
-          "fsku_id",
-          "expanded_items"
-        ],
-        "title": "PlatformOrderResolvePreviewResolvedLineOut"
-      },
-      "PmsBrandCreate": {
-        "properties": {
-          "name_cn": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Name Cn"
-          },
-          "code": {
-            "type": "string",
-            "maxLength": 32,
-            "minLength": 1,
-            "title": "Code"
-          },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order",
-            "default": 0
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 500
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          }
-        },
-        "type": "object",
-        "required": [
-          "name_cn",
-          "code"
-        ],
-        "title": "PmsBrandCreate"
-      },
-      "PmsBrandOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "name_cn": {
-            "type": "string",
-            "title": "Name Cn"
-          },
-          "code": {
-            "type": "string",
-            "title": "Code"
-          },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
-          },
-          "is_locked": {
-            "type": "boolean",
-            "title": "Is Locked"
-          },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order"
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "name_cn",
-          "code",
-          "is_active",
-          "is_locked",
-          "sort_order"
-        ],
-        "title": "PmsBrandOut"
-      },
-      "PmsBrandUpdate": {
-        "properties": {
-          "name_cn": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name Cn"
-          },
-          "code": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 32
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Code"
-          },
-          "sort_order": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sort Order"
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 500
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          }
-        },
-        "type": "object",
-        "title": "PmsBrandUpdate"
-      },
-      "PmsCategoryCreate": {
-        "properties": {
-          "parent_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Parent Id"
-          },
-          "level": {
-            "type": "integer",
-            "maximum": 3.0,
-            "minimum": 1.0,
-            "title": "Level"
-          },
-          "product_kind": {
-            "type": "string",
-            "enum": [
-              "FOOD",
-              "SUPPLY",
-              "OTHER"
-            ],
-            "title": "Product Kind"
-          },
-          "category_name": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Category Name"
-          },
-          "category_code": {
-            "type": "string",
-            "maxLength": 32,
-            "minLength": 1,
-            "title": "Category Code"
-          },
-          "is_leaf": {
-            "type": "boolean",
-            "title": "Is Leaf",
-            "default": false
-          },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order",
-            "default": 0
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 500
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          }
-        },
-        "type": "object",
-        "required": [
-          "level",
-          "product_kind",
-          "category_name",
-          "category_code"
-        ],
-        "title": "PmsCategoryCreate"
-      },
-      "PmsCategoryOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "parent_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Parent Id"
-          },
-          "level": {
-            "type": "integer",
-            "title": "Level"
-          },
-          "product_kind": {
-            "type": "string",
-            "title": "Product Kind"
-          },
-          "category_name": {
-            "type": "string",
-            "title": "Category Name"
-          },
-          "category_code": {
-            "type": "string",
-            "title": "Category Code"
-          },
-          "path_code": {
-            "type": "string",
-            "title": "Path Code"
-          },
-          "is_leaf": {
-            "type": "boolean",
-            "title": "Is Leaf"
-          },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
-          },
-          "is_locked": {
-            "type": "boolean",
-            "title": "Is Locked"
-          },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order"
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "parent_id",
-          "level",
-          "product_kind",
-          "category_name",
-          "category_code",
-          "path_code",
-          "is_leaf",
-          "is_active",
-          "is_locked",
-          "sort_order"
-        ],
-        "title": "PmsCategoryOut"
-      },
-      "PmsCategoryUpdate": {
-        "properties": {
-          "category_name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Category Name"
-          },
-          "category_code": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 32
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Category Code"
-          },
-          "is_leaf": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Leaf"
-          },
-          "sort_order": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sort Order"
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 500
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          }
-        },
-        "type": "object",
-        "title": "PmsCategoryUpdate"
-      },
-      "PmsExportBarcode": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "item_uom_id": {
-            "type": "integer",
-            "title": "Item Uom Id"
-          },
-          "barcode": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Barcode"
-          },
-          "symbology": {
-            "type": "string",
-            "title": "Symbology"
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active"
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary"
-          },
-          "uom": {
-            "type": "string",
-            "title": "Uom"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "uom_name": {
-            "type": "string",
-            "title": "Uom Name"
-          },
-          "ratio_to_base": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Ratio To Base"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "item_id",
-          "item_uom_id",
-          "barcode",
-          "symbology",
-          "active",
-          "is_primary",
-          "uom",
-          "uom_name",
-          "ratio_to_base"
-        ],
-        "title": "PmsExportBarcode",
-        "description": "PMS 对外条码读模型。\n\n定位：\n- 只读 export contract；\n- 不承载 owner 写入、改绑、设主条码语义；\n- barcode 绑定终态来自 item_barcodes；\n- 包装语义通过 item_uom_id 关联 item_uoms。"
-      },
-      "PmsExportSkuCode": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "code": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Code"
-          },
-          "code_type": {
-            "type": "string",
-            "enum": [
-              "PRIMARY",
-              "ALIAS",
-              "LEGACY",
-              "MANUAL"
-            ],
-            "title": "Code Type"
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary"
-          },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
-          },
-          "effective_from": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Effective From"
-          },
-          "effective_to": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Effective To"
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          },
-          "item_sku": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Item Sku"
-          },
-          "item_name": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Item Name"
-          },
-          "item_enabled": {
-            "type": "boolean",
-            "title": "Item Enabled"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "item_id",
-          "code",
-          "code_type",
-          "is_primary",
-          "is_active",
-          "item_sku",
-          "item_name",
-          "item_enabled"
-        ],
-        "title": "PmsExportSkuCode",
-        "description": "PMS 对外 SKU 编码读模型。\n\n定位：\n- 只读 export contract；\n- 不承载 owner 写入、停用、启用、主编码切换语义；\n- item_sku_codes 是编码治理真相表；\n- items.sku 只是当前主 SKU 投影。"
-      },
-      "PmsExportSkuCodeResolution": {
-        "properties": {
-          "sku_code_id": {
-            "type": "integer",
-            "title": "Sku Code Id"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "sku_code": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Sku Code"
-          },
-          "code_type": {
-            "type": "string",
-            "enum": [
-              "PRIMARY",
-              "ALIAS",
-              "LEGACY",
-              "MANUAL"
-            ],
-            "title": "Code Type"
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary"
-          },
-          "item_sku": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Item Sku"
-          },
-          "item_name": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Item Name"
-          },
-          "item_uom_id": {
-            "type": "integer",
-            "title": "Item Uom Id"
-          },
-          "uom": {
-            "type": "string",
-            "title": "Uom"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "uom_name": {
-            "type": "string",
-            "title": "Uom Name"
-          },
-          "ratio_to_base": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Ratio To Base"
-          }
-        },
-        "type": "object",
-        "required": [
-          "sku_code_id",
-          "item_id",
-          "sku_code",
-          "code_type",
-          "is_primary",
-          "item_sku",
-          "item_name",
-          "item_uom_id",
-          "uom",
-          "uom_name",
-          "ratio_to_base"
-        ],
-        "title": "PmsExportSkuCodeResolution",
-        "description": "PMS SKU 编码解析结果。\n\n用途：\n- OMS FSKU 表达式组件解析；\n- 通过 SKU code 得到稳定 item_id / sku_code_id；\n- 同时返回该商品出库默认包装或基础包装，用于生成 OMS FSKU 组件快照。"
-      },
-      "PmsExportUom": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "uom": {
-            "type": "string",
-            "title": "Uom"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "uom_name": {
-            "type": "string",
-            "title": "Uom Name"
-          },
-          "ratio_to_base": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Ratio To Base"
-          },
-          "net_weight_kg": {
-            "anyOf": [
-              {
-                "type": "number",
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Weight Kg"
-          },
-          "is_base": {
-            "type": "boolean",
-            "title": "Is Base"
-          },
-          "is_purchase_default": {
-            "type": "boolean",
-            "title": "Is Purchase Default"
-          },
-          "is_inbound_default": {
-            "type": "boolean",
-            "title": "Is Inbound Default"
-          },
-          "is_outbound_default": {
-            "type": "boolean",
-            "title": "Is Outbound Default"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "item_id",
-          "uom",
-          "uom_name",
-          "ratio_to_base",
-          "is_base",
-          "is_purchase_default",
-          "is_inbound_default",
-          "is_outbound_default"
-        ],
-        "title": "PmsExportUom",
-        "description": "PMS 对外包装单位读模型。\n\n定位：\n- 只读 export contract；\n- 不承载 owner 写入语义；\n- 供 WMS / OMS / Procurement / Finance 等跨域消费；\n- item_uoms 表仍是 PMS 内部真相源。"
-      },
-      "ProvinceRouteCreateIn": {
-        "properties": {
-          "province": {
-            "type": "string",
-            "maxLength": 32,
-            "minLength": 1,
-            "title": "Province"
+            "title": "Procurement Po Line Id"
           },
           "warehouse_id": {
             "type": "integer",
             "minimum": 1.0,
             "title": "Warehouse Id"
           },
-          "priority": {
+          "item_id": {
             "type": "integer",
-            "maximum": 100000.0,
-            "minimum": 0.0,
-            "title": "Priority",
-            "default": 100
+            "minimum": 1.0,
+            "title": "Item Id"
           },
-          "active": {
-            "type": "boolean",
-            "title": "Active",
-            "default": true
-          }
-        },
-        "type": "object",
-        "required": [
-          "province",
-          "warehouse_id"
-        ],
-        "title": "ProvinceRouteCreateIn"
-      },
-      "ProvinceRouteItem": {
-        "properties": {
-          "id": {
+          "qty_delta_base": {
             "type": "integer",
-            "title": "Id"
+            "title": "Qty Delta Base"
           },
-          "store_id": {
-            "type": "integer",
-            "title": "Store Id"
-          },
-          "province": {
-            "type": "string",
-            "title": "Province"
-          },
-          "warehouse_id": {
-            "type": "integer",
-            "title": "Warehouse Id"
-          },
-          "warehouse_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Warehouse Name"
-          },
-          "warehouse_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Warehouse Code"
-          },
-          "warehouse_active": {
-            "type": "boolean",
-            "title": "Warehouse Active",
-            "default": true
-          },
-          "priority": {
-            "type": "integer",
-            "title": "Priority",
-            "default": 100
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active",
-            "default": true
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "store_id",
-          "province",
-          "warehouse_id"
-        ],
-        "title": "ProvinceRouteItem"
-      },
-      "ProvinceRouteListOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/ProvinceRouteItem"
-            },
-            "type": "array",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "ProvinceRouteListOut"
-      },
-      "ProvinceRouteUpdateIn": {
-        "properties": {
-          "province": {
+          "lot_code_input": {
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 32,
-                "minLength": 1
+                "maxLength": 128
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Province"
+            "title": "Lot Code Input"
           },
-          "warehouse_id": {
+          "production_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Production Date"
+          },
+          "expiry_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expiry Date"
+          },
+          "lot_id": {
             "anyOf": [
               {
                 "type": "integer",
@@ -35772,54 +23016,68 @@
                 "type": "null"
               }
             ],
-            "title": "Warehouse Id"
-          },
-          "priority": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "maximum": 100000.0,
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Priority"
-          },
-          "active": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Active"
+            "title": "Lot Id"
           }
         },
-        "type": "object",
-        "title": "ProvinceRouteUpdateIn"
-      },
-      "ProvinceRouteWriteOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
+        "additionalProperties": false,
         "type": "object",
         "required": [
-          "data"
+          "wms_event_id",
+          "wms_event_no",
+          "trace_id",
+          "event_kind",
+          "event_status",
+          "occurred_at",
+          "receipt_no",
+          "procurement_po_id",
+          "procurement_po_no",
+          "wms_event_line_no",
+          "procurement_po_line_id",
+          "warehouse_id",
+          "item_id",
+          "qty_delta_base"
         ],
-        "title": "ProvinceRouteWriteOut"
+        "title": "ProcurementReceivingResultLineOut"
+      },
+      "ProcurementReceivingResultsOut": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ProcurementReceivingResultLineOut"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "after_event_id": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "After Event Id"
+          },
+          "next_after_event_id": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Next After Event Id"
+          },
+          "limit": {
+            "type": "integer",
+            "maximum": 200.0,
+            "minimum": 1.0,
+            "title": "Limit"
+          },
+          "has_more": {
+            "type": "boolean",
+            "title": "Has More"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "after_event_id",
+          "next_after_event_id",
+          "limit",
+          "has_more"
+        ],
+        "title": "ProcurementReceivingResultsOut"
       },
       "PurchaseCostDailyRow": {
         "properties": {
@@ -38035,25 +25293,6 @@
         ],
         "title": "ReturnTaskReceiveIn"
       },
-      "RoutingHealthOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "RoutingHealthOut"
-      },
       "ScanRequest": {
         "properties": {
           "mode": {
@@ -39569,214 +26808,6 @@
         ],
         "title": "ShippingRecordsWarehouseOption"
       },
-      "SimilarItemOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "sku": {
-            "type": "string",
-            "title": "Sku"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "spec": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spec"
-          },
-          "brand_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Brand Id"
-          },
-          "category_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Category Id"
-          },
-          "brand": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Brand"
-          },
-          "category": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Category"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "sku",
-          "name",
-          "spec",
-          "brand",
-          "category"
-        ],
-        "title": "SimilarItemOut"
-      },
-      "SkuGenerateDataOut": {
-        "properties": {
-          "sku": {
-            "type": "string",
-            "title": "Sku"
-          },
-          "segments": {
-            "items": {
-              "$ref": "#/components/schemas/SkuGeneratedSegmentOut"
-            },
-            "type": "array",
-            "title": "Segments"
-          },
-          "exists": {
-            "type": "boolean",
-            "title": "Exists"
-          },
-          "similar_items": {
-            "items": {
-              "$ref": "#/components/schemas/SimilarItemOut"
-            },
-            "type": "array",
-            "title": "Similar Items"
-          }
-        },
-        "type": "object",
-        "required": [
-          "sku",
-          "segments",
-          "exists",
-          "similar_items"
-        ],
-        "title": "SkuGenerateDataOut"
-      },
-      "SkuGenerateIn": {
-        "properties": {
-          "product_kind": {
-            "type": "string",
-            "enum": [
-              "FOOD",
-              "SUPPLY"
-            ],
-            "title": "Product Kind"
-          },
-          "brand_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Brand Id"
-          },
-          "category_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Category Id"
-          },
-          "attribute_option_ids": {
-            "additionalProperties": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "type": "object",
-            "title": "Attribute Option Ids"
-          },
-          "text_segments": {
-            "additionalProperties": {
-              "type": "string"
-            },
-            "type": "object",
-            "title": "Text Segments"
-          },
-          "spec_text": {
-            "type": "string",
-            "maxLength": 64,
-            "minLength": 1,
-            "title": "Spec Text"
-          }
-        },
-        "type": "object",
-        "required": [
-          "product_kind",
-          "brand_id",
-          "category_id",
-          "spec_text"
-        ],
-        "title": "SkuGenerateIn"
-      },
-      "SkuGenerateOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "$ref": "#/components/schemas/SkuGenerateDataOut"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "SkuGenerateOut"
-      },
-      "SkuGeneratedSegmentOut": {
-        "properties": {
-          "segment_key": {
-            "type": "string",
-            "title": "Segment Key"
-          },
-          "name_cn": {
-            "type": "string",
-            "title": "Name Cn"
-          },
-          "code": {
-            "type": "string",
-            "title": "Code"
-          }
-        },
-        "type": "object",
-        "required": [
-          "segment_key",
-          "name_cn",
-          "code"
-        ],
-        "title": "SkuGeneratedSegmentOut"
-      },
       "SkuPurchaseLedgerItemOption": {
         "properties": {
           "item_id": {
@@ -40114,301 +27145,6 @@
         ],
         "title": "StockRecountRequest"
       },
-      "StoreCreateIn": {
-        "properties": {
-          "platform": {
-            "type": "string",
-            "maxLength": 32,
-            "minLength": 2,
-            "title": "Platform"
-          },
-          "store_code": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Store Code"
-          },
-          "store_name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 256,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Store Name"
-          },
-          "store_type": {
-            "type": "string",
-            "enum": [
-              "TEST",
-              "PROD"
-            ],
-            "title": "Store Type",
-            "default": "PROD"
-          }
-        },
-        "type": "object",
-        "required": [
-          "platform",
-          "store_code"
-        ],
-        "title": "StoreCreateIn"
-      },
-      "StoreCreateOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "StoreCreateOut"
-      },
-      "StoreDetailOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "StoreDetailOut"
-      },
-      "StoreListItem": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "store_code": {
-            "type": "string",
-            "title": "Store Code"
-          },
-          "store_name": {
-            "type": "string",
-            "title": "Store Name"
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active"
-          },
-          "route_mode": {
-            "type": "string",
-            "title": "Route Mode"
-          },
-          "store_type": {
-            "type": "string",
-            "title": "Store Type",
-            "default": "PROD"
-          },
-          "email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Email"
-          },
-          "contact_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Contact Name"
-          },
-          "contact_phone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Contact Phone"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "platform",
-          "store_code",
-          "store_name",
-          "active",
-          "route_mode"
-        ],
-        "title": "StoreListItem"
-      },
-      "StoreListOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/StoreListItem"
-            },
-            "type": "array",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "StoreListOut"
-      },
-      "StoreLiteOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "store_name": {
-            "type": "string",
-            "title": "Store Name"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "store_name"
-        ],
-        "title": "StoreLiteOut"
-      },
-      "StoreUpdateIn": {
-        "properties": {
-          "store_name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 256,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Store Name"
-          },
-          "active": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Active"
-          },
-          "route_mode": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 32,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Route Mode"
-          },
-          "email": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Email"
-          },
-          "contact_name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 100
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Contact Name"
-          },
-          "contact_phone": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 50
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Contact Phone"
-          }
-        },
-        "type": "object",
-        "title": "StoreUpdateIn"
-      },
-      "StoreUpdateOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "StoreUpdateOut"
-      },
       "SubReason": {
         "type": "string",
         "enum": [
@@ -40515,319 +27251,6 @@
         "title": "SupplierBasic",
         "description": "Partners 对外最小供应商读模型。\n\n说明：\n- 这是跨域 export read surface\n- 只暴露其他模块稳定需要的最小读取字段\n- 不承载 owner contacts / 写入语义"
       },
-      "SupplierContactCreateIn": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "maxLength": 100,
-            "minLength": 1,
-            "title": "Name"
-          },
-          "phone": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 50
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Phone"
-          },
-          "email": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255,
-                "format": "email"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Email"
-          },
-          "wechat": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 64
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Wechat"
-          },
-          "role": {
-            "type": "string",
-            "maxLength": 32,
-            "title": "Role",
-            "default": "other"
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary",
-            "default": false
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active",
-            "default": true
-          }
-        },
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "title": "SupplierContactCreateIn"
-      },
-      "SupplierContactOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "supplier_id": {
-            "type": "integer",
-            "title": "Supplier Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "phone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Phone"
-          },
-          "email": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "email"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Email"
-          },
-          "wechat": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Wechat"
-          },
-          "role": {
-            "type": "string",
-            "title": "Role"
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary"
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "supplier_id",
-          "name",
-          "role",
-          "is_primary",
-          "active"
-        ],
-        "title": "SupplierContactOut"
-      },
-      "SupplierContactUpdateIn": {
-        "properties": {
-          "name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 100,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          },
-          "phone": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 50
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Phone"
-          },
-          "email": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255,
-                "format": "email"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Email"
-          },
-          "wechat": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 64
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Wechat"
-          },
-          "role": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 32
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Role"
-          },
-          "is_primary": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Primary"
-          },
-          "active": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Active"
-          }
-        },
-        "type": "object",
-        "title": "SupplierContactUpdateIn"
-      },
-      "SupplierCreateIn": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Name"
-          },
-          "code": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Code"
-          },
-          "website": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Website"
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active",
-            "default": true
-          }
-        },
-        "type": "object",
-        "required": [
-          "name",
-          "code"
-        ],
-        "title": "SupplierCreateIn"
-      },
-      "SupplierOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "code": {
-            "type": "string",
-            "title": "Code"
-          },
-          "website": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Website"
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active"
-          },
-          "contacts": {
-            "items": {
-              "$ref": "#/components/schemas/SupplierContactOut"
-            },
-            "type": "array",
-            "title": "Contacts"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "name",
-          "code",
-          "active",
-          "contacts"
-        ],
-        "title": "SupplierOut"
-      },
       "SupplierPurchaseReportItem": {
         "properties": {
           "supplier_id": {
@@ -40898,56 +27321,6 @@
           "total_units"
         ],
         "title": "SupplierPurchaseReportItem"
-      },
-      "SupplierUpdateIn": {
-        "properties": {
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          },
-          "code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Code"
-          },
-          "website": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Website"
-          },
-          "active": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Active"
-          }
-        },
-        "type": "object",
-        "title": "SupplierUpdateIn"
       },
       "SyncLogisticsShippingRecordsIn": {
         "properties": {
@@ -41028,180 +27401,6 @@
           "has_more"
         ],
         "title": "SyncLogisticsShippingRecordsOut"
-      },
-      "SyncPlatformOrderMirrorErrorOut": {
-        "properties": {
-          "collector_order_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Collector Order Id"
-          },
-          "error_code": {
-            "type": "string",
-            "title": "Error Code"
-          },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          }
-        },
-        "type": "object",
-        "required": [
-          "error_code",
-          "message"
-        ],
-        "title": "SyncPlatformOrderMirrorErrorOut"
-      },
-      "SyncPlatformOrderMirrorItemOut": {
-        "properties": {
-          "collector_order_id": {
-            "type": "integer",
-            "title": "Collector Order Id"
-          },
-          "mirror_id": {
-            "type": "integer",
-            "title": "Mirror Id"
-          },
-          "imported": {
-            "type": "boolean",
-            "title": "Imported",
-            "default": true
-          }
-        },
-        "type": "object",
-        "required": [
-          "collector_order_id",
-          "mirror_id"
-        ],
-        "title": "SyncPlatformOrderMirrorItemOut"
-      },
-      "SyncPlatformOrderMirrorsFromCollectorIn": {
-        "properties": {
-          "limit": {
-            "type": "integer",
-            "maximum": 1000.0,
-            "minimum": 1.0,
-            "title": "Limit",
-            "default": 50
-          },
-          "offset": {
-            "type": "integer",
-            "minimum": 0.0,
-            "title": "Offset",
-            "default": 0
-          },
-          "since": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Since",
-            "description": "Inclusive lower bound for Collector Export source update time."
-          },
-          "until": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Until",
-            "description": "Exclusive upper bound for Collector Export source update time."
-          }
-        },
-        "type": "object",
-        "title": "SyncPlatformOrderMirrorsFromCollectorIn"
-      },
-      "SyncPlatformOrderMirrorsFromCollectorOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "limit": {
-            "type": "integer",
-            "title": "Limit"
-          },
-          "offset": {
-            "type": "integer",
-            "title": "Offset"
-          },
-          "since": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Since"
-          },
-          "until": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Until"
-          },
-          "fetched_count": {
-            "type": "integer",
-            "title": "Fetched Count"
-          },
-          "imported_count": {
-            "type": "integer",
-            "title": "Imported Count"
-          },
-          "failed_count": {
-            "type": "integer",
-            "title": "Failed Count"
-          },
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/SyncPlatformOrderMirrorItemOut"
-            },
-            "type": "array",
-            "title": "Items"
-          },
-          "errors": {
-            "items": {
-              "$ref": "#/components/schemas/SyncPlatformOrderMirrorErrorOut"
-            },
-            "type": "array",
-            "title": "Errors"
-          }
-        },
-        "type": "object",
-        "required": [
-          "platform",
-          "limit",
-          "offset",
-          "fetched_count",
-          "imported_count",
-          "failed_count"
-        ],
-        "title": "SyncPlatformOrderMirrorsFromCollectorOut"
       },
       "ThreeBooksPayload": {
         "properties": {
@@ -41998,6 +28197,1199 @@
           "data"
         ],
         "title": "WarehouseUpdateOut"
+      },
+      "WmsReadWarehouseListOut": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/WmsReadWarehouseOut"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "WmsReadWarehouseListOut"
+      },
+      "WmsReadWarehouseOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Id"
+          },
+          "code": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 64
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Code"
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Name"
+          },
+          "active": {
+            "type": "boolean",
+            "title": "Active"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "active"
+        ],
+        "title": "WmsReadWarehouseOut",
+        "description": "WMS warehouse read-v1 contract for cross-system consumers.\n\nBoundary:\n- WMS owns warehouse master data.\n- Cross-system consumers only receive stable read fields.\n- This contract intentionally does not expose management fields."
+      },
+      "WmsSystemAppManifestBuildInfoOut": {
+        "properties": {
+          "environment": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Environment"
+          },
+          "git_sha": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Git Sha"
+          },
+          "build_time": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Build Time"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "environment"
+        ],
+        "title": "WmsSystemAppManifestBuildInfoOut"
+      },
+      "WmsSystemAppManifestOut": {
+        "properties": {
+          "app_code": {
+            "type": "string",
+            "const": "wms",
+            "title": "App Code"
+          },
+          "app_name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "App Name"
+          },
+          "app_type": {
+            "type": "string",
+            "minLength": 1,
+            "title": "App Type"
+          },
+          "status": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Status"
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Description"
+          },
+          "default_web_path": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Default Web Path"
+          },
+          "default_api_path": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Default Api Path"
+          },
+          "local_web_url": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Local Web Url"
+          },
+          "local_api_url": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Local Api Url"
+          },
+          "health_url": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Health Url"
+          },
+          "db_health_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Db Health Url"
+          },
+          "openapi_url": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Openapi Url"
+          },
+          "page_catalog_url": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Page Catalog Url"
+          },
+          "service_capabilities_url": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Service Capabilities Url"
+          },
+          "service_dependencies_url": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Service Dependencies Url"
+          },
+          "version": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Version"
+          },
+          "build_info": {
+            "$ref": "#/components/schemas/WmsSystemAppManifestBuildInfoOut"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "app_code",
+          "app_name",
+          "app_type",
+          "status",
+          "description",
+          "default_web_path",
+          "default_api_path",
+          "local_web_url",
+          "local_api_url",
+          "health_url",
+          "openapi_url",
+          "page_catalog_url",
+          "service_capabilities_url",
+          "service_dependencies_url",
+          "version",
+          "build_info"
+        ],
+        "title": "WmsSystemAppManifestOut"
+      },
+      "WmsSystemIamSnapshotOut": {
+        "properties": {
+          "app_code": {
+            "type": "string",
+            "const": "wms",
+            "title": "App Code"
+          },
+          "app_name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "App Name"
+          },
+          "snapshot_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Snapshot At"
+          },
+          "users": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemIamSnapshotUserOut"
+            },
+            "type": "array",
+            "title": "Users"
+          },
+          "permissions": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemIamSnapshotPermissionOut"
+            },
+            "type": "array",
+            "title": "Permissions"
+          },
+          "user_permissions": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemIamSnapshotUserPermissionOut"
+            },
+            "type": "array",
+            "title": "User Permissions"
+          },
+          "page_registry": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemIamSnapshotPageOut"
+            },
+            "type": "array",
+            "title": "Page Registry"
+          },
+          "page_route_prefixes": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemIamSnapshotRoutePrefixOut"
+            },
+            "type": "array",
+            "title": "Page Route Prefixes"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "app_code",
+          "app_name",
+          "snapshot_at"
+        ],
+        "title": "WmsSystemIamSnapshotOut"
+      },
+      "WmsSystemIamSnapshotPageOut": {
+        "properties": {
+          "page_code": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Page Code"
+          },
+          "page_name": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Page Name"
+          },
+          "parent_page_code": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 64
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Page Code"
+          },
+          "level": {
+            "type": "integer",
+            "maximum": 3.0,
+            "minimum": 1.0,
+            "title": "Level"
+          },
+          "domain_code": {
+            "type": "string",
+            "maxLength": 32,
+            "minLength": 1,
+            "title": "Domain Code"
+          },
+          "show_in_topbar": {
+            "type": "boolean",
+            "title": "Show In Topbar"
+          },
+          "show_in_sidebar": {
+            "type": "boolean",
+            "title": "Show In Sidebar"
+          },
+          "inherit_permissions": {
+            "type": "boolean",
+            "title": "Inherit Permissions"
+          },
+          "read_permission_code": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Read Permission Code"
+          },
+          "write_permission_code": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Write Permission Code"
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "page_code",
+          "page_name",
+          "level",
+          "domain_code",
+          "show_in_topbar",
+          "show_in_sidebar",
+          "inherit_permissions",
+          "sort_order",
+          "is_active"
+        ],
+        "title": "WmsSystemIamSnapshotPageOut"
+      },
+      "WmsSystemIamSnapshotPermissionOut": {
+        "properties": {
+          "permission_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Permission Id"
+          },
+          "permission_code": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Permission Code"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "permission_id",
+          "permission_code"
+        ],
+        "title": "WmsSystemIamSnapshotPermissionOut"
+      },
+      "WmsSystemIamSnapshotRoutePrefixOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Id"
+          },
+          "page_code": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Page Code"
+          },
+          "route_prefix": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Route Prefix"
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "id",
+          "page_code",
+          "route_prefix",
+          "sort_order",
+          "is_active"
+        ],
+        "title": "WmsSystemIamSnapshotRoutePrefixOut"
+      },
+      "WmsSystemIamSnapshotUserOut": {
+        "properties": {
+          "user_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "User Id"
+          },
+          "username": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Username"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "full_name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Name"
+          },
+          "phone": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 32
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phone"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "user_id",
+          "username",
+          "is_active"
+        ],
+        "title": "WmsSystemIamSnapshotUserOut"
+      },
+      "WmsSystemIamSnapshotUserPermissionOut": {
+        "properties": {
+          "user_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "User Id"
+          },
+          "permission_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Permission Id"
+          },
+          "permission_code": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Permission Code"
+          },
+          "granted_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Granted At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "user_id",
+          "permission_id",
+          "permission_code",
+          "granted_at"
+        ],
+        "title": "WmsSystemIamSnapshotUserPermissionOut"
+      },
+      "WmsSystemPageCatalogOut": {
+        "properties": {
+          "app_code": {
+            "type": "string",
+            "const": "wms",
+            "title": "App Code"
+          },
+          "app_name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "App Name"
+          },
+          "pages": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemPageCatalogPageOut"
+            },
+            "type": "array",
+            "title": "Pages"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "app_code",
+          "app_name"
+        ],
+        "title": "WmsSystemPageCatalogOut"
+      },
+      "WmsSystemPageCatalogPageOut": {
+        "properties": {
+          "page_code": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Page Code"
+          },
+          "page_name": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Page Name"
+          },
+          "route_path": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Route Path"
+          },
+          "parent_page_code": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 64
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Page Code"
+          },
+          "level": {
+            "type": "integer",
+            "maximum": 3.0,
+            "minimum": 1.0,
+            "title": "Level"
+          },
+          "read_permission_code": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Read Permission Code"
+          },
+          "write_permission_code": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Write Permission Code"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order"
+          },
+          "source_updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Updated At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "page_code",
+          "page_name",
+          "level",
+          "is_active",
+          "sort_order"
+        ],
+        "title": "WmsSystemPageCatalogPageOut"
+      },
+      "WmsSystemServiceCapabilitiesOut": {
+        "properties": {
+          "app_code": {
+            "type": "string",
+            "const": "wms",
+            "title": "App Code"
+          },
+          "app_name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "App Name"
+          },
+          "capabilities": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemServiceCapabilityOut"
+            },
+            "type": "array",
+            "title": "Capabilities"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "app_code",
+          "app_name"
+        ],
+        "title": "WmsSystemServiceCapabilitiesOut"
+      },
+      "WmsSystemServiceCapabilityOut": {
+        "properties": {
+          "capability_code": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Capability Code"
+          },
+          "capability_name": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Capability Name"
+          },
+          "resource_code": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Resource Code"
+          },
+          "permission_code": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Permission Code"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "source_updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Updated At"
+          },
+          "routes": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemServiceCapabilityRouteOut"
+            },
+            "type": "array",
+            "title": "Routes"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "capability_code",
+          "capability_name",
+          "resource_code",
+          "permission_code",
+          "is_active"
+        ],
+        "title": "WmsSystemServiceCapabilityOut"
+      },
+      "WmsSystemServiceCapabilityRouteOut": {
+        "properties": {
+          "http_method": {
+            "type": "string",
+            "maxLength": 16,
+            "minLength": 1,
+            "title": "Http Method"
+          },
+          "path": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Path"
+          },
+          "route_name": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Route Name"
+          },
+          "auth_required": {
+            "type": "boolean",
+            "title": "Auth Required"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "source_created_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Created At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "http_method",
+          "path",
+          "route_name",
+          "auth_required",
+          "is_active"
+        ],
+        "title": "WmsSystemServiceCapabilityRouteOut"
+      },
+      "WmsSystemServiceDependenciesOut": {
+        "properties": {
+          "app_code": {
+            "type": "string",
+            "const": "wms",
+            "title": "App Code"
+          },
+          "app_name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "App Name"
+          },
+          "source_service_client_code": {
+            "type": "string",
+            "const": "wms-service",
+            "title": "Source Service Client Code"
+          },
+          "dependencies": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemServiceDependencyOut"
+            },
+            "type": "array",
+            "title": "Dependencies"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "app_code",
+          "app_name",
+          "source_service_client_code"
+        ],
+        "title": "WmsSystemServiceDependenciesOut"
+      },
+      "WmsSystemServiceDependencyEndpointOut": {
+        "properties": {
+          "http_method": {
+            "type": "string",
+            "maxLength": 16,
+            "minLength": 1,
+            "title": "Http Method"
+          },
+          "path": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Path"
+          },
+          "purpose": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Purpose"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "http_method",
+          "path"
+        ],
+        "title": "WmsSystemServiceDependencyEndpointOut"
+      },
+      "WmsSystemServiceDependencyOut": {
+        "properties": {
+          "dependency_code": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Dependency Code"
+          },
+          "dependency_name": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Dependency Name"
+          },
+          "target_app_code": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Target App Code"
+          },
+          "target_capability_code": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Target Capability Code"
+          },
+          "required_permission_code": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Required Permission Code"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "is_required": {
+            "type": "boolean",
+            "title": "Is Required"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "required_config_keys": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Required Config Keys"
+          },
+          "source_modules": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Source Modules"
+          },
+          "endpoints": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemServiceDependencyEndpointOut"
+            },
+            "type": "array",
+            "title": "Endpoints"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "dependency_code",
+          "dependency_name",
+          "target_app_code",
+          "target_capability_code",
+          "required_permission_code",
+          "is_required",
+          "is_active"
+        ],
+        "title": "WmsSystemServiceDependencyOut"
+      },
+      "WmsSystemServicePermissionApplyIn": {
+        "properties": {
+          "client_code": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Client Code"
+          },
+          "client_name": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Client Name"
+          },
+          "capability_code": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Capability Code"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "client_code",
+          "client_name",
+          "capability_code",
+          "is_active"
+        ],
+        "title": "WmsSystemServicePermissionApplyIn"
+      },
+      "WmsSystemServicePermissionApplyOut": {
+        "properties": {
+          "app_code": {
+            "type": "string",
+            "const": "wms",
+            "title": "App Code"
+          },
+          "client_code": {
+            "type": "string",
+            "title": "Client Code"
+          },
+          "client_name": {
+            "type": "string",
+            "title": "Client Name"
+          },
+          "capability_code": {
+            "type": "string",
+            "title": "Capability Code"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "applied": {
+            "type": "boolean",
+            "title": "Applied"
+          },
+          "verified": {
+            "type": "boolean",
+            "title": "Verified"
+          },
+          "permission_id": {
+            "type": "integer",
+            "title": "Permission Id"
+          },
+          "granted_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Granted At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "app_code",
+          "client_code",
+          "client_name",
+          "capability_code",
+          "description",
+          "is_active",
+          "applied",
+          "verified",
+          "permission_id",
+          "granted_at"
+        ],
+        "title": "WmsSystemServicePermissionApplyOut"
+      },
+      "WmsSystemServicePermissionVerifyOut": {
+        "properties": {
+          "app_code": {
+            "type": "string",
+            "const": "wms",
+            "title": "App Code"
+          },
+          "client_code": {
+            "type": "string",
+            "title": "Client Code"
+          },
+          "capability_code": {
+            "type": "string",
+            "title": "Capability Code"
+          },
+          "client_exists": {
+            "type": "boolean",
+            "title": "Client Exists"
+          },
+          "capability_exists": {
+            "type": "boolean",
+            "title": "Capability Exists"
+          },
+          "permission_exists": {
+            "type": "boolean",
+            "title": "Permission Exists"
+          },
+          "client_is_active": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Is Active"
+          },
+          "capability_is_active": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Capability Is Active"
+          },
+          "permission_is_active": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Permission Is Active"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "verified": {
+            "type": "boolean",
+            "title": "Verified"
+          },
+          "permission_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Permission Id"
+          },
+          "granted_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Granted At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "app_code",
+          "client_code",
+          "capability_code",
+          "client_exists",
+          "capability_exists",
+          "permission_exists",
+          "client_is_active",
+          "capability_is_active",
+          "permission_is_active",
+          "description",
+          "verified",
+          "permission_id",
+          "granted_at"
+        ],
+        "title": "WmsSystemServicePermissionVerifyOut"
       }
     },
     "securitySchemes": {

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "WMS-DU",
+    "title": "wms-api",
     "version": "1.1.0"
   },
   "paths": {
@@ -735,6 +735,285 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/FulfillmentDebugOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/wms/outbound/orders/oms-projection-candidates": {
+      "get": {
+        "tags": [
+          "wms-outbound-order-import"
+        ],
+        "summary": "List Wms Outbound Oms Projection Candidates",
+        "operationId": "list_wms_outbound_oms_projection_candidates_wms_outbound_orders_oms_projection_candidates_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Q"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "default": 20,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OmsProjectionOrderImportCandidatesOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/wms/outbound/orders/import-from-oms-projection": {
+      "post": {
+        "tags": [
+          "wms-outbound-order-import"
+        ],
+        "summary": "Import Wms Orders From Oms Projection",
+        "operationId": "import_wms_orders_from_oms_projection_wms_outbound_orders_import_from_oms_projection_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OmsProjectionOrderImportIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OmsProjectionOrderImportOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/wms/outbound/orders/options": {
+      "get": {
+        "tags": [
+          "wms-outbound-order-read"
+        ],
+        "summary": "Get Wms Outbound Order Options",
+        "operationId": "get_wms_outbound_order_options_wms_outbound_orders_options_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Q"
+            }
+          },
+          {
+            "name": "platform",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Platform"
+            }
+          },
+          {
+            "name": "store_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Store Code"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "default": 20,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrderOutboundOptionsOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/wms/outbound/orders/{order_id}/view": {
+      "get": {
+        "tags": [
+          "wms-outbound-order-read"
+        ],
+        "summary": "Get Wms Outbound Order View",
+        "operationId": "get_wms_outbound_order_view_wms_outbound_orders__order_id__view_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "order_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Order Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrderOutboundViewResponse"
                 }
               }
             }
@@ -2726,6 +3005,84 @@
         }
       }
     },
+    "/inbound-receipts/purchase-source-options": {
+      "get": {
+        "tags": [
+          "inbound-receipts"
+        ],
+        "summary": "List Inbound Receipt Purchase Source Options Endpoint",
+        "operationId": "list_inbound_receipt_purchase_source_options_endpoint_inbound_receipts_purchase_source_options_get",
+        "parameters": [
+          {
+            "name": "target_warehouse_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "exclusiveMinimum": 0
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Target Warehouse Id"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Q"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "default": 200,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboundReceiptPurchaseSourceOptionsOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/inbound-receipts/from-purchase": {
       "post": {
         "tags": [
@@ -3197,6 +3554,177 @@
             "OAuth2PasswordBearer": []
           }
         ]
+      }
+    },
+    "/wms/inbound/procurement-receiving-results": {
+      "get": {
+        "tags": [
+          "wms-inbound-events"
+        ],
+        "summary": "List Procurement Receiving Results Endpoint",
+        "operationId": "list_procurement_receiving_results_endpoint_wms_inbound_procurement_receiving_results_get",
+        "parameters": [
+          {
+            "name": "after_event_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "只返回 event_id 大于该值的收货结果",
+              "default": 0,
+              "title": "After Event Id"
+            },
+            "description": "只返回 event_id 大于该值的收货结果"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "description": "最多读取多少个 WMS event",
+              "default": 50,
+              "title": "Limit"
+            },
+            "description": "最多读取多少个 WMS event"
+          },
+          {
+            "name": "procurement_po_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "采购系统采购单 ID",
+              "title": "Procurement Po Id"
+            },
+            "description": "采购系统采购单 ID"
+          },
+          {
+            "name": "receipt_no",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "WMS 入库单号",
+              "title": "Receipt No"
+            },
+            "description": "WMS 入库单号"
+          },
+          {
+            "name": "X-Service-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Service-Client"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcurementReceivingResultsOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/wms/inbound/procurement-receiving-results/{event_id}": {
+      "get": {
+        "tags": [
+          "wms-inbound-events"
+        ],
+        "summary": "Get Procurement Receiving Result Detail Endpoint",
+        "operationId": "get_procurement_receiving_result_detail_endpoint_wms_inbound_procurement_receiving_results__event_id__get",
+        "parameters": [
+          {
+            "name": "event_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Event Id"
+            }
+          },
+          {
+            "name": "X-Service-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Service-Client"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcurementReceivingResultDetailOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/wms/inbound/events": {
@@ -4287,1325 +4815,132 @@
         ]
       }
     },
-    "/oms/pdd/platform-order-mirrors/import": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Pdd Import Platform Order Mirror",
-        "operationId": "pdd_import_platform_order_mirror_oms_pdd_platform_order_mirrors_import_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlatformOrderMirrorImportIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderMirrorEnvelopeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/pdd/platform-order-mirrors/import-from-collector": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Pdd Import Platform Order Mirror From Collector Route",
-        "operationId": "pdd_import_platform_order_mirror_from_collector_route_oms_pdd_platform_order_mirrors_import_from_collector_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ImportPlatformOrderMirrorFromCollectorIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportPlatformOrderMirrorFromCollectorOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/pdd/platform-order-mirrors/sync-from-collector": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Pdd Sync Platform Order Mirrors From Collector Route",
-        "operationId": "pdd_sync_platform_order_mirrors_from_collector_route_oms_pdd_platform_order_mirrors_sync_from_collector_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SyncPlatformOrderMirrorsFromCollectorIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SyncPlatformOrderMirrorsFromCollectorOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/pdd/platform-order-mirrors": {
+    "/oms/fulfillment-projection/status": {
       "get": {
         "tags": [
           "OMS",
-          "oms-platform-order-mirrors"
+          "oms-fulfillment-projection"
         ],
-        "summary": "Pdd List Platform Order Mirror Rows",
-        "operationId": "pdd_list_platform_order_mirror_rows_oms_pdd_platform_order_mirrors_get",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 1000,
-              "minimum": 1,
-              "default": 200,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
-          }
-        ],
+        "summary": "Get Oms Fulfillment Projection Status",
+        "operationId": "get_oms_fulfillment_projection_status_oms_fulfillment_projection_status_get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderMirrorListOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/OmsProjectionStatusOut"
                 }
               }
             }
           }
-        }
-      }
-    },
-    "/oms/pdd/platform-order-mirrors/{mirror_id}": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Pdd Get Platform Order Mirror Row",
-        "operationId": "pdd_get_platform_order_mirror_row_oms_pdd_platform_order_mirrors__mirror_id__get",
-        "parameters": [
-          {
-            "name": "mirror_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Mirror Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderMirrorEnvelopeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/taobao/platform-order-mirrors/import": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Taobao Import Platform Order Mirror",
-        "operationId": "taobao_import_platform_order_mirror_oms_taobao_platform_order_mirrors_import_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlatformOrderMirrorImportIn"
-              }
-            }
-          },
-          "required": true
         },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderMirrorEnvelopeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
           }
-        }
+        ]
       }
     },
-    "/oms/taobao/platform-order-mirrors/import-from-collector": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Taobao Import Platform Order Mirror From Collector Route",
-        "operationId": "taobao_import_platform_order_mirror_from_collector_route_oms_taobao_platform_order_mirrors_import_from_collector_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ImportPlatformOrderMirrorFromCollectorIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportPlatformOrderMirrorFromCollectorOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/taobao/platform-order-mirrors/sync-from-collector": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Taobao Sync Platform Order Mirrors From Collector Route",
-        "operationId": "taobao_sync_platform_order_mirrors_from_collector_route_oms_taobao_platform_order_mirrors_sync_from_collector_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SyncPlatformOrderMirrorsFromCollectorIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SyncPlatformOrderMirrorsFromCollectorOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/taobao/platform-order-mirrors": {
+    "/oms/fulfillment-projection/sync-runs": {
       "get": {
         "tags": [
           "OMS",
-          "oms-platform-order-mirrors"
+          "oms-fulfillment-projection"
         ],
-        "summary": "Taobao List Platform Order Mirror Rows",
-        "operationId": "taobao_list_platform_order_mirror_rows_oms_taobao_platform_order_mirrors_get",
-        "parameters": [
+        "summary": "List Oms Fulfillment Projection Sync Runs",
+        "operationId": "list_oms_fulfillment_projection_sync_runs_oms_fulfillment_projection_sync_runs_get",
+        "security": [
           {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 1000,
-              "minimum": 1,
-              "default": 200,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
+            "OAuth2PasswordBearer": []
           }
         ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderMirrorListOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/taobao/platform-order-mirrors/{mirror_id}": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Taobao Get Platform Order Mirror Row",
-        "operationId": "taobao_get_platform_order_mirror_row_oms_taobao_platform_order_mirrors__mirror_id__get",
-        "parameters": [
-          {
-            "name": "mirror_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Mirror Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderMirrorEnvelopeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/jd/platform-order-mirrors/import": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Jd Import Platform Order Mirror",
-        "operationId": "jd_import_platform_order_mirror_oms_jd_platform_order_mirrors_import_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlatformOrderMirrorImportIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderMirrorEnvelopeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/jd/platform-order-mirrors/import-from-collector": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Jd Import Platform Order Mirror From Collector Route",
-        "operationId": "jd_import_platform_order_mirror_from_collector_route_oms_jd_platform_order_mirrors_import_from_collector_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ImportPlatformOrderMirrorFromCollectorIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportPlatformOrderMirrorFromCollectorOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/jd/platform-order-mirrors/sync-from-collector": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Jd Sync Platform Order Mirrors From Collector Route",
-        "operationId": "jd_sync_platform_order_mirrors_from_collector_route_oms_jd_platform_order_mirrors_sync_from_collector_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SyncPlatformOrderMirrorsFromCollectorIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SyncPlatformOrderMirrorsFromCollectorOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/jd/platform-order-mirrors": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Jd List Platform Order Mirror Rows",
-        "operationId": "jd_list_platform_order_mirror_rows_oms_jd_platform_order_mirrors_get",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 1000,
-              "minimum": 1,
-              "default": 200,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderMirrorListOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/jd/platform-order-mirrors/{mirror_id}": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-platform-order-mirrors"
-        ],
-        "summary": "Jd Get Platform Order Mirror Row",
-        "operationId": "jd_get_platform_order_mirror_row_oms_jd_platform_order_mirrors__mirror_id__get",
-        "parameters": [
-          {
-            "name": "mirror_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Mirror Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderMirrorEnvelopeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/pdd/code-mapping/code-options": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-code-mapping"
-        ],
-        "summary": "Pdd List Platform Code Mapping Code Options",
-        "operationId": "pdd_list_platform_code_mapping_code_options_oms_pdd_code_mapping_code_options_get",
-        "parameters": [
-          {
-            "name": "store_code",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 128
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Store Code"
-            }
-          },
-          {
-            "name": "merchant_code",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 128
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Merchant Code"
-            }
-          },
-          {
-            "name": "only_unbound",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Only Unbound"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 1000,
-              "minimum": 1,
-              "default": 200,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CodeMappingCodeOptionListOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/taobao/code-mapping/code-options": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-code-mapping"
-        ],
-        "summary": "Taobao List Platform Code Mapping Code Options",
-        "operationId": "taobao_list_platform_code_mapping_code_options_oms_taobao_code_mapping_code_options_get",
-        "parameters": [
-          {
-            "name": "store_code",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 128
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Store Code"
-            }
-          },
-          {
-            "name": "merchant_code",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 128
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Merchant Code"
-            }
-          },
-          {
-            "name": "only_unbound",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Only Unbound"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 1000,
-              "minimum": 1,
-              "default": 200,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CodeMappingCodeOptionListOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/jd/code-mapping/code-options": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-code-mapping"
-        ],
-        "summary": "Jd List Platform Code Mapping Code Options",
-        "operationId": "jd_list_platform_code_mapping_code_options_oms_jd_code_mapping_code_options_get",
-        "parameters": [
-          {
-            "name": "store_code",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 128
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Store Code"
-            }
-          },
-          {
-            "name": "merchant_code",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 128
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Merchant Code"
-            }
-          },
-          {
-            "name": "only_unbound",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Only Unbound"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 1000,
-              "minimum": 1,
-              "default": 200,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CodeMappingCodeOptionListOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/pdd/platform-order-mirrors/{mirror_id}/sku-resolution": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-order-sku-resolution"
-        ],
-        "summary": "Pdd Get Platform Order Sku Resolution",
-        "operationId": "pdd_get_platform_order_sku_resolution_oms_pdd_platform_order_mirrors__mirror_id__sku_resolution_get",
-        "parameters": [
-          {
-            "name": "mirror_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Mirror Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrderSkuResolutionOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/taobao/platform-order-mirrors/{mirror_id}/sku-resolution": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-order-sku-resolution"
-        ],
-        "summary": "Taobao Get Platform Order Sku Resolution",
-        "operationId": "taobao_get_platform_order_sku_resolution_oms_taobao_platform_order_mirrors__mirror_id__sku_resolution_get",
-        "parameters": [
-          {
-            "name": "mirror_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Mirror Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrderSkuResolutionOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/jd/platform-order-mirrors/{mirror_id}/sku-resolution": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-order-sku-resolution"
-        ],
-        "summary": "Jd Get Platform Order Sku Resolution",
-        "operationId": "jd_get_platform_order_sku_resolution_oms_jd_platform_order_mirrors__mirror_id__sku_resolution_get",
-        "parameters": [
-          {
-            "name": "mirror_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Mirror Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrderSkuResolutionOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/platform-orders/ingest": {
-      "post": {
-        "tags": [
-          "OMS",
-          "platform-orders"
-        ],
-        "summary": "平台订单接入（Phase N+2）：填写码 → FSKU → Items → /orders",
-        "operationId": "ingest_platform_order_oms_platform_orders_ingest_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlatformOrderIngestIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderIngestOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/platform-orders/confirm-and-create": {
-      "post": {
-        "tags": [
-          "OMS",
-          "platform-orders"
-        ],
-        "summary": "当单执行：人工确认选货后生成内部订单（不写任何映射；人工决策写入证据表）",
-        "operationId": "confirm_and_create_platform_order_oms_platform_orders_confirm_and_create_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlatformOrderConfirmCreateIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderConfirmCreateOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/platform-orders/replay": {
-      "post": {
-        "tags": [
-          "OMS",
-          "platform-orders"
-        ],
-        "summary": "平台订单事实重放解码：从 platform_order_lines 读取事实，复用 resolver + /orders ingest 主线幂等生成订单",
-        "operationId": "replay_platform_order_oms_platform_orders_replay_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlatformOrderReplayIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderReplayOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/platform-orders/resolve-preview": {
-      "post": {
-        "tags": [
-          "OMS",
-          "platform-orders"
-        ],
-        "summary": "平台订单事实只读解析预览：读取 platform_order_lines 并展开到 FSKU/SKU，不建单",
-        "description": "只读解析预览。\n\n边界：\n- 读取 platform_order_lines；\n- 复用 resolver 展开 FSKU / item；\n- 返回 resolved / unresolved / item_qty_map；\n- 不写 platform_order_lines；\n- 不建 orders/order_items；\n- 不触碰 finance。",
-        "operationId": "preview_platform_order_resolve_oms_platform_orders_resolve_preview_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlatformOrderResolvePreviewIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformOrderResolvePreviewOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/platform-orders/manual-decisions/latest": {
-      "get": {
-        "tags": [
-          "OMS",
-          "platform-orders"
-        ],
-        "summary": "读取最近的人工救火批次（platform_order_manual_decisions），用于治理证据回流（不写绑定）",
-        "operationId": "list_latest_manual_decisions_oms_platform_orders_manual_decisions_latest_get",
         "parameters": [
           {
             "name": "platform",
             "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "pdd",
+                    "taobao",
+                    "jd"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Platform"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 20,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OmsProjectionSyncRunsOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/fulfillment-projection/projections/{resource}": {
+      "get": {
+        "tags": [
+          "OMS",
+          "oms-fulfillment-projection"
+        ],
+        "summary": "List Oms Fulfillment Projection Rows",
+        "operationId": "list_oms_fulfillment_projection_rows_oms_fulfillment_projection_projections__resource__get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "resource",
+            "in": "path",
             "required": true,
             "schema": {
+              "enum": [
+                "orders",
+                "lines",
+                "components"
+              ],
               "type": "string",
-              "description": "平台（如 DEMO/PDD/TB），大小写不敏感",
-              "title": "Platform"
-            },
-            "description": "平台（如 DEMO/PDD/TB），大小写不敏感"
-          },
-          {
-            "name": "store_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "description": "内部店铺 store_id（stores.id）",
-              "title": "Store Id"
-            },
-            "description": "内部店铺 store_id（stores.id）"
+              "title": "Resource"
+            }
           },
           {
             "name": "limit",
@@ -5613,9 +4948,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "maximum": 200,
+              "maximum": 500,
               "minimum": 1,
-              "default": 20,
+              "default": 50,
               "title": "Limit"
             }
           },
@@ -5629,6 +4964,22 @@
               "default": 0,
               "title": "Offset"
             }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Q"
+            }
           }
         ],
         "responses": {
@@ -5637,7 +4988,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ManualDecisionOrdersOut"
+                  "$ref": "#/components/schemas/OmsProjectionListOut"
                 }
               }
             }
@@ -5655,15 +5006,14 @@
         }
       }
     },
-    "/oms/stores": {
-      "get": {
+    "/oms/fulfillment-projection/projections/fulfillment-ready-orders/sync": {
+      "post": {
         "tags": [
           "OMS",
-          "stores"
+          "oms-fulfillment-projection"
         ],
-        "summary": "List Stores",
-        "description": "店铺列表（基础信息，不含仓绑定）。\n\n权限：config.store.read\n\n✅ 合同：\n- 支持 platform/q/limit/offset\n- 返回结构保持：{ ok: true, data: [...] }",
-        "operationId": "list_stores_oms_stores_get",
+        "summary": "Sync Oms Fulfillment Ready Orders",
+        "operationId": "sync_oms_fulfillment_ready_orders_oms_fulfillment_projection_projections_fulfillment_ready_orders_sync_post",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -5677,34 +5027,102 @@
             "schema": {
               "anyOf": [
                 {
+                  "enum": [
+                    "pdd",
+                    "taobao",
+                    "jd"
+                  ],
                   "type": "string"
                 },
                 {
                   "type": "null"
                 }
               ],
-              "description": "平台过滤（如 PDD/TB/DEMO），大小写不敏感",
               "title": "Platform"
-            },
-            "description": "平台过滤（如 PDD/TB/DEMO），大小写不敏感"
+            }
           },
           {
-            "name": "q",
+            "name": "store_code",
             "in": "query",
             "required": false,
             "schema": {
               "anyOf": [
                 {
-                  "type": "string"
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 128
                 },
                 {
                   "type": "null"
                 }
               ],
-              "description": "模糊搜索：store_name / store_code / id",
-              "title": "Q"
-            },
-            "description": "模糊搜索：store_name / store_code / id"
+              "title": "Store Code"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "default": 200,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OmsProjectionSyncOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oms/fulfillment-projection/projections/{resource}/check": {
+      "post": {
+        "tags": [
+          "OMS",
+          "oms-fulfillment-projection"
+        ],
+        "summary": "Check Oms Fulfillment Projection Resource",
+        "operationId": "check_oms_fulfillment_projection_resource_oms_fulfillment_projection_projections__resource__check_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "resource",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "enum": [
+                "orders",
+                "lines",
+                "components"
+              ],
+              "type": "string",
+              "title": "Resource"
+            }
           },
           {
             "name": "limit",
@@ -5717,17 +5135,6 @@
               "default": 200,
               "title": "Limit"
             }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
           }
         ],
         "responses": {
@@ -5736,53 +5143,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/StoreListOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Create Or Get Store",
-        "description": "店铺建档 / 补录（幂等）。\n\n权限：config.store.write\n\n✅ 合同收敛：\n- store_type 的唯一真相为 platform_test_stores（code='DEFAULT'）\n- 创建时可选择 TEST/PROD：\n  * TEST：写入/更新 platform_test_stores（绑定 store_id）\n  * PROD：确保该 store_id 不在 platform_test_stores（删除绑定）",
-        "operationId": "create_or_get_store_oms_stores_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StoreCreateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StoreCreateOut"
+                  "$ref": "#/components/schemas/OmsProjectionCheckOut"
                 }
               }
             }
@@ -5800,123 +5161,41 @@
         }
       }
     },
-    "/oms/stores/{store_id}": {
-      "patch": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Update Store",
-        "description": "更新店铺基础信息（name / active / route_mode / email / 联系人 / 电话）。\n\n权限：config.store.write",
-        "operationId": "update_store_oms_stores__store_id__patch",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StoreUpdateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StoreUpdateOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
+    "/pms/projections/status": {
       "get": {
         "tags": [
-          "OMS",
-          "stores"
+          "pms",
+          "pms-projections"
         ],
-        "summary": "Get Store Detail",
-        "description": "店铺详情（含绑定仓列表）。\n权限：config.store.read",
-        "operationId": "get_store_detail_oms_stores__store_id__get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
+        "summary": "Get Pms Projection Sync Status",
+        "operationId": "get_pms_projection_sync_status_pms_projections_status_get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/StoreDetailOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/PmsProjectionStatusOut"
                 }
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
       }
     },
-    "/oms/stores/{store_id}/default-warehouse": {
+    "/pms/projections/sync-runs": {
       "get": {
         "tags": [
-          "OMS",
-          "stores"
+          "pms",
+          "pms-projections"
         ],
-        "summary": "Get Default Warehouse",
-        "description": "解析默认仓（若无绑定返回 null）。\n权限：config.store.read",
-        "operationId": "get_default_warehouse_oms_stores__store_id__default_warehouse_get",
+        "summary": "List Pms Projection Sync Runs",
+        "operationId": "list_pms_projection_sync_runs_pms_projections_sync_runs_get",
         "security": [
           {
             "OAuth2PasswordBearer": []
@@ -5924,1005 +5203,27 @@
         ],
         "parameters": [
           {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DefaultWarehouseOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/warehouses/bind": {
-      "post": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Bind Store Warehouse",
-        "description": "店 ↔ 仓 绑定（幂等）。\n权限：config.store.write\n\n约束：\n- 若 is_default=true，会保证该店铺“唯一默认仓”\n- 若 is_top 为 null，由后端按 is_default 推导（由 StoreService.bind_warehouse 负责）",
-        "operationId": "bind_store_warehouse_oms_stores__store_id__warehouses_bind_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BindWarehouseIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BindWarehouseOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/warehouses/{warehouse_id}": {
-      "patch": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Update Binding",
-        "description": "更新绑定关系（is_default / priority / is_top）。\n权限：config.store.write\n\n✅ 强约束：当 is_default=true 时，必须保证“唯一默认仓”。\n实现方式：调用 StoreService.set_default_warehouse（清空同店其它 default，再置当前为 default）。",
-        "operationId": "update_binding_oms_stores__store_id__warehouses__warehouse_id__patch",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          },
-          {
-            "name": "warehouse_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Warehouse Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BindingUpdateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BindingUpdateOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Delete Binding",
-        "description": "解除店 ↔ 仓 绑定关系。\n权限：config.store.write",
-        "operationId": "delete_binding_oms_stores__store_id__warehouses__warehouse_id__delete",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          },
-          {
-            "name": "warehouse_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Warehouse Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BindingDeleteOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/routes/provinces": {
-      "get": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "List Province Routes",
-        "operationId": "list_province_routes_oms_stores__store_id__routes_provinces_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProvinceRouteListOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Create Province Route",
-        "operationId": "create_province_route_oms_stores__store_id__routes_provinces_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ProvinceRouteCreateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProvinceRouteWriteOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/routes/provinces/{route_id}": {
-      "patch": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Update Province Route",
-        "operationId": "update_province_route_oms_stores__store_id__routes_provinces__route_id__patch",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          },
-          {
-            "name": "route_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Route Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ProvinceRouteUpdateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProvinceRouteWriteOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Delete Province Route",
-        "operationId": "delete_province_route_oms_stores__store_id__routes_provinces__route_id__delete",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          },
-          {
-            "name": "route_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Route Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProvinceRouteWriteOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/routing/health": {
-      "get": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Routing Health",
-        "operationId": "routing_health_oms_stores__store_id__routing_health_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RoutingHealthOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/order-sim/merchant-lines": {
-      "get": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Get Order Sim Merchant Lines",
-        "operationId": "get_order_sim_merchant_lines_oms_stores__store_id__order_sim_merchant_lines_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrderSimMerchantLinesGetOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Put Order Sim Merchant Lines",
-        "operationId": "put_order_sim_merchant_lines_oms_stores__store_id__order_sim_merchant_lines_put",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/OrderSimMerchantLinesPutIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrderSimMerchantLinesPutOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/order-sim/filled-code-options": {
-      "get": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Get Order Sim Filled Code Options",
-        "operationId": "get_order_sim_filled_code_options_oms_stores__store_id__order_sim_filled_code_options_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrderSimFilledCodeOptionsOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/order-sim/cart": {
-      "get": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Get Order Sim Cart",
-        "operationId": "get_order_sim_cart_oms_stores__store_id__order_sim_cart_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrderSimCartGetOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Put Order Sim Cart",
-        "operationId": "put_order_sim_cart_oms_stores__store_id__order_sim_cart_put",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/OrderSimCartPutIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrderSimCartPutOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/order-sim/preview-order": {
-      "post": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Preview Order Sim Order",
-        "operationId": "preview_order_sim_order_oms_stores__store_id__order_sim_preview_order_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/OrderSimPreviewOrderIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrderSimPreviewOrderOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/stores/{store_id}/order-sim/generate-order": {
-      "post": {
-        "tags": [
-          "OMS",
-          "stores"
-        ],
-        "summary": "Generate Order Sim Order",
-        "operationId": "generate_order_sim_order_oms_stores__store_id__order_sim_generate_order_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "store_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Store Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/OrderSimGenerateOrderIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrderSimGenerateOrderOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/fskus": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-fsku",
-          "oms-fsku",
-          "oms-fsku"
-        ],
-        "summary": "Create",
-        "operationId": "create_oms_fskus_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FskuCreateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FskuDetailOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-fsku",
-          "oms-fsku",
-          "oms-fsku"
-        ],
-        "summary": "List ",
-        "operationId": "list__oms_fskus_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "query",
+            "name": "resource",
             "in": "query",
             "required": false,
             "schema": {
               "anyOf": [
                 {
+                  "enum": [
+                    "items",
+                    "suppliers",
+                    "uoms",
+                    "sku-codes",
+                    "barcodes"
+                  ],
                   "type": "string"
                 },
                 {
                   "type": "null"
                 }
               ],
-              "description": "按 name/code/expression 模糊搜索",
-              "title": "Query"
-            },
-            "description": "按 name/code/expression 模糊搜索"
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "draft/published/retired",
-              "title": "Status"
-            },
-            "description": "draft/published/retired"
-          },
-          {
-            "name": "store_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer",
-                  "minimum": 1
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "保留查询上下文；OMS FSKU 主数据不按店铺过滤",
-              "title": "Store Id"
-            },
-            "description": "保留查询上下文；OMS FSKU 主数据不按店铺过滤"
+              "title": "Resource"
+            }
           },
           {
             "name": "limit",
@@ -6930,7 +5231,74 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "maximum": 200,
+              "maximum": 100,
+              "minimum": 1,
+              "default": 20,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PmsProjectionSyncRunsOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/projections/{resource}": {
+      "get": {
+        "tags": [
+          "pms",
+          "pms-projections"
+        ],
+        "summary": "List Pms Projection Rows",
+        "operationId": "list_pms_projection_rows_pms_projections__resource__get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "resource",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "enum": [
+                "items",
+                "suppliers",
+                "uoms",
+                "sku-codes",
+                "barcodes"
+              ],
+              "type": "string",
+              "title": "Resource"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
               "minimum": 1,
               "default": 50,
               "title": "Limit"
@@ -6946,610 +5314,7 @@
               "default": 0,
               "title": "Offset"
             }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FskuListOut"
-                }
-              }
-            }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/fskus/{fsku_id}": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-fsku",
-          "oms-fsku",
-          "oms-fsku"
-        ],
-        "summary": "Detail",
-        "operationId": "detail_oms_fskus__fsku_id__get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "fsku_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Fsku Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FskuDetailOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "OMS",
-          "oms-fsku",
-          "oms-fsku",
-          "oms-fsku"
-        ],
-        "summary": "Patch Fsku",
-        "operationId": "patch_fsku_oms_fskus__fsku_id__patch",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "fsku_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Fsku Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FskuNameUpdateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FskuDetailOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/fskus/{fsku_id}/expression": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-fsku",
-          "oms-fsku",
-          "oms-fsku"
-        ],
-        "summary": "Replace Expression",
-        "operationId": "replace_expression_oms_fskus__fsku_id__expression_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "fsku_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Fsku Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FskuExpressionReplaceIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FskuDetailOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/fskus/{fsku_id}/publish": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-fsku",
-          "oms-fsku",
-          "oms-fsku"
-        ],
-        "summary": "Publish",
-        "operationId": "publish_oms_fskus__fsku_id__publish_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "fsku_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Fsku Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FskuDetailOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/fskus/{fsku_id}/retire": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-fsku",
-          "oms-fsku",
-          "oms-fsku"
-        ],
-        "summary": "Retire",
-        "operationId": "retire_oms_fskus__fsku_id__retire_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "fsku_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Fsku Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FskuDetailOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/fskus/{fsku_id}/unretire": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-fsku",
-          "oms-fsku",
-          "oms-fsku"
-        ],
-        "summary": "Unretire",
-        "operationId": "unretire_oms_fskus__fsku_id__unretire_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "fsku_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Fsku Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FskuDetailOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/platform-code-mappings": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-fsku",
-          "platform-code-mappings"
-        ],
-        "summary": "列表：平台订单行身份 → published OMS FSKU 映射",
-        "operationId": "list_platform_code_mappings_oms_platform_code_mappings_get",
-        "parameters": [
-          {
-            "name": "platform",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 32
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Platform"
-            }
-          },
-          {
-            "name": "store_code",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 128
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Store Code"
-            }
-          },
-          {
-            "name": "identity_kind",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 32
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Identity Kind"
-            }
-          },
-          {
-            "name": "identity_value",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 256
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Identity Value"
-            }
-          },
-          {
-            "name": "fsku_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer",
-                  "minimum": 1
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Fsku Id"
-            }
-          },
-          {
-            "name": "fsku_code",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 128
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Fsku Code"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 200,
-              "minimum": 1,
-              "default": 50,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformCodeMappingListOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/platform-code-mappings/bind": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-fsku",
-          "platform-code-mappings"
-        ],
-        "summary": "新增/覆盖：平台订单行身份 → published OMS FSKU",
-        "operationId": "bind_platform_code_mapping_oms_platform_code_mappings_bind_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlatformCodeMappingBindIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformCodeMappingOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/platform-code-mappings/delete": {
-      "post": {
-        "tags": [
-          "OMS",
-          "oms-fsku",
-          "platform-code-mappings"
-        ],
-        "summary": "删除：平台订单行身份 → OMS FSKU 映射",
-        "operationId": "delete_platform_code_mapping_oms_platform_code_mappings_delete_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlatformCodeMappingDeleteIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformCodeMappingOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/oms/orders/outbound-options": {
-      "get": {
-        "tags": [
-          "OMS",
-          "oms-order-outbound-options"
-        ],
-        "summary": "Get Order Outbound Options",
-        "operationId": "get_order_outbound_options_oms_orders_outbound_options_get",
-        "parameters": [
           {
             "name": "q",
             "in": "query",
@@ -7565,61 +5330,6 @@
               ],
               "title": "Q"
             }
-          },
-          {
-            "name": "platform",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Platform"
-            }
-          },
-          {
-            "name": "store_code",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Store Code"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 200,
-              "minimum": 1,
-              "default": 20,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
           }
         ],
         "responses": {
@@ -7628,7 +5338,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/OrderOutboundOptionsOut"
+                  "$ref": "#/components/schemas/PmsProjectionListOut"
                 }
               }
             }
@@ -7646,22 +5356,34 @@
         }
       }
     },
-    "/oms/orders/{order_id}/outbound-view": {
-      "get": {
+    "/pms/projections/{resource}/sync": {
+      "post": {
         "tags": [
-          "OMS",
-          "oms-order-outbound-view"
+          "pms",
+          "pms-projections"
         ],
-        "summary": "Get Order Outbound View",
-        "operationId": "get_order_outbound_view_oms_orders__order_id__outbound_view_get",
+        "summary": "Sync Pms Projection Resource",
+        "operationId": "sync_pms_projection_resource_pms_projections__resource__sync_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
         "parameters": [
           {
-            "name": "order_id",
+            "name": "resource",
             "in": "path",
             "required": true,
             "schema": {
-              "type": "integer",
-              "title": "Order Id"
+              "enum": [
+                "items",
+                "suppliers",
+                "uoms",
+                "sku-codes",
+                "barcodes"
+              ],
+              "type": "string",
+              "title": "Resource"
             }
           }
         ],
@@ -7671,7 +5393,216 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/OrderOutboundViewResponse"
+                  "$ref": "#/components/schemas/PmsProjectionSyncOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pms/projections/{resource}/check": {
+      "post": {
+        "tags": [
+          "pms",
+          "pms-projections"
+        ],
+        "summary": "Check Pms Projection Resource",
+        "operationId": "check_pms_projection_resource_pms_projections__resource__check_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "resource",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "enum": [
+                "items",
+                "suppliers",
+                "uoms",
+                "sku-codes",
+                "barcodes"
+              ],
+              "type": "string",
+              "title": "Resource"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "default": 200,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PmsProjectionCheckOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/wms/read/v1/warehouses": {
+      "get": {
+        "tags": [
+          "warehouses",
+          "wms-read-v1"
+        ],
+        "summary": "List Wms Read Warehouses",
+        "description": "List WMS warehouses for cross-system read contracts.\n\nBoundary:\n- No consumer system should read WMS DB directly.\n- No management-only fields are exposed.\n- Consumers should store scalar id + code/name snapshot when needed.",
+        "operationId": "list_wms_read_warehouses_wms_read_v1_warehouses_get",
+        "parameters": [
+          {
+            "name": "active",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "是否过滤启用仓库；默认只返回 active=true，用于跨系统下拉。",
+              "default": true,
+              "title": "Active"
+            },
+            "description": "是否过滤启用仓库；默认只返回 active=true，用于跨系统下拉。"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "default": 200,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "X-Service-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Service-Client"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WmsReadWarehouseListOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/wms/read/v1/warehouses/{warehouse_id}": {
+      "get": {
+        "tags": [
+          "warehouses",
+          "wms-read-v1"
+        ],
+        "summary": "Get Wms Read Warehouse",
+        "operationId": "get_wms_read_warehouse_wms_read_v1_warehouses__warehouse_id__get",
+        "parameters": [
+          {
+            "name": "warehouse_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "title": "Warehouse Id"
+            }
+          },
+          {
+            "name": "X-Service-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Service-Client"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WmsReadWarehouseOut"
                 }
               }
             }
@@ -8179,111 +6110,21 @@
         }
       }
     },
-    "/pms/export/items": {
+    "/system/read/v1/app-manifest": {
       "get": {
         "tags": [
-          "pms-export-items"
+          "system-read-v1"
         ],
-        "summary": "List Export Items",
-        "operationId": "list_export_items_pms_export_items_get",
-        "parameters": [
-          {
-            "name": "supplier_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer",
-                  "minimum": 1
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "按供应商过滤",
-              "title": "Supplier Id"
-            },
-            "description": "按供应商过滤"
-          },
-          {
-            "name": "enabled",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "按启用状态过滤",
-              "title": "Enabled"
-            },
-            "description": "按启用状态过滤"
-          },
-          {
-            "name": "q",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "关键词搜索（sku/name）",
-              "title": "Q"
-            },
-            "description": "关键词搜索（sku/name）"
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer",
-                  "maximum": 200,
-                  "minimum": 1
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "限制返回条数（默认 50，最大 200）",
-              "title": "Limit"
-            },
-            "description": "限制返回条数（默认 50，最大 200）"
-          }
-        ],
+        "summary": "Get WMS app manifest",
+        "description": "Return WMS self-description defaults for ERP app registration sync.\n\nBoundary:\n- This endpoint does not register itself into ERP.\n- This endpoint does not decide whether WMS is enabled, visible, or published in ERP.\n- This endpoint exposes no secrets and does not read/write business data.",
+        "operationId": "get_wms_app_manifest_system_read_v1_app_manifest_get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ItemBasic"
-                  },
-                  "title": "Response List Export Items Pms Export Items Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/WmsSystemAppManifestOut"
                 }
               }
             }
@@ -8291,41 +6132,21 @@
         }
       }
     },
-    "/pms/export/items/{item_id}": {
+    "/system/read/v1/page-catalog": {
       "get": {
         "tags": [
-          "pms-export-items"
+          "system-read-v1"
         ],
-        "summary": "Get Export Item By Id",
-        "operationId": "get_export_item_by_id_pms_export_items__item_id__get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
+        "summary": "Get WMS page catalog",
+        "description": "Return WMS page catalog for ERP page projection sync.\n\nBoundary:\n- This endpoint is read-only.\n- ERP must not connect to WMS DB directly.\n- ERP must not infer WMS pages from frontend routes.",
+        "operationId": "get_wms_page_catalog_system_read_v1_page_catalog_get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ItemBasic"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/WmsSystemPageCatalogOut"
                 }
               }
             }
@@ -8333,66 +6154,21 @@
         }
       }
     },
-    "/pms/export/uoms": {
+    "/system/read/v1/service-capabilities": {
       "get": {
         "tags": [
-          "pms-export-uoms"
+          "system-read-v1"
         ],
-        "summary": "List Export Uoms",
-        "operationId": "list_export_uoms_pms_export_uoms_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              },
-              "description": "可重复：item_id=1&item_id=2",
-              "default": [],
-              "title": "Item Id"
-            },
-            "description": "可重复：item_id=1&item_id=2"
-          },
-          {
-            "name": "item_uom_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              },
-              "description": "可重复：item_uom_id=1&item_uom_id=2",
-              "default": [],
-              "title": "Item Uom Id"
-            },
-            "description": "可重复：item_uom_id=1&item_uom_id=2"
-          }
-        ],
+        "summary": "Get WMS service capabilities",
+        "description": "Return WMS service capabilities for ERP system collaboration sync.\n\nBoundary:\n- WMS declares what WMS provides.\n- ERP must not guess WMS capabilities.\n- This endpoint is read-only.\n- This endpoint does not expose approval, grant, written, or verified state.",
+        "operationId": "get_wms_service_capabilities_system_read_v1_service_capabilities_get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/PmsExportUom"
-                  },
-                  "title": "Response List Export Uoms Pms Export Uoms Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/WmsSystemServiceCapabilitiesOut"
                 }
               }
             }
@@ -8400,41 +6176,21 @@
         }
       }
     },
-    "/pms/export/uoms/{item_uom_id}": {
+    "/system/read/v1/service-dependencies": {
       "get": {
         "tags": [
-          "pms-export-uoms"
+          "system-read-v1"
         ],
-        "summary": "Get Export Uom",
-        "operationId": "get_export_uom_pms_export_uoms__item_uom_id__get",
-        "parameters": [
-          {
-            "name": "item_uom_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Uom Id"
-            }
-          }
-        ],
+        "summary": "Get WMS service dependencies",
+        "description": "Return WMS declared outbound service dependencies for ERP collaboration sync.\n\nBoundary:\n- Declared dependency does not mean approved.\n- Declared dependency does not mean permission has been written to target system.\n- Declared dependency does not mean runtime verification has passed.\n- ERP remains responsible for matching, approval, write-back, and verification state.",
+        "operationId": "get_wms_service_dependencies_system_read_v1_service_dependencies_get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PmsExportUom"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/WmsSystemServiceDependenciesOut"
                 }
               }
             }
@@ -8442,93 +6198,18 @@
         }
       }
     },
-    "/pms/export/items/{item_id}/uoms": {
+    "/system/read/v1/iam-snapshot": {
       "get": {
         "tags": [
-          "pms-export-uoms"
+          "system-read-v1"
         ],
-        "summary": "List Export Item Uoms",
-        "operationId": "list_export_item_uoms_pms_export_items__item_id__uoms_get",
+        "summary": "Get WMS IAM snapshot",
+        "description": "Return WMS users, user permissions, and page permission catalog for ERP projection sync.\n\nBoundary:\n- Only ERP service client should be granted this capability.\n- This endpoint is read-only.\n- This endpoint never exposes password_hash, tokens, or secrets.\n- This endpoint does not write WMS permissions.\n- This endpoint does not migrate permission execution to ERP.",
+        "operationId": "get_wms_iam_snapshot_system_read_v1_iam_snapshot_get",
         "parameters": [
           {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/PmsExportUom"
-                  },
-                  "title": "Response List Export Item Uoms Pms Export Items  Item Id  Uoms Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/export/sku-codes": {
-      "get": {
-        "tags": [
-          "pms-export-sku-codes"
-        ],
-        "summary": "List Export Sku Codes",
-        "operationId": "list_export_sku_codes_pms_export_sku_codes_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              },
-              "description": "可重复：item_id=1&item_id=2",
-              "default": [],
-              "title": "Item Id"
-            },
-            "description": "可重复：item_id=1&item_id=2"
-          },
-          {
-            "name": "sku_code_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              },
-              "description": "可重复：sku_code_id=1&sku_code_id=2",
-              "default": [],
-              "title": "Sku Code Id"
-            },
-            "description": "可重复：sku_code_id=1&sku_code_id=2"
-          },
-          {
-            "name": "code",
-            "in": "query",
+            "name": "X-Service-Client",
+            "in": "header",
             "required": false,
             "schema": {
               "anyOf": [
@@ -8539,41 +6220,8 @@
                   "type": "null"
                 }
               ],
-              "description": "精确 SKU code，大小写不敏感",
-              "title": "Code"
-            },
-            "description": "精确 SKU code，大小写不敏感"
-          },
-          {
-            "name": "active",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "默认只返回 active=true；传空则不过滤",
-              "default": true,
-              "title": "Active"
-            },
-            "description": "默认只返回 active=true；传空则不过滤"
-          },
-          {
-            "name": "primary_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "true 时只返回主编码",
-              "default": false,
-              "title": "Primary Only"
-            },
-            "description": "true 时只返回主编码"
+              "title": "X-Service-Client"
+            }
           }
         ],
         "responses": {
@@ -8582,11 +6230,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/PmsExportSkuCode"
-                  },
-                  "title": "Response List Export Sku Codes Pms Export Sku Codes Get"
+                  "$ref": "#/components/schemas/WmsSystemIamSnapshotOut"
                 }
               }
             }
@@ -8604,433 +6248,41 @@
         }
       }
     },
-    "/pms/export/sku-codes/resolve": {
-      "get": {
-        "tags": [
-          "pms-export-sku-codes"
-        ],
-        "summary": "Resolve Export Sku Code",
-        "operationId": "resolve_export_sku_code_pms_export_sku_codes_resolve_get",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "description": "SKU code，大小写不敏感",
-              "title": "Code"
-            },
-            "description": "SKU code，大小写不敏感"
-          },
-          {
-            "name": "enabled_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "默认只解析 enabled=true 的商品",
-              "default": true,
-              "title": "Enabled Only"
-            },
-            "description": "默认只解析 enabled=true 的商品"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsExportSkuCodeResolution"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/export/sku-codes/{sku_code_id}": {
-      "get": {
-        "tags": [
-          "pms-export-sku-codes"
-        ],
-        "summary": "Get Export Sku Code",
-        "operationId": "get_export_sku_code_pms_export_sku_codes__sku_code_id__get",
-        "parameters": [
-          {
-            "name": "sku_code_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Sku Code Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsExportSkuCode"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/export/items/{item_id}/sku-codes": {
-      "get": {
-        "tags": [
-          "pms-export-sku-codes"
-        ],
-        "summary": "List Export Item Sku Codes",
-        "operationId": "list_export_item_sku_codes_pms_export_items__item_id__sku_codes_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          },
-          {
-            "name": "active",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "默认只返回 active=true；传空则不过滤",
-              "default": true,
-              "title": "Active"
-            },
-            "description": "默认只返回 active=true；传空则不过滤"
-          },
-          {
-            "name": "primary_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "true 时只返回主编码",
-              "default": false,
-              "title": "Primary Only"
-            },
-            "description": "true 时只返回主编码"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/PmsExportSkuCode"
-                  },
-                  "title": "Response List Export Item Sku Codes Pms Export Items  Item Id  Sku Codes Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/export/barcodes": {
-      "get": {
-        "tags": [
-          "pms-export-barcodes"
-        ],
-        "summary": "List Export Barcodes",
-        "operationId": "list_export_barcodes_pms_export_barcodes_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              },
-              "description": "可重复：item_id=1&item_id=2",
-              "default": [],
-              "title": "Item Id"
-            },
-            "description": "可重复：item_id=1&item_id=2"
-          },
-          {
-            "name": "item_uom_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              },
-              "description": "可重复：item_uom_id=1&item_uom_id=2",
-              "default": [],
-              "title": "Item Uom Id"
-            },
-            "description": "可重复：item_uom_id=1&item_uom_id=2"
-          },
-          {
-            "name": "barcode",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "精确条码查询",
-              "title": "Barcode"
-            },
-            "description": "精确条码查询"
-          },
-          {
-            "name": "active",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "默认只返回 active=true；传空则不过滤",
-              "default": true,
-              "title": "Active"
-            },
-            "description": "默认只返回 active=true；传空则不过滤"
-          },
-          {
-            "name": "primary_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "true 时只返回主条码",
-              "default": false,
-              "title": "Primary Only"
-            },
-            "description": "true 时只返回主条码"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/PmsExportBarcode"
-                  },
-                  "title": "Response List Export Barcodes Pms Export Barcodes Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/export/barcodes/{barcode_id}": {
-      "get": {
-        "tags": [
-          "pms-export-barcodes"
-        ],
-        "summary": "Get Export Barcode",
-        "operationId": "get_export_barcode_pms_export_barcodes__barcode_id__get",
-        "parameters": [
-          {
-            "name": "barcode_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Barcode Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsExportBarcode"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/export/items/{item_id}/barcodes": {
-      "get": {
-        "tags": [
-          "pms-export-barcodes"
-        ],
-        "summary": "List Export Item Barcodes",
-        "operationId": "list_export_item_barcodes_pms_export_items__item_id__barcodes_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          },
-          {
-            "name": "active",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "默认只返回 active=true；传空则不过滤",
-              "default": true,
-              "title": "Active"
-            },
-            "description": "默认只返回 active=true；传空则不过滤"
-          },
-          {
-            "name": "primary_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "true 时只返回主条码",
-              "default": false,
-              "title": "Primary Only"
-            },
-            "description": "true 时只返回主条码"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/PmsExportBarcode"
-                  },
-                  "title": "Response List Export Item Barcodes Pms Export Items  Item Id  Barcodes Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/export/items/barcode-probe": {
+    "/system/write/v1/service-permissions/apply": {
       "post": {
         "tags": [
-          "pms-export-items"
+          "system-write-v1"
         ],
-        "summary": "Probe Barcode",
-        "operationId": "probe_barcode_pms_export_items_barcode_probe_post",
+        "summary": "Apply WMS service permission",
+        "description": "Apply one WMS local service permission from ERP.\n\nBoundary:\n- Only X-Service-Client: erp-service may call this endpoint.\n- Writes only wms_service_clients and wms_service_permissions.\n- Does not write ERP tables.\n- Does not write other systems.\n- Does not read users / permissions / user_permissions.",
+        "operationId": "apply_wms_service_permission_system_write_v1_service_permissions_apply_post",
+        "parameters": [
+          {
+            "name": "X-Service-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Service-Client"
+            }
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/BarcodeProbeIn"
+                "$ref": "#/components/schemas/WmsSystemServicePermissionApplyIn"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -9038,7 +6290,79 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BarcodeProbeOut"
+                  "$ref": "#/components/schemas/WmsSystemServicePermissionApplyOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/system/write/v1/service-permissions/verify": {
+      "get": {
+        "tags": [
+          "system-write-v1"
+        ],
+        "summary": "Verify WMS service permission",
+        "description": "Verify one WMS local service permission for ERP.\n\nBoundary:\n- Only X-Service-Client: erp-service may call this endpoint.\n- Reads only wms_service_clients, wms_service_capabilities, and wms_service_permissions.\n- Does not write anything.\n- Does not read users / permissions / user_permissions.",
+        "operationId": "verify_wms_service_permission_system_write_v1_service_permissions_verify_get",
+        "parameters": [
+          {
+            "name": "client_code",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 64,
+              "title": "Client Code"
+            }
+          },
+          {
+            "name": "capability_code",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128,
+              "title": "Capability Code"
+            }
+          },
+          {
+            "name": "X-Service-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Service-Client"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WmsSystemServicePermissionVerifyOut"
                 }
               }
             }
@@ -9114,3278 +6438,6 @@
                   },
                   "title": "Response List Public Suppliers Partners Export Suppliers Get"
                 }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/items/{item_id}/aggregate": {
-      "get": {
-        "tags": [
-          "items-owner-aggregate"
-        ],
-        "summary": "Get Item Aggregate",
-        "operationId": "get_item_aggregate_items__item_id__aggregate_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAggregateOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "items-owner-aggregate"
-        ],
-        "summary": "Replace Item Aggregate",
-        "operationId": "replace_item_aggregate_items__item_id__aggregate_put",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemAggregatePayload"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAggregateOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/items/aggregate": {
-      "post": {
-        "tags": [
-          "items-owner-aggregate"
-        ],
-        "summary": "Create Item Aggregate",
-        "operationId": "create_item_aggregate_items_aggregate_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemAggregatePayload"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAggregateOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/items/list-rows": {
-      "get": {
-        "tags": [
-          "items-list"
-        ],
-        "summary": "List Item Rows",
-        "operationId": "list_item_rows_items_list_rows_get",
-        "parameters": [
-          {
-            "name": "enabled",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "true=有效商品；false=无效商品；不传=全部",
-              "title": "Enabled"
-            },
-            "description": "true=有效商品；false=无效商品；不传=全部"
-          },
-          {
-            "name": "supplier_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer",
-                  "minimum": 1
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "按供应商过滤",
-              "title": "Supplier Id"
-            },
-            "description": "按供应商过滤"
-          },
-          {
-            "name": "q",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "关键词搜索 SKU / 名称 / 规格 / 品牌 / 分类 / 供应商 / 主条码",
-              "title": "Q"
-            },
-            "description": "关键词搜索 SKU / 名称 / 规格 / 品牌 / 分类 / 供应商 / 主条码"
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 500,
-              "minimum": 1,
-              "default": 200,
-              "title": "Limit"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ItemListRowOut"
-                  },
-                  "title": "Response List Item Rows Items List Rows Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/items/{item_id}/list-detail": {
-      "get": {
-        "tags": [
-          "items-list"
-        ],
-        "summary": "Get Item List Detail",
-        "operationId": "get_item_list_detail_items__item_id__list_detail_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemListDetailOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/items": {
-      "post": {
-        "tags": [
-          "items"
-        ],
-        "summary": "Create Item",
-        "operationId": "create_item_items_post",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemCreate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "tags": [
-          "items"
-        ],
-        "summary": "Get All Items",
-        "operationId": "get_all_items_items_get",
-        "parameters": [
-          {
-            "name": "supplier_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer",
-                  "minimum": 1
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "按供应商过滤（采购单创建/收货用）",
-              "title": "Supplier Id"
-            },
-            "description": "按供应商过滤（采购单创建/收货用）"
-          },
-          {
-            "name": "enabled",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "按启用状态过滤（enabled=true 只取启用商品）",
-              "title": "Enabled"
-            },
-            "description": "按启用状态过滤（enabled=true 只取启用商品）"
-          },
-          {
-            "name": "q",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "关键词搜索（命中 sku/name/primary_barcode/id；大小写不敏感）",
-              "title": "Q"
-            },
-            "description": "关键词搜索（命中 sku/name/primary_barcode/id；大小写不敏感）"
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer",
-                  "maximum": 200,
-                  "minimum": 1
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "限制返回条数（默认 50，最大 200）",
-              "title": "Limit"
-            },
-            "description": "限制返回条数（默认 50，最大 200）"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ItemOut"
-                  },
-                  "title": "Response Get All Items Items Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/items/sku/{sku}": {
-      "get": {
-        "tags": [
-          "items"
-        ],
-        "summary": "Get Item By Sku",
-        "operationId": "get_item_by_sku_items_sku__sku__get",
-        "parameters": [
-          {
-            "name": "sku",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Sku"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/items/{id}": {
-      "get": {
-        "tags": [
-          "items"
-        ],
-        "summary": "Get Item By Id",
-        "operationId": "get_item_by_id_items__id__get",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "items"
-        ],
-        "summary": "Update Item",
-        "operationId": "update_item_items__id__patch",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/brands": {
-      "get": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "List Pms Brands",
-        "operationId": "list_pms_brands_pms_brands_get",
-        "parameters": [
-          {
-            "name": "active_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Active Only"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListOut_PmsBrandOut_"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Create Pms Brand",
-        "operationId": "create_pms_brand_pms_brands_post",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PmsBrandCreate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsBrandOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/brands/{brand_id}": {
-      "patch": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Update Pms Brand",
-        "operationId": "update_pms_brand_pms_brands__brand_id__patch",
-        "parameters": [
-          {
-            "name": "brand_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Brand Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PmsBrandUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsBrandOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/brands/{brand_id}/enable": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Enable Pms Brand",
-        "operationId": "enable_pms_brand_pms_brands__brand_id__enable_post",
-        "parameters": [
-          {
-            "name": "brand_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Brand Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsBrandOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/brands/{brand_id}/disable": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Disable Pms Brand",
-        "operationId": "disable_pms_brand_pms_brands__brand_id__disable_post",
-        "parameters": [
-          {
-            "name": "brand_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Brand Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsBrandOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/brands/{brand_id}/lock": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Lock Pms Brand",
-        "operationId": "lock_pms_brand_pms_brands__brand_id__lock_post",
-        "parameters": [
-          {
-            "name": "brand_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Brand Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsBrandOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/brands/{brand_id}/unlock": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Unlock Pms Brand",
-        "operationId": "unlock_pms_brand_pms_brands__brand_id__unlock_post",
-        "parameters": [
-          {
-            "name": "brand_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Brand Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsBrandOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/categories": {
-      "get": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "List Pms Categories",
-        "operationId": "list_pms_categories_pms_categories_get",
-        "parameters": [
-          {
-            "name": "product_kind",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Product Kind"
-            }
-          },
-          {
-            "name": "active_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Active Only"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListOut_PmsCategoryOut_"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Create Pms Category",
-        "operationId": "create_pms_category_pms_categories_post",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PmsCategoryCreate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsCategoryOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/categories/{category_id}": {
-      "patch": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Update Pms Category",
-        "operationId": "update_pms_category_pms_categories__category_id__patch",
-        "parameters": [
-          {
-            "name": "category_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Category Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PmsCategoryUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsCategoryOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/categories/{category_id}/enable": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Enable Pms Category",
-        "operationId": "enable_pms_category_pms_categories__category_id__enable_post",
-        "parameters": [
-          {
-            "name": "category_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Category Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsCategoryOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/categories/{category_id}/disable": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Disable Pms Category",
-        "operationId": "disable_pms_category_pms_categories__category_id__disable_post",
-        "parameters": [
-          {
-            "name": "category_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Category Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsCategoryOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/categories/{category_id}/lock": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Lock Pms Category",
-        "operationId": "lock_pms_category_pms_categories__category_id__lock_post",
-        "parameters": [
-          {
-            "name": "category_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Category Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsCategoryOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/categories/{category_id}/unlock": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Unlock Pms Category",
-        "operationId": "unlock_pms_category_pms_categories__category_id__unlock_post",
-        "parameters": [
-          {
-            "name": "category_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Category Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PmsCategoryOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/item-attribute-defs": {
-      "get": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "List Item Attribute Defs",
-        "operationId": "list_item_attribute_defs_pms_item_attribute_defs_get",
-        "parameters": [
-          {
-            "name": "product_kind",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Product Kind"
-            }
-          },
-          {
-            "name": "active_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Active Only"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListOut_ItemAttributeDefOut_"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Create Item Attribute Def",
-        "operationId": "create_item_attribute_def_pms_item_attribute_defs_post",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemAttributeDefCreate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAttributeDefOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/item-attribute-defs/{attribute_def_id}": {
-      "patch": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Update Item Attribute Def",
-        "operationId": "update_item_attribute_def_pms_item_attribute_defs__attribute_def_id__patch",
-        "parameters": [
-          {
-            "name": "attribute_def_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Attribute Def Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemAttributeDefUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAttributeDefOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/item-attribute-defs/{attribute_def_id}/enable": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Enable Item Attribute Def",
-        "operationId": "enable_item_attribute_def_pms_item_attribute_defs__attribute_def_id__enable_post",
-        "parameters": [
-          {
-            "name": "attribute_def_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Attribute Def Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAttributeDefOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/item-attribute-defs/{attribute_def_id}/disable": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Disable Item Attribute Def",
-        "operationId": "disable_item_attribute_def_pms_item_attribute_defs__attribute_def_id__disable_post",
-        "parameters": [
-          {
-            "name": "attribute_def_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Attribute Def Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAttributeDefOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/item-attribute-defs/{attribute_def_id}/lock": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Lock Item Attribute Def",
-        "operationId": "lock_item_attribute_def_pms_item_attribute_defs__attribute_def_id__lock_post",
-        "parameters": [
-          {
-            "name": "attribute_def_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Attribute Def Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAttributeDefOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/item-attribute-defs/{attribute_def_id}/unlock": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Unlock Item Attribute Def",
-        "operationId": "unlock_item_attribute_def_pms_item_attribute_defs__attribute_def_id__unlock_post",
-        "parameters": [
-          {
-            "name": "attribute_def_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Attribute Def Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAttributeDefOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/item-attribute-defs/{attribute_def_id}/options": {
-      "get": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "List Item Attribute Options",
-        "operationId": "list_item_attribute_options_pms_item_attribute_defs__attribute_def_id__options_get",
-        "parameters": [
-          {
-            "name": "attribute_def_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Attribute Def Id"
-            }
-          },
-          {
-            "name": "active_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Active Only"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListOut_ItemAttributeOptionOut_"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Create Item Attribute Option",
-        "operationId": "create_item_attribute_option_pms_item_attribute_defs__attribute_def_id__options_post",
-        "parameters": [
-          {
-            "name": "attribute_def_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Attribute Def Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemAttributeOptionCreate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAttributeOptionOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/item-attribute-options/{option_id}": {
-      "patch": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Update Item Attribute Option",
-        "operationId": "update_item_attribute_option_pms_item_attribute_options__option_id__patch",
-        "parameters": [
-          {
-            "name": "option_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Option Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemAttributeOptionUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAttributeOptionOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/item-attribute-options/{option_id}/lock": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Lock Item Attribute Option",
-        "operationId": "lock_item_attribute_option_pms_item_attribute_options__option_id__lock_post",
-        "parameters": [
-          {
-            "name": "option_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Option Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAttributeOptionOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/item-attribute-options/{option_id}/unlock": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Unlock Item Attribute Option",
-        "operationId": "unlock_item_attribute_option_pms_item_attribute_options__option_id__unlock_post",
-        "parameters": [
-          {
-            "name": "option_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Option Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAttributeOptionOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/item-attribute-options/{option_id}/enable": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Enable Item Attribute Option",
-        "operationId": "enable_item_attribute_option_pms_item_attribute_options__option_id__enable_post",
-        "parameters": [
-          {
-            "name": "option_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Option Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAttributeOptionOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/item-attribute-options/{option_id}/disable": {
-      "post": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Disable Item Attribute Option",
-        "operationId": "disable_item_attribute_option_pms_item_attribute_options__option_id__disable_post",
-        "parameters": [
-          {
-            "name": "option_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Option Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemAttributeOptionOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/items/{item_id}/attributes": {
-      "get": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "List Item Attribute Values",
-        "operationId": "list_item_attribute_values_items__item_id__attributes_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListOut_ItemAttributeValueOut_"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "pms-master-data"
-        ],
-        "summary": "Replace Item Attribute Values",
-        "operationId": "replace_item_attribute_values_items__item_id__attributes_put",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemAttributeValuesReplaceIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListOut_ItemAttributeValueOut_"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/items/{item_id}/sku-codes": {
-      "get": {
-        "tags": [
-          "item-sku-codes"
-        ],
-        "summary": "List Item Sku Codes",
-        "operationId": "list_item_sku_codes_items__item_id__sku_codes_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ItemSkuCodeOut"
-                  },
-                  "title": "Response List Item Sku Codes Items  Item Id  Sku Codes Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "item-sku-codes"
-        ],
-        "summary": "Create Item Sku Code",
-        "operationId": "create_item_sku_code_items__item_id__sku_codes_post",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemSkuCodeCreate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemSkuCodeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/items/{item_id}/sku-codes/{code_id}/disable": {
-      "post": {
-        "tags": [
-          "item-sku-codes"
-        ],
-        "summary": "Disable Item Sku Code",
-        "operationId": "disable_item_sku_code_items__item_id__sku_codes__code_id__disable_post",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          },
-          {
-            "name": "code_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Code Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemSkuCodeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/items/{item_id}/sku-codes/{code_id}/enable": {
-      "post": {
-        "tags": [
-          "item-sku-codes"
-        ],
-        "summary": "Enable Item Sku Code",
-        "operationId": "enable_item_sku_code_items__item_id__sku_codes__code_id__enable_post",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          },
-          {
-            "name": "code_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Code Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemSkuCodeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/items/{item_id}/sku-codes/change-primary": {
-      "post": {
-        "tags": [
-          "item-sku-codes"
-        ],
-        "summary": "Change Primary Item Sku Code",
-        "operationId": "change_primary_item_sku_code_items__item_id__sku_codes_change_primary_post",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemSkuCodeChangePrimary"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemSkuCodeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/sku-coding/generate": {
-      "post": {
-        "tags": [
-          "pms-sku-coding"
-        ],
-        "summary": "Generate Sku",
-        "operationId": "generate_sku_pms_sku_coding_generate_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SkuGenerateIn"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SkuGenerateOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pms/sku-coding/items/{item_id}/generate": {
-      "post": {
-        "tags": [
-          "pms-sku-coding"
-        ],
-        "summary": "Generate Sku From Item",
-        "operationId": "generate_sku_from_item_pms_sku_coding_items__item_id__generate_post",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SkuGenerateOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/item-barcodes": {
-      "post": {
-        "tags": [
-          "item-barcodes"
-        ],
-        "summary": "Create Barcode",
-        "operationId": "create_barcode_item_barcodes_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemBarcodeCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemBarcodeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/item-barcodes/by-items": {
-      "get": {
-        "tags": [
-          "item-barcodes"
-        ],
-        "summary": "List Barcodes For Items",
-        "operationId": "list_barcodes_for_items_item_barcodes_by_items_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              },
-              "description": "item_id 可重复：item_id=1&item_id=2",
-              "title": "Item Id"
-            },
-            "description": "item_id 可重复：item_id=1&item_id=2"
-          },
-          {
-            "name": "active_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "默认只返回 active=true",
-              "default": true,
-              "title": "Active Only"
-            },
-            "description": "默认只返回 active=true"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ItemBarcodeOut"
-                  },
-                  "title": "Response List Barcodes For Items Item Barcodes By Items Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/item-barcodes/item/{item_id}/rows": {
-      "get": {
-        "tags": [
-          "item-barcodes"
-        ],
-        "summary": "List Barcode Rows For Item",
-        "description": "Owner 读模型：\n- 返回“一个商品、一个单位、一行条码”的复合结果\n- 供 PMS 商品条码页直接渲染当前商品条码表",
-        "operationId": "list_barcode_rows_for_item_item_barcodes_item__item_id__rows_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          },
-          {
-            "name": "active_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "true 时仅返回 active=true 的条码行",
-              "default": false,
-              "title": "Active Only"
-            },
-            "description": "true 时仅返回 active=true 的条码行"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ItemBarcodeCompositeRow"
-                  },
-                  "title": "Response List Barcode Rows For Item Item Barcodes Item  Item Id  Rows Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/item-barcodes/item/{item_id}": {
-      "get": {
-        "tags": [
-          "item-barcodes"
-        ],
-        "summary": "List Barcodes For Item",
-        "operationId": "list_barcodes_for_item_item_barcodes_item__item_id__get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ItemBarcodeOut"
-                  },
-                  "title": "Response List Barcodes For Item Item Barcodes Item  Item Id  Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/item-barcodes/{id}/set-primary": {
-      "post": {
-        "tags": [
-          "item-barcodes"
-        ],
-        "summary": "Set Primary",
-        "operationId": "set_primary_item_barcodes__id__set_primary_post",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemBarcodeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/item-barcodes/{id}": {
-      "patch": {
-        "tags": [
-          "item-barcodes"
-        ],
-        "summary": "Update Barcode",
-        "operationId": "update_barcode_item_barcodes__id__patch",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemBarcodeUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemBarcodeOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "item-barcodes"
-        ],
-        "summary": "Delete Barcode",
-        "operationId": "delete_barcode_item_barcodes__id__delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Id"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/item-uoms": {
-      "post": {
-        "tags": [
-          "item-uoms"
-        ],
-        "summary": "Create Item Uom Route",
-        "operationId": "create_item_uom_route_item_uoms_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemUomCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemUomOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/item-uoms/item/{item_id}": {
-      "get": {
-        "tags": [
-          "item-uoms"
-        ],
-        "summary": "List Item Uoms",
-        "operationId": "list_item_uoms_item_uoms_item__item_id__get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ItemUomOut"
-                  },
-                  "title": "Response List Item Uoms Item Uoms Item  Item Id  Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/item-uoms/item/{item_id}/rows": {
-      "get": {
-        "tags": [
-          "item-uoms"
-        ],
-        "summary": "List Item Uom Rows For Item",
-        "operationId": "list_item_uom_rows_for_item_item_uoms_item__item_id__rows_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Item Id"
-            }
-          },
-          {
-            "name": "active_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "true 时仅挂 active=true 的条码；无条码包装仍返回",
-              "default": false,
-              "title": "Active Only"
-            },
-            "description": "true 时仅挂 active=true 的条码；无条码包装仍返回"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ItemUomBarcodeRowOut"
-                  },
-                  "title": "Response List Item Uom Rows For Item Item Uoms Item  Item Id  Rows Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/item-uoms/by-items": {
-      "get": {
-        "tags": [
-          "item-uoms"
-        ],
-        "summary": "List Item Uoms For Items",
-        "operationId": "list_item_uoms_for_items_item_uoms_by_items_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              },
-              "default": [],
-              "title": "Item Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ItemUomOut"
-                  },
-                  "title": "Response List Item Uoms For Items Item Uoms By Items Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/item-uoms/rows/by-items": {
-      "get": {
-        "tags": [
-          "item-uoms"
-        ],
-        "summary": "List Item Uom Rows For Items",
-        "operationId": "list_item_uom_rows_for_items_item_uoms_rows_by_items_get",
-        "parameters": [
-          {
-            "name": "item_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              },
-              "default": [],
-              "title": "Item Id"
-            }
-          },
-          {
-            "name": "active_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "true 时仅挂 active=true 的条码；无条码包装仍返回",
-              "default": false,
-              "title": "Active Only"
-            },
-            "description": "true 时仅挂 active=true 的条码；无条码包装仍返回"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ItemUomBarcodeRowOut"
-                  },
-                  "title": "Response List Item Uom Rows For Items Item Uoms Rows By Items Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/item-uoms/{id}": {
-      "patch": {
-        "tags": [
-          "item-uoms"
-        ],
-        "summary": "Update Item Uom Route",
-        "operationId": "update_item_uom_route_item_uoms__id__patch",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ItemUomUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ItemUomOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "item-uoms"
-        ],
-        "summary": "Delete Item Uom Route",
-        "operationId": "delete_item_uom_route_item_uoms__id__delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/partners/suppliers": {
-      "get": {
-        "tags": [
-          "suppliers"
-        ],
-        "summary": "List Suppliers",
-        "operationId": "list_suppliers_partners_suppliers_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "active",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "active=true 仅返回合作中供应商（owner 页面使用）",
-              "title": "Active"
-            },
-            "description": "active=true 仅返回合作中供应商（owner 页面使用）"
-          },
-          {
-            "name": "q",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "名称/编码/联系人/电话/邮箱/微信 模糊搜索",
-              "title": "Q"
-            },
-            "description": "名称/编码/联系人/电话/邮箱/微信 模糊搜索"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/SupplierOut"
-                  },
-                  "title": "Response List Suppliers Partners Suppliers Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "suppliers"
-        ],
-        "summary": "Create Supplier",
-        "operationId": "create_supplier_partners_suppliers_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SupplierCreateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SupplierOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/partners/suppliers/{supplier_id}": {
-      "patch": {
-        "tags": [
-          "suppliers"
-        ],
-        "summary": "Update Supplier",
-        "operationId": "update_supplier_partners_suppliers__supplier_id__patch",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "supplier_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Supplier Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SupplierUpdateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SupplierOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/partners/suppliers/{supplier_id}/contacts": {
-      "post": {
-        "tags": [
-          "supplier-contacts"
-        ],
-        "summary": "Supplier Create Contact",
-        "operationId": "supplier_create_contact_partners_suppliers__supplier_id__contacts_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "supplier_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Supplier Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SupplierContactCreateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SupplierContactOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/partners/supplier-contacts/{contact_id}": {
-      "patch": {
-        "tags": [
-          "supplier-contacts"
-        ],
-        "summary": "Supplier Update Contact",
-        "operationId": "supplier_update_contact_partners_supplier_contacts__contact_id__patch",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "contact_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Contact Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SupplierContactUpdateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SupplierContactOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "supplier-contacts"
-        ],
-        "summary": "Supplier Delete Contact",
-        "operationId": "supplier_delete_contact_partners_supplier_contacts__contact_id__delete",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "contact_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "title": "Contact Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
               }
             }
           },
@@ -12589,11 +6641,6 @@
         ],
         "summary": "独立 Logistics 拉取待导入交接数据",
         "operationId": "list_shipping_assist_handoff_ready_shipping_assist_handoffs_ready_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
         "parameters": [
           {
             "name": "source_doc_type",
@@ -12661,6 +6708,22 @@
               "default": 0,
               "title": "Offset"
             }
+          },
+          {
+            "name": "X-Service-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Service-Client"
+            }
           }
         ],
         "responses": {
@@ -12694,15 +6757,33 @@
         ],
         "summary": "独立 Logistics 导入结果回写",
         "operationId": "record_shipping_assist_handoff_import_result_shipping_assist_handoffs_import_results_post",
+        "parameters": [
+          {
+            "name": "X-Service-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Service-Client"
+            }
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/LogisticsImportResultIn"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -12725,12 +6806,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
+        }
       }
     },
     "/shipping-assist/handoffs/shipping-results": {
@@ -12740,15 +6816,33 @@
         ],
         "summary": "独立 Logistics 发货完成结果回写",
         "operationId": "record_shipping_assist_handoff_shipping_result_shipping_assist_handoffs_shipping_results_post",
+        "parameters": [
+          {
+            "name": "X-Service-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Service-Client"
+            }
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/LogisticsShippingResultIn"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -12771,12 +6865,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
+        }
       }
     },
     "/shipping-assist/records": {
@@ -16019,951 +10108,6 @@
   },
   "components": {
     "schemas": {
-      "AggregateBarcodeInput": {
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Id"
-          },
-          "barcode": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Barcode"
-          },
-          "symbology": {
-            "type": "string",
-            "enum": [
-              "EAN13",
-              "UPC",
-              "UPC12",
-              "EAN8",
-              "GS1",
-              "CUSTOM"
-            ],
-            "title": "Symbology",
-            "default": "CUSTOM"
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active",
-            "default": true
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary",
-            "default": false
-          },
-          "bind_uom_key": {
-            "type": "string",
-            "maxLength": 64,
-            "minLength": 1,
-            "title": "Bind Uom Key"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "barcode",
-          "bind_uom_key"
-        ],
-        "title": "AggregateBarcodeInput"
-      },
-      "AggregateBarcodeOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "item_uom_id": {
-            "type": "integer",
-            "title": "Item Uom Id"
-          },
-          "barcode": {
-            "type": "string",
-            "title": "Barcode"
-          },
-          "symbology": {
-            "type": "string",
-            "title": "Symbology"
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active"
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary"
-          },
-          "created_at": {
-            "anyOf": [
-              {},
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {},
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "id",
-          "item_id",
-          "item_uom_id",
-          "barcode",
-          "symbology",
-          "active",
-          "is_primary"
-        ],
-        "title": "AggregateBarcodeOut"
-      },
-      "AggregateItemInput": {
-        "properties": {
-          "sku": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Sku"
-          },
-          "name": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Name"
-          },
-          "spec": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spec"
-          },
-          "brand_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Brand Id"
-          },
-          "category_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Category Id"
-          },
-          "enabled": {
-            "type": "boolean",
-            "title": "Enabled",
-            "default": true
-          },
-          "supplier_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Supplier Id"
-          },
-          "lot_source_policy": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "INTERNAL_ONLY",
-                  "SUPPLIER_ONLY"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Lot Source Policy"
-          },
-          "expiry_policy": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "NONE",
-                  "REQUIRED"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Expiry Policy"
-          },
-          "derivation_allowed": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Derivation Allowed"
-          },
-          "uom_governance_enabled": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Uom Governance Enabled"
-          },
-          "shelf_life_value": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "exclusiveMinimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Shelf Life Value"
-          },
-          "shelf_life_unit": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "DAY",
-                  "WEEK",
-                  "MONTH",
-                  "YEAR"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Shelf Life Unit"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "sku",
-          "name"
-        ],
-        "title": "AggregateItemInput"
-      },
-      "AggregateUomInput": {
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Id"
-          },
-          "uom_key": {
-            "type": "string",
-            "maxLength": 64,
-            "minLength": 1,
-            "title": "Uom Key"
-          },
-          "uom": {
-            "type": "string",
-            "maxLength": 16,
-            "minLength": 1,
-            "title": "Uom"
-          },
-          "ratio_to_base": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Ratio To Base"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 32
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "net_weight_kg": {
-            "anyOf": [
-              {
-                "type": "number",
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Weight Kg"
-          },
-          "is_base": {
-            "type": "boolean",
-            "title": "Is Base",
-            "default": false
-          },
-          "is_purchase_default": {
-            "type": "boolean",
-            "title": "Is Purchase Default",
-            "default": false
-          },
-          "is_inbound_default": {
-            "type": "boolean",
-            "title": "Is Inbound Default",
-            "default": false
-          },
-          "is_outbound_default": {
-            "type": "boolean",
-            "title": "Is Outbound Default",
-            "default": false
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "uom_key",
-          "uom",
-          "ratio_to_base"
-        ],
-        "title": "AggregateUomInput"
-      },
-      "BarcodeProbeError": {
-        "properties": {
-          "stage": {
-            "type": "string",
-            "title": "Stage"
-          },
-          "error": {
-            "type": "string",
-            "title": "Error"
-          }
-        },
-        "type": "object",
-        "required": [
-          "stage",
-          "error"
-        ],
-        "title": "BarcodeProbeError"
-      },
-      "BarcodeProbeIn": {
-        "properties": {
-          "barcode": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Barcode"
-          }
-        },
-        "type": "object",
-        "required": [
-          "barcode"
-        ],
-        "title": "BarcodeProbeIn"
-      },
-      "BarcodeProbeOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok"
-          },
-          "status": {
-            "$ref": "#/components/schemas/BarcodeProbeStatus"
-          },
-          "barcode": {
-            "type": "string",
-            "title": "Barcode"
-          },
-          "item_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Item Id"
-          },
-          "item_uom_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Item Uom Id"
-          },
-          "ratio_to_base": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Ratio To Base"
-          },
-          "symbology": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Symbology"
-          },
-          "active": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Active"
-          },
-          "item_basic": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ItemBasic"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "errors": {
-            "items": {
-              "$ref": "#/components/schemas/BarcodeProbeError"
-            },
-            "type": "array",
-            "title": "Errors"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ok",
-          "status",
-          "barcode"
-        ],
-        "title": "BarcodeProbeOut"
-      },
-      "BarcodeProbeStatus": {
-        "type": "string",
-        "enum": [
-          "BOUND",
-          "UNBOUND",
-          "ERROR"
-        ],
-        "title": "BarcodeProbeStatus"
-      },
-      "BindWarehouseIn": {
-        "properties": {
-          "warehouse_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Warehouse Id"
-          },
-          "is_default": {
-            "type": "boolean",
-            "title": "Is Default",
-            "default": false
-          },
-          "priority": {
-            "type": "integer",
-            "maximum": 100000.0,
-            "minimum": 0.0,
-            "title": "Priority",
-            "default": 100
-          },
-          "is_top": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Top",
-            "description": "是否主仓；若为 null，由后端按 is_default 推导"
-          }
-        },
-        "type": "object",
-        "required": [
-          "warehouse_id"
-        ],
-        "title": "BindWarehouseIn"
-      },
-      "BindWarehouseOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "BindWarehouseOut"
-      },
-      "BindingDeleteOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "BindingDeleteOut"
-      },
-      "BindingUpdateIn": {
-        "properties": {
-          "is_default": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Default"
-          },
-          "priority": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "maximum": 100000.0,
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Priority"
-          },
-          "is_top": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Top"
-          }
-        },
-        "type": "object",
-        "title": "BindingUpdateIn"
-      },
-      "BindingUpdateOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "BindingUpdateOut"
-      },
-      "CartLineItemIn": {
-        "properties": {
-          "row_no": {
-            "type": "integer",
-            "maximum": 6.0,
-            "minimum": 1.0,
-            "title": "Row No"
-          },
-          "checked": {
-            "type": "boolean",
-            "title": "Checked",
-            "default": false
-          },
-          "qty": {
-            "type": "integer",
-            "title": "Qty",
-            "default": 0
-          },
-          "receiver_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Name"
-          },
-          "receiver_phone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Phone"
-          },
-          "province": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Province"
-          },
-          "city": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "City"
-          },
-          "district": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "District"
-          },
-          "detail": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Detail"
-          },
-          "zipcode": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Zipcode"
-          },
-          "if_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "If Version"
-          }
-        },
-        "type": "object",
-        "required": [
-          "row_no"
-        ],
-        "title": "CartLineItemIn"
-      },
-      "CodeMappingCodeOptionListDataOut": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/CodeMappingCodeOptionOut"
-            },
-            "type": "array",
-            "title": "Items"
-          },
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          },
-          "limit": {
-            "type": "integer",
-            "title": "Limit"
-          },
-          "offset": {
-            "type": "integer",
-            "title": "Offset"
-          }
-        },
-        "type": "object",
-        "required": [
-          "total",
-          "limit",
-          "offset"
-        ],
-        "title": "CodeMappingCodeOptionListDataOut"
-      },
-      "CodeMappingCodeOptionListOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "$ref": "#/components/schemas/CodeMappingCodeOptionListDataOut"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "CodeMappingCodeOptionListOut"
-      },
-      "CodeMappingCodeOptionOut": {
-        "properties": {
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "store_code": {
-            "type": "string",
-            "title": "Store Code"
-          },
-          "merchant_code": {
-            "type": "string",
-            "title": "Merchant Code"
-          },
-          "latest_title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Latest Title"
-          },
-          "platform_item_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Item Id"
-          },
-          "platform_sku_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Sku Id"
-          },
-          "latest_platform_order_no": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Latest Platform Order No"
-          },
-          "latest_synced_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Latest Synced At"
-          },
-          "orders_count": {
-            "type": "integer",
-            "title": "Orders Count"
-          },
-          "is_bound": {
-            "type": "boolean",
-            "title": "Is Bound"
-          },
-          "binding_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Binding Id"
-          },
-          "fsku_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fsku Id"
-          },
-          "fsku_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fsku Code"
-          },
-          "fsku_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fsku Name"
-          },
-          "fsku_status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fsku Status"
-          },
-          "binding_updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Binding Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "platform",
-          "store_code",
-          "merchant_code",
-          "orders_count",
-          "is_bound"
-        ],
-        "title": "CodeMappingCodeOptionOut"
-      },
       "CountDocCreateIn": {
         "properties": {
           "warehouse_id": {
@@ -17802,34 +10946,6 @@
         ],
         "title": "DailyPurchaseReportItem"
       },
-      "DefaultWarehouseOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "additionalProperties": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "DefaultWarehouseOut"
-      },
       "ExplainAnchor": {
         "properties": {
           "ref": {
@@ -18605,422 +11721,6 @@
         ],
         "title": "FinanceOverviewSummary"
       },
-      "FskuComponentOut": {
-        "properties": {
-          "component_sku_code": {
-            "type": "string",
-            "title": "Component Sku Code"
-          },
-          "qty_per_fsku": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Qty Per Fsku"
-          },
-          "alloc_unit_price": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Alloc Unit Price"
-          },
-          "resolved_item_id": {
-            "type": "integer",
-            "title": "Resolved Item Id"
-          },
-          "resolved_item_sku_code_id": {
-            "type": "integer",
-            "title": "Resolved Item Sku Code Id"
-          },
-          "resolved_item_uom_id": {
-            "type": "integer",
-            "title": "Resolved Item Uom Id"
-          },
-          "sku_code_snapshot": {
-            "type": "string",
-            "title": "Sku Code Snapshot"
-          },
-          "item_name_snapshot": {
-            "type": "string",
-            "title": "Item Name Snapshot"
-          },
-          "uom_snapshot": {
-            "type": "string",
-            "title": "Uom Snapshot"
-          },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order"
-          }
-        },
-        "type": "object",
-        "required": [
-          "component_sku_code",
-          "qty_per_fsku",
-          "alloc_unit_price",
-          "resolved_item_id",
-          "resolved_item_sku_code_id",
-          "resolved_item_uom_id",
-          "sku_code_snapshot",
-          "item_name_snapshot",
-          "uom_snapshot",
-          "sort_order"
-        ],
-        "title": "FskuComponentOut"
-      },
-      "FskuCreateIn": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "maxLength": 200,
-            "minLength": 1,
-            "title": "Name"
-          },
-          "code": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Code"
-          },
-          "shape": {
-            "type": "string",
-            "enum": [
-              "single",
-              "bundle"
-            ],
-            "title": "Shape",
-            "default": "bundle"
-          },
-          "fsku_expr": {
-            "type": "string",
-            "maxLength": 2000,
-            "minLength": 1,
-            "title": "Fsku Expr"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "name",
-          "fsku_expr"
-        ],
-        "title": "FskuCreateIn"
-      },
-      "FskuDetailOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "code": {
-            "type": "string",
-            "title": "Code"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "shape": {
-            "type": "string",
-            "enum": [
-              "single",
-              "bundle"
-            ],
-            "title": "Shape"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "draft",
-              "published",
-              "retired"
-            ],
-            "title": "Status"
-          },
-          "fsku_expr": {
-            "type": "string",
-            "title": "Fsku Expr"
-          },
-          "normalized_expr": {
-            "type": "string",
-            "title": "Normalized Expr"
-          },
-          "expr_type": {
-            "type": "string",
-            "enum": [
-              "DIRECT",
-              "SEGMENT_GROUP"
-            ],
-            "title": "Expr Type"
-          },
-          "component_count": {
-            "type": "integer",
-            "title": "Component Count"
-          },
-          "published_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Published At"
-          },
-          "retired_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Retired At"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Updated At"
-          },
-          "components": {
-            "items": {
-              "$ref": "#/components/schemas/FskuComponentOut"
-            },
-            "type": "array",
-            "title": "Components"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "code",
-          "name",
-          "shape",
-          "status",
-          "fsku_expr",
-          "normalized_expr",
-          "expr_type",
-          "component_count",
-          "published_at",
-          "retired_at",
-          "created_at",
-          "updated_at",
-          "components"
-        ],
-        "title": "FskuDetailOut"
-      },
-      "FskuExpressionReplaceIn": {
-        "properties": {
-          "fsku_expr": {
-            "type": "string",
-            "maxLength": 2000,
-            "minLength": 1,
-            "title": "Fsku Expr"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "fsku_expr"
-        ],
-        "title": "FskuExpressionReplaceIn"
-      },
-      "FskuListItem": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "code": {
-            "type": "string",
-            "title": "Code"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "shape": {
-            "type": "string",
-            "enum": [
-              "single",
-              "bundle"
-            ],
-            "title": "Shape"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "draft",
-              "published",
-              "retired"
-            ],
-            "title": "Status"
-          },
-          "fsku_expr": {
-            "type": "string",
-            "title": "Fsku Expr"
-          },
-          "normalized_expr": {
-            "type": "string",
-            "title": "Normalized Expr"
-          },
-          "expr_type": {
-            "type": "string",
-            "enum": [
-              "DIRECT",
-              "SEGMENT_GROUP"
-            ],
-            "title": "Expr Type"
-          },
-          "component_count": {
-            "type": "integer",
-            "title": "Component Count"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Updated At"
-          },
-          "published_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Published At"
-          },
-          "retired_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Retired At"
-          },
-          "components_summary": {
-            "type": "string",
-            "title": "Components Summary"
-          },
-          "components_summary_name": {
-            "type": "string",
-            "title": "Components Summary Name"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "code",
-          "name",
-          "shape",
-          "status",
-          "fsku_expr",
-          "normalized_expr",
-          "expr_type",
-          "component_count",
-          "updated_at",
-          "published_at",
-          "retired_at",
-          "components_summary",
-          "components_summary_name"
-        ],
-        "title": "FskuListItem"
-      },
-      "FskuListOut": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/FskuListItem"
-            },
-            "type": "array",
-            "title": "Items"
-          },
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          },
-          "limit": {
-            "type": "integer",
-            "title": "Limit"
-          },
-          "offset": {
-            "type": "integer",
-            "title": "Offset"
-          }
-        },
-        "type": "object",
-        "required": [
-          "items",
-          "total",
-          "limit",
-          "offset"
-        ],
-        "title": "FskuListOut"
-      },
-      "FskuLiteOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "code": {
-            "type": "string",
-            "title": "Code"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "status": {
-            "type": "string",
-            "title": "Status"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "code",
-          "name",
-          "status"
-        ],
-        "title": "FskuLiteOut"
-      },
-      "FskuNameUpdateIn": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "maxLength": 200,
-            "minLength": 1,
-            "title": "Name"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "title": "FskuNameUpdateIn"
-      },
       "FulfillmentDebugAddress": {
         "properties": {
           "province": {
@@ -19191,53 +11891,6 @@
         "type": "object",
         "title": "HTTPValidationError"
       },
-      "ImportPlatformOrderMirrorFromCollectorIn": {
-        "properties": {
-          "collector_order_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Collector Order Id"
-          }
-        },
-        "type": "object",
-        "required": [
-          "collector_order_id"
-        ],
-        "title": "ImportPlatformOrderMirrorFromCollectorIn"
-      },
-      "ImportPlatformOrderMirrorFromCollectorOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "imported": {
-            "type": "boolean",
-            "title": "Imported",
-            "default": true
-          },
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "collector_order_id": {
-            "type": "integer",
-            "title": "Collector Order Id"
-          },
-          "mirror_id": {
-            "type": "integer",
-            "title": "Mirror Id"
-          }
-        },
-        "type": "object",
-        "required": [
-          "platform",
-          "collector_order_id",
-          "mirror_id"
-        ],
-        "title": "ImportPlatformOrderMirrorFromCollectorOut"
-      },
       "InboundCommitIn": {
         "properties": {
           "warehouse_id": {
@@ -19398,7 +12051,7 @@
             "title": "Expiry Date",
             "description": "到期日期"
           },
-          "po_line_id": {
+          "source_line_id": {
             "anyOf": [
               {
                 "type": "integer",
@@ -19408,8 +12061,8 @@
                 "type": "null"
               }
             ],
-            "title": "Po Line Id",
-            "description": "采购来源时的采购单行 ID"
+            "title": "Source Line Id",
+            "description": "采购来源时的外部来源行 ID"
           },
           "remark": {
             "anyOf": [
@@ -19431,7 +12084,7 @@
           "qty_input"
         ],
         "title": "InboundCommitLineIn",
-        "description": "一层式入库提交行输入。\n\n设计原则：\n- 输入只接用户事实：商品/条码、包装单位、输入数量、批号/日期\n- 不接 qty_base，qty_base 由后端根据 PMS item_uoms.ratio_to_base 计算\n- 采购来源时允许显式带 po_line_id；其他来源不需要 source_line_ref 这种泛字段"
+        "description": "一层式入库提交行输入。\n\n设计原则：\n- 输入只接用户事实：商品/条码、包装单位、输入数量、批号/日期\n- 不接 qty_base，qty_base 由后端根据 PMS item_uoms.ratio_to_base 计算\n- 采购来源时允许显式带 source_line_id；其他来源不需要来源行引用"
       },
       "InboundCommitOut": {
         "properties": {
@@ -19597,7 +12250,7 @@
             "title": "Lot Code",
             "description": "实际落账 lot_code"
           },
-          "po_line_id": {
+          "source_line_id": {
             "anyOf": [
               {
                 "type": "integer",
@@ -19607,8 +12260,8 @@
                 "type": "null"
               }
             ],
-            "title": "Po Line Id",
-            "description": "采购来源时的采购单行 ID"
+            "title": "Source Line Id",
+            "description": "采购来源时的外部来源行 ID"
           },
           "remark": {
             "anyOf": [
@@ -19814,7 +12467,7 @@
             "title": "Expiry Date",
             "description": "到期日期"
           },
-          "po_line_id": {
+          "source_line_id": {
             "anyOf": [
               {
                 "type": "integer",
@@ -19824,8 +12477,8 @@
                 "type": "null"
               }
             ],
-            "title": "Po Line Id",
-            "description": "采购来源时的采购单行 ID"
+            "title": "Source Line Id",
+            "description": "采购来源时的外部来源行 ID"
           },
           "remark": {
             "anyOf": [
@@ -21071,6 +13724,138 @@
           "receipt_no"
         ],
         "title": "InboundReceiptProgressOut"
+      },
+      "InboundReceiptPurchaseSourceOptionOut": {
+        "properties": {
+          "po_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Po Id",
+            "description": "采购单 ID"
+          },
+          "po_no": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Po No",
+            "description": "采购单号"
+          },
+          "target_warehouse_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Target Warehouse Id",
+            "description": "目标仓库 ID"
+          },
+          "target_warehouse_code_snapshot": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 64
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Warehouse Code Snapshot",
+            "description": "目标仓库编码快照"
+          },
+          "target_warehouse_name_snapshot": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Warehouse Name Snapshot",
+            "description": "目标仓库名称快照"
+          },
+          "supplier_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Supplier Id",
+            "description": "供应商 ID"
+          },
+          "supplier_code_snapshot": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Supplier Code Snapshot",
+            "description": "供应商编码快照"
+          },
+          "supplier_name_snapshot": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Supplier Name Snapshot",
+            "description": "供应商名称快照"
+          },
+          "purchase_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Purchase Time"
+          },
+          "order_status": {
+            "type": "string",
+            "maxLength": 32,
+            "minLength": 1,
+            "title": "Order Status",
+            "description": "采购单状态"
+          },
+          "completion_status": {
+            "type": "string",
+            "enum": [
+              "NOT_RECEIVED",
+              "PARTIAL",
+              "RECEIVED"
+            ],
+            "title": "Completion Status"
+          },
+          "last_received_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Received At",
+            "description": "最近收货时间"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "po_id",
+          "po_no",
+          "target_warehouse_id",
+          "supplier_id",
+          "supplier_code_snapshot",
+          "supplier_name_snapshot",
+          "purchase_time",
+          "order_status",
+          "completion_status"
+        ],
+        "title": "InboundReceiptPurchaseSourceOptionOut"
+      },
+      "InboundReceiptPurchaseSourceOptionsOut": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/InboundReceiptPurchaseSourceOptionOut"
+            },
+            "type": "array",
+            "title": "Items",
+            "description": "可生成采购入库单的采购来源"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "InboundReceiptPurchaseSourceOptionsOut"
       },
       "InboundReceiptReadOut": {
         "properties": {
@@ -24064,2231 +16849,6 @@
         ],
         "title": "InventoryWarehouseOption"
       },
-      "ItemAggregateOut": {
-        "properties": {
-          "item": {
-            "$ref": "#/components/schemas/ItemOut"
-          },
-          "uoms": {
-            "items": {
-              "$ref": "#/components/schemas/ItemUomOut"
-            },
-            "type": "array",
-            "title": "Uoms"
-          },
-          "barcodes": {
-            "items": {
-              "$ref": "#/components/schemas/AggregateBarcodeOut"
-            },
-            "type": "array",
-            "title": "Barcodes"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "item",
-          "uoms",
-          "barcodes"
-        ],
-        "title": "ItemAggregateOut"
-      },
-      "ItemAggregatePayload": {
-        "properties": {
-          "item": {
-            "$ref": "#/components/schemas/AggregateItemInput"
-          },
-          "uoms": {
-            "items": {
-              "$ref": "#/components/schemas/AggregateUomInput"
-            },
-            "type": "array",
-            "title": "Uoms"
-          },
-          "barcodes": {
-            "items": {
-              "$ref": "#/components/schemas/AggregateBarcodeInput"
-            },
-            "type": "array",
-            "title": "Barcodes"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "item",
-          "uoms",
-          "barcodes"
-        ],
-        "title": "ItemAggregatePayload"
-      },
-      "ItemAttributeDefCreate": {
-        "properties": {
-          "code": {
-            "type": "string",
-            "maxLength": 64,
-            "minLength": 1,
-            "title": "Code"
-          },
-          "name_cn": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Name Cn"
-          },
-          "name_en": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name En"
-          },
-          "product_kind": {
-            "type": "string",
-            "enum": [
-              "FOOD",
-              "SUPPLY",
-              "OTHER",
-              "COMMON"
-            ],
-            "title": "Product Kind"
-          },
-          "value_type": {
-            "type": "string",
-            "enum": [
-              "TEXT",
-              "NUMBER",
-              "OPTION",
-              "BOOL"
-            ],
-            "title": "Value Type"
-          },
-          "selection_mode": {
-            "type": "string",
-            "enum": [
-              "SINGLE",
-              "MULTI"
-            ],
-            "title": "Selection Mode",
-            "default": "SINGLE"
-          },
-          "unit": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 16
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Unit"
-          },
-          "is_item_required": {
-            "type": "boolean",
-            "title": "Is Item Required",
-            "default": false
-          },
-          "is_sku_required": {
-            "type": "boolean",
-            "title": "Is Sku Required",
-            "default": false
-          },
-          "is_sku_segment": {
-            "type": "boolean",
-            "title": "Is Sku Segment",
-            "default": false
-          },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order",
-            "default": 0
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 500
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          }
-        },
-        "type": "object",
-        "required": [
-          "code",
-          "name_cn",
-          "product_kind",
-          "value_type"
-        ],
-        "title": "ItemAttributeDefCreate"
-      },
-      "ItemAttributeDefOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "code": {
-            "type": "string",
-            "title": "Code"
-          },
-          "name_cn": {
-            "type": "string",
-            "title": "Name Cn"
-          },
-          "name_en": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name En"
-          },
-          "product_kind": {
-            "type": "string",
-            "title": "Product Kind"
-          },
-          "value_type": {
-            "type": "string",
-            "title": "Value Type"
-          },
-          "selection_mode": {
-            "type": "string",
-            "title": "Selection Mode"
-          },
-          "unit": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Unit"
-          },
-          "is_item_required": {
-            "type": "boolean",
-            "title": "Is Item Required"
-          },
-          "is_sku_required": {
-            "type": "boolean",
-            "title": "Is Sku Required"
-          },
-          "is_sku_segment": {
-            "type": "boolean",
-            "title": "Is Sku Segment"
-          },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
-          },
-          "is_locked": {
-            "type": "boolean",
-            "title": "Is Locked"
-          },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order"
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "code",
-          "name_cn",
-          "product_kind",
-          "value_type",
-          "selection_mode",
-          "is_item_required",
-          "is_sku_required",
-          "is_sku_segment",
-          "is_active",
-          "is_locked",
-          "sort_order"
-        ],
-        "title": "ItemAttributeDefOut"
-      },
-      "ItemAttributeDefUpdate": {
-        "properties": {
-          "name_cn": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name Cn"
-          },
-          "name_en": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name En"
-          },
-          "selection_mode": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "SINGLE",
-                  "MULTI"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Selection Mode"
-          },
-          "unit": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 16
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Unit"
-          },
-          "is_item_required": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Item Required"
-          },
-          "is_sku_required": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Sku Required"
-          },
-          "is_sku_segment": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Sku Segment"
-          },
-          "sort_order": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sort Order"
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 500
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          }
-        },
-        "type": "object",
-        "title": "ItemAttributeDefUpdate"
-      },
-      "ItemAttributeOptionCreate": {
-        "properties": {
-          "option_code": {
-            "type": "string",
-            "maxLength": 64,
-            "minLength": 1,
-            "title": "Option Code"
-          },
-          "option_name": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Option Name"
-          },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order",
-            "default": 0
-          }
-        },
-        "type": "object",
-        "required": [
-          "option_code",
-          "option_name"
-        ],
-        "title": "ItemAttributeOptionCreate"
-      },
-      "ItemAttributeOptionOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "attribute_def_id": {
-            "type": "integer",
-            "title": "Attribute Def Id"
-          },
-          "option_code": {
-            "type": "string",
-            "title": "Option Code"
-          },
-          "option_name": {
-            "type": "string",
-            "title": "Option Name"
-          },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
-          },
-          "is_locked": {
-            "type": "boolean",
-            "title": "Is Locked"
-          },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "attribute_def_id",
-          "option_code",
-          "option_name",
-          "is_active",
-          "is_locked",
-          "sort_order"
-        ],
-        "title": "ItemAttributeOptionOut"
-      },
-      "ItemAttributeOptionUpdate": {
-        "properties": {
-          "option_name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Option Name"
-          },
-          "sort_order": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sort Order"
-          }
-        },
-        "type": "object",
-        "title": "ItemAttributeOptionUpdate"
-      },
-      "ItemAttributeValueIn": {
-        "properties": {
-          "attribute_def_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Attribute Def Id"
-          },
-          "value_text": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Text"
-          },
-          "value_number": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Number"
-          },
-          "value_bool": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Bool"
-          },
-          "value_option_ids": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "integer",
-                  "minimum": 1.0
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Option Ids"
-          }
-        },
-        "type": "object",
-        "required": [
-          "attribute_def_id"
-        ],
-        "title": "ItemAttributeValueIn"
-      },
-      "ItemAttributeValueOut": {
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Id"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "attribute_def_id": {
-            "type": "integer",
-            "title": "Attribute Def Id"
-          },
-          "value_text": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Text"
-          },
-          "value_number": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Number"
-          },
-          "value_bool": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Bool"
-          },
-          "value_option_ids": {
-            "items": {
-              "type": "integer"
-            },
-            "type": "array",
-            "title": "Value Option Ids"
-          },
-          "value_option_code_snapshots": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Value Option Code Snapshots"
-          },
-          "value_unit_snapshot": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Unit Snapshot"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "item_id",
-          "attribute_def_id"
-        ],
-        "title": "ItemAttributeValueOut"
-      },
-      "ItemAttributeValuesReplaceIn": {
-        "properties": {
-          "values": {
-            "items": {
-              "$ref": "#/components/schemas/ItemAttributeValueIn"
-            },
-            "type": "array",
-            "title": "Values"
-          }
-        },
-        "type": "object",
-        "title": "ItemAttributeValuesReplaceIn"
-      },
-      "ItemBarcodeCompositeRow": {
-        "properties": {
-          "sku": {
-            "type": "string",
-            "title": "Sku"
-          },
-          "item_name": {
-            "type": "string",
-            "title": "Item Name"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "item_uom_id": {
-            "type": "integer",
-            "title": "Item Uom Id"
-          },
-          "uom": {
-            "type": "string",
-            "title": "Uom"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "ratio_to_base": {
-            "type": "integer",
-            "title": "Ratio To Base"
-          },
-          "net_weight_kg": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Weight Kg"
-          },
-          "is_base": {
-            "type": "boolean",
-            "title": "Is Base"
-          },
-          "is_purchase_default": {
-            "type": "boolean",
-            "title": "Is Purchase Default"
-          },
-          "is_inbound_default": {
-            "type": "boolean",
-            "title": "Is Inbound Default"
-          },
-          "is_outbound_default": {
-            "type": "boolean",
-            "title": "Is Outbound Default"
-          },
-          "barcode_id": {
-            "type": "integer",
-            "title": "Barcode Id"
-          },
-          "barcode": {
-            "type": "string",
-            "title": "Barcode"
-          },
-          "symbology": {
-            "type": "string",
-            "title": "Symbology"
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary"
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "sku",
-          "item_name",
-          "item_id",
-          "item_uom_id",
-          "uom",
-          "display_name",
-          "ratio_to_base",
-          "net_weight_kg",
-          "is_base",
-          "is_purchase_default",
-          "is_inbound_default",
-          "is_outbound_default",
-          "barcode_id",
-          "barcode",
-          "symbology",
-          "is_primary",
-          "active",
-          "updated_at"
-        ],
-        "title": "ItemBarcodeCompositeRow",
-        "description": "商品条码页 owner 复合只读行：\n- 继承 item_uoms owner 复合读模型，包装字段以 item_uoms 合同为唯一来源\n- 当前接口只返回已绑定条码的行，因此条码字段在这里收紧为必填"
-      },
-      "ItemBarcodeCreate": {
-        "properties": {
-          "item_uom_id": {
-            "type": "integer",
-            "title": "Item Uom Id"
-          },
-          "barcode": {
-            "type": "string",
-            "title": "Barcode"
-          },
-          "symbology": {
-            "type": "string",
-            "title": "Symbology",
-            "default": "CUSTOM"
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active",
-            "default": true
-          }
-        },
-        "type": "object",
-        "required": [
-          "item_uom_id",
-          "barcode"
-        ],
-        "title": "ItemBarcodeCreate"
-      },
-      "ItemBarcodeOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "item_uom_id": {
-            "type": "integer",
-            "title": "Item Uom Id"
-          },
-          "barcode": {
-            "type": "string",
-            "title": "Barcode"
-          },
-          "symbology": {
-            "type": "string",
-            "title": "Symbology"
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active"
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "item_id",
-          "item_uom_id",
-          "barcode",
-          "symbology",
-          "active",
-          "is_primary"
-        ],
-        "title": "ItemBarcodeOut"
-      },
-      "ItemBarcodeUpdate": {
-        "properties": {
-          "item_uom_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Item Uom Id"
-          },
-          "barcode": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Barcode"
-          },
-          "symbology": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Symbology"
-          },
-          "active": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Active"
-          },
-          "is_primary": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Primary"
-          }
-        },
-        "type": "object",
-        "title": "ItemBarcodeUpdate",
-        "description": "PATCH 更新条码：可用于改绑包装 / 改条码 / 改码制 / 切主条码"
-      },
-      "ItemBasic": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "exclusiveMinimum": 0.0,
-            "title": "Id"
-          },
-          "sku": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Sku"
-          },
-          "name": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Name"
-          },
-          "spec": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spec"
-          },
-          "enabled": {
-            "type": "boolean",
-            "title": "Enabled",
-            "default": true
-          },
-          "supplier_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Supplier Id"
-          },
-          "brand": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 64
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Brand"
-          },
-          "category": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 64
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Category"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "sku",
-          "name"
-        ],
-        "title": "ItemBasic",
-        "description": "PMS 对外最小商品读模型。\n\n说明：\n- 这是跨域 public read surface，不承载 owner 内部兼容输入语义\n- 只暴露 items 主表稳定需要的最小读取字段\n- 不承载条码 / 单位 / 净重等跨子表事实"
-      },
-      "ItemCompletenessOut": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "enum": [
-              "COMPLETE",
-              "WARNING",
-              "BLOCKED"
-            ],
-            "title": "Status"
-          },
-          "is_complete": {
-            "type": "boolean",
-            "title": "Is Complete"
-          },
-          "product_kind": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "FOOD",
-                  "SUPPLY",
-                  "OTHER"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Product Kind"
-          },
-          "has_brand": {
-            "type": "boolean",
-            "title": "Has Brand",
-            "default": false
-          },
-          "has_active_leaf_category": {
-            "type": "boolean",
-            "title": "Has Active Leaf Category",
-            "default": false
-          },
-          "has_base_uom": {
-            "type": "boolean",
-            "title": "Has Base Uom",
-            "default": false
-          },
-          "has_active_primary_barcode": {
-            "type": "boolean",
-            "title": "Has Active Primary Barcode",
-            "default": false
-          },
-          "has_active_primary_sku": {
-            "type": "boolean",
-            "title": "Has Active Primary Sku",
-            "default": false
-          },
-          "item_required_attributes_complete": {
-            "type": "boolean",
-            "title": "Item Required Attributes Complete",
-            "default": true
-          },
-          "sku_required_attributes_complete": {
-            "type": "boolean",
-            "title": "Sku Required Attributes Complete",
-            "default": true
-          },
-          "sku_segment_attributes_present": {
-            "type": "boolean",
-            "title": "Sku Segment Attributes Present",
-            "default": true
-          },
-          "sku_generation_applicable": {
-            "type": "boolean",
-            "title": "Sku Generation Applicable",
-            "default": false
-          },
-          "can_generate_sku": {
-            "type": "boolean",
-            "title": "Can Generate Sku",
-            "default": false
-          },
-          "missing_item_required_attribute_codes": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Missing Item Required Attribute Codes"
-          },
-          "missing_sku_required_attribute_codes": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Missing Sku Required Attribute Codes"
-          },
-          "missing_sku_segment_attribute_codes": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Missing Sku Segment Attribute Codes"
-          },
-          "missing_items": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Missing Items"
-          },
-          "blocking_items": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Blocking Items"
-          },
-          "warnings": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Warnings"
-          }
-        },
-        "type": "object",
-        "required": [
-          "status",
-          "is_complete"
-        ],
-        "title": "ItemCompletenessOut",
-        "description": "PMS 商品完整度 owner read model。\n\n定位：\n- 后端统一计算商品完整度\n- 前端列表、详情、编辑流程只消费这个合同\n- 不让前端根据多个数组自行拼完整度判断"
-      },
-      "ItemCreate": {
-        "properties": {
-          "sku": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Sku"
-          },
-          "name": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Name"
-          },
-          "spec": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spec"
-          },
-          "brand_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Brand Id"
-          },
-          "category_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Category Id"
-          },
-          "enabled": {
-            "type": "boolean",
-            "title": "Enabled",
-            "default": true
-          },
-          "supplier_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Supplier Id"
-          },
-          "lot_source_policy": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "INTERNAL_ONLY",
-                  "SUPPLIER_ONLY"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Lot Source Policy"
-          },
-          "expiry_policy": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "NONE",
-                  "REQUIRED"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Expiry Policy"
-          },
-          "derivation_allowed": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Derivation Allowed"
-          },
-          "uom_governance_enabled": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Uom Governance Enabled"
-          },
-          "shelf_life_value": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "exclusiveMinimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Shelf Life Value"
-          },
-          "shelf_life_unit": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "DAY",
-                  "WEEK",
-                  "MONTH",
-                  "YEAR"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Shelf Life Unit"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "sku",
-          "name"
-        ],
-        "title": "ItemCreate",
-        "description": "Create Item（SKU 由调用方显式输入）：\n- 必须传 sku；SKU 编码页只负责生成候选 SKU，最终由商品创建合同写入 items.sku\n- brand/category 不再接受自由文本；请传 brand_id/category_id\n- 不接受 barcode 输入；主条码请走 /item-barcodes\n- 不接受 weight_kg 输入；基础包装净重请走 item_uoms（base uom）\n\nPhase M-3：\n- items.case_ratio/case_uom 已删除；包装单位请走 item_uoms"
-      },
-      "ItemListAttributeOut": {
-        "properties": {
-          "attribute_def_id": {
-            "type": "integer",
-            "title": "Attribute Def Id"
-          },
-          "code": {
-            "type": "string",
-            "title": "Code"
-          },
-          "name_cn": {
-            "type": "string",
-            "title": "Name Cn"
-          },
-          "value_type": {
-            "type": "string",
-            "title": "Value Type"
-          },
-          "selection_mode": {
-            "type": "string",
-            "title": "Selection Mode"
-          },
-          "unit": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Unit"
-          },
-          "is_item_required": {
-            "type": "boolean",
-            "title": "Is Item Required"
-          },
-          "is_sku_required": {
-            "type": "boolean",
-            "title": "Is Sku Required"
-          },
-          "is_sku_segment": {
-            "type": "boolean",
-            "title": "Is Sku Segment"
-          },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order"
-          },
-          "value_text": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Text"
-          },
-          "value_number": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Number"
-          },
-          "value_bool": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Bool"
-          },
-          "value_option_ids": {
-            "items": {
-              "type": "integer"
-            },
-            "type": "array",
-            "title": "Value Option Ids"
-          },
-          "value_option_code_snapshots": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Value Option Code Snapshots"
-          },
-          "value_option_names": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Value Option Names"
-          },
-          "value_unit_snapshot": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value Unit Snapshot"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "attribute_def_id",
-          "code",
-          "name_cn",
-          "value_type",
-          "selection_mode",
-          "is_item_required",
-          "is_sku_required",
-          "is_sku_segment",
-          "sort_order"
-        ],
-        "title": "ItemListAttributeOut"
-      },
-      "ItemListBarcodeOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "item_uom_id": {
-            "type": "integer",
-            "title": "Item Uom Id"
-          },
-          "uom": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Uom"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "barcode": {
-            "type": "string",
-            "title": "Barcode"
-          },
-          "symbology": {
-            "type": "string",
-            "title": "Symbology"
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active"
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "item_id",
-          "item_uom_id",
-          "barcode",
-          "symbology",
-          "active",
-          "is_primary"
-        ],
-        "title": "ItemListBarcodeOut"
-      },
-      "ItemListDetailOut": {
-        "properties": {
-          "row": {
-            "$ref": "#/components/schemas/ItemListRowOut"
-          },
-          "uoms": {
-            "items": {
-              "$ref": "#/components/schemas/ItemListUomOut"
-            },
-            "type": "array",
-            "title": "Uoms"
-          },
-          "barcodes": {
-            "items": {
-              "$ref": "#/components/schemas/ItemListBarcodeOut"
-            },
-            "type": "array",
-            "title": "Barcodes"
-          },
-          "sku_codes": {
-            "items": {
-              "$ref": "#/components/schemas/ItemListSkuCodeOut"
-            },
-            "type": "array",
-            "title": "Sku Codes"
-          },
-          "attributes": {
-            "items": {
-              "$ref": "#/components/schemas/ItemListAttributeOut"
-            },
-            "type": "array",
-            "title": "Attributes"
-          }
-        },
-        "type": "object",
-        "required": [
-          "row",
-          "uoms",
-          "barcodes",
-          "sku_codes",
-          "attributes"
-        ],
-        "title": "ItemListDetailOut",
-        "description": "PMS 商品列表详情读模型。\n\n定位：\n- 只读展示合同\n- 给商品列表页“详情展开”使用\n- row 复用 ItemListRowOut，确保列表摘要与详情头部一致"
-      },
-      "ItemListRowOut": {
-        "properties": {
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "sku": {
-            "type": "string",
-            "title": "Sku"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "spec": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spec"
-          },
-          "enabled": {
-            "type": "boolean",
-            "title": "Enabled"
-          },
-          "brand": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Brand"
-          },
-          "category": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Category"
-          },
-          "supplier_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Supplier Name"
-          },
-          "primary_barcode": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Primary Barcode"
-          },
-          "base_uom": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Base Uom"
-          },
-          "base_net_weight_kg": {
-            "anyOf": [
-              {
-                "type": "number",
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Base Net Weight Kg"
-          },
-          "purchase_uom": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Purchase Uom"
-          },
-          "purchase_ratio_to_base": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "minimum": 1.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Purchase Ratio To Base"
-          },
-          "lot_source_policy": {
-            "type": "string",
-            "title": "Lot Source Policy"
-          },
-          "expiry_policy": {
-            "type": "string",
-            "title": "Expiry Policy"
-          },
-          "shelf_life_value": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Shelf Life Value"
-          },
-          "shelf_life_unit": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Shelf Life Unit"
-          },
-          "uom_count": {
-            "type": "integer",
-            "minimum": 0.0,
-            "title": "Uom Count",
-            "default": 0
-          },
-          "barcode_count": {
-            "type": "integer",
-            "minimum": 0.0,
-            "title": "Barcode Count",
-            "default": 0
-          },
-          "sku_code_count": {
-            "type": "integer",
-            "minimum": 0.0,
-            "title": "Sku Code Count",
-            "default": 0
-          },
-          "attribute_count": {
-            "type": "integer",
-            "minimum": 0.0,
-            "title": "Attribute Count",
-            "default": 0
-          },
-          "completeness": {
-            "$ref": "#/components/schemas/ItemCompletenessOut"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "item_id",
-          "sku",
-          "name",
-          "enabled",
-          "lot_source_policy",
-          "expiry_policy",
-          "completeness"
-        ],
-        "title": "ItemListRowOut",
-        "description": "PMS 商品列表页专用 owner 读模型。\n\n定位：\n- 一行 = 一个商品的完整列表摘要\n- 只服务商品主数据总览页\n- 不承载写入语义\n- 不让前端再自行拼 item_uoms / item_barcodes / item_sku_codes / item_attribute_values"
-      },
-      "ItemListSkuCodeOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "code": {
-            "type": "string",
-            "title": "Code"
-          },
-          "code_type": {
-            "type": "string",
-            "title": "Code Type"
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary"
-          },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
-          },
-          "effective_from": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Effective From"
-          },
-          "effective_to": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Effective To"
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "item_id",
-          "code",
-          "code_type",
-          "is_primary",
-          "is_active"
-        ],
-        "title": "ItemListSkuCodeOut"
-      },
-      "ItemListUomOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "uom": {
-            "type": "string",
-            "title": "Uom"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "ratio_to_base": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Ratio To Base"
-          },
-          "net_weight_kg": {
-            "anyOf": [
-              {
-                "type": "number",
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Weight Kg"
-          },
-          "is_base": {
-            "type": "boolean",
-            "title": "Is Base"
-          },
-          "is_purchase_default": {
-            "type": "boolean",
-            "title": "Is Purchase Default"
-          },
-          "is_inbound_default": {
-            "type": "boolean",
-            "title": "Is Inbound Default"
-          },
-          "is_outbound_default": {
-            "type": "boolean",
-            "title": "Is Outbound Default"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "item_id",
-          "uom",
-          "ratio_to_base",
-          "is_base",
-          "is_purchase_default",
-          "is_inbound_default",
-          "is_outbound_default"
-        ],
-        "title": "ItemListUomOut"
-      },
-      "ItemOut": {
-        "properties": {
-          "sku": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Sku"
-          },
-          "name": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Name"
-          },
-          "spec": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spec"
-          },
-          "barcode": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 64
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Barcode"
-          },
-          "primary_barcode": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 64
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Primary Barcode"
-          },
-          "brand_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Brand Id"
-          },
-          "category_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Category Id"
-          },
-          "brand": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Brand"
-          },
-          "category": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Category"
-          },
-          "enabled": {
-            "type": "boolean",
-            "title": "Enabled",
-            "default": true
-          },
-          "supplier_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Supplier Id"
-          },
-          "lot_source_policy": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "INTERNAL_ONLY",
-                  "SUPPLIER_ONLY"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Lot Source Policy"
-          },
-          "expiry_policy": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "NONE",
-                  "REQUIRED"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Expiry Policy"
-          },
-          "derivation_allowed": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Derivation Allowed"
-          },
-          "uom_governance_enabled": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Uom Governance Enabled"
-          },
-          "shelf_life_value": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "exclusiveMinimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Shelf Life Value"
-          },
-          "shelf_life_unit": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "DAY",
-                  "WEEK",
-                  "MONTH",
-                  "YEAR"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Shelf Life Unit"
-          },
-          "weight_kg": {
-            "anyOf": [
-              {
-                "type": "number",
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Weight Kg"
-          },
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "supplier_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Supplier Name"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          },
-          "requires_batch": {
-            "type": "boolean",
-            "title": "Requires Batch",
-            "default": true
-          },
-          "requires_dates": {
-            "type": "boolean",
-            "title": "Requires Dates",
-            "default": true
-          }
-        },
-        "type": "object",
-        "required": [
-          "sku",
-          "name",
-          "id"
-        ],
-        "title": "ItemOut"
-      },
       "ItemPurchaseReportItem": {
         "properties": {
           "item_id": {
@@ -26513,735 +17073,6 @@
           "planned_line_amount"
         ],
         "title": "ItemPurchaseReportLineItem"
-      },
-      "ItemSkuCodeChangePrimary": {
-        "properties": {
-          "code": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Code"
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "code"
-        ],
-        "title": "ItemSkuCodeChangePrimary"
-      },
-      "ItemSkuCodeCreate": {
-        "properties": {
-          "code": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Code"
-          },
-          "code_type": {
-            "type": "string",
-            "enum": [
-              "PRIMARY",
-              "ALIAS",
-              "LEGACY",
-              "MANUAL"
-            ],
-            "title": "Code Type",
-            "default": "ALIAS"
-          },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active",
-            "default": true
-          },
-          "effective_from": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Effective From"
-          },
-          "effective_to": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Effective To"
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "code"
-        ],
-        "title": "ItemSkuCodeCreate"
-      },
-      "ItemSkuCodeOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "code": {
-            "type": "string",
-            "title": "Code"
-          },
-          "code_type": {
-            "type": "string",
-            "enum": [
-              "PRIMARY",
-              "ALIAS",
-              "LEGACY",
-              "MANUAL"
-            ],
-            "title": "Code Type"
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary"
-          },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
-          },
-          "effective_from": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Effective From"
-          },
-          "effective_to": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Effective To"
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "item_id",
-          "code",
-          "code_type",
-          "is_primary",
-          "is_active"
-        ],
-        "title": "ItemSkuCodeOut"
-      },
-      "ItemUomBarcodeRowOut": {
-        "properties": {
-          "sku": {
-            "type": "string",
-            "title": "Sku"
-          },
-          "item_name": {
-            "type": "string",
-            "title": "Item Name"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "item_uom_id": {
-            "type": "integer",
-            "title": "Item Uom Id"
-          },
-          "uom": {
-            "type": "string",
-            "title": "Uom"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "ratio_to_base": {
-            "type": "integer",
-            "title": "Ratio To Base"
-          },
-          "net_weight_kg": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Weight Kg"
-          },
-          "is_base": {
-            "type": "boolean",
-            "title": "Is Base"
-          },
-          "is_purchase_default": {
-            "type": "boolean",
-            "title": "Is Purchase Default"
-          },
-          "is_inbound_default": {
-            "type": "boolean",
-            "title": "Is Inbound Default"
-          },
-          "is_outbound_default": {
-            "type": "boolean",
-            "title": "Is Outbound Default"
-          },
-          "barcode_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Barcode Id"
-          },
-          "barcode": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Barcode"
-          },
-          "symbology": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Symbology"
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary",
-            "default": false
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active",
-            "default": false
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "sku",
-          "item_name",
-          "item_id",
-          "item_uom_id",
-          "uom",
-          "display_name",
-          "ratio_to_base",
-          "net_weight_kg",
-          "is_base",
-          "is_purchase_default",
-          "is_inbound_default",
-          "is_outbound_default",
-          "updated_at"
-        ],
-        "title": "ItemUomBarcodeRowOut",
-        "description": "owner 复合读模型：\n- 一行 = 一个商品 + 一个包装 + 零/一条码\n- 主权归 item_uoms，不归 item_barcodes"
-      },
-      "ItemUomCreate": {
-        "properties": {
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "uom": {
-            "type": "string",
-            "maxLength": 16,
-            "minLength": 1,
-            "title": "Uom"
-          },
-          "ratio_to_base": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Ratio To Base"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 32
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "net_weight_kg": {
-            "anyOf": [
-              {
-                "type": "number",
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Weight Kg"
-          },
-          "is_base": {
-            "type": "boolean",
-            "title": "Is Base",
-            "default": false
-          },
-          "is_purchase_default": {
-            "type": "boolean",
-            "title": "Is Purchase Default",
-            "default": false
-          },
-          "is_inbound_default": {
-            "type": "boolean",
-            "title": "Is Inbound Default",
-            "default": false
-          },
-          "is_outbound_default": {
-            "type": "boolean",
-            "title": "Is Outbound Default",
-            "default": false
-          }
-        },
-        "type": "object",
-        "required": [
-          "item_id",
-          "uom",
-          "ratio_to_base"
-        ],
-        "title": "ItemUomCreate"
-      },
-      "ItemUomOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "uom": {
-            "type": "string",
-            "title": "Uom"
-          },
-          "ratio_to_base": {
-            "type": "integer",
-            "title": "Ratio To Base"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "net_weight_kg": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Weight Kg"
-          },
-          "is_base": {
-            "type": "boolean",
-            "title": "Is Base"
-          },
-          "is_purchase_default": {
-            "type": "boolean",
-            "title": "Is Purchase Default"
-          },
-          "is_inbound_default": {
-            "type": "boolean",
-            "title": "Is Inbound Default"
-          },
-          "is_outbound_default": {
-            "type": "boolean",
-            "title": "Is Outbound Default"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "item_id",
-          "uom",
-          "ratio_to_base",
-          "display_name",
-          "net_weight_kg",
-          "is_base",
-          "is_purchase_default",
-          "is_inbound_default",
-          "is_outbound_default"
-        ],
-        "title": "ItemUomOut"
-      },
-      "ItemUomUpdate": {
-        "properties": {
-          "uom": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 16,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Uom"
-          },
-          "ratio_to_base": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "minimum": 1.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Ratio To Base"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 32
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "net_weight_kg": {
-            "anyOf": [
-              {
-                "type": "number",
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Weight Kg"
-          },
-          "is_base": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Base"
-          },
-          "is_purchase_default": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Purchase Default"
-          },
-          "is_inbound_default": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Inbound Default"
-          },
-          "is_outbound_default": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Outbound Default"
-          }
-        },
-        "type": "object",
-        "title": "ItemUomUpdate"
-      },
-      "ItemUpdate": {
-        "properties": {
-          "name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          },
-          "spec": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spec"
-          },
-          "brand_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Brand Id"
-          },
-          "category_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Category Id"
-          },
-          "enabled": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Enabled"
-          },
-          "supplier_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Supplier Id"
-          },
-          "lot_source_policy": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "INTERNAL_ONLY",
-                  "SUPPLIER_ONLY"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Lot Source Policy"
-          },
-          "expiry_policy": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "NONE",
-                  "REQUIRED"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Expiry Policy"
-          },
-          "derivation_allowed": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Derivation Allowed"
-          },
-          "uom_governance_enabled": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Uom Governance Enabled"
-          },
-          "shelf_life_value": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "exclusiveMinimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Shelf Life Value"
-          },
-          "shelf_life_unit": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "DAY",
-                  "WEEK",
-                  "MONTH",
-                  "YEAR"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Shelf Life Unit"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "title": "ItemUpdate",
-        "description": "Patch Item：\n\n- 不开放 sku 变更\n- brand/category 不再接受自由文本；请传 brand_id/category_id\n- 不接受 barcode / has_shelf_life\n- 不接受 weight_kg；基础包装净重请改 item_uoms\n- nullable 字段支持显式传 null 清空"
       },
       "LedgerDateViolationRow": {
         "properties": {
@@ -27831,111 +17662,6 @@
           "net_delta"
         ],
         "title": "LedgerSummary"
-      },
-      "ListOut_ItemAttributeDefOut_": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/ItemAttributeDefOut"
-            },
-            "type": "array",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "ListOut[ItemAttributeDefOut]"
-      },
-      "ListOut_ItemAttributeOptionOut_": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/ItemAttributeOptionOut"
-            },
-            "type": "array",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "ListOut[ItemAttributeOptionOut]"
-      },
-      "ListOut_ItemAttributeValueOut_": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/ItemAttributeValueOut"
-            },
-            "type": "array",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "ListOut[ItemAttributeValueOut]"
-      },
-      "ListOut_PmsBrandOut_": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/PmsBrandOut"
-            },
-            "type": "array",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "ListOut[PmsBrandOut]"
-      },
-      "ListOut_PmsCategoryOut_": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/PmsCategoryOut"
-            },
-            "type": "array",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "ListOut[PmsCategoryOut]"
       },
       "LogisticsImportResultIn": {
         "properties": {
@@ -28955,221 +18681,6 @@
         ],
         "title": "ManualAssignResponse"
       },
-      "ManualDecisionLineOut": {
-        "properties": {
-          "line_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Line Key"
-          },
-          "line_no": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Line No"
-          },
-          "locator_kind": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Locator Kind",
-            "description": "对外定位类型（推荐）：FILLED_CODE / LINE_NO"
-          },
-          "locator_value": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Locator Value",
-            "description": "对外定位值（推荐）"
-          },
-          "filled_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Filled Code",
-            "description": "商家后台填写码（对外语义字段）"
-          },
-          "fact_qty": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fact Qty"
-          },
-          "item_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Item Id"
-          },
-          "qty": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Qty"
-          },
-          "note": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Note"
-          }
-        },
-        "type": "object",
-        "title": "ManualDecisionLineOut",
-        "description": "人工救火明细行（证据表读侧输出）。\n\nPhase N+4：line_key（内部幂等锚点）与 locator（对外定位语义）分层。"
-      },
-      "ManualDecisionOrderOut": {
-        "properties": {
-          "batch_id": {
-            "type": "string",
-            "title": "Batch Id",
-            "description": "治理事实批次 id（platform_order_manual_decisions.batch_id）"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At",
-            "description": "该批次最新写入时间（MAX(created_at)）"
-          },
-          "order_id": {
-            "type": "integer",
-            "title": "Order Id"
-          },
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "store_code": {
-            "type": "string",
-            "title": "Store Code"
-          },
-          "ext_order_no": {
-            "type": "string",
-            "title": "Ext Order No"
-          },
-          "ref": {
-            "type": "string",
-            "title": "Ref"
-          },
-          "store_id": {
-            "type": "integer",
-            "title": "Store Id"
-          },
-          "manual_reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Manual Reason"
-          },
-          "risk_flags": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Risk Flags"
-          },
-          "manual_decisions": {
-            "items": {
-              "$ref": "#/components/schemas/ManualDecisionLineOut"
-            },
-            "type": "array",
-            "title": "Manual Decisions"
-          }
-        },
-        "type": "object",
-        "required": [
-          "batch_id",
-          "created_at",
-          "order_id",
-          "platform",
-          "store_code",
-          "ext_order_no",
-          "ref",
-          "store_id"
-        ],
-        "title": "ManualDecisionOrderOut"
-      },
-      "ManualDecisionOrdersOut": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/ManualDecisionOrderOut"
-            },
-            "type": "array",
-            "title": "Items"
-          },
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          },
-          "limit": {
-            "type": "integer",
-            "title": "Limit"
-          },
-          "offset": {
-            "type": "integer",
-            "title": "Offset"
-          }
-        },
-        "type": "object",
-        "required": [
-          "total",
-          "limit",
-          "offset"
-        ],
-        "title": "ManualDecisionOrdersOut"
-      },
       "ManualOutboundDocCreateIn": {
         "properties": {
           "warehouse_id": {
@@ -29787,66 +19298,6 @@
         "type": "object",
         "title": "MarkPrintedIn"
       },
-      "MerchantLineItemIn": {
-        "properties": {
-          "row_no": {
-            "type": "integer",
-            "maximum": 6.0,
-            "minimum": 1.0,
-            "title": "Row No"
-          },
-          "filled_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Filled Code"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title"
-          },
-          "spec": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spec"
-          },
-          "if_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "If Version",
-            "description": "可选乐观锁版本；不传则强制覆盖"
-          }
-        },
-        "type": "object",
-        "required": [
-          "row_no"
-        ],
-        "title": "MerchantLineItemIn"
-      },
       "MetaPlatformItem": {
         "properties": {
           "platform": {
@@ -30073,6 +19524,799 @@
         ],
         "title": "NavigationRoutePrefixOut"
       },
+      "OmsProjectionCheckIssueOut": {
+        "properties": {
+          "issue_type": {
+            "type": "string",
+            "title": "Issue Type"
+          },
+          "resource": {
+            "type": "string",
+            "enum": [
+              "orders",
+              "lines",
+              "components"
+            ],
+            "title": "Resource"
+          },
+          "source_id": {
+            "type": "string",
+            "title": "Source Id"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "ready_order_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ready Order Id"
+          },
+          "ready_line_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ready Line Id"
+          },
+          "ready_component_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ready Component Id"
+          },
+          "expected_value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected Value"
+          },
+          "actual_value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Actual Value"
+          }
+        },
+        "type": "object",
+        "required": [
+          "issue_type",
+          "resource",
+          "source_id",
+          "message"
+        ],
+        "title": "OmsProjectionCheckIssueOut"
+      },
+      "OmsProjectionCheckOut": {
+        "properties": {
+          "resource": {
+            "type": "string",
+            "enum": [
+              "orders",
+              "lines",
+              "components"
+            ],
+            "title": "Resource"
+          },
+          "ok": {
+            "type": "boolean",
+            "title": "Ok"
+          },
+          "issue_count": {
+            "type": "integer",
+            "title": "Issue Count"
+          },
+          "issues": {
+            "items": {
+              "$ref": "#/components/schemas/OmsProjectionCheckIssueOut"
+            },
+            "type": "array",
+            "title": "Issues"
+          }
+        },
+        "type": "object",
+        "required": [
+          "resource",
+          "ok",
+          "issue_count"
+        ],
+        "title": "OmsProjectionCheckOut"
+      },
+      "OmsProjectionListOut": {
+        "properties": {
+          "resource": {
+            "type": "string",
+            "enum": [
+              "orders",
+              "lines",
+              "components"
+            ],
+            "title": "Resource"
+          },
+          "table_name": {
+            "type": "string",
+            "title": "Table Name"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "columns": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Columns"
+          },
+          "rows": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Rows"
+          }
+        },
+        "type": "object",
+        "required": [
+          "resource",
+          "table_name",
+          "limit",
+          "offset",
+          "total"
+        ],
+        "title": "OmsProjectionListOut"
+      },
+      "OmsProjectionOrderImportCandidateOut": {
+        "properties": {
+          "ready_order_id": {
+            "type": "string",
+            "title": "Ready Order Id"
+          },
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "store_code": {
+            "type": "string",
+            "title": "Store Code"
+          },
+          "store_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Store Name"
+          },
+          "platform_order_no": {
+            "type": "string",
+            "title": "Platform Order No"
+          },
+          "platform_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform Status"
+          },
+          "receiver_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Receiver Name"
+          },
+          "receiver_phone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Receiver Phone"
+          },
+          "ready_status": {
+            "type": "string",
+            "title": "Ready Status"
+          },
+          "ready_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ready At"
+          },
+          "synced_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Synced At"
+          },
+          "line_count": {
+            "type": "integer",
+            "title": "Line Count",
+            "default": 0
+          },
+          "component_count": {
+            "type": "integer",
+            "title": "Component Count",
+            "default": 0
+          },
+          "total_required_qty": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Required Qty"
+          },
+          "import_status": {
+            "type": "string",
+            "title": "Import Status"
+          },
+          "imported_order_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Imported Order Id"
+          },
+          "imported_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Imported At"
+          },
+          "can_import": {
+            "type": "boolean",
+            "title": "Can Import",
+            "default": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "ready_order_id",
+          "platform",
+          "store_code",
+          "platform_order_no",
+          "ready_status",
+          "import_status"
+        ],
+        "title": "OmsProjectionOrderImportCandidateOut",
+        "description": "订单出库页专用：OMS fulfillment projection 待接入候选订单。\n\nBoundary:\n- 来源是 WMS 本地 OMS fulfillment projection。\n- import_status 来自 WMS 导入审计表。\n- 给订单出库页展示/导入使用，不回写 projection。"
+      },
+      "OmsProjectionOrderImportCandidatesOut": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/OmsProjectionOrderImportCandidateOut"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "OmsProjectionOrderImportCandidatesOut"
+      },
+      "OmsProjectionOrderImportIn": {
+        "properties": {
+          "ready_order_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "maxItems": 200,
+            "minItems": 1,
+            "title": "Ready Order Ids"
+          },
+          "dry_run": {
+            "type": "boolean",
+            "title": "Dry Run",
+            "default": false
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "ready_order_ids"
+        ],
+        "title": "OmsProjectionOrderImportIn",
+        "description": "从 WMS 本地 OMS fulfillment projection 手动导入 WMS 执行订单。\n\nBoundary:\n- 输入是 ready_order_id。\n- 来源只允许 wms_oms_fulfillment_* projection。\n- 输出写入 WMS 执行 facts：orders / order_address / order_items / order_lines / order_fulfillment。\n- 不写回 projection 表。"
+      },
+      "OmsProjectionOrderImportOut": {
+        "properties": {
+          "dry_run": {
+            "type": "boolean",
+            "title": "Dry Run"
+          },
+          "requested": {
+            "type": "integer",
+            "title": "Requested"
+          },
+          "imported": {
+            "type": "integer",
+            "title": "Imported"
+          },
+          "already_imported": {
+            "type": "integer",
+            "title": "Already Imported"
+          },
+          "failed": {
+            "type": "integer",
+            "title": "Failed"
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/OmsProjectionOrderImportRowOut"
+            },
+            "type": "array",
+            "title": "Results"
+          }
+        },
+        "type": "object",
+        "required": [
+          "dry_run",
+          "requested",
+          "imported",
+          "already_imported",
+          "failed",
+          "results"
+        ],
+        "title": "OmsProjectionOrderImportOut"
+      },
+      "OmsProjectionOrderImportRowOut": {
+        "properties": {
+          "ready_order_id": {
+            "type": "string",
+            "title": "Ready Order Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "order_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Order Id"
+          },
+          "platform": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform"
+          },
+          "store_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Store Code"
+          },
+          "platform_order_no": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform Order No"
+          },
+          "order_line_count": {
+            "type": "integer",
+            "title": "Order Line Count",
+            "default": 0
+          },
+          "component_count": {
+            "type": "integer",
+            "title": "Component Count",
+            "default": 0
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ready_order_id",
+          "status"
+        ],
+        "title": "OmsProjectionOrderImportRowOut"
+      },
+      "OmsProjectionResourceStatusOut": {
+        "properties": {
+          "resource": {
+            "type": "string",
+            "enum": [
+              "orders",
+              "lines",
+              "components"
+            ],
+            "title": "Resource"
+          },
+          "table_name": {
+            "type": "string",
+            "title": "Table Name"
+          },
+          "row_count": {
+            "type": "integer",
+            "title": "Row Count"
+          },
+          "max_synced_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Synced At"
+          },
+          "last_sync_run": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OmsProjectionSyncRunOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "resource",
+          "table_name",
+          "row_count"
+        ],
+        "title": "OmsProjectionResourceStatusOut"
+      },
+      "OmsProjectionStatusOut": {
+        "properties": {
+          "oms_api_base_url_configured": {
+            "type": "boolean",
+            "title": "Oms Api Base Url Configured"
+          },
+          "resources": {
+            "items": {
+              "$ref": "#/components/schemas/OmsProjectionResourceStatusOut"
+            },
+            "type": "array",
+            "title": "Resources"
+          }
+        },
+        "type": "object",
+        "required": [
+          "oms_api_base_url_configured"
+        ],
+        "title": "OmsProjectionStatusOut"
+      },
+      "OmsProjectionSyncOut": {
+        "properties": {
+          "run": {
+            "$ref": "#/components/schemas/OmsProjectionSyncRunOut"
+          }
+        },
+        "type": "object",
+        "required": [
+          "run"
+        ],
+        "title": "OmsProjectionSyncOut"
+      },
+      "OmsProjectionSyncRunOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "resource": {
+            "type": "string",
+            "const": "fulfillment-ready-orders",
+            "title": "Resource"
+          },
+          "platform": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "pdd",
+                  "taobao",
+                  "jd"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform"
+          },
+          "store_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Store Code"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "RUNNING",
+              "SUCCESS",
+              "FAILED"
+            ],
+            "title": "Status"
+          },
+          "fetched": {
+            "type": "integer",
+            "title": "Fetched",
+            "default": 0
+          },
+          "upserted_orders": {
+            "type": "integer",
+            "title": "Upserted Orders",
+            "default": 0
+          },
+          "upserted_lines": {
+            "type": "integer",
+            "title": "Upserted Lines",
+            "default": 0
+          },
+          "upserted_components": {
+            "type": "integer",
+            "title": "Upserted Components",
+            "default": 0
+          },
+          "pages": {
+            "type": "integer",
+            "title": "Pages",
+            "default": 0
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Started At"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finished At"
+          },
+          "duration_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration Ms"
+          },
+          "error_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Message"
+          },
+          "triggered_by_user_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Triggered By User Id"
+          },
+          "oms_api_base_url_snapshot": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Oms Api Base Url Snapshot"
+          },
+          "sync_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sync Version"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "resource",
+          "status",
+          "started_at"
+        ],
+        "title": "OmsProjectionSyncRunOut"
+      },
+      "OmsProjectionSyncRunsOut": {
+        "properties": {
+          "resource": {
+            "anyOf": [
+              {
+                "type": "string",
+                "const": "fulfillment-ready-orders"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resource"
+          },
+          "platform": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "pdd",
+                  "taobao",
+                  "jd"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "runs": {
+            "items": {
+              "$ref": "#/components/schemas/OmsProjectionSyncRunOut"
+            },
+            "type": "array",
+            "title": "Runs"
+          }
+        },
+        "type": "object",
+        "required": [
+          "limit"
+        ],
+        "title": "OmsProjectionSyncRunsOut"
+      },
       "OrderOutboundOptionOut": {
         "properties": {
           "id": {
@@ -30128,7 +20372,7 @@
           "created_at"
         ],
         "title": "OrderOutboundOptionOut",
-        "description": "订单出库页专用：订单选择器列表项（来源真相 = orders）\n\n说明：\n- 只返回“选单”需要的最小头字段\n- 不掺执行仓 / 履约阶段 / 平台 ledger 明细"
+        "description": "WMS 订单出库页专用：订单选择器列表项。\n\nBoundary:\n- 路由归属 WMS outbound。\n- 来源仍是 WMS 本地执行订单 facts：orders / order_lines。\n- 不读取 OMS owner 表，不挂在 /oms/orders。"
       },
       "OrderOutboundOptionsOut": {
         "properties": {
@@ -30159,7 +20403,7 @@
           "offset"
         ],
         "title": "OrderOutboundOptionsOut",
-        "description": "订单出库页专用：订单选择器列表响应"
+        "description": "WMS 订单出库页专用：订单选择器列表响应。"
       },
       "OrderOutboundSubmitIn": {
         "properties": {
@@ -30379,7 +20623,7 @@
           "req_qty"
         ],
         "title": "OrderOutboundViewLineOut",
-        "description": "订单出库页专用：订单行只读模型（来源真相 = order_lines + item display）\n\n说明：\n- 核心真相仍然是 order_lines\n- 为作业页补充商品展示字段：sku / name / spec / base_uom\n- 不掺平台 ledger / 执行上下文 / lot 分配结果"
+        "description": "WMS 订单出库页专用：订单行只读模型。\n\nBoundary:\n- 核心来源是 WMS 本地 order_lines。\n- 商品展示字段通过 PMS read client / WMS PMS projection 获取。\n- 不直接 JOIN PMS owner 表。"
       },
       "OrderOutboundViewOrderOut": {
         "properties": {
@@ -30483,7 +20727,7 @@
           "created_at"
         ],
         "title": "OrderOutboundViewOrderOut",
-        "description": "订单出库页专用：订单头只读模型（来源真相 = orders）\n\n说明：\n- 这里只表达真实订单头字段\n- 不掺执行仓 / 履约阶段 / 出库状态投影\n- order_fulfillment 后续若要展示，单独做 execution_context，不混入这里"
+        "description": "WMS 订单出库页专用：订单头只读模型。\n\nBoundary:\n- 路由归属 WMS outbound。\n- 来源仍是 WMS 本地执行订单 facts：orders。\n- 不读取 OMS owner 表，不挂在 /oms/orders。"
       },
       "OrderOutboundViewResponse": {
         "properties": {
@@ -30508,7 +20752,7 @@
           "order"
         ],
         "title": "OrderOutboundViewResponse",
-        "description": "订单出库页专用：只读聚合响应\n\n结构：\n- order: 订单头（orders）\n- lines: 订单行（order_lines + display）"
+        "description": "WMS 订单出库页专用：只读聚合响应。"
       },
       "OrderSalesDailyRow": {
         "properties": {
@@ -31024,613 +21268,6 @@
           "revenue"
         ],
         "title": "OrderSalesSummary"
-      },
-      "OrderSimCartGetOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok"
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ok",
-          "data"
-        ],
-        "title": "OrderSimCartGetOut"
-      },
-      "OrderSimCartPutIn": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/CartLineItemIn"
-            },
-            "type": "array",
-            "title": "Items"
-          }
-        },
-        "type": "object",
-        "title": "OrderSimCartPutIn"
-      },
-      "OrderSimCartPutOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok"
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ok",
-          "data"
-        ],
-        "title": "OrderSimCartPutOut"
-      },
-      "OrderSimFilledCodeOptionOut": {
-        "properties": {
-          "filled_code": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Filled Code",
-            "description": "商家后台填写码（merchant_code / filled_code）"
-          },
-          "suggested_title": {
-            "type": "string",
-            "title": "Suggested Title",
-            "description": "下拉选中后默认带出的标题（可编辑）"
-          },
-          "components_summary": {
-            "type": "string",
-            "title": "Components Summary",
-            "description": "FSKU components 摘要（spec 只读展示，不参与解析）"
-          }
-        },
-        "type": "object",
-        "required": [
-          "filled_code",
-          "suggested_title",
-          "components_summary"
-        ],
-        "title": "OrderSimFilledCodeOptionOut"
-      },
-      "OrderSimFilledCodeOptionsData": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/OrderSimFilledCodeOptionOut"
-            },
-            "type": "array",
-            "title": "Items"
-          }
-        },
-        "type": "object",
-        "title": "OrderSimFilledCodeOptionsData"
-      },
-      "OrderSimFilledCodeOptionsOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok"
-          },
-          "data": {
-            "$ref": "#/components/schemas/OrderSimFilledCodeOptionsData"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ok",
-          "data"
-        ],
-        "title": "OrderSimFilledCodeOptionsOut"
-      },
-      "OrderSimGenerateOrderIn": {
-        "properties": {
-          "idempotency_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Idempotency Key",
-            "description": "可选：用于 ext_order_no 幂等锚点（同 key → 同 ext_order_no）"
-          }
-        },
-        "type": "object",
-        "title": "OrderSimGenerateOrderIn"
-      },
-      "OrderSimGenerateOrderOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok"
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ok",
-          "data"
-        ],
-        "title": "OrderSimGenerateOrderOut"
-      },
-      "OrderSimMerchantLinesGetOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok"
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ok",
-          "data"
-        ],
-        "title": "OrderSimMerchantLinesGetOut"
-      },
-      "OrderSimMerchantLinesPutIn": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/MerchantLineItemIn"
-            },
-            "type": "array",
-            "title": "Items"
-          }
-        },
-        "type": "object",
-        "title": "OrderSimMerchantLinesPutIn"
-      },
-      "OrderSimMerchantLinesPutOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok"
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ok",
-          "data"
-        ],
-        "title": "OrderSimMerchantLinesPutOut"
-      },
-      "OrderSimPreviewOrderIn": {
-        "properties": {
-          "idempotency_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Idempotency Key",
-            "description": "可选：用于 preview 的 ext_order_no（与 generate-order 对齐）"
-          }
-        },
-        "type": "object",
-        "title": "OrderSimPreviewOrderIn"
-      },
-      "OrderSimPreviewOrderOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok"
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ok",
-          "data"
-        ],
-        "title": "OrderSimPreviewOrderOut"
-      },
-      "OrderSkuResolutionComponentOut": {
-        "properties": {
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "item_sku_code_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Item Sku Code Id"
-          },
-          "item_uom_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Item Uom Id"
-          },
-          "sku_code": {
-            "type": "string",
-            "title": "Sku Code"
-          },
-          "item_name": {
-            "type": "string",
-            "title": "Item Name"
-          },
-          "uom": {
-            "type": "string",
-            "title": "Uom"
-          },
-          "qty": {
-            "type": "string",
-            "title": "Qty"
-          },
-          "alloc_unit_price": {
-            "type": "string",
-            "title": "Alloc Unit Price"
-          },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order"
-          }
-        },
-        "type": "object",
-        "required": [
-          "item_id",
-          "sku_code",
-          "item_name",
-          "uom",
-          "qty",
-          "alloc_unit_price",
-          "sort_order"
-        ],
-        "title": "OrderSkuResolutionComponentOut"
-      },
-      "OrderSkuResolutionDataOut": {
-        "properties": {
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "mirror_id": {
-            "type": "integer",
-            "title": "Mirror Id"
-          },
-          "platform_order_no": {
-            "type": "string",
-            "title": "Platform Order No"
-          },
-          "store_code": {
-            "type": "string",
-            "title": "Store Code"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "resolved",
-              "needs_mapping"
-            ],
-            "title": "Status"
-          },
-          "lines": {
-            "items": {
-              "$ref": "#/components/schemas/OrderSkuResolutionLineOut"
-            },
-            "type": "array",
-            "title": "Lines"
-          }
-        },
-        "type": "object",
-        "required": [
-          "platform",
-          "mirror_id",
-          "platform_order_no",
-          "store_code",
-          "status"
-        ],
-        "title": "OrderSkuResolutionDataOut"
-      },
-      "OrderSkuResolutionLineOut": {
-        "properties": {
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "mirror_id": {
-            "type": "integer",
-            "title": "Mirror Id"
-          },
-          "line_id": {
-            "type": "integer",
-            "title": "Line Id"
-          },
-          "collector_order_id": {
-            "type": "integer",
-            "title": "Collector Order Id"
-          },
-          "collector_line_id": {
-            "type": "integer",
-            "title": "Collector Line Id"
-          },
-          "store_code": {
-            "type": "string",
-            "title": "Store Code"
-          },
-          "platform_order_no": {
-            "type": "string",
-            "title": "Platform Order No"
-          },
-          "merchant_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Merchant Code"
-          },
-          "platform_item_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Item Id"
-          },
-          "platform_sku_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Sku Id"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title"
-          },
-          "quantity": {
-            "type": "string",
-            "title": "Quantity"
-          },
-          "line_amount": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Line Amount"
-          },
-          "resolution_status": {
-            "type": "string",
-            "enum": [
-              "resolved",
-              "needs_mapping"
-            ],
-            "title": "Resolution Status"
-          },
-          "resolution_source": {
-            "type": "string",
-            "enum": [
-              "direct_fsku_code",
-              "code_mapping",
-              "unresolved"
-            ],
-            "title": "Resolution Source"
-          },
-          "resolved_identity_kind": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "merchant_code",
-                  "platform_sku_id",
-                  "platform_item_sku"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Resolved Identity Kind"
-          },
-          "resolved_identity_value": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Resolved Identity Value"
-          },
-          "fsku_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fsku Id"
-          },
-          "fsku_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fsku Code"
-          },
-          "fsku_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fsku Name"
-          },
-          "unresolved_reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Unresolved Reason"
-          },
-          "next_actions": {
-            "items": {
-              "$ref": "#/components/schemas/OrderSkuResolutionNextActionOut"
-            },
-            "type": "array",
-            "title": "Next Actions"
-          },
-          "components": {
-            "items": {
-              "$ref": "#/components/schemas/OrderSkuResolutionComponentOut"
-            },
-            "type": "array",
-            "title": "Components"
-          }
-        },
-        "type": "object",
-        "required": [
-          "platform",
-          "mirror_id",
-          "line_id",
-          "collector_order_id",
-          "collector_line_id",
-          "store_code",
-          "platform_order_no",
-          "quantity",
-          "resolution_status",
-          "resolution_source"
-        ],
-        "title": "OrderSkuResolutionLineOut"
-      },
-      "OrderSkuResolutionNextActionOut": {
-        "properties": {
-          "action": {
-            "type": "string",
-            "title": "Action"
-          },
-          "label": {
-            "type": "string",
-            "title": "Label"
-          },
-          "route_path": {
-            "type": "string",
-            "title": "Route Path"
-          },
-          "payload": {
-            "additionalProperties": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "type": "object",
-            "title": "Payload"
-          }
-        },
-        "type": "object",
-        "required": [
-          "action",
-          "label",
-          "route_path"
-        ],
-        "title": "OrderSkuResolutionNextActionOut"
-      },
-      "OrderSkuResolutionOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "$ref": "#/components/schemas/OrderSkuResolutionDataOut"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "OrderSkuResolutionOut"
       },
       "OrdersDailyStatsModel": {
         "properties": {
@@ -32826,114 +22463,138 @@
         ],
         "title": "PermissionMatrixRowOut"
       },
-      "PlatformCodeMappingBindIn": {
+      "PmsProjectionCheckIssueOut": {
         "properties": {
-          "platform": {
+          "issue_type": {
             "type": "string",
-            "maxLength": 32,
-            "minLength": 1,
-            "title": "Platform"
+            "title": "Issue Type"
           },
-          "store_code": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Store Code"
-          },
-          "identity_kind": {
+          "resource": {
             "type": "string",
             "enum": [
-              "merchant_code",
-              "platform_sku_id",
-              "platform_item_sku"
+              "items",
+              "suppliers",
+              "uoms",
+              "sku-codes",
+              "barcodes"
             ],
-            "title": "Identity Kind"
+            "title": "Resource"
           },
-          "identity_value": {
+          "source_id": {
             "type": "string",
-            "maxLength": 256,
-            "minLength": 1,
-            "title": "Identity Value"
+            "title": "Source Id"
           },
-          "fsku_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Fsku Id"
+          "message": {
+            "type": "string",
+            "title": "Message"
           },
-          "reason": {
+          "item_id": {
             "anyOf": [
               {
-                "type": "string",
-                "maxLength": 500
+                "type": "integer"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Reason"
+            "title": "Item Id"
+          },
+          "item_uom_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Item Uom Id"
+          },
+          "supplier_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Supplier Id"
+          },
+          "projection_item_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Projection Item Id"
           }
         },
         "type": "object",
         "required": [
-          "platform",
-          "store_code",
-          "identity_kind",
-          "identity_value",
-          "fsku_id"
+          "issue_type",
+          "resource",
+          "source_id",
+          "message"
         ],
-        "title": "PlatformCodeMappingBindIn"
+        "title": "PmsProjectionCheckIssueOut"
       },
-      "PlatformCodeMappingDeleteIn": {
+      "PmsProjectionCheckOut": {
         "properties": {
-          "platform": {
-            "type": "string",
-            "maxLength": 32,
-            "minLength": 1,
-            "title": "Platform"
-          },
-          "store_code": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Store Code"
-          },
-          "identity_kind": {
+          "resource": {
             "type": "string",
             "enum": [
-              "merchant_code",
-              "platform_sku_id",
-              "platform_item_sku"
+              "items",
+              "suppliers",
+              "uoms",
+              "sku-codes",
+              "barcodes"
             ],
-            "title": "Identity Kind"
+            "title": "Resource"
           },
-          "identity_value": {
-            "type": "string",
-            "maxLength": 256,
-            "minLength": 1,
-            "title": "Identity Value"
+          "ok": {
+            "type": "boolean",
+            "title": "Ok"
+          },
+          "issue_count": {
+            "type": "integer",
+            "title": "Issue Count"
+          },
+          "issues": {
+            "items": {
+              "$ref": "#/components/schemas/PmsProjectionCheckIssueOut"
+            },
+            "type": "array",
+            "title": "Issues"
           }
         },
         "type": "object",
         "required": [
-          "platform",
-          "store_code",
-          "identity_kind",
-          "identity_value"
+          "resource",
+          "ok",
+          "issue_count"
         ],
-        "title": "PlatformCodeMappingDeleteIn"
+        "title": "PmsProjectionCheckOut"
       },
-      "PlatformCodeMappingListDataOut": {
+      "PmsProjectionListOut": {
         "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/PlatformCodeMappingRowOut"
-            },
-            "type": "array",
-            "title": "Items"
+          "resource": {
+            "type": "string",
+            "enum": [
+              "items",
+              "suppliers",
+              "uoms",
+              "sku-codes",
+              "barcodes"
+            ],
+            "title": "Resource"
           },
-          "total": {
-            "type": "integer",
-            "title": "Total"
+          "table_name": {
+            "type": "string",
+            "title": "Table Name"
           },
           "limit": {
             "type": "integer",
@@ -32942,503 +22603,173 @@
           "offset": {
             "type": "integer",
             "title": "Offset"
-          }
-        },
-        "type": "object",
-        "required": [
-          "items",
-          "total",
-          "limit",
-          "offset"
-        ],
-        "title": "PlatformCodeMappingListDataOut"
-      },
-      "PlatformCodeMappingListOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
           },
-          "data": {
-            "$ref": "#/components/schemas/PlatformCodeMappingListDataOut"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "PlatformCodeMappingListOut"
-      },
-      "PlatformCodeMappingOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "$ref": "#/components/schemas/PlatformCodeMappingRowOut"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "PlatformCodeMappingOut"
-      },
-      "PlatformCodeMappingRowOut": {
-        "properties": {
-          "id": {
+          "total": {
             "type": "integer",
-            "title": "Id"
+            "title": "Total"
           },
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "store_code": {
-            "type": "string",
-            "title": "Store Code"
-          },
-          "store": {
-            "$ref": "#/components/schemas/StoreLiteOut"
-          },
-          "identity_kind": {
-            "type": "string",
-            "enum": [
-              "merchant_code",
-              "platform_sku_id",
-              "platform_item_sku"
-            ],
-            "title": "Identity Kind"
-          },
-          "identity_value": {
-            "type": "string",
-            "title": "Identity Value"
-          },
-          "fsku_id": {
-            "type": "integer",
-            "title": "Fsku Id"
-          },
-          "fsku": {
-            "$ref": "#/components/schemas/FskuLiteOut"
-          },
-          "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Reason"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "platform",
-          "store_code",
-          "store",
-          "identity_kind",
-          "identity_value",
-          "fsku_id",
-          "fsku",
-          "reason",
-          "created_at",
-          "updated_at"
-        ],
-        "title": "PlatformCodeMappingRowOut"
-      },
-      "PlatformOrderConfirmCreateDecisionIn": {
-        "properties": {
-          "line_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Line Key"
-          },
-          "line_no": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Line No"
-          },
-          "locator_kind": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Locator Kind",
-            "description": "对外定位类型（推荐）：FILLED_CODE / LINE_NO"
-          },
-          "locator_value": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Locator Value",
-            "description": "对外定位值（推荐）：当 FILLED_CODE 时为 filled_code；当 LINE_NO 时为 line_no 文本"
-          },
-          "filled_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Filled Code",
-            "description": "商家后台填写码（推荐；唯一语义字段）"
-          },
-          "platform_sku_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Sku Id",
-            "description": "已废弃：出现即报错（请使用 filled_code）"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "qty": {
-            "type": "integer",
-            "title": "Qty"
-          },
-          "note": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Note"
-          }
-        },
-        "type": "object",
-        "required": [
-          "item_id",
-          "qty"
-        ],
-        "title": "PlatformOrderConfirmCreateDecisionIn",
-        "description": "Phase N+4 · 人工决策输入（单行）\n\n说明：\n- filled_code 是“填写码”唯一语义字段\n- line_key 是内部幂等锚点（不推荐外部使用）\n- locator_kind/locator_value 是对外定位语义（推荐）\n  * FILLED_CODE + filled_code\n  * LINE_NO + str(line_no)"
-      },
-      "PlatformOrderConfirmCreateDecisionOut": {
-        "properties": {
-          "filled_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Filled Code",
-            "description": "商家后台填写码（唯一语义字段）"
-          },
-          "locator_kind": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Locator Kind",
-            "description": "对外定位类型（推荐）：FILLED_CODE / LINE_NO"
-          },
-          "locator_value": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Locator Value",
-            "description": "对外定位值（推荐）"
-          },
-          "line_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Line Key"
-          },
-          "line_no": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Line No"
-          },
-          "item_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Item Id"
-          },
-          "qty": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Qty"
-          },
-          "fact_qty": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fact Qty"
-          },
-          "note": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Note"
-          }
-        },
-        "type": "object",
-        "title": "PlatformOrderConfirmCreateDecisionOut",
-        "description": "Phase N+4 · 人工决策明细（输出）\n\n说明：\n- filled_code 为唯一语义字段\n- locator_kind/value 为推荐定位语义（与 line_key 分层）"
-      },
-      "PlatformOrderConfirmCreateIn": {
-        "properties": {
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "store_id": {
-            "type": "integer",
-            "title": "Store Id"
-          },
-          "ext_order_no": {
-            "type": "string",
-            "title": "Ext Order No"
-          },
-          "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Reason"
-          },
-          "decisions": {
-            "items": {
-              "$ref": "#/components/schemas/PlatformOrderConfirmCreateDecisionIn"
-            },
-            "type": "array",
-            "title": "Decisions",
-            "description": "人工决策行列表"
-          }
-        },
-        "type": "object",
-        "required": [
-          "platform",
-          "store_id",
-          "ext_order_no"
-        ],
-        "title": "PlatformOrderConfirmCreateIn",
-        "description": "Phase N+4 · 当单执行（人工确认后创建订单）\n\n解析语义：\n- 决策行优先使用 locator（locator_kind/value）\n- 其次使用 filled_code / line_no\n- line_key 仅作为旧链路兼容"
-      },
-      "PlatformOrderConfirmCreateOut": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Id"
-          },
-          "ref": {
-            "type": "string",
-            "title": "Ref"
-          },
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "store_id": {
-            "type": "integer",
-            "title": "Store Id"
-          },
-          "ext_order_no": {
-            "type": "string",
-            "title": "Ext Order No"
-          },
-          "manual_override": {
-            "type": "boolean",
-            "title": "Manual Override"
-          },
-          "manual_reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Manual Reason"
-          },
-          "manual_batch_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Manual Batch Id"
-          },
-          "decisions": {
-            "items": {
-              "$ref": "#/components/schemas/PlatformOrderConfirmCreateDecisionOut"
-            },
-            "type": "array",
-            "title": "Decisions"
-          },
-          "risk_flags": {
+          "columns": {
             "items": {
               "type": "string"
             },
             "type": "array",
-            "title": "Risk Flags"
+            "title": "Columns"
           },
-          "facts_n": {
-            "type": "integer",
-            "title": "Facts N"
-          },
-          "fulfillment_status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fulfillment Status"
-          },
-          "blocked_reasons": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Blocked Reasons"
+          "rows": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Rows"
           }
         },
         "type": "object",
         "required": [
-          "status",
-          "id",
-          "ref",
-          "platform",
-          "store_id",
-          "ext_order_no",
-          "manual_override",
-          "facts_n"
+          "resource",
+          "table_name",
+          "limit",
+          "offset",
+          "total"
         ],
-        "title": "PlatformOrderConfirmCreateOut"
+        "title": "PmsProjectionListOut"
       },
-      "PlatformOrderIngestIn": {
+      "PmsProjectionResourceStatusOut": {
         "properties": {
-          "platform": {
+          "resource": {
             "type": "string",
-            "maxLength": 32,
-            "minLength": 1,
-            "title": "Platform"
+            "enum": [
+              "items",
+              "suppliers",
+              "uoms",
+              "sku-codes",
+              "barcodes"
+            ],
+            "title": "Resource"
           },
-          "store_id": {
+          "table_name": {
+            "type": "string",
+            "title": "Table Name"
+          },
+          "row_count": {
+            "type": "integer",
+            "title": "Row Count"
+          },
+          "max_synced_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Synced At"
+          },
+          "last_sync_run": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PmsProjectionSyncRunOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "resource",
+          "table_name",
+          "row_count"
+        ],
+        "title": "PmsProjectionResourceStatusOut"
+      },
+      "PmsProjectionStatusOut": {
+        "properties": {
+          "pms_api_base_url_configured": {
+            "type": "boolean",
+            "title": "Pms Api Base Url Configured"
+          },
+          "resources": {
+            "items": {
+              "$ref": "#/components/schemas/PmsProjectionResourceStatusOut"
+            },
+            "type": "array",
+            "title": "Resources"
+          }
+        },
+        "type": "object",
+        "required": [
+          "pms_api_base_url_configured"
+        ],
+        "title": "PmsProjectionStatusOut"
+      },
+      "PmsProjectionSyncOut": {
+        "properties": {
+          "run": {
+            "$ref": "#/components/schemas/PmsProjectionSyncRunOut"
+          }
+        },
+        "type": "object",
+        "required": [
+          "run"
+        ],
+        "title": "PmsProjectionSyncOut"
+      },
+      "PmsProjectionSyncRunOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "resource": {
+            "type": "string",
+            "title": "Resource"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "RUNNING",
+              "SUCCESS",
+              "FAILED"
+            ],
+            "title": "Status"
+          },
+          "fetched": {
+            "type": "integer",
+            "title": "Fetched",
+            "default": 0
+          },
+          "upserted": {
+            "type": "integer",
+            "title": "Upserted",
+            "default": 0
+          },
+          "pages": {
+            "type": "integer",
+            "title": "Pages",
+            "default": 0
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Started At"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finished At"
+          },
+          "duration_ms": {
             "anyOf": [
               {
                 "type": "integer"
@@ -33447,2322 +22778,235 @@
                 "type": "null"
               }
             ],
-            "title": "Store Id"
+            "title": "Duration Ms"
           },
-          "store_code": {
+          "error_message": {
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Store Code"
+            "title": "Error Message"
           },
-          "ext_order_no": {
+          "triggered_by_user_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Triggered By User Id"
+          },
+          "pms_api_base_url_snapshot": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pms Api Base Url Snapshot"
+          },
+          "sync_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sync Version"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "resource",
+          "status",
+          "started_at"
+        ],
+        "title": "PmsProjectionSyncRunOut"
+      },
+      "PmsProjectionSyncRunsOut": {
+        "properties": {
+          "resource": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "items",
+                  "suppliers",
+                  "uoms",
+                  "sku-codes",
+                  "barcodes"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resource"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "runs": {
+            "items": {
+              "$ref": "#/components/schemas/PmsProjectionSyncRunOut"
+            },
+            "type": "array",
+            "title": "Runs"
+          }
+        },
+        "type": "object",
+        "required": [
+          "limit"
+        ],
+        "title": "PmsProjectionSyncRunsOut"
+      },
+      "ProcurementReceivingResultDetailOut": {
+        "properties": {
+          "event_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Event Id"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ProcurementReceivingResultLineOut"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "event_id"
+        ],
+        "title": "ProcurementReceivingResultDetailOut"
+      },
+      "ProcurementReceivingResultLineOut": {
+        "properties": {
+          "wms_event_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Wms Event Id"
+          },
+          "wms_event_no": {
             "type": "string",
+            "maxLength": 64,
             "minLength": 1,
-            "title": "Ext Order No"
+            "title": "Wms Event No"
+          },
+          "trace_id": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Trace Id"
+          },
+          "event_kind": {
+            "type": "string",
+            "const": "COMMIT",
+            "title": "Event Kind"
+          },
+          "event_status": {
+            "type": "string",
+            "maxLength": 16,
+            "minLength": 1,
+            "title": "Event Status"
           },
           "occurred_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "string",
+            "format": "date-time",
             "title": "Occurred At"
           },
-          "buyer_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Buyer Name"
-          },
-          "buyer_phone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Buyer Phone"
-          },
-          "receiver_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Name"
-          },
-          "receiver_phone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiver Phone"
-          },
-          "province": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Province"
-          },
-          "city": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "City"
-          },
-          "district": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "District"
-          },
-          "detail": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Detail"
-          },
-          "zipcode": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Zipcode"
-          },
-          "lines": {
-            "items": {
-              "$ref": "#/components/schemas/PlatformOrderLineIn"
-            },
-            "type": "array",
-            "title": "Lines",
-            "description": "订单行列表（可含 legacy 形态行）"
-          },
-          "store_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Store Name"
-          },
-          "raw_payload": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Raw Payload"
-          }
-        },
-        "type": "object",
-        "required": [
-          "platform",
-          "ext_order_no"
-        ],
-        "title": "PlatformOrderIngestIn",
-        "description": "Phase N+2 · 平台订单接入（宽进严出）"
-      },
-      "PlatformOrderIngestOut": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Id"
-          },
-          "ref": {
-            "type": "string",
-            "title": "Ref"
-          },
-          "store_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Store Id"
-          },
-          "resolved": {
-            "items": {
-              "$ref": "#/components/schemas/PlatformOrderLineResult"
-            },
-            "type": "array",
-            "title": "Resolved"
-          },
-          "unresolved": {
-            "items": {
-              "$ref": "#/components/schemas/PlatformOrderLineResult"
-            },
-            "type": "array",
-            "title": "Unresolved"
-          },
-          "facts_written": {
-            "type": "integer",
-            "title": "Facts Written"
-          },
-          "fulfillment_status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fulfillment Status"
-          },
-          "blocked_reasons": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Blocked Reasons"
-          },
-          "allow_manual_continue": {
-            "type": "boolean",
-            "title": "Allow Manual Continue",
-            "default": false
-          },
-          "risk_flags": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Risk Flags"
-          },
-          "risk_level": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Risk Level"
-          },
-          "risk_reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Risk Reason"
-          },
-          "reason_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Reason Code",
-            "description": "单一主因（OK / CODE_NOT_BOUND / MISSING_FILLED_CODE / ROUTING_BLOCKED 等）"
-          },
-          "next_actions": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "type": "array",
-            "title": "Next Actions",
-            "description": "面向操作者的下一步动作建议（可执行）"
-          }
-        },
-        "type": "object",
-        "required": [
-          "status",
-          "id",
-          "ref",
-          "store_id",
-          "facts_written"
-        ],
-        "title": "PlatformOrderIngestOut",
-        "description": "Phase D · 证据结构化输出（顶层）\n\n- reason_code：单一主因（稳定治理锚点）\n- next_actions：面向操作者的全局动作建议（可执行）"
-      },
-      "PlatformOrderLineIn": {
-        "properties": {
-          "filled_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Filled Code",
-            "description": "商家后台填写码（Phase N+2 推荐字段）"
-          },
-          "qty": {
-            "type": "integer",
-            "exclusiveMinimum": 0.0,
-            "title": "Qty",
-            "description": "数量（>0）",
-            "default": 1
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title",
-            "description": "商品标题（可选）"
-          },
-          "spec": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spec",
-            "description": "规格描述（可选）"
-          },
-          "extras": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Extras",
-            "description": "行级扩展字段"
-          }
-        },
-        "type": "object",
-        "title": "PlatformOrderLineIn",
-        "description": "Phase N+2 · 平台订单行输入\n\n说明：\n- filled_code 为推荐字段（Phase N+2 语义）\n- 二者均可缺失，是否可执行由 resolver 判定（而非 schema 阶段）"
-      },
-      "PlatformOrderLineResult": {
-        "properties": {
-          "filled_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Filled Code"
-          },
-          "qty": {
-            "type": "integer",
-            "title": "Qty"
-          },
-          "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Reason"
-          },
-          "hint": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Hint"
-          },
-          "fsku_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fsku Id"
-          },
-          "expanded_items": {
-            "anyOf": [
-              {
-                "items": {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Expanded Items"
-          },
-          "risk_flags": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Risk Flags"
-          },
-          "risk_level": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Risk Level"
-          },
-          "risk_reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Risk Reason"
-          },
-          "next_actions": {
-            "anyOf": [
-              {
-                "items": {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Next Actions"
-          }
-        },
-        "type": "object",
-        "required": [
-          "qty"
-        ],
-        "title": "PlatformOrderLineResult",
-        "description": "行级解析结果（Phase N+2 输出）"
-      },
-      "PlatformOrderMirrorEnvelopeOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "$ref": "#/components/schemas/PlatformOrderMirrorOut"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "PlatformOrderMirrorEnvelopeOut"
-      },
-      "PlatformOrderMirrorImportIn": {
-        "properties": {
-          "collector_order_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Collector Order Id"
-          },
-          "collector_store_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Collector Store Id"
-          },
-          "collector_store_code": {
+          "receipt_no": {
             "type": "string",
             "maxLength": 128,
             "minLength": 1,
-            "title": "Collector Store Code"
+            "title": "Receipt No"
           },
-          "collector_store_name": {
-            "type": "string",
-            "maxLength": 255,
-            "minLength": 1,
-            "title": "Collector Store Name"
+          "procurement_po_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Procurement Po Id"
           },
-          "platform": {
-            "type": "string",
-            "enum": [
-              "pdd",
-              "taobao",
-              "jd"
-            ],
-            "title": "Platform"
-          },
-          "platform_order_no": {
+          "procurement_po_no": {
             "type": "string",
             "maxLength": 128,
             "minLength": 1,
-            "title": "Platform Order No"
+            "title": "Procurement Po No"
           },
-          "platform_status": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 64
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Status"
-          },
-          "source_updated_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source Updated At"
-          },
-          "pulled_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pulled At"
-          },
-          "last_synced_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Synced At"
-          },
-          "receiver": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Receiver"
-          },
-          "amounts": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Amounts"
-          },
-          "platform_fields": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Platform Fields"
-          },
-          "raw_refs": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Raw Refs"
-          },
-          "lines": {
-            "items": {
-              "$ref": "#/components/schemas/PlatformOrderMirrorLineImportIn"
-            },
-            "type": "array",
-            "title": "Lines"
-          }
-        },
-        "type": "object",
-        "required": [
-          "collector_order_id",
-          "collector_store_id",
-          "collector_store_code",
-          "collector_store_name",
-          "platform",
-          "platform_order_no"
-        ],
-        "title": "PlatformOrderMirrorImportIn"
-      },
-      "PlatformOrderMirrorLineImportIn": {
-        "properties": {
-          "collector_line_id": {
+          "wms_event_line_no": {
             "type": "integer",
             "minimum": 1.0,
-            "title": "Collector Line Id"
+            "title": "Wms Event Line No"
           },
-          "collector_order_id": {
+          "procurement_po_line_id": {
             "type": "integer",
             "minimum": 1.0,
-            "title": "Collector Order Id"
-          },
-          "platform_order_no": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Platform Order No"
-          },
-          "merchant_sku": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Merchant Sku"
-          },
-          "platform_item_id": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Item Id"
-          },
-          "platform_sku_id": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Sku Id"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title"
-          },
-          "quantity": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              }
-            ],
-            "title": "Quantity",
-            "default": "0"
-          },
-          "unit_price": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Unit Price"
-          },
-          "line_amount": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Line Amount"
-          },
-          "platform_fields": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Platform Fields"
-          },
-          "raw_item_payload": {
-            "title": "Raw Item Payload"
-          }
-        },
-        "type": "object",
-        "required": [
-          "collector_line_id",
-          "collector_order_id",
-          "platform_order_no"
-        ],
-        "title": "PlatformOrderMirrorLineImportIn"
-      },
-      "PlatformOrderMirrorLineOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "collector_line_id": {
-            "type": "integer",
-            "title": "Collector Line Id"
-          },
-          "collector_order_id": {
-            "type": "integer",
-            "title": "Collector Order Id"
-          },
-          "platform_order_no": {
-            "type": "string",
-            "title": "Platform Order No"
-          },
-          "merchant_sku": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Merchant Sku"
-          },
-          "platform_item_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Item Id"
-          },
-          "platform_sku_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Sku Id"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title"
-          },
-          "quantity": {
-            "type": "string",
-            "title": "Quantity"
-          },
-          "unit_price": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Unit Price"
-          },
-          "line_amount": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Line Amount"
-          },
-          "platform_fields": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Platform Fields"
-          },
-          "raw_item_payload": {
-            "title": "Raw Item Payload"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "collector_line_id",
-          "collector_order_id",
-          "platform_order_no",
-          "quantity"
-        ],
-        "title": "PlatformOrderMirrorLineOut"
-      },
-      "PlatformOrderMirrorListOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/PlatformOrderMirrorOut"
-            },
-            "type": "array",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "PlatformOrderMirrorListOut"
-      },
-      "PlatformOrderMirrorOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "collector_order_id": {
-            "type": "integer",
-            "title": "Collector Order Id"
-          },
-          "collector_store_id": {
-            "type": "integer",
-            "title": "Collector Store Id"
-          },
-          "collector_store_code": {
-            "type": "string",
-            "title": "Collector Store Code"
-          },
-          "collector_store_name": {
-            "type": "string",
-            "title": "Collector Store Name"
-          },
-          "wms_store_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Wms Store Id"
-          },
-          "platform": {
-            "type": "string",
-            "enum": [
-              "pdd",
-              "taobao",
-              "jd"
-            ],
-            "title": "Platform"
-          },
-          "platform_order_no": {
-            "type": "string",
-            "title": "Platform Order No"
-          },
-          "platform_status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Platform Status"
-          },
-          "import_status": {
-            "type": "string",
-            "title": "Import Status"
-          },
-          "mirror_status": {
-            "type": "string",
-            "title": "Mirror Status"
-          },
-          "source_updated_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source Updated At"
-          },
-          "pulled_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pulled At"
-          },
-          "collector_last_synced_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Collector Last Synced At"
-          },
-          "imported_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Imported At"
-          },
-          "last_synced_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Synced At"
-          },
-          "receiver": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Receiver"
-          },
-          "amounts": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Amounts"
-          },
-          "platform_fields": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Platform Fields"
-          },
-          "raw_refs": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Raw Refs"
-          },
-          "lines": {
-            "items": {
-              "$ref": "#/components/schemas/PlatformOrderMirrorLineOut"
-            },
-            "type": "array",
-            "title": "Lines"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "collector_order_id",
-          "collector_store_id",
-          "collector_store_code",
-          "collector_store_name",
-          "platform",
-          "platform_order_no",
-          "import_status",
-          "mirror_status"
-        ],
-        "title": "PlatformOrderMirrorOut"
-      },
-      "PlatformOrderReplayIn": {
-        "properties": {
-          "platform": {
-            "type": "string",
-            "maxLength": 32,
-            "minLength": 1,
-            "title": "Platform"
-          },
-          "store_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Store Id"
-          },
-          "ext_order_no": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Ext Order No"
-          }
-        },
-        "type": "object",
-        "required": [
-          "platform",
-          "store_id",
-          "ext_order_no"
-        ],
-        "title": "PlatformOrderReplayIn",
-        "description": "平台订单事实重放解码（内部治理接口）：\n- 入参只接收 store_id（stores.id）\n- 读取 platform_order_lines 事实行\n- 复用 resolver + OrderService.ingest 主线幂等"
-      },
-      "PlatformOrderReplayOut": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Id"
-          },
-          "ref": {
-            "type": "string",
-            "title": "Ref"
-          },
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "store_id": {
-            "type": "integer",
-            "title": "Store Id"
-          },
-          "ext_order_no": {
-            "type": "string",
-            "title": "Ext Order No"
-          },
-          "facts_n": {
-            "type": "integer",
-            "title": "Facts N",
-            "default": 0
-          },
-          "resolved": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "type": "array",
-            "title": "Resolved"
-          },
-          "unresolved": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "type": "array",
-            "title": "Unresolved"
-          },
-          "fulfillment_status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fulfillment Status"
-          },
-          "blocked_reasons": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Blocked Reasons"
-          }
-        },
-        "type": "object",
-        "required": [
-          "status",
-          "ref",
-          "platform",
-          "store_id",
-          "ext_order_no"
-        ],
-        "title": "PlatformOrderReplayOut"
-      },
-      "PlatformOrderResolvePreviewFactLineOut": {
-        "properties": {
-          "line_no": {
-            "type": "integer",
-            "title": "Line No"
-          },
-          "line_key": {
-            "type": "string",
-            "title": "Line Key"
-          },
-          "locator_kind": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Locator Kind"
-          },
-          "locator_value": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Locator Value"
-          },
-          "filled_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Filled Code"
-          },
-          "qty": {
-            "type": "integer",
-            "title": "Qty"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title"
-          },
-          "spec": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spec"
-          },
-          "extras": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Extras"
-          }
-        },
-        "type": "object",
-        "required": [
-          "line_no",
-          "line_key",
-          "qty"
-        ],
-        "title": "PlatformOrderResolvePreviewFactLineOut"
-      },
-      "PlatformOrderResolvePreviewIn": {
-        "properties": {
-          "platform": {
-            "type": "string",
-            "maxLength": 50,
-            "minLength": 1,
-            "title": "Platform"
-          },
-          "store_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Store Id"
-          },
-          "ext_order_no": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Ext Order No"
-          }
-        },
-        "type": "object",
-        "required": [
-          "platform",
-          "store_id",
-          "ext_order_no"
-        ],
-        "title": "PlatformOrderResolvePreviewIn"
-      },
-      "PlatformOrderResolvePreviewItemQtyOut": {
-        "properties": {
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "qty": {
-            "type": "integer",
-            "title": "Qty"
-          },
-          "sku": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sku"
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          }
-        },
-        "type": "object",
-        "required": [
-          "item_id",
-          "qty"
-        ],
-        "title": "PlatformOrderResolvePreviewItemQtyOut"
-      },
-      "PlatformOrderResolvePreviewOut": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "ref": {
-            "type": "string",
-            "title": "Ref"
-          },
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "store_id": {
-            "type": "integer",
-            "title": "Store Id"
-          },
-          "ext_order_no": {
-            "type": "string",
-            "title": "Ext Order No"
-          },
-          "facts_n": {
-            "type": "integer",
-            "title": "Facts N"
-          },
-          "fact_lines": {
-            "items": {
-              "$ref": "#/components/schemas/PlatformOrderResolvePreviewFactLineOut"
-            },
-            "type": "array",
-            "title": "Fact Lines"
-          },
-          "resolved": {
-            "items": {
-              "$ref": "#/components/schemas/PlatformOrderResolvePreviewResolvedLineOut"
-            },
-            "type": "array",
-            "title": "Resolved"
-          },
-          "unresolved": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "type": "array",
-            "title": "Unresolved"
-          },
-          "item_qty_map": {
-            "additionalProperties": {
-              "type": "integer"
-            },
-            "type": "object",
-            "title": "Item Qty Map"
-          },
-          "item_qty_items": {
-            "items": {
-              "$ref": "#/components/schemas/PlatformOrderResolvePreviewItemQtyOut"
-            },
-            "type": "array",
-            "title": "Item Qty Items"
-          }
-        },
-        "type": "object",
-        "required": [
-          "status",
-          "ref",
-          "platform",
-          "store_id",
-          "ext_order_no",
-          "facts_n",
-          "fact_lines",
-          "resolved",
-          "unresolved",
-          "item_qty_map",
-          "item_qty_items"
-        ],
-        "title": "PlatformOrderResolvePreviewOut"
-      },
-      "PlatformOrderResolvePreviewResolvedLineOut": {
-        "properties": {
-          "filled_code": {
-            "type": "string",
-            "title": "Filled Code"
-          },
-          "qty": {
-            "type": "integer",
-            "title": "Qty"
-          },
-          "fsku_id": {
-            "type": "integer",
-            "title": "Fsku Id"
-          },
-          "expanded_items": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "type": "array",
-            "title": "Expanded Items"
-          }
-        },
-        "type": "object",
-        "required": [
-          "filled_code",
-          "qty",
-          "fsku_id",
-          "expanded_items"
-        ],
-        "title": "PlatformOrderResolvePreviewResolvedLineOut"
-      },
-      "PmsBrandCreate": {
-        "properties": {
-          "name_cn": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Name Cn"
-          },
-          "code": {
-            "type": "string",
-            "maxLength": 32,
-            "minLength": 1,
-            "title": "Code"
-          },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order",
-            "default": 0
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 500
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          }
-        },
-        "type": "object",
-        "required": [
-          "name_cn",
-          "code"
-        ],
-        "title": "PmsBrandCreate"
-      },
-      "PmsBrandOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "name_cn": {
-            "type": "string",
-            "title": "Name Cn"
-          },
-          "code": {
-            "type": "string",
-            "title": "Code"
-          },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
-          },
-          "is_locked": {
-            "type": "boolean",
-            "title": "Is Locked"
-          },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order"
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "name_cn",
-          "code",
-          "is_active",
-          "is_locked",
-          "sort_order"
-        ],
-        "title": "PmsBrandOut"
-      },
-      "PmsBrandUpdate": {
-        "properties": {
-          "name_cn": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name Cn"
-          },
-          "code": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 32
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Code"
-          },
-          "sort_order": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sort Order"
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 500
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          }
-        },
-        "type": "object",
-        "title": "PmsBrandUpdate"
-      },
-      "PmsCategoryCreate": {
-        "properties": {
-          "parent_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Parent Id"
-          },
-          "level": {
-            "type": "integer",
-            "maximum": 3.0,
-            "minimum": 1.0,
-            "title": "Level"
-          },
-          "product_kind": {
-            "type": "string",
-            "enum": [
-              "FOOD",
-              "SUPPLY",
-              "OTHER"
-            ],
-            "title": "Product Kind"
-          },
-          "category_name": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Category Name"
-          },
-          "category_code": {
-            "type": "string",
-            "maxLength": 32,
-            "minLength": 1,
-            "title": "Category Code"
-          },
-          "is_leaf": {
-            "type": "boolean",
-            "title": "Is Leaf",
-            "default": false
-          },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order",
-            "default": 0
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 500
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          }
-        },
-        "type": "object",
-        "required": [
-          "level",
-          "product_kind",
-          "category_name",
-          "category_code"
-        ],
-        "title": "PmsCategoryCreate"
-      },
-      "PmsCategoryOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "parent_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Parent Id"
-          },
-          "level": {
-            "type": "integer",
-            "title": "Level"
-          },
-          "product_kind": {
-            "type": "string",
-            "title": "Product Kind"
-          },
-          "category_name": {
-            "type": "string",
-            "title": "Category Name"
-          },
-          "category_code": {
-            "type": "string",
-            "title": "Category Code"
-          },
-          "path_code": {
-            "type": "string",
-            "title": "Path Code"
-          },
-          "is_leaf": {
-            "type": "boolean",
-            "title": "Is Leaf"
-          },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
-          },
-          "is_locked": {
-            "type": "boolean",
-            "title": "Is Locked"
-          },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order"
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "parent_id",
-          "level",
-          "product_kind",
-          "category_name",
-          "category_code",
-          "path_code",
-          "is_leaf",
-          "is_active",
-          "is_locked",
-          "sort_order"
-        ],
-        "title": "PmsCategoryOut"
-      },
-      "PmsCategoryUpdate": {
-        "properties": {
-          "category_name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Category Name"
-          },
-          "category_code": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 32
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Category Code"
-          },
-          "is_leaf": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Leaf"
-          },
-          "sort_order": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sort Order"
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 500
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          }
-        },
-        "type": "object",
-        "title": "PmsCategoryUpdate"
-      },
-      "PmsExportBarcode": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "item_uom_id": {
-            "type": "integer",
-            "title": "Item Uom Id"
-          },
-          "barcode": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Barcode"
-          },
-          "symbology": {
-            "type": "string",
-            "title": "Symbology"
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active"
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary"
-          },
-          "uom": {
-            "type": "string",
-            "title": "Uom"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "uom_name": {
-            "type": "string",
-            "title": "Uom Name"
-          },
-          "ratio_to_base": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Ratio To Base"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "item_id",
-          "item_uom_id",
-          "barcode",
-          "symbology",
-          "active",
-          "is_primary",
-          "uom",
-          "uom_name",
-          "ratio_to_base"
-        ],
-        "title": "PmsExportBarcode",
-        "description": "PMS 对外条码读模型。\n\n定位：\n- 只读 export contract；\n- 不承载 owner 写入、改绑、设主条码语义；\n- barcode 绑定终态来自 item_barcodes；\n- 包装语义通过 item_uom_id 关联 item_uoms。"
-      },
-      "PmsExportSkuCode": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "code": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Code"
-          },
-          "code_type": {
-            "type": "string",
-            "enum": [
-              "PRIMARY",
-              "ALIAS",
-              "LEGACY",
-              "MANUAL"
-            ],
-            "title": "Code Type"
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary"
-          },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
-          },
-          "effective_from": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Effective From"
-          },
-          "effective_to": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Effective To"
-          },
-          "remark": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Remark"
-          },
-          "item_sku": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Item Sku"
-          },
-          "item_name": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Item Name"
-          },
-          "item_enabled": {
-            "type": "boolean",
-            "title": "Item Enabled"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "item_id",
-          "code",
-          "code_type",
-          "is_primary",
-          "is_active",
-          "item_sku",
-          "item_name",
-          "item_enabled"
-        ],
-        "title": "PmsExportSkuCode",
-        "description": "PMS 对外 SKU 编码读模型。\n\n定位：\n- 只读 export contract；\n- 不承载 owner 写入、停用、启用、主编码切换语义；\n- item_sku_codes 是编码治理真相表；\n- items.sku 只是当前主 SKU 投影。"
-      },
-      "PmsExportSkuCodeResolution": {
-        "properties": {
-          "sku_code_id": {
-            "type": "integer",
-            "title": "Sku Code Id"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "sku_code": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Sku Code"
-          },
-          "code_type": {
-            "type": "string",
-            "enum": [
-              "PRIMARY",
-              "ALIAS",
-              "LEGACY",
-              "MANUAL"
-            ],
-            "title": "Code Type"
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary"
-          },
-          "item_sku": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Item Sku"
-          },
-          "item_name": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Item Name"
-          },
-          "item_uom_id": {
-            "type": "integer",
-            "title": "Item Uom Id"
-          },
-          "uom": {
-            "type": "string",
-            "title": "Uom"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "uom_name": {
-            "type": "string",
-            "title": "Uom Name"
-          },
-          "ratio_to_base": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Ratio To Base"
-          }
-        },
-        "type": "object",
-        "required": [
-          "sku_code_id",
-          "item_id",
-          "sku_code",
-          "code_type",
-          "is_primary",
-          "item_sku",
-          "item_name",
-          "item_uom_id",
-          "uom",
-          "uom_name",
-          "ratio_to_base"
-        ],
-        "title": "PmsExportSkuCodeResolution",
-        "description": "PMS SKU 编码解析结果。\n\n用途：\n- OMS FSKU 表达式组件解析；\n- 通过 SKU code 得到稳定 item_id / sku_code_id；\n- 同时返回该商品出库默认包装或基础包装，用于生成 OMS FSKU 组件快照。"
-      },
-      "PmsExportUom": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "item_id": {
-            "type": "integer",
-            "title": "Item Id"
-          },
-          "uom": {
-            "type": "string",
-            "title": "Uom"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "uom_name": {
-            "type": "string",
-            "title": "Uom Name"
-          },
-          "ratio_to_base": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Ratio To Base"
-          },
-          "net_weight_kg": {
-            "anyOf": [
-              {
-                "type": "number",
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Weight Kg"
-          },
-          "is_base": {
-            "type": "boolean",
-            "title": "Is Base"
-          },
-          "is_purchase_default": {
-            "type": "boolean",
-            "title": "Is Purchase Default"
-          },
-          "is_inbound_default": {
-            "type": "boolean",
-            "title": "Is Inbound Default"
-          },
-          "is_outbound_default": {
-            "type": "boolean",
-            "title": "Is Outbound Default"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "item_id",
-          "uom",
-          "uom_name",
-          "ratio_to_base",
-          "is_base",
-          "is_purchase_default",
-          "is_inbound_default",
-          "is_outbound_default"
-        ],
-        "title": "PmsExportUom",
-        "description": "PMS 对外包装单位读模型。\n\n定位：\n- 只读 export contract；\n- 不承载 owner 写入语义；\n- 供 WMS / OMS / Procurement / Finance 等跨域消费；\n- item_uoms 表仍是 PMS 内部真相源。"
-      },
-      "ProvinceRouteCreateIn": {
-        "properties": {
-          "province": {
-            "type": "string",
-            "maxLength": 32,
-            "minLength": 1,
-            "title": "Province"
+            "title": "Procurement Po Line Id"
           },
           "warehouse_id": {
             "type": "integer",
             "minimum": 1.0,
             "title": "Warehouse Id"
           },
-          "priority": {
+          "item_id": {
             "type": "integer",
-            "maximum": 100000.0,
-            "minimum": 0.0,
-            "title": "Priority",
-            "default": 100
+            "minimum": 1.0,
+            "title": "Item Id"
           },
-          "active": {
-            "type": "boolean",
-            "title": "Active",
-            "default": true
-          }
-        },
-        "type": "object",
-        "required": [
-          "province",
-          "warehouse_id"
-        ],
-        "title": "ProvinceRouteCreateIn"
-      },
-      "ProvinceRouteItem": {
-        "properties": {
-          "id": {
+          "qty_delta_base": {
             "type": "integer",
-            "title": "Id"
+            "title": "Qty Delta Base"
           },
-          "store_id": {
-            "type": "integer",
-            "title": "Store Id"
-          },
-          "province": {
-            "type": "string",
-            "title": "Province"
-          },
-          "warehouse_id": {
-            "type": "integer",
-            "title": "Warehouse Id"
-          },
-          "warehouse_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Warehouse Name"
-          },
-          "warehouse_code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Warehouse Code"
-          },
-          "warehouse_active": {
-            "type": "boolean",
-            "title": "Warehouse Active",
-            "default": true
-          },
-          "priority": {
-            "type": "integer",
-            "title": "Priority",
-            "default": 100
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active",
-            "default": true
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "store_id",
-          "province",
-          "warehouse_id"
-        ],
-        "title": "ProvinceRouteItem"
-      },
-      "ProvinceRouteListOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/ProvinceRouteItem"
-            },
-            "type": "array",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "ProvinceRouteListOut"
-      },
-      "ProvinceRouteUpdateIn": {
-        "properties": {
-          "province": {
+          "lot_code_input": {
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 32,
-                "minLength": 1
+                "maxLength": 128
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Province"
+            "title": "Lot Code Input"
           },
-          "warehouse_id": {
+          "production_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Production Date"
+          },
+          "expiry_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expiry Date"
+          },
+          "lot_id": {
             "anyOf": [
               {
                 "type": "integer",
@@ -35772,54 +23016,68 @@
                 "type": "null"
               }
             ],
-            "title": "Warehouse Id"
-          },
-          "priority": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "maximum": 100000.0,
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Priority"
-          },
-          "active": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Active"
+            "title": "Lot Id"
           }
         },
-        "type": "object",
-        "title": "ProvinceRouteUpdateIn"
-      },
-      "ProvinceRouteWriteOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
+        "additionalProperties": false,
         "type": "object",
         "required": [
-          "data"
+          "wms_event_id",
+          "wms_event_no",
+          "trace_id",
+          "event_kind",
+          "event_status",
+          "occurred_at",
+          "receipt_no",
+          "procurement_po_id",
+          "procurement_po_no",
+          "wms_event_line_no",
+          "procurement_po_line_id",
+          "warehouse_id",
+          "item_id",
+          "qty_delta_base"
         ],
-        "title": "ProvinceRouteWriteOut"
+        "title": "ProcurementReceivingResultLineOut"
+      },
+      "ProcurementReceivingResultsOut": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ProcurementReceivingResultLineOut"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "after_event_id": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "After Event Id"
+          },
+          "next_after_event_id": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Next After Event Id"
+          },
+          "limit": {
+            "type": "integer",
+            "maximum": 200.0,
+            "minimum": 1.0,
+            "title": "Limit"
+          },
+          "has_more": {
+            "type": "boolean",
+            "title": "Has More"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "after_event_id",
+          "next_after_event_id",
+          "limit",
+          "has_more"
+        ],
+        "title": "ProcurementReceivingResultsOut"
       },
       "PurchaseCostDailyRow": {
         "properties": {
@@ -38035,25 +25293,6 @@
         ],
         "title": "ReturnTaskReceiveIn"
       },
-      "RoutingHealthOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "RoutingHealthOut"
-      },
       "ScanRequest": {
         "properties": {
           "mode": {
@@ -39569,214 +26808,6 @@
         ],
         "title": "ShippingRecordsWarehouseOption"
       },
-      "SimilarItemOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "sku": {
-            "type": "string",
-            "title": "Sku"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "spec": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spec"
-          },
-          "brand_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Brand Id"
-          },
-          "category_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Category Id"
-          },
-          "brand": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Brand"
-          },
-          "category": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Category"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "sku",
-          "name",
-          "spec",
-          "brand",
-          "category"
-        ],
-        "title": "SimilarItemOut"
-      },
-      "SkuGenerateDataOut": {
-        "properties": {
-          "sku": {
-            "type": "string",
-            "title": "Sku"
-          },
-          "segments": {
-            "items": {
-              "$ref": "#/components/schemas/SkuGeneratedSegmentOut"
-            },
-            "type": "array",
-            "title": "Segments"
-          },
-          "exists": {
-            "type": "boolean",
-            "title": "Exists"
-          },
-          "similar_items": {
-            "items": {
-              "$ref": "#/components/schemas/SimilarItemOut"
-            },
-            "type": "array",
-            "title": "Similar Items"
-          }
-        },
-        "type": "object",
-        "required": [
-          "sku",
-          "segments",
-          "exists",
-          "similar_items"
-        ],
-        "title": "SkuGenerateDataOut"
-      },
-      "SkuGenerateIn": {
-        "properties": {
-          "product_kind": {
-            "type": "string",
-            "enum": [
-              "FOOD",
-              "SUPPLY"
-            ],
-            "title": "Product Kind"
-          },
-          "brand_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Brand Id"
-          },
-          "category_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Category Id"
-          },
-          "attribute_option_ids": {
-            "additionalProperties": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "type": "object",
-            "title": "Attribute Option Ids"
-          },
-          "text_segments": {
-            "additionalProperties": {
-              "type": "string"
-            },
-            "type": "object",
-            "title": "Text Segments"
-          },
-          "spec_text": {
-            "type": "string",
-            "maxLength": 64,
-            "minLength": 1,
-            "title": "Spec Text"
-          }
-        },
-        "type": "object",
-        "required": [
-          "product_kind",
-          "brand_id",
-          "category_id",
-          "spec_text"
-        ],
-        "title": "SkuGenerateIn"
-      },
-      "SkuGenerateOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "$ref": "#/components/schemas/SkuGenerateDataOut"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "SkuGenerateOut"
-      },
-      "SkuGeneratedSegmentOut": {
-        "properties": {
-          "segment_key": {
-            "type": "string",
-            "title": "Segment Key"
-          },
-          "name_cn": {
-            "type": "string",
-            "title": "Name Cn"
-          },
-          "code": {
-            "type": "string",
-            "title": "Code"
-          }
-        },
-        "type": "object",
-        "required": [
-          "segment_key",
-          "name_cn",
-          "code"
-        ],
-        "title": "SkuGeneratedSegmentOut"
-      },
       "SkuPurchaseLedgerItemOption": {
         "properties": {
           "item_id": {
@@ -40114,301 +27145,6 @@
         ],
         "title": "StockRecountRequest"
       },
-      "StoreCreateIn": {
-        "properties": {
-          "platform": {
-            "type": "string",
-            "maxLength": 32,
-            "minLength": 2,
-            "title": "Platform"
-          },
-          "store_code": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Store Code"
-          },
-          "store_name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 256,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Store Name"
-          },
-          "store_type": {
-            "type": "string",
-            "enum": [
-              "TEST",
-              "PROD"
-            ],
-            "title": "Store Type",
-            "default": "PROD"
-          }
-        },
-        "type": "object",
-        "required": [
-          "platform",
-          "store_code"
-        ],
-        "title": "StoreCreateIn"
-      },
-      "StoreCreateOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "StoreCreateOut"
-      },
-      "StoreDetailOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "StoreDetailOut"
-      },
-      "StoreListItem": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "store_code": {
-            "type": "string",
-            "title": "Store Code"
-          },
-          "store_name": {
-            "type": "string",
-            "title": "Store Name"
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active"
-          },
-          "route_mode": {
-            "type": "string",
-            "title": "Route Mode"
-          },
-          "store_type": {
-            "type": "string",
-            "title": "Store Type",
-            "default": "PROD"
-          },
-          "email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Email"
-          },
-          "contact_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Contact Name"
-          },
-          "contact_phone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Contact Phone"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "platform",
-          "store_code",
-          "store_name",
-          "active",
-          "route_mode"
-        ],
-        "title": "StoreListItem"
-      },
-      "StoreListOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/StoreListItem"
-            },
-            "type": "array",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "StoreListOut"
-      },
-      "StoreLiteOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "store_name": {
-            "type": "string",
-            "title": "Store Name"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "store_name"
-        ],
-        "title": "StoreLiteOut"
-      },
-      "StoreUpdateIn": {
-        "properties": {
-          "store_name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 256,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Store Name"
-          },
-          "active": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Active"
-          },
-          "route_mode": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 32,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Route Mode"
-          },
-          "email": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Email"
-          },
-          "contact_name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 100
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Contact Name"
-          },
-          "contact_phone": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 50
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Contact Phone"
-          }
-        },
-        "type": "object",
-        "title": "StoreUpdateIn"
-      },
-      "StoreUpdateOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "data": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Data"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "title": "StoreUpdateOut"
-      },
       "SubReason": {
         "type": "string",
         "enum": [
@@ -40515,319 +27251,6 @@
         "title": "SupplierBasic",
         "description": "Partners 对外最小供应商读模型。\n\n说明：\n- 这是跨域 export read surface\n- 只暴露其他模块稳定需要的最小读取字段\n- 不承载 owner contacts / 写入语义"
       },
-      "SupplierContactCreateIn": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "maxLength": 100,
-            "minLength": 1,
-            "title": "Name"
-          },
-          "phone": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 50
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Phone"
-          },
-          "email": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255,
-                "format": "email"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Email"
-          },
-          "wechat": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 64
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Wechat"
-          },
-          "role": {
-            "type": "string",
-            "maxLength": 32,
-            "title": "Role",
-            "default": "other"
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary",
-            "default": false
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active",
-            "default": true
-          }
-        },
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "title": "SupplierContactCreateIn"
-      },
-      "SupplierContactOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "supplier_id": {
-            "type": "integer",
-            "title": "Supplier Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "phone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Phone"
-          },
-          "email": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "email"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Email"
-          },
-          "wechat": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Wechat"
-          },
-          "role": {
-            "type": "string",
-            "title": "Role"
-          },
-          "is_primary": {
-            "type": "boolean",
-            "title": "Is Primary"
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "supplier_id",
-          "name",
-          "role",
-          "is_primary",
-          "active"
-        ],
-        "title": "SupplierContactOut"
-      },
-      "SupplierContactUpdateIn": {
-        "properties": {
-          "name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 100,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          },
-          "phone": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 50
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Phone"
-          },
-          "email": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255,
-                "format": "email"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Email"
-          },
-          "wechat": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 64
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Wechat"
-          },
-          "role": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 32
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Role"
-          },
-          "is_primary": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Primary"
-          },
-          "active": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Active"
-          }
-        },
-        "type": "object",
-        "title": "SupplierContactUpdateIn"
-      },
-      "SupplierCreateIn": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Name"
-          },
-          "code": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Code"
-          },
-          "website": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Website"
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active",
-            "default": true
-          }
-        },
-        "type": "object",
-        "required": [
-          "name",
-          "code"
-        ],
-        "title": "SupplierCreateIn"
-      },
-      "SupplierOut": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "code": {
-            "type": "string",
-            "title": "Code"
-          },
-          "website": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Website"
-          },
-          "active": {
-            "type": "boolean",
-            "title": "Active"
-          },
-          "contacts": {
-            "items": {
-              "$ref": "#/components/schemas/SupplierContactOut"
-            },
-            "type": "array",
-            "title": "Contacts"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "name",
-          "code",
-          "active",
-          "contacts"
-        ],
-        "title": "SupplierOut"
-      },
       "SupplierPurchaseReportItem": {
         "properties": {
           "supplier_id": {
@@ -40898,56 +27321,6 @@
           "total_units"
         ],
         "title": "SupplierPurchaseReportItem"
-      },
-      "SupplierUpdateIn": {
-        "properties": {
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          },
-          "code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Code"
-          },
-          "website": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Website"
-          },
-          "active": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Active"
-          }
-        },
-        "type": "object",
-        "title": "SupplierUpdateIn"
       },
       "SyncLogisticsShippingRecordsIn": {
         "properties": {
@@ -41028,180 +27401,6 @@
           "has_more"
         ],
         "title": "SyncLogisticsShippingRecordsOut"
-      },
-      "SyncPlatformOrderMirrorErrorOut": {
-        "properties": {
-          "collector_order_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Collector Order Id"
-          },
-          "error_code": {
-            "type": "string",
-            "title": "Error Code"
-          },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          }
-        },
-        "type": "object",
-        "required": [
-          "error_code",
-          "message"
-        ],
-        "title": "SyncPlatformOrderMirrorErrorOut"
-      },
-      "SyncPlatformOrderMirrorItemOut": {
-        "properties": {
-          "collector_order_id": {
-            "type": "integer",
-            "title": "Collector Order Id"
-          },
-          "mirror_id": {
-            "type": "integer",
-            "title": "Mirror Id"
-          },
-          "imported": {
-            "type": "boolean",
-            "title": "Imported",
-            "default": true
-          }
-        },
-        "type": "object",
-        "required": [
-          "collector_order_id",
-          "mirror_id"
-        ],
-        "title": "SyncPlatformOrderMirrorItemOut"
-      },
-      "SyncPlatformOrderMirrorsFromCollectorIn": {
-        "properties": {
-          "limit": {
-            "type": "integer",
-            "maximum": 1000.0,
-            "minimum": 1.0,
-            "title": "Limit",
-            "default": 50
-          },
-          "offset": {
-            "type": "integer",
-            "minimum": 0.0,
-            "title": "Offset",
-            "default": 0
-          },
-          "since": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Since",
-            "description": "Inclusive lower bound for Collector Export source update time."
-          },
-          "until": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Until",
-            "description": "Exclusive upper bound for Collector Export source update time."
-          }
-        },
-        "type": "object",
-        "title": "SyncPlatformOrderMirrorsFromCollectorIn"
-      },
-      "SyncPlatformOrderMirrorsFromCollectorOut": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok",
-            "default": true
-          },
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "limit": {
-            "type": "integer",
-            "title": "Limit"
-          },
-          "offset": {
-            "type": "integer",
-            "title": "Offset"
-          },
-          "since": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Since"
-          },
-          "until": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Until"
-          },
-          "fetched_count": {
-            "type": "integer",
-            "title": "Fetched Count"
-          },
-          "imported_count": {
-            "type": "integer",
-            "title": "Imported Count"
-          },
-          "failed_count": {
-            "type": "integer",
-            "title": "Failed Count"
-          },
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/SyncPlatformOrderMirrorItemOut"
-            },
-            "type": "array",
-            "title": "Items"
-          },
-          "errors": {
-            "items": {
-              "$ref": "#/components/schemas/SyncPlatformOrderMirrorErrorOut"
-            },
-            "type": "array",
-            "title": "Errors"
-          }
-        },
-        "type": "object",
-        "required": [
-          "platform",
-          "limit",
-          "offset",
-          "fetched_count",
-          "imported_count",
-          "failed_count"
-        ],
-        "title": "SyncPlatformOrderMirrorsFromCollectorOut"
       },
       "ThreeBooksPayload": {
         "properties": {
@@ -41998,6 +28197,1199 @@
           "data"
         ],
         "title": "WarehouseUpdateOut"
+      },
+      "WmsReadWarehouseListOut": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/WmsReadWarehouseOut"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "WmsReadWarehouseListOut"
+      },
+      "WmsReadWarehouseOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Id"
+          },
+          "code": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 64
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Code"
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Name"
+          },
+          "active": {
+            "type": "boolean",
+            "title": "Active"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "active"
+        ],
+        "title": "WmsReadWarehouseOut",
+        "description": "WMS warehouse read-v1 contract for cross-system consumers.\n\nBoundary:\n- WMS owns warehouse master data.\n- Cross-system consumers only receive stable read fields.\n- This contract intentionally does not expose management fields."
+      },
+      "WmsSystemAppManifestBuildInfoOut": {
+        "properties": {
+          "environment": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Environment"
+          },
+          "git_sha": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Git Sha"
+          },
+          "build_time": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Build Time"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "environment"
+        ],
+        "title": "WmsSystemAppManifestBuildInfoOut"
+      },
+      "WmsSystemAppManifestOut": {
+        "properties": {
+          "app_code": {
+            "type": "string",
+            "const": "wms",
+            "title": "App Code"
+          },
+          "app_name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "App Name"
+          },
+          "app_type": {
+            "type": "string",
+            "minLength": 1,
+            "title": "App Type"
+          },
+          "status": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Status"
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Description"
+          },
+          "default_web_path": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Default Web Path"
+          },
+          "default_api_path": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Default Api Path"
+          },
+          "local_web_url": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Local Web Url"
+          },
+          "local_api_url": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Local Api Url"
+          },
+          "health_url": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Health Url"
+          },
+          "db_health_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Db Health Url"
+          },
+          "openapi_url": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Openapi Url"
+          },
+          "page_catalog_url": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Page Catalog Url"
+          },
+          "service_capabilities_url": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Service Capabilities Url"
+          },
+          "service_dependencies_url": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Service Dependencies Url"
+          },
+          "version": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Version"
+          },
+          "build_info": {
+            "$ref": "#/components/schemas/WmsSystemAppManifestBuildInfoOut"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "app_code",
+          "app_name",
+          "app_type",
+          "status",
+          "description",
+          "default_web_path",
+          "default_api_path",
+          "local_web_url",
+          "local_api_url",
+          "health_url",
+          "openapi_url",
+          "page_catalog_url",
+          "service_capabilities_url",
+          "service_dependencies_url",
+          "version",
+          "build_info"
+        ],
+        "title": "WmsSystemAppManifestOut"
+      },
+      "WmsSystemIamSnapshotOut": {
+        "properties": {
+          "app_code": {
+            "type": "string",
+            "const": "wms",
+            "title": "App Code"
+          },
+          "app_name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "App Name"
+          },
+          "snapshot_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Snapshot At"
+          },
+          "users": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemIamSnapshotUserOut"
+            },
+            "type": "array",
+            "title": "Users"
+          },
+          "permissions": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemIamSnapshotPermissionOut"
+            },
+            "type": "array",
+            "title": "Permissions"
+          },
+          "user_permissions": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemIamSnapshotUserPermissionOut"
+            },
+            "type": "array",
+            "title": "User Permissions"
+          },
+          "page_registry": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemIamSnapshotPageOut"
+            },
+            "type": "array",
+            "title": "Page Registry"
+          },
+          "page_route_prefixes": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemIamSnapshotRoutePrefixOut"
+            },
+            "type": "array",
+            "title": "Page Route Prefixes"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "app_code",
+          "app_name",
+          "snapshot_at"
+        ],
+        "title": "WmsSystemIamSnapshotOut"
+      },
+      "WmsSystemIamSnapshotPageOut": {
+        "properties": {
+          "page_code": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Page Code"
+          },
+          "page_name": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Page Name"
+          },
+          "parent_page_code": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 64
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Page Code"
+          },
+          "level": {
+            "type": "integer",
+            "maximum": 3.0,
+            "minimum": 1.0,
+            "title": "Level"
+          },
+          "domain_code": {
+            "type": "string",
+            "maxLength": 32,
+            "minLength": 1,
+            "title": "Domain Code"
+          },
+          "show_in_topbar": {
+            "type": "boolean",
+            "title": "Show In Topbar"
+          },
+          "show_in_sidebar": {
+            "type": "boolean",
+            "title": "Show In Sidebar"
+          },
+          "inherit_permissions": {
+            "type": "boolean",
+            "title": "Inherit Permissions"
+          },
+          "read_permission_code": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Read Permission Code"
+          },
+          "write_permission_code": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Write Permission Code"
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "page_code",
+          "page_name",
+          "level",
+          "domain_code",
+          "show_in_topbar",
+          "show_in_sidebar",
+          "inherit_permissions",
+          "sort_order",
+          "is_active"
+        ],
+        "title": "WmsSystemIamSnapshotPageOut"
+      },
+      "WmsSystemIamSnapshotPermissionOut": {
+        "properties": {
+          "permission_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Permission Id"
+          },
+          "permission_code": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Permission Code"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "permission_id",
+          "permission_code"
+        ],
+        "title": "WmsSystemIamSnapshotPermissionOut"
+      },
+      "WmsSystemIamSnapshotRoutePrefixOut": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Id"
+          },
+          "page_code": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Page Code"
+          },
+          "route_prefix": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Route Prefix"
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "id",
+          "page_code",
+          "route_prefix",
+          "sort_order",
+          "is_active"
+        ],
+        "title": "WmsSystemIamSnapshotRoutePrefixOut"
+      },
+      "WmsSystemIamSnapshotUserOut": {
+        "properties": {
+          "user_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "User Id"
+          },
+          "username": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Username"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "full_name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Name"
+          },
+          "phone": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 32
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phone"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "user_id",
+          "username",
+          "is_active"
+        ],
+        "title": "WmsSystemIamSnapshotUserOut"
+      },
+      "WmsSystemIamSnapshotUserPermissionOut": {
+        "properties": {
+          "user_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "User Id"
+          },
+          "permission_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Permission Id"
+          },
+          "permission_code": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Permission Code"
+          },
+          "granted_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Granted At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "user_id",
+          "permission_id",
+          "permission_code",
+          "granted_at"
+        ],
+        "title": "WmsSystemIamSnapshotUserPermissionOut"
+      },
+      "WmsSystemPageCatalogOut": {
+        "properties": {
+          "app_code": {
+            "type": "string",
+            "const": "wms",
+            "title": "App Code"
+          },
+          "app_name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "App Name"
+          },
+          "pages": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemPageCatalogPageOut"
+            },
+            "type": "array",
+            "title": "Pages"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "app_code",
+          "app_name"
+        ],
+        "title": "WmsSystemPageCatalogOut"
+      },
+      "WmsSystemPageCatalogPageOut": {
+        "properties": {
+          "page_code": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Page Code"
+          },
+          "page_name": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Page Name"
+          },
+          "route_path": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Route Path"
+          },
+          "parent_page_code": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 64
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Page Code"
+          },
+          "level": {
+            "type": "integer",
+            "maximum": 3.0,
+            "minimum": 1.0,
+            "title": "Level"
+          },
+          "read_permission_code": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Read Permission Code"
+          },
+          "write_permission_code": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Write Permission Code"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order"
+          },
+          "source_updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Updated At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "page_code",
+          "page_name",
+          "level",
+          "is_active",
+          "sort_order"
+        ],
+        "title": "WmsSystemPageCatalogPageOut"
+      },
+      "WmsSystemServiceCapabilitiesOut": {
+        "properties": {
+          "app_code": {
+            "type": "string",
+            "const": "wms",
+            "title": "App Code"
+          },
+          "app_name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "App Name"
+          },
+          "capabilities": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemServiceCapabilityOut"
+            },
+            "type": "array",
+            "title": "Capabilities"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "app_code",
+          "app_name"
+        ],
+        "title": "WmsSystemServiceCapabilitiesOut"
+      },
+      "WmsSystemServiceCapabilityOut": {
+        "properties": {
+          "capability_code": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Capability Code"
+          },
+          "capability_name": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Capability Name"
+          },
+          "resource_code": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Resource Code"
+          },
+          "permission_code": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Permission Code"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "source_updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Updated At"
+          },
+          "routes": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemServiceCapabilityRouteOut"
+            },
+            "type": "array",
+            "title": "Routes"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "capability_code",
+          "capability_name",
+          "resource_code",
+          "permission_code",
+          "is_active"
+        ],
+        "title": "WmsSystemServiceCapabilityOut"
+      },
+      "WmsSystemServiceCapabilityRouteOut": {
+        "properties": {
+          "http_method": {
+            "type": "string",
+            "maxLength": 16,
+            "minLength": 1,
+            "title": "Http Method"
+          },
+          "path": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Path"
+          },
+          "route_name": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Route Name"
+          },
+          "auth_required": {
+            "type": "boolean",
+            "title": "Auth Required"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "source_created_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Created At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "http_method",
+          "path",
+          "route_name",
+          "auth_required",
+          "is_active"
+        ],
+        "title": "WmsSystemServiceCapabilityRouteOut"
+      },
+      "WmsSystemServiceDependenciesOut": {
+        "properties": {
+          "app_code": {
+            "type": "string",
+            "const": "wms",
+            "title": "App Code"
+          },
+          "app_name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "App Name"
+          },
+          "source_service_client_code": {
+            "type": "string",
+            "const": "wms-service",
+            "title": "Source Service Client Code"
+          },
+          "dependencies": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemServiceDependencyOut"
+            },
+            "type": "array",
+            "title": "Dependencies"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "app_code",
+          "app_name",
+          "source_service_client_code"
+        ],
+        "title": "WmsSystemServiceDependenciesOut"
+      },
+      "WmsSystemServiceDependencyEndpointOut": {
+        "properties": {
+          "http_method": {
+            "type": "string",
+            "maxLength": 16,
+            "minLength": 1,
+            "title": "Http Method"
+          },
+          "path": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Path"
+          },
+          "purpose": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Purpose"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "http_method",
+          "path"
+        ],
+        "title": "WmsSystemServiceDependencyEndpointOut"
+      },
+      "WmsSystemServiceDependencyOut": {
+        "properties": {
+          "dependency_code": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Dependency Code"
+          },
+          "dependency_name": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Dependency Name"
+          },
+          "target_app_code": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Target App Code"
+          },
+          "target_capability_code": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Target Capability Code"
+          },
+          "required_permission_code": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Required Permission Code"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "is_required": {
+            "type": "boolean",
+            "title": "Is Required"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "required_config_keys": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Required Config Keys"
+          },
+          "source_modules": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Source Modules"
+          },
+          "endpoints": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemServiceDependencyEndpointOut"
+            },
+            "type": "array",
+            "title": "Endpoints"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "dependency_code",
+          "dependency_name",
+          "target_app_code",
+          "target_capability_code",
+          "required_permission_code",
+          "is_required",
+          "is_active"
+        ],
+        "title": "WmsSystemServiceDependencyOut"
+      },
+      "WmsSystemServicePermissionApplyIn": {
+        "properties": {
+          "client_code": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Client Code"
+          },
+          "client_name": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Client Name"
+          },
+          "capability_code": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Capability Code"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "client_code",
+          "client_name",
+          "capability_code",
+          "is_active"
+        ],
+        "title": "WmsSystemServicePermissionApplyIn"
+      },
+      "WmsSystemServicePermissionApplyOut": {
+        "properties": {
+          "app_code": {
+            "type": "string",
+            "const": "wms",
+            "title": "App Code"
+          },
+          "client_code": {
+            "type": "string",
+            "title": "Client Code"
+          },
+          "client_name": {
+            "type": "string",
+            "title": "Client Name"
+          },
+          "capability_code": {
+            "type": "string",
+            "title": "Capability Code"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "applied": {
+            "type": "boolean",
+            "title": "Applied"
+          },
+          "verified": {
+            "type": "boolean",
+            "title": "Verified"
+          },
+          "permission_id": {
+            "type": "integer",
+            "title": "Permission Id"
+          },
+          "granted_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Granted At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "app_code",
+          "client_code",
+          "client_name",
+          "capability_code",
+          "description",
+          "is_active",
+          "applied",
+          "verified",
+          "permission_id",
+          "granted_at"
+        ],
+        "title": "WmsSystemServicePermissionApplyOut"
+      },
+      "WmsSystemServicePermissionVerifyOut": {
+        "properties": {
+          "app_code": {
+            "type": "string",
+            "const": "wms",
+            "title": "App Code"
+          },
+          "client_code": {
+            "type": "string",
+            "title": "Client Code"
+          },
+          "capability_code": {
+            "type": "string",
+            "title": "Capability Code"
+          },
+          "client_exists": {
+            "type": "boolean",
+            "title": "Client Exists"
+          },
+          "capability_exists": {
+            "type": "boolean",
+            "title": "Capability Exists"
+          },
+          "permission_exists": {
+            "type": "boolean",
+            "title": "Permission Exists"
+          },
+          "client_is_active": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Is Active"
+          },
+          "capability_is_active": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Capability Is Active"
+          },
+          "permission_is_active": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Permission Is Active"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "verified": {
+            "type": "boolean",
+            "title": "Verified"
+          },
+          "permission_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Permission Id"
+          },
+          "granted_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Granted At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "app_code",
+          "client_code",
+          "capability_code",
+          "client_exists",
+          "capability_exists",
+          "permission_exists",
+          "client_is_active",
+          "capability_is_active",
+          "permission_is_active",
+          "description",
+          "verified",
+          "permission_id",
+          "granted_at"
+        ],
+        "title": "WmsSystemServicePermissionVerifyOut"
       }
     },
     "securitySchemes": {

--- a/tests/api/test_wms_system_service_permission_write_api.py
+++ b/tests/api/test_wms_system_service_permission_write_api.py
@@ -1,0 +1,175 @@
+# tests/api/test_wms_system_service_permission_write_api.py
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+APPLY_PATH = "/system/write/v1/service-permissions/apply"
+VERIFY_PATH = "/system/write/v1/service-permissions/verify"
+ERP_HEADERS = {"X-Service-Client": "erp-service"}
+
+
+def _apply_payload(
+    *,
+    client_code: str = "zz-erp-write-test-service",
+    capability_code: str = "wms.read.warehouses",
+    is_active: bool = True,
+) -> dict:
+    return {
+        "client_code": client_code,
+        "client_name": "ERP Write Test Service",
+        "capability_code": capability_code,
+        "description": "ERP 写入 WMS service permission 测试",
+        "is_active": is_active,
+    }
+
+
+def test_wms_service_permission_apply_requires_erp_service_client_header() -> None:
+    client = TestClient(app)
+
+    response = client.post(APPLY_PATH, json=_apply_payload())
+
+    assert response.status_code == 401
+    assert "wms_service_client_required" in response.text
+
+
+def test_wms_service_permission_apply_rejects_non_erp_service_client() -> None:
+    client = TestClient(app)
+
+    response = client.post(
+        APPLY_PATH,
+        headers={"X-Service-Client": "logistics-service"},
+        json=_apply_payload(),
+    )
+
+    assert response.status_code == 403
+    assert "wms_service_permission_write_denied" in response.text
+
+
+def test_wms_service_permission_apply_and_verify_round_trip() -> None:
+    client = TestClient(app)
+
+    response = client.post(APPLY_PATH, headers=ERP_HEADERS, json=_apply_payload())
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    assert body["app_code"] == "wms"
+    assert body["client_code"] == "zz-erp-write-test-service"
+    assert body["client_name"] == "ERP Write Test Service"
+    assert body["capability_code"] == "wms.read.warehouses"
+    assert body["description"] == "ERP 写入 WMS service permission 测试"
+    assert body["is_active"] is True
+    assert body["applied"] is True
+    assert body["verified"] is True
+    assert body["permission_id"] > 0
+    assert body["granted_at"]
+
+    verify_response = client.get(
+        VERIFY_PATH,
+        headers=ERP_HEADERS,
+        params={
+            "client_code": "zz-erp-write-test-service",
+            "capability_code": "wms.read.warehouses",
+        },
+    )
+
+    assert verify_response.status_code == 200, verify_response.text
+    verify_body = verify_response.json()
+
+    assert verify_body["app_code"] == "wms"
+    assert verify_body["client_code"] == "zz-erp-write-test-service"
+    assert verify_body["capability_code"] == "wms.read.warehouses"
+    assert verify_body["client_exists"] is True
+    assert verify_body["capability_exists"] is True
+    assert verify_body["permission_exists"] is True
+    assert verify_body["client_is_active"] is True
+    assert verify_body["capability_is_active"] is True
+    assert verify_body["permission_is_active"] is True
+    assert verify_body["verified"] is True
+
+
+def test_wms_service_permission_apply_can_disable_permission_without_disabling_client() -> None:
+    client = TestClient(app)
+
+    response = client.post(
+        APPLY_PATH,
+        headers=ERP_HEADERS,
+        json=_apply_payload(
+            client_code="zz-erp-write-test-disable-service",
+            capability_code="wms.read.warehouses",
+            is_active=False,
+        ),
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    assert body["client_code"] == "zz-erp-write-test-disable-service"
+    assert body["is_active"] is False
+    assert body["verified"] is False
+
+    verify_response = client.get(
+        VERIFY_PATH,
+        headers=ERP_HEADERS,
+        params={
+            "client_code": "zz-erp-write-test-disable-service",
+            "capability_code": "wms.read.warehouses",
+        },
+    )
+
+    assert verify_response.status_code == 200, verify_response.text
+    verify_body = verify_response.json()
+
+    assert verify_body["client_is_active"] is True
+    assert verify_body["permission_is_active"] is False
+    assert verify_body["verified"] is False
+
+
+def test_wms_service_permission_apply_rejects_unknown_capability() -> None:
+    client = TestClient(app)
+
+    response = client.post(
+        APPLY_PATH,
+        headers=ERP_HEADERS,
+        json=_apply_payload(capability_code="wms.read.unknown_for_write_test"),
+    )
+
+    assert response.status_code == 404
+    assert "wms_service_capability_not_found" in response.text
+
+
+def test_wms_service_permission_verify_returns_false_for_missing_permission() -> None:
+    client = TestClient(app)
+
+    response = client.get(
+        VERIFY_PATH,
+        headers=ERP_HEADERS,
+        params={
+            "client_code": "zz-erp-write-test-missing-service",
+            "capability_code": "wms.read.warehouses",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    assert body["client_exists"] is False
+    assert body["capability_exists"] is True
+    assert body["permission_exists"] is False
+    assert body["verified"] is False
+
+
+def test_wms_service_permission_write_routes_are_registered_in_openapi() -> None:
+    client = TestClient(app)
+
+    response = client.get("/openapi.json")
+
+    assert response.status_code == 200, response.text
+    paths = response.json()["paths"]
+
+    assert APPLY_PATH in paths
+    assert "post" in paths[APPLY_PATH]
+    assert VERIFY_PATH in paths
+    assert "get" in paths[VERIFY_PATH]


### PR DESCRIPTION
## Summary
- add WMS target-side service permission write-v1 endpoint
- support ERP-only apply and verify for WMS service permissions
- write only wms_service_clients and wms_service_permissions
- reject non-ERP service clients
- keep user permissions and ERP tables untouched
- update OpenAPI artifacts for the new write-v1 endpoints

## Endpoints
- POST /system/write/v1/service-permissions/apply
- GET /system/write/v1/service-permissions/verify

## Tests
- make lint
- make openapi
- make alembic-check
- make test TESTS="tests/api/test_wms_system_service_permission_write_api.py tests/ci/test_wms_service_permission_runtime_contract.py tests/ci/test_wms_service_auth_contract.py"
- git diff --check
- local curl apply/verify with X-Service-Client: erp-service