### PR TITLE
feat(system): add WMS IAM write-v1 endpoint

### DIFF
--- a/app/wms/system/write_v1/contracts/__init__.py
+++ b/app/wms/system/write_v1/contracts/__init__.py
@@ -1,6 +1,15 @@
 # app/wms/system/write_v1/contracts/__init__.py
 from __future__ import annotations
 
+from app.wms.system.write_v1.contracts.iam import (
+    WmsSystemIamApplyIn,
+    WmsSystemIamApplyOut,
+    WmsSystemIamPermissionDiffOut,
+    WmsSystemIamUserDiffOut,
+    WmsSystemIamUserIn,
+    WmsSystemIamUserPermissionIn,
+    WmsSystemIamVerifyOut,
+)
 from app.wms.system.write_v1.contracts.service_permissions import (
     WmsSystemServicePermissionApplyIn,
     WmsSystemServicePermissionApplyOut,
@@ -8,6 +17,13 @@ from app.wms.system.write_v1.contracts.service_permissions import (
 )
 
 __all__ = [
+    "WmsSystemIamApplyIn",
+    "WmsSystemIamApplyOut",
+    "WmsSystemIamPermissionDiffOut",
+    "WmsSystemIamUserDiffOut",
+    "WmsSystemIamUserIn",
+    "WmsSystemIamUserPermissionIn",
+    "WmsSystemIamVerifyOut",
     "WmsSystemServicePermissionApplyIn",
     "WmsSystemServicePermissionApplyOut",
     "WmsSystemServicePermissionVerifyOut",

--- a/app/wms/system/write_v1/contracts/iam.py
+++ b/app/wms/system/write_v1/contracts/iam.py
@@ -1,0 +1,68 @@
+# app/wms/system/write_v1/contracts/iam.py
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class WmsSystemIamUserIn(_Base):
+    username: str = Field(..., min_length=1, max_length=64)
+    full_name: str | None = Field(default=None, max_length=128)
+    phone: str | None = Field(default=None, max_length=32)
+    email: str | None = Field(default=None, max_length=255)
+    is_active: bool = True
+
+
+class WmsSystemIamUserPermissionIn(_Base):
+    username: str = Field(..., min_length=1, max_length=64)
+    permission_code: str = Field(..., min_length=1, max_length=128)
+    is_active: bool = True
+
+
+class WmsSystemIamApplyIn(_Base):
+    users: list[WmsSystemIamUserIn] = Field(default_factory=list)
+    user_permissions: list[WmsSystemIamUserPermissionIn] = Field(default_factory=list)
+
+
+class WmsSystemIamPermissionDiffOut(_Base):
+    username: str
+    permission_code: str
+
+
+class WmsSystemIamUserDiffOut(_Base):
+    username: str
+    field_name: str
+    expected: str | bool | None
+    actual: str | bool | None
+
+
+class WmsSystemIamVerifyOut(_Base):
+    app_code: Literal["wms"]
+    verified: bool
+    user_count: int
+    desired_permission_count: int
+    missing_users: list[str] = Field(default_factory=list)
+    missing_permission_codes: list[str] = Field(default_factory=list)
+    mismatched_users: list[WmsSystemIamUserDiffOut] = Field(default_factory=list)
+    missing_user_permissions: list[WmsSystemIamPermissionDiffOut] = Field(default_factory=list)
+    extra_user_permissions: list[WmsSystemIamPermissionDiffOut] = Field(default_factory=list)
+
+
+class WmsSystemIamApplyOut(WmsSystemIamVerifyOut):
+    applied: bool
+
+
+__all__ = [
+    "WmsSystemIamApplyIn",
+    "WmsSystemIamApplyOut",
+    "WmsSystemIamPermissionDiffOut",
+    "WmsSystemIamUserDiffOut",
+    "WmsSystemIamUserIn",
+    "WmsSystemIamUserPermissionIn",
+    "WmsSystemIamVerifyOut",
+]

--- a/app/wms/system/write_v1/repos/__init__.py
+++ b/app/wms/system/write_v1/repos/__init__.py
@@ -1,12 +1,18 @@
 # app/wms/system/write_v1/repos/__init__.py
 from __future__ import annotations
 
+from app.wms.system.write_v1.repos.iam_write_repo import (
+    WmsIamWriteRepo,
+    WmsIamWriteSaveError,
+)
 from app.wms.system.write_v1.repos.service_permission_write_repo import (
     WmsServicePermissionWriteRepo,
     WmsServicePermissionWriteSaveError,
 )
 
 __all__ = [
+    "WmsIamWriteRepo",
+    "WmsIamWriteSaveError",
     "WmsServicePermissionWriteRepo",
     "WmsServicePermissionWriteSaveError",
 ]

--- a/app/wms/system/write_v1/repos/iam_write_repo.py
+++ b/app/wms/system/write_v1/repos/iam_write_repo.py
@@ -1,0 +1,93 @@
+# app/wms/system/write_v1/repos/iam_write_repo.py
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from app.user.models.permission import Permission
+from app.user.models.user import User, user_permissions
+
+
+class WmsIamWriteSaveError(RuntimeError):
+    pass
+
+
+class WmsIamWriteRepo:
+    """
+    WMS IAM write-v1 repository.
+
+    Boundary:
+    - Writes only users / user_permissions runtime tables.
+    - Reads permissions only to validate WMS-owned permission codes.
+    - Never writes permissions / page_registry / page_route_prefixes.
+    - Never writes ERP tables or other systems.
+    """
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def get_user_by_username(self, username: str) -> User | None:
+        return self.db.query(User).filter(User.username == username).one_or_none()
+
+    def list_users_by_usernames(self, usernames: Iterable[str]) -> dict[str, User]:
+        names = sorted({name for name in usernames if name})
+        if not names:
+            return {}
+        rows = self.db.query(User).filter(User.username.in_(names)).all()
+        return {str(row.username): row for row in rows}
+
+    def list_permissions_by_codes(self, permission_codes: Iterable[str]) -> dict[str, Permission]:
+        codes = sorted({code for code in permission_codes if code})
+        if not codes:
+            return {}
+        rows = self.db.query(Permission).filter(Permission.name.in_(codes)).all()
+        return {str(row.name): row for row in rows}
+
+    def list_permission_codes_for_user(self, user_id: int) -> set[str]:
+        rows = (
+            self.db.query(Permission.name)
+            .join(user_permissions, Permission.id == user_permissions.c.permission_id)
+            .filter(user_permissions.c.user_id == int(user_id))
+            .order_by(Permission.name.asc())
+            .all()
+        )
+        return {str(name) for (name,) in rows if name}
+
+    def replace_user_permissions(self, *, user_id: int, permission_ids: Iterable[int]) -> None:
+        unique_permission_ids = sorted({int(permission_id) for permission_id in permission_ids})
+        self.db.execute(user_permissions.delete().where(user_permissions.c.user_id == int(user_id)))
+        for permission_id in unique_permission_ids:
+            self.db.execute(
+                user_permissions.insert().values(
+                    user_id=int(user_id),
+                    permission_id=int(permission_id),
+                )
+            )
+
+    def add(self, row: object) -> None:
+        self.db.add(row)
+
+    def flush(self) -> None:
+        try:
+            self.db.flush()
+        except SQLAlchemyError as exc:
+            self.db.rollback()
+            raise WmsIamWriteSaveError("wms_iam_write_flush_failed") from exc
+
+    def commit(self) -> None:
+        try:
+            self.db.commit()
+        except SQLAlchemyError as exc:
+            self.db.rollback()
+            raise WmsIamWriteSaveError("wms_iam_write_commit_failed") from exc
+
+    def refresh(self, row: object) -> None:
+        self.db.refresh(row)
+
+
+__all__ = [
+    "WmsIamWriteRepo",
+    "WmsIamWriteSaveError",
+]

--- a/app/wms/system/write_v1/routers/__init__.py
+++ b/app/wms/system/write_v1/routers/__init__.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+from app.wms.system.write_v1.routers.iam import router as iam_router
 from app.wms.system.write_v1.routers.service_permissions import (
     router as service_permissions_router,
 )
 
 router = APIRouter()
 router.include_router(service_permissions_router)
+router.include_router(iam_router)
 
 __all__ = ["router"]

--- a/app/wms/system/write_v1/routers/iam.py
+++ b/app/wms/system/write_v1/routers/iam.py
@@ -1,0 +1,78 @@
+# app/wms/system/write_v1/routers/iam.py
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.wms.system.write_v1.contracts import (
+    WmsSystemIamApplyIn,
+    WmsSystemIamApplyOut,
+    WmsSystemIamVerifyOut,
+)
+from app.wms.system.write_v1.repos import WmsIamWriteSaveError
+from app.wms.system.write_v1.routers.service_permissions import require_erp_service_client
+from app.wms.system.write_v1.services import (
+    WmsIamPayloadError,
+    WmsIamPermissionNotFoundError,
+    WmsIamWriteService,
+)
+
+router = APIRouter(prefix="/system/write/v1", tags=["system-write-v1"])
+
+
+@router.post(
+    "/iam/apply",
+    response_model=WmsSystemIamApplyOut,
+    summary="Apply WMS IAM desired state",
+)
+async def apply_wms_iam(
+    payload: WmsSystemIamApplyIn,
+    _erp_service_client: None = Depends(require_erp_service_client),
+    db: Session = Depends(get_db),
+) -> WmsSystemIamApplyOut:
+    """
+    Apply WMS local user IAM runtime projection from ERP.
+
+    Boundary:
+    - Only X-Service-Client: erp-service may call this endpoint.
+    - Writes only users / user_permissions.
+    - Reads permissions only to validate WMS-owned permission codes.
+    - Does not create unknown permissions.
+    - Does not write page_registry / page_route_prefixes.
+    """
+
+    try:
+        return WmsIamWriteService(db).apply(payload)
+    except WmsIamPermissionNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except WmsIamPayloadError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    except WmsIamWriteSaveError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(exc),
+        ) from exc
+
+
+@router.post(
+    "/iam/verify",
+    response_model=WmsSystemIamVerifyOut,
+    summary="Verify WMS IAM desired state",
+)
+async def verify_wms_iam(
+    payload: WmsSystemIamApplyIn,
+    _erp_service_client: None = Depends(require_erp_service_client),
+    db: Session = Depends(get_db),
+) -> WmsSystemIamVerifyOut:
+    """
+    Verify WMS local user IAM runtime projection against ERP desired state.
+    """
+
+    try:
+        return WmsIamWriteService(db).verify(payload)
+    except WmsIamPayloadError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+
+
+__all__ = ["router"]

--- a/app/wms/system/write_v1/services/__init__.py
+++ b/app/wms/system/write_v1/services/__init__.py
@@ -1,8 +1,13 @@
 # app/wms/system/write_v1/services/__init__.py
 from __future__ import annotations
 
-from app.wms.system.write_v1.services.service_permission_write_service import (
+from app.wms.system.write_v1.services.iam_write_service import (
     WMS_APP_CODE,
+    WmsIamPayloadError,
+    WmsIamPermissionNotFoundError,
+    WmsIamWriteService,
+)
+from app.wms.system.write_v1.services.service_permission_write_service import (
     WmsServicePermissionCapabilityNotFoundError,
     WmsServicePermissionClientCodeReservedError,
     WmsServicePermissionWriteService,
@@ -10,6 +15,9 @@ from app.wms.system.write_v1.services.service_permission_write_service import (
 
 __all__ = [
     "WMS_APP_CODE",
+    "WmsIamPayloadError",
+    "WmsIamPermissionNotFoundError",
+    "WmsIamWriteService",
     "WmsServicePermissionCapabilityNotFoundError",
     "WmsServicePermissionClientCodeReservedError",
     "WmsServicePermissionWriteService",

--- a/app/wms/system/write_v1/services/iam_write_service.py
+++ b/app/wms/system/write_v1/services/iam_write_service.py
@@ -1,0 +1,278 @@
+# app/wms/system/write_v1/services/iam_write_service.py
+from __future__ import annotations
+
+import secrets
+
+from sqlalchemy.orm import Session
+
+from app.core.security import get_password_hash
+from app.user.models.user import User
+from app.wms.system.write_v1.contracts import (
+    WmsSystemIamApplyIn,
+    WmsSystemIamApplyOut,
+    WmsSystemIamPermissionDiffOut,
+    WmsSystemIamUserDiffOut,
+    WmsSystemIamVerifyOut,
+)
+from app.wms.system.write_v1.repos import WmsIamWriteRepo
+
+WMS_APP_CODE = "wms"
+
+
+class WmsIamPayloadError(ValueError):
+    pass
+
+
+class WmsIamPermissionNotFoundError(ValueError):
+    pass
+
+
+def _strip(value: str | None) -> str:
+    return (value or "").strip()
+
+
+def _optional_strip(value: str | None) -> str | None:
+    text = _strip(value)
+    return text or None
+
+
+def _disabled_password_hash() -> str:
+    return get_password_hash(secrets.token_urlsafe(48))
+
+
+class NormalizedIamPayload:
+    def __init__(
+        self,
+        *,
+        users: dict[str, dict[str, object]],
+        desired_permissions_by_username: dict[str, set[str]],
+    ) -> None:
+        self.users = users
+        self.desired_permissions_by_username = desired_permissions_by_username
+
+    @property
+    def usernames(self) -> set[str]:
+        return set(self.users)
+
+    @property
+    def permission_codes(self) -> set[str]:
+        out: set[str] = set()
+        for codes in self.desired_permissions_by_username.values():
+            out.update(codes)
+        return out
+
+
+class WmsIamWriteService:
+    """
+    Apply and verify WMS local user IAM runtime projection for ERP.
+
+    Boundary:
+    - ERP calls this service through /system/write/v1.
+    - ERP owns user and user-permission assignment decisions.
+    - WMS keeps users / user_permissions as local runtime execution tables.
+    - This service does not create unknown permissions.
+    - This service does not write page_registry / page_route_prefixes.
+    """
+
+    def __init__(
+        self,
+        db: Session,
+        repo: WmsIamWriteRepo | None = None,
+    ) -> None:
+        self.repo = repo or WmsIamWriteRepo(db)
+
+    def apply(self, payload: WmsSystemIamApplyIn) -> WmsSystemIamApplyOut:
+        normalized = self._normalize_payload(payload)
+        permissions_by_code = self.repo.list_permissions_by_codes(normalized.permission_codes)
+        self._ensure_permissions_exist(normalized.permission_codes, permissions_by_code)
+
+        for username, user_payload in normalized.users.items():
+            user = self.repo.get_user_by_username(username)
+            if user is None:
+                user = User(
+                    username=username,
+                    password_hash=_disabled_password_hash(),
+                    is_active=bool(user_payload["is_active"]),
+                    full_name=user_payload["full_name"],
+                    phone=user_payload["phone"],
+                    email=user_payload["email"],
+                )
+                self.repo.add(user)
+                self.repo.flush()
+            else:
+                user.is_active = bool(user_payload["is_active"])
+                user.full_name = user_payload["full_name"]
+                user.phone = user_payload["phone"]
+                user.email = user_payload["email"]
+                self.repo.flush()
+
+            desired_codes = normalized.desired_permissions_by_username.get(username, set())
+            desired_permission_ids = [
+                int(permissions_by_code[permission_code].id)
+                for permission_code in sorted(desired_codes)
+            ]
+            self.repo.replace_user_permissions(
+                user_id=int(user.id),
+                permission_ids=desired_permission_ids,
+            )
+
+        self.repo.commit()
+
+        verify = self.verify(payload)
+        return WmsSystemIamApplyOut(
+            **verify.model_dump(),
+            applied=True,
+        )
+
+    def verify(self, payload: WmsSystemIamApplyIn) -> WmsSystemIamVerifyOut:
+        normalized = self._normalize_payload(payload)
+        permissions_by_code = self.repo.list_permissions_by_codes(normalized.permission_codes)
+        users_by_username = self.repo.list_users_by_usernames(normalized.usernames)
+
+        missing_users = sorted(username for username in normalized.usernames if username not in users_by_username)
+        missing_permission_codes = sorted(
+            permission_code
+            for permission_code in normalized.permission_codes
+            if permission_code not in permissions_by_code
+        )
+
+        mismatched_users: list[WmsSystemIamUserDiffOut] = []
+        missing_user_permissions: list[WmsSystemIamPermissionDiffOut] = []
+        extra_user_permissions: list[WmsSystemIamPermissionDiffOut] = []
+
+        for username, expected in normalized.users.items():
+            user = users_by_username.get(username)
+            if user is None:
+                continue
+
+            self._append_user_mismatches(
+                mismatched_users=mismatched_users,
+                username=username,
+                user=user,
+                expected=expected,
+            )
+
+            desired_codes = normalized.desired_permissions_by_username.get(username, set())
+            actual_codes = self.repo.list_permission_codes_for_user(int(user.id))
+
+            for permission_code in sorted(desired_codes - actual_codes):
+                missing_user_permissions.append(
+                    WmsSystemIamPermissionDiffOut(
+                        username=username,
+                        permission_code=permission_code,
+                    )
+                )
+
+            for permission_code in sorted(actual_codes - desired_codes):
+                extra_user_permissions.append(
+                    WmsSystemIamPermissionDiffOut(
+                        username=username,
+                        permission_code=permission_code,
+                    )
+                )
+
+        verified = not (
+            missing_users
+            or missing_permission_codes
+            or mismatched_users
+            or missing_user_permissions
+            or extra_user_permissions
+        )
+
+        return WmsSystemIamVerifyOut(
+            app_code=WMS_APP_CODE,
+            verified=verified,
+            user_count=len(normalized.users),
+            desired_permission_count=sum(
+                len(codes) for codes in normalized.desired_permissions_by_username.values()
+            ),
+            missing_users=missing_users,
+            missing_permission_codes=missing_permission_codes,
+            mismatched_users=mismatched_users,
+            missing_user_permissions=missing_user_permissions,
+            extra_user_permissions=extra_user_permissions,
+        )
+
+    def _normalize_payload(self, payload: WmsSystemIamApplyIn) -> NormalizedIamPayload:
+        users: dict[str, dict[str, object]] = {}
+        for user in payload.users:
+            username = _strip(user.username)
+            if not username:
+                raise WmsIamPayloadError("wms_iam_username_required")
+            if username in users:
+                raise WmsIamPayloadError("wms_iam_duplicate_username")
+
+            users[username] = {
+                "username": username,
+                "full_name": _optional_strip(user.full_name),
+                "phone": _optional_strip(user.phone),
+                "email": _optional_strip(user.email),
+                "is_active": bool(user.is_active),
+            }
+
+        desired_permissions_by_username: dict[str, set[str]] = {
+            username: set()
+            for username in users
+        }
+
+        for user_permission in payload.user_permissions:
+            username = _strip(user_permission.username)
+            permission_code = _strip(user_permission.permission_code)
+
+            if username not in users:
+                raise WmsIamPayloadError("wms_iam_user_permission_unknown_username")
+            if not permission_code:
+                raise WmsIamPayloadError("wms_iam_permission_code_required")
+
+            if bool(user_permission.is_active):
+                desired_permissions_by_username.setdefault(username, set()).add(permission_code)
+
+        return NormalizedIamPayload(
+            users=users,
+            desired_permissions_by_username=desired_permissions_by_username,
+        )
+
+    def _ensure_permissions_exist(
+        self,
+        permission_codes: set[str],
+        permissions_by_code: dict[str, object],
+    ) -> None:
+        missing = sorted(permission_code for permission_code in permission_codes if permission_code not in permissions_by_code)
+        if missing:
+            raise WmsIamPermissionNotFoundError(
+                "wms_iam_permission_not_found: " + ",".join(missing)
+            )
+
+    def _append_user_mismatches(
+        self,
+        *,
+        mismatched_users: list[WmsSystemIamUserDiffOut],
+        username: str,
+        user: User,
+        expected: dict[str, object],
+    ) -> None:
+        fields = (
+            ("is_active", bool(getattr(user, "is_active", True)), bool(expected["is_active"])),
+            ("full_name", _optional_strip(getattr(user, "full_name", None)), expected["full_name"]),
+            ("phone", _optional_strip(getattr(user, "phone", None)), expected["phone"]),
+            ("email", _optional_strip(getattr(user, "email", None)), expected["email"]),
+        )
+
+        for field_name, actual, expected_value in fields:
+            if actual != expected_value:
+                mismatched_users.append(
+                    WmsSystemIamUserDiffOut(
+                        username=username,
+                        field_name=field_name,
+                        expected=expected_value,
+                        actual=actual,
+                    )
+                )
+
+
+__all__ = [
+    "WMS_APP_CODE",
+    "WmsIamPayloadError",
+    "WmsIamPermissionNotFoundError",
+    "WmsIamWriteService",
+]

--- a/tests/api/test_wms_system_iam_write_api.py
+++ b/tests/api/test_wms_system_iam_write_api.py
@@ -1,0 +1,160 @@
+# tests/api/test_wms_system_iam_write_api.py
+from __future__ import annotations
+
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+APPLY_PATH = "/system/write/v1/iam/apply"
+VERIFY_PATH = "/system/write/v1/iam/verify"
+ERP_HEADER = {"X-Service-Client": "erp-service"}
+
+
+def _payload(username: str) -> dict:
+    return {
+        "users": [
+            {
+                "username": username,
+                "full_name": "ERP Managed User",
+                "phone": "13900001111",
+                "email": f"{username}@example.com",
+                "is_active": True,
+            }
+        ],
+        "user_permissions": [
+            {
+                "username": username,
+                "permission_code": "page.wms.read",
+                "is_active": True,
+            },
+            {
+                "username": username,
+                "permission_code": "page.inbound.read",
+                "is_active": True,
+            },
+        ],
+    }
+
+
+def test_wms_iam_apply_requires_erp_service_client_header() -> None:
+    client = TestClient(app)
+
+    response = client.post(APPLY_PATH, json=_payload("zz_missing_header"))
+
+    assert response.status_code == 401
+    assert "wms_service_client_required" in response.text
+
+
+def test_wms_iam_apply_rejects_non_erp_service_client() -> None:
+    client = TestClient(app)
+
+    response = client.post(
+        APPLY_PATH,
+        headers={"X-Service-Client": "logistics-service"},
+        json=_payload("zz_wrong_header"),
+    )
+
+    assert response.status_code == 403
+    assert "wms_service_permission_write_denied" in response.text
+
+
+def test_wms_iam_apply_and_verify_desired_state() -> None:
+    client = TestClient(app)
+    username = f"zz_erp_iam_{uuid4().hex[:10]}"
+    payload = _payload(username)
+
+    verify_before = client.post(VERIFY_PATH, headers=ERP_HEADER, json=payload)
+    assert verify_before.status_code == 200, verify_before.text
+    assert verify_before.json()["verified"] is False
+    assert username in verify_before.json()["missing_users"]
+
+    apply_response = client.post(APPLY_PATH, headers=ERP_HEADER, json=payload)
+    assert apply_response.status_code == 200, apply_response.text
+
+    applied = apply_response.json()
+    assert applied["app_code"] == "wms"
+    assert applied["applied"] is True
+    assert applied["verified"] is True
+    assert applied["user_count"] == 1
+    assert applied["desired_permission_count"] == 2
+    assert applied["missing_users"] == []
+    assert applied["missing_permission_codes"] == []
+    assert applied["missing_user_permissions"] == []
+    assert applied["extra_user_permissions"] == []
+
+    verify_after = client.post(VERIFY_PATH, headers=ERP_HEADER, json=payload)
+    assert verify_after.status_code == 200, verify_after.text
+    assert verify_after.json()["verified"] is True
+
+
+def test_wms_iam_apply_replaces_supplied_user_permissions() -> None:
+    client = TestClient(app)
+    username = f"zz_erp_iam_{uuid4().hex[:10]}"
+
+    first_payload = _payload(username)
+    first_response = client.post(APPLY_PATH, headers=ERP_HEADER, json=first_payload)
+    assert first_response.status_code == 200, first_response.text
+    assert first_response.json()["verified"] is True
+
+    second_payload = {
+        "users": first_payload["users"],
+        "user_permissions": [
+            {
+                "username": username,
+                "permission_code": "page.wms.read",
+                "is_active": True,
+            }
+        ],
+    }
+    second_response = client.post(APPLY_PATH, headers=ERP_HEADER, json=second_payload)
+    assert second_response.status_code == 200, second_response.text
+    assert second_response.json()["verified"] is True
+
+    old_verify = client.post(VERIFY_PATH, headers=ERP_HEADER, json=first_payload)
+    assert old_verify.status_code == 200, old_verify.text
+    old_body = old_verify.json()
+    assert old_body["verified"] is False
+    assert {
+        "username": username,
+        "permission_code": "page.inbound.read",
+    } in old_body["missing_user_permissions"]
+
+
+def test_wms_iam_apply_rejects_unknown_permission_code() -> None:
+    client = TestClient(app)
+    username = f"zz_erp_iam_{uuid4().hex[:10]}"
+    payload = {
+        "users": [
+            {
+                "username": username,
+                "is_active": True,
+            }
+        ],
+        "user_permissions": [
+            {
+                "username": username,
+                "permission_code": "page.not_exists.read",
+                "is_active": True,
+            }
+        ],
+    }
+
+    response = client.post(APPLY_PATH, headers=ERP_HEADER, json=payload)
+
+    assert response.status_code == 404
+    assert "wms_iam_permission_not_found" in response.text
+
+
+def test_wms_iam_routes_are_registered_in_openapi() -> None:
+    client = TestClient(app)
+
+    response = client.get("/openapi.json")
+
+    assert response.status_code == 200, response.text
+    paths = response.json()["paths"]
+    assert APPLY_PATH in paths
+    assert VERIFY_PATH in paths
+    assert "post" in paths[APPLY_PATH]
+    assert "post" in paths[VERIFY_PATH]


### PR DESCRIPTION
## Summary
- add /system/write/v1/iam/apply for ERP-owned IAM desired-state apply
- add /system/write/v1/iam/verify for local runtime IAM verification
- write only WMS local users / user_permissions runtime tables
- validate permission codes against WMS-owned permissions
- keep page_registry / page_route_prefixes untouched
- require X-Service-Client: erp-service

## Validation
- ruff check --no-fix targeted IAM write-v1 files
- pytest tests/api/test_wms_system_iam_write_api.py tests/api/test_wms_system_service_permission_write_api.py tests/ci/test_wms_service_auth_contract.py
- route inspection confirms:
  - POST /system/write/v1/iam/apply
  - POST /system/write/v1/iam/verify

## Architecture
ERP becomes the IAM owner. WMS keeps users / user_permissions as local runtime execution projection and does not recreate unknown permissions.