### PR TITLE
fix(system): split PMS projection dependencies

### DIFF
--- a/app/wms/system/read_v1/services/service_dependencies_service.py
+++ b/app/wms/system/read_v1/services/service_dependencies_service.py
@@ -35,41 +35,95 @@ class ServiceDependency:
     endpoints: tuple[ServiceDependencyEndpoint, ...]
 
 
+PMS_PROJECTION_SOURCE_MODULES = (
+    "app.integrations.pms.projection_sync",
+    "scripts.pms.sync_projection",
+)
+
 WMS_SERVICE_DEPENDENCIES: tuple[ServiceDependency, ...] = (
     ServiceDependency(
-        dependency_code="wms.depends_on.pms.projection_feed",
-        dependency_name="PMS projection feed",
+        dependency_code="wms.depends_on.pms.items_projection_feed",
+        dependency_name="PMS item projection feed",
         target_app_code="pms",
-        target_capability_code="pms.read.projection_feed",
-        description="WMS 同步 PMS 当前态只读投影，用于商品、供应商、包装单位、SKU 编码与条码查询。",
+        target_capability_code="pms.read.items",
+        description="WMS 同步 PMS 商品投影，用于仓储侧商品当前态只读查询。",
         is_required=True,
         is_active=True,
         required_config_keys=("PMS_API_BASE_URL",),
-        source_modules=(
-            "app.integrations.pms.projection_sync",
-            "scripts.pms.sync_projection",
-        ),
+        source_modules=PMS_PROJECTION_SOURCE_MODULES,
         endpoints=(
             ServiceDependencyEndpoint(
                 http_method="GET",
                 path="/pms/read/v1/projection-feed/items",
                 purpose="同步 PMS 商品投影。",
             ),
+        ),
+    ),
+    ServiceDependency(
+        dependency_code="wms.depends_on.pms.suppliers_projection_feed",
+        dependency_name="PMS supplier projection feed",
+        target_app_code="pms",
+        target_capability_code="pms.read.suppliers",
+        description="WMS 同步 PMS 供应商投影，用于仓储侧供应商当前态只读查询。",
+        is_required=True,
+        is_active=True,
+        required_config_keys=("PMS_API_BASE_URL",),
+        source_modules=PMS_PROJECTION_SOURCE_MODULES,
+        endpoints=(
             ServiceDependencyEndpoint(
                 http_method="GET",
                 path="/pms/read/v1/projection-feed/suppliers",
                 purpose="同步 PMS 供应商投影。",
             ),
+        ),
+    ),
+    ServiceDependency(
+        dependency_code="wms.depends_on.pms.uoms_projection_feed",
+        dependency_name="PMS UOM projection feed",
+        target_app_code="pms",
+        target_capability_code="pms.read.uoms",
+        description="WMS 同步 PMS 包装单位投影，用于仓储侧包装单位当前态只读查询。",
+        is_required=True,
+        is_active=True,
+        required_config_keys=("PMS_API_BASE_URL",),
+        source_modules=PMS_PROJECTION_SOURCE_MODULES,
+        endpoints=(
             ServiceDependencyEndpoint(
                 http_method="GET",
                 path="/pms/read/v1/projection-feed/uoms",
                 purpose="同步 PMS 包装单位投影。",
             ),
+        ),
+    ),
+    ServiceDependency(
+        dependency_code="wms.depends_on.pms.sku_codes_projection_feed",
+        dependency_name="PMS SKU code projection feed",
+        target_app_code="pms",
+        target_capability_code="pms.read.sku_codes",
+        description="WMS 同步 PMS SKU 编码投影，用于仓储侧 SKU 编码当前态只读查询。",
+        is_required=True,
+        is_active=True,
+        required_config_keys=("PMS_API_BASE_URL",),
+        source_modules=PMS_PROJECTION_SOURCE_MODULES,
+        endpoints=(
             ServiceDependencyEndpoint(
                 http_method="GET",
                 path="/pms/read/v1/projection-feed/sku-codes",
                 purpose="同步 PMS SKU 编码投影。",
             ),
+        ),
+    ),
+    ServiceDependency(
+        dependency_code="wms.depends_on.pms.barcodes_projection_feed",
+        dependency_name="PMS barcode projection feed",
+        target_app_code="pms",
+        target_capability_code="pms.read.barcodes",
+        description="WMS 同步 PMS 条码投影，用于仓储侧条码当前态只读查询。",
+        is_required=True,
+        is_active=True,
+        required_config_keys=("PMS_API_BASE_URL",),
+        source_modules=PMS_PROJECTION_SOURCE_MODULES,
+        endpoints=(
             ServiceDependencyEndpoint(
                 http_method="GET",
                 path="/pms/read/v1/projection-feed/barcodes",

--- a/tests/api/test_wms_system_service_dependencies_api.py
+++ b/tests/api/test_wms_system_service_dependencies_api.py
@@ -10,6 +10,13 @@ def _dependency_by_code(dependencies: list[dict]) -> dict[str, dict]:
     return {str(item["dependency_code"]): item for item in dependencies}
 
 
+def _endpoint_paths(dependency: dict) -> set[tuple[str, str]]:
+    return {
+        (endpoint["http_method"], endpoint["path"])
+        for endpoint in dependency["endpoints"]
+    }
+
+
 def test_wms_system_service_dependencies_returns_declared_dependencies() -> None:
     client = TestClient(app)
 
@@ -28,42 +35,69 @@ def test_wms_system_service_dependencies_returns_declared_dependencies() -> None
 
     by_code = _dependency_by_code(dependencies)
 
-    pms_projection = by_code["wms.depends_on.pms.projection_feed"]
-    assert pms_projection["target_app_code"] == "pms"
-    assert pms_projection["target_capability_code"] == "pms.read.projection_feed"
-    assert pms_projection["required_permission_code"] == "pms.read.projection_feed"
-    assert pms_projection["is_required"] is True
-    assert pms_projection["is_active"] is True
-    assert "PMS_API_BASE_URL" in pms_projection["required_config_keys"]
+    assert "wms.depends_on.pms.projection_feed" not in by_code
 
-    pms_projection_paths = {
-        (endpoint["http_method"], endpoint["path"])
-        for endpoint in pms_projection["endpoints"]
+    pms_items_projection = by_code["wms.depends_on.pms.items_projection_feed"]
+    assert pms_items_projection["target_app_code"] == "pms"
+    assert pms_items_projection["target_capability_code"] == "pms.read.items"
+    assert pms_items_projection["required_permission_code"] == "pms.read.items"
+    assert pms_items_projection["is_required"] is True
+    assert pms_items_projection["is_active"] is True
+    assert "PMS_API_BASE_URL" in pms_items_projection["required_config_keys"]
+    assert _endpoint_paths(pms_items_projection) == {
+        ("GET", "/pms/read/v1/projection-feed/items")
     }
-    assert ("GET", "/pms/read/v1/projection-feed/items") in pms_projection_paths
-    assert ("GET", "/pms/read/v1/projection-feed/suppliers") in pms_projection_paths
-    assert ("GET", "/pms/read/v1/projection-feed/uoms") in pms_projection_paths
-    assert ("GET", "/pms/read/v1/projection-feed/sku-codes") in pms_projection_paths
-    assert ("GET", "/pms/read/v1/projection-feed/barcodes") in pms_projection_paths
+
+    pms_suppliers_projection = by_code[
+        "wms.depends_on.pms.suppliers_projection_feed"
+    ]
+    assert pms_suppliers_projection["target_app_code"] == "pms"
+    assert pms_suppliers_projection["target_capability_code"] == "pms.read.suppliers"
+    assert pms_suppliers_projection["required_permission_code"] == "pms.read.suppliers"
+    assert _endpoint_paths(pms_suppliers_projection) == {
+        ("GET", "/pms/read/v1/projection-feed/suppliers")
+    }
+
+    pms_uoms_projection = by_code["wms.depends_on.pms.uoms_projection_feed"]
+    assert pms_uoms_projection["target_app_code"] == "pms"
+    assert pms_uoms_projection["target_capability_code"] == "pms.read.uoms"
+    assert pms_uoms_projection["required_permission_code"] == "pms.read.uoms"
+    assert _endpoint_paths(pms_uoms_projection) == {
+        ("GET", "/pms/read/v1/projection-feed/uoms")
+    }
+
+    pms_sku_codes_projection = by_code[
+        "wms.depends_on.pms.sku_codes_projection_feed"
+    ]
+    assert pms_sku_codes_projection["target_app_code"] == "pms"
+    assert pms_sku_codes_projection["target_capability_code"] == "pms.read.sku_codes"
+    assert pms_sku_codes_projection["required_permission_code"] == "pms.read.sku_codes"
+    assert _endpoint_paths(pms_sku_codes_projection) == {
+        ("GET", "/pms/read/v1/projection-feed/sku-codes")
+    }
+
+    pms_barcodes_projection = by_code[
+        "wms.depends_on.pms.barcodes_projection_feed"
+    ]
+    assert pms_barcodes_projection["target_app_code"] == "pms"
+    assert pms_barcodes_projection["target_capability_code"] == "pms.read.barcodes"
+    assert pms_barcodes_projection["required_permission_code"] == "pms.read.barcodes"
+    assert _endpoint_paths(pms_barcodes_projection) == {
+        ("GET", "/pms/read/v1/projection-feed/barcodes")
+    }
 
     oms = by_code["wms.depends_on.oms.fulfillment_ready_orders"]
     assert oms["target_app_code"] == "oms"
     assert oms["target_capability_code"] == "oms.read.fulfillment_ready_orders"
     assert "OMS_API_BASE_URL" in oms["required_config_keys"]
-    assert {
-        (endpoint["http_method"], endpoint["path"])
-        for endpoint in oms["endpoints"]
-    } == {("GET", "/oms/read/v1/fulfillment-ready-orders")}
+    assert _endpoint_paths(oms) == {("GET", "/oms/read/v1/fulfillment-ready-orders")}
 
     procurement = by_code["wms.depends_on.procurement.receiving_sources"]
     assert procurement["target_app_code"] == "procurement"
     assert procurement["target_capability_code"] == "procurement.read.wms_receiving_sources"
     assert "PROCUREMENT_API_BASE_URL" in procurement["required_config_keys"]
 
-    procurement_paths = {
-        (endpoint["http_method"], endpoint["path"])
-        for endpoint in procurement["endpoints"]
-    }
+    procurement_paths = _endpoint_paths(procurement)
     assert ("GET", "/procurement/read/v1/wms/receiving-sources") in procurement_paths
     assert ("GET", "/procurement/read/v1/wms/receiving-sources/{po_id}") in procurement_paths
 
@@ -111,10 +145,7 @@ def test_wms_system_service_dependencies_includes_pms_runtime_read_dependencies(
     assert "wms.depends_on.pms.sku_code_read" in by_code
 
     sku_code = by_code["wms.depends_on.pms.sku_code_read"]
-    sku_code_paths = {
-        (endpoint["http_method"], endpoint["path"])
-        for endpoint in sku_code["endpoints"]
-    }
+    sku_code_paths = _endpoint_paths(sku_code)
     assert ("POST", "/pms/read/v1/sku-codes/query") in sku_code_paths
     assert ("GET", "/pms/read/v1/sku-codes/resolve-outbound-default") in sku_code_paths
 


### PR DESCRIPTION
## Summary
- replace legacy aggregate PMS projection dependency
- split WMS PMS projection declaration into item, supplier, UOM, SKU code and barcode capabilities
- align WMS service dependency declarations with PMS terminal capabilities
- keep runtime calls unchanged

## Validation
- make lint
- compileall targeted files
- make test TESTS="tests/api/test_wms_system_service_dependencies_api.py tests/api/test_wms_system_app_manifest_api.py"
- curl /system/read/v1/service-dependencies confirms pms.read.projection_feed is gone