### PR TITLE
feat(system): expose WMS app manifest v2

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,9 +5,13 @@ import logging
 import os
 from typing import Any, Dict, List
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
 
+from app.db.session import get_db
 from app.http_problem_handlers import register_exception_handlers
 from app.router_mount import mount_routers
 
@@ -79,4 +83,14 @@ async def ping() -> Dict[str, Any]:
 
 @app.get("/healthz")
 async def healthz() -> Dict[str, Any]:
+    return {"status": "ok"}
+
+
+@app.get("/health/db")
+def health_db(db: Session = Depends(get_db)) -> Dict[str, Any]:
+    try:
+        db.execute(text("SELECT 1"))
+    except SQLAlchemyError as exc:
+        raise HTTPException(status_code=503, detail="database_unavailable") from exc
+
     return {"status": "ok"}

--- a/app/wms/system/read_v1/contracts/__init__.py
+++ b/app/wms/system/read_v1/contracts/__init__.py
@@ -2,8 +2,13 @@
 from __future__ import annotations
 
 from app.wms.system.read_v1.contracts.app_manifest import (
-    WmsSystemAppManifestBuildInfoOut,
+    WmsSystemAppInfoOut,
     WmsSystemAppManifestOut,
+    WmsSystemBuildInfoOut,
+    WmsSystemDeploymentOut,
+    WmsSystemEndpointDescriptorOut,
+    WmsSystemSecurityPolicyOut,
+    WmsSystemServiceIdentityOut,
 )
 from app.wms.system.read_v1.contracts.page_catalog import (
     WmsSystemPageCatalogOut,
@@ -21,14 +26,19 @@ from app.wms.system.read_v1.contracts.service_dependencies import (
 )
 
 __all__ = [
-    "WmsSystemAppManifestBuildInfoOut",
+    "WmsSystemAppInfoOut",
     "WmsSystemAppManifestOut",
+    "WmsSystemBuildInfoOut",
+    "WmsSystemDeploymentOut",
+    "WmsSystemEndpointDescriptorOut",
     "WmsSystemPageCatalogOut",
     "WmsSystemPageCatalogPageOut",
+    "WmsSystemSecurityPolicyOut",
     "WmsSystemServiceCapabilitiesOut",
     "WmsSystemServiceCapabilityOut",
     "WmsSystemServiceCapabilityRouteOut",
     "WmsSystemServiceDependenciesOut",
     "WmsSystemServiceDependencyEndpointOut",
     "WmsSystemServiceDependencyOut",
+    "WmsSystemServiceIdentityOut",
 ]

--- a/app/wms/system/read_v1/contracts/app_manifest.py
+++ b/app/wms/system/read_v1/contracts/app_manifest.py
@@ -1,6 +1,7 @@
 # app/wms/system/read_v1/contracts/app_manifest.py
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -10,36 +11,84 @@ class _Base(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class WmsSystemAppManifestBuildInfoOut(_Base):
-    environment: str = Field(..., min_length=1)
-    git_sha: str | None = None
-    build_time: str | None = None
+HttpMethod = Literal["GET", "POST", "PUT", "PATCH", "DELETE"]
+ManifestContractVersion = Literal["2.0"]
+EndpointAuthPolicy = Literal[
+    "internal_control_plane",
+    "erp_service_client_required",
+    "public_health",
+]
+
+
+class WmsSystemEndpointDescriptorOut(_Base):
+    code: str = Field(..., min_length=1, max_length=128)
+    method: HttpMethod
+    path: str = Field(..., min_length=1, max_length=255)
+    purpose: str = Field(..., min_length=1, max_length=255)
+    is_required: bool = True
+    is_active: bool = True
+    auth_policy: EndpointAuthPolicy
+
+
+class WmsSystemAppInfoOut(_Base):
+    app_code: Literal["wms"]
+    app_name: str = Field(..., min_length=1, max_length=128)
+    app_type: str = Field(..., min_length=1, max_length=64)
+    owner_domain: str = Field(..., min_length=1, max_length=128)
+    status: str = Field(..., min_length=1, max_length=64)
+    description: str = Field(..., min_length=1, max_length=512)
+
+
+class WmsSystemDeploymentOut(_Base):
+    env_code: str = Field(..., min_length=1, max_length=64)
+    deployment_mode: str = Field(..., min_length=1, max_length=64)
+    web_path: str = Field(..., min_length=1, max_length=255)
+    api_path: str = Field(..., min_length=1, max_length=255)
+    control_base_url: str = Field(..., min_length=1, max_length=255)
+    internal_api_base_url: str = Field(..., min_length=1, max_length=255)
+    public_web_url: str = Field(..., min_length=1, max_length=255)
+    public_api_base_url: str | None = Field(default=None, max_length=255)
+
+
+class WmsSystemServiceIdentityOut(_Base):
+    service_client_code: Literal["wms-service"]
+    service_client_header: Literal["X-Service-Client"]
+
+
+class WmsSystemSecurityPolicyOut(_Base):
+    self_description_auth_policy: Literal["internal_control_plane"]
+    write_auth_policy: Literal["erp_service_client_required"]
+    required_write_caller: Literal["erp-service"]
+
+
+class WmsSystemBuildInfoOut(_Base):
+    app_version: str = Field(..., min_length=1, max_length=64)
+    git_sha: str | None = Field(default=None, max_length=128)
+    image_tag: str | None = Field(default=None, max_length=128)
+    build_time: str | None = Field(default=None, max_length=128)
 
 
 class WmsSystemAppManifestOut(_Base):
-    app_code: Literal["wms"]
-    app_name: str = Field(..., min_length=1)
-    app_type: str = Field(..., min_length=1)
-    status: str = Field(..., min_length=1)
-    description: str = Field(..., min_length=1)
+    manifest_contract_version: ManifestContractVersion
+    generated_at: datetime
 
-    default_web_path: str = Field(..., min_length=1)
-    default_api_path: str = Field(..., min_length=1)
-    local_web_url: str = Field(..., min_length=1)
-    local_api_url: str = Field(..., min_length=1)
+    app: WmsSystemAppInfoOut
+    deployment: WmsSystemDeploymentOut
+    service_identity: WmsSystemServiceIdentityOut
 
-    health_url: str = Field(..., min_length=1)
-    db_health_url: str | None = None
-    openapi_url: str = Field(..., min_length=1)
-    page_catalog_url: str = Field(..., min_length=1)
-    service_capabilities_url: str = Field(..., min_length=1)
-    service_dependencies_url: str = Field(..., min_length=1)
+    control_endpoints: list[WmsSystemEndpointDescriptorOut] = Field(default_factory=list)
+    write_endpoints: list[WmsSystemEndpointDescriptorOut] = Field(default_factory=list)
 
-    version: str = Field(..., min_length=1)
-    build_info: WmsSystemAppManifestBuildInfoOut
+    security: WmsSystemSecurityPolicyOut
+    build: WmsSystemBuildInfoOut
 
 
 __all__ = [
-    "WmsSystemAppManifestBuildInfoOut",
+    "WmsSystemAppInfoOut",
     "WmsSystemAppManifestOut",
+    "WmsSystemBuildInfoOut",
+    "WmsSystemDeploymentOut",
+    "WmsSystemEndpointDescriptorOut",
+    "WmsSystemSecurityPolicyOut",
+    "WmsSystemServiceIdentityOut",
 ]

--- a/app/wms/system/read_v1/services/app_manifest_service.py
+++ b/app/wms/system/read_v1/services/app_manifest_service.py
@@ -2,13 +2,27 @@
 from __future__ import annotations
 
 import os
+from datetime import UTC, datetime
+from typing import Literal
 
 from app.wms.system.read_v1.contracts import (
-    WmsSystemAppManifestBuildInfoOut,
+    WmsSystemAppInfoOut,
     WmsSystemAppManifestOut,
+    WmsSystemBuildInfoOut,
+    WmsSystemDeploymentOut,
+    WmsSystemEndpointDescriptorOut,
+    WmsSystemSecurityPolicyOut,
+    WmsSystemServiceIdentityOut,
 )
 
+WMS_APP_CODE = "wms"
+WMS_APP_NAME = "WMS 仓储执行系统"
 WMS_APP_VERSION = "1.1.0"
+WMS_MANIFEST_CONTRACT_VERSION = "2.0"
+
+WMS_SERVICE_CLIENT_CODE = "wms-service"
+WMS_SERVICE_CLIENT_HEADER = "X-Service-Client"
+ERP_SERVICE_CLIENT_CODE = "erp-service"
 
 
 def _env_value(*names: str) -> str | None:
@@ -19,35 +33,171 @@ def _env_value(*names: str) -> str | None:
     return None
 
 
+def _endpoint(
+    *,
+    code: str,
+    method: Literal["GET", "POST", "PUT", "PATCH", "DELETE"],
+    path: str,
+    purpose: str,
+    auth_policy: Literal[
+        "internal_control_plane",
+        "erp_service_client_required",
+        "public_health",
+    ],
+    is_required: bool = True,
+    is_active: bool = True,
+) -> WmsSystemEndpointDescriptorOut:
+    return WmsSystemEndpointDescriptorOut(
+        code=code,
+        method=method,
+        path=path,
+        purpose=purpose,
+        is_required=is_required,
+        is_active=is_active,
+        auth_policy=auth_policy,
+    )
+
+
 def build_wms_app_manifest() -> WmsSystemAppManifestOut:
-    version = _env_value("WMS_APP_VERSION", "APP_VERSION") or WMS_APP_VERSION
+    app_version = _env_value("WMS_APP_VERSION", "APP_VERSION") or WMS_APP_VERSION
+    env_code = _env_value("WMS_ENV_CODE", "ENV_CODE", "WMS_ENV", "ENV") or "dev"
+    deployment_mode = _env_value("WMS_DEPLOYMENT_MODE", "DEPLOYMENT_MODE") or "local"
+
+    control_base_url = (
+        _env_value("WMS_CONTROL_BASE_URL", "WMS_INTERNAL_API_BASE_URL", "WMS_LOCAL_API_URL")
+        or "http://127.0.0.1:8000"
+    )
+    internal_api_base_url = (
+        _env_value("WMS_INTERNAL_API_BASE_URL", "WMS_LOCAL_API_URL") or control_base_url
+    )
 
     return WmsSystemAppManifestOut(
-        app_code="wms",
-        app_name="仓储管理",
-        app_type="business_system",
-        status="available",
-        description="WMS 仓储管理系统，负责库存、入库、出库、仓库与仓内作业等仓储域能力。",
-        default_web_path="/wms/",
-        default_api_path="/api/wms",
-        local_web_url=_env_value("WMS_LOCAL_WEB_URL") or "http://127.0.0.1:5173",
-        local_api_url=_env_value("WMS_LOCAL_API_URL") or "http://127.0.0.1:8000",
-        health_url="/healthz",
-        db_health_url=_env_value("WMS_DB_HEALTH_URL"),
-        openapi_url="/openapi.json",
-        page_catalog_url="/system/read/v1/page-catalog",
-        service_capabilities_url="/system/read/v1/service-capabilities",
-        service_dependencies_url="/system/read/v1/service-dependencies",
-        version=version,
-        build_info=WmsSystemAppManifestBuildInfoOut(
-            environment=_env_value("WMS_ENV", "ENV") or "dev",
+        manifest_contract_version=WMS_MANIFEST_CONTRACT_VERSION,
+        generated_at=datetime.now(UTC),
+        app=WmsSystemAppInfoOut(
+            app_code=WMS_APP_CODE,
+            app_name=WMS_APP_NAME,
+            app_type="business_system",
+            owner_domain="warehouse_execution",
+            status="available",
+            description=(
+                "WMS 仓储执行系统，负责库存、入库、出库、仓库、仓内作业、"
+                "发货交接和仓储侧执行事实能力。"
+            ),
+        ),
+        deployment=WmsSystemDeploymentOut(
+            env_code=env_code,
+            deployment_mode=deployment_mode,
+            web_path=_env_value("WMS_WEB_PATH") or "/wms",
+            api_path=_env_value("WMS_API_PATH") or "/api/wms",
+            control_base_url=control_base_url,
+            internal_api_base_url=internal_api_base_url,
+            public_web_url=_env_value("WMS_PUBLIC_WEB_URL", "WMS_LOCAL_WEB_URL")
+            or "http://127.0.0.1:5173",
+            public_api_base_url=_env_value("WMS_PUBLIC_API_BASE_URL"),
+        ),
+        service_identity=WmsSystemServiceIdentityOut(
+            service_client_code=WMS_SERVICE_CLIENT_CODE,
+            service_client_header=WMS_SERVICE_CLIENT_HEADER,
+        ),
+        control_endpoints=[
+            _endpoint(
+                code="app_manifest",
+                method="GET",
+                path="/system/read/v1/app-manifest",
+                purpose="应用清单自描述",
+                auth_policy="internal_control_plane",
+            ),
+            _endpoint(
+                code="page_catalog",
+                method="GET",
+                path="/system/read/v1/page-catalog",
+                purpose="页面目录",
+                auth_policy="internal_control_plane",
+            ),
+            _endpoint(
+                code="service_capabilities",
+                method="GET",
+                path="/system/read/v1/service-capabilities",
+                purpose="服务能力目录",
+                auth_policy="internal_control_plane",
+            ),
+            _endpoint(
+                code="service_dependencies",
+                method="GET",
+                path="/system/read/v1/service-dependencies",
+                purpose="服务依赖声明",
+                auth_policy="internal_control_plane",
+            ),
+            _endpoint(
+                code="openapi",
+                method="GET",
+                path="/openapi.json",
+                purpose="OpenAPI 合同",
+                auth_policy="internal_control_plane",
+            ),
+            _endpoint(
+                code="health",
+                method="GET",
+                path="/healthz",
+                purpose="应用健康检查",
+                auth_policy="public_health",
+            ),
+            _endpoint(
+                code="db_health",
+                method="GET",
+                path="/health/db",
+                purpose="数据库健康检查",
+                auth_policy="internal_control_plane",
+            ),
+        ],
+        write_endpoints=[
+            _endpoint(
+                code="iam_apply",
+                method="POST",
+                path="/system/write/v1/iam/apply",
+                purpose="ERP 用户与页面权限写入",
+                auth_policy="erp_service_client_required",
+            ),
+            _endpoint(
+                code="iam_verify",
+                method="POST",
+                path="/system/write/v1/iam/verify",
+                purpose="ERP 用户与页面权限校验",
+                auth_policy="erp_service_client_required",
+            ),
+            _endpoint(
+                code="service_permission_apply",
+                method="POST",
+                path="/system/write/v1/service-permissions/apply",
+                purpose="ERP 系统间访问白名单写入",
+                auth_policy="erp_service_client_required",
+            ),
+            _endpoint(
+                code="service_permission_verify",
+                method="GET",
+                path="/system/write/v1/service-permissions/verify",
+                purpose="ERP 系统间访问白名单校验",
+                auth_policy="erp_service_client_required",
+            ),
+        ],
+        security=WmsSystemSecurityPolicyOut(
+            self_description_auth_policy="internal_control_plane",
+            write_auth_policy="erp_service_client_required",
+            required_write_caller=ERP_SERVICE_CLIENT_CODE,
+        ),
+        build=WmsSystemBuildInfoOut(
+            app_version=app_version,
             git_sha=_env_value("WMS_GIT_SHA", "GIT_SHA", "COMMIT_SHA"),
+            image_tag=_env_value("WMS_IMAGE_TAG", "IMAGE_TAG"),
             build_time=_env_value("WMS_BUILD_TIME", "BUILD_TIME"),
         ),
     )
 
 
 __all__ = [
+    "WMS_APP_CODE",
+    "WMS_APP_NAME",
     "WMS_APP_VERSION",
     "build_wms_app_manifest",
 ]

--- a/tests/api/test_wms_system_app_manifest_api.py
+++ b/tests/api/test_wms_system_app_manifest_api.py
@@ -28,29 +28,75 @@ def test_wms_system_app_manifest_returns_self_description_defaults() -> None:
     assert response.status_code == 200, response.text
     body = response.json()
 
-    assert body["app_code"] == "wms"
-    assert body["app_name"] == "仓储管理"
-    assert body["app_type"] == "business_system"
-    assert body["status"] == "available"
-    assert body["default_web_path"] == "/wms/"
-    assert body["default_api_path"] == "/api/wms"
-    assert body["local_web_url"] == "http://127.0.0.1:5173"
-    assert body["local_api_url"] == "http://127.0.0.1:8000"
-    assert body["health_url"] == "/healthz"
-    assert body["db_health_url"] is None
-    assert body["openapi_url"] == "/openapi.json"
-    assert body["page_catalog_url"] == "/system/read/v1/page-catalog"
-    assert body["service_capabilities_url"] == "/system/read/v1/service-capabilities"
-    assert body["service_dependencies_url"] == "/system/read/v1/service-dependencies"
-    assert body["version"] == "1.1.0"
+    assert body["manifest_contract_version"] == "2.0"
+    assert body["generated_at"]
 
-    build_info = body["build_info"]
-    assert isinstance(build_info, dict)
-    assert isinstance(build_info["environment"], str)
-    assert build_info["environment"]
-    assert "git_sha" in build_info
-    assert "build_time" in build_info
+    app_info = body["app"]
+    assert app_info["app_code"] == "wms"
+    assert app_info["app_name"] == "WMS 仓储执行系统"
+    assert app_info["app_type"] == "business_system"
+    assert app_info["owner_domain"] == "warehouse_execution"
+    assert app_info["status"] == "available"
 
+    deployment = body["deployment"]
+    assert deployment["env_code"] == "test"
+    assert deployment["deployment_mode"] == "local"
+    assert deployment["web_path"] == "/wms"
+    assert deployment["api_path"] == "/api/wms"
+    assert deployment["control_base_url"] == "http://127.0.0.1:8000"
+    assert deployment["internal_api_base_url"] == "http://127.0.0.1:8000"
+    assert deployment["public_web_url"] == "http://127.0.0.1:5173"
+
+    service_identity = body["service_identity"]
+    assert service_identity["service_client_code"] == "wms-service"
+    assert service_identity["service_client_header"] == "X-Service-Client"
+
+    control_endpoints = {row["code"]: row for row in body["control_endpoints"]}
+    assert control_endpoints["app_manifest"]["path"] == "/system/read/v1/app-manifest"
+    assert control_endpoints["page_catalog"]["path"] == "/system/read/v1/page-catalog"
+    assert control_endpoints["service_capabilities"]["path"] == (
+        "/system/read/v1/service-capabilities"
+    )
+    assert control_endpoints["service_dependencies"]["path"] == (
+        "/system/read/v1/service-dependencies"
+    )
+    assert control_endpoints["openapi"]["path"] == "/openapi.json"
+    assert control_endpoints["health"]["path"] == "/healthz"
+    assert control_endpoints["db_health"]["path"] == "/health/db"
+
+    write_endpoints = {row["code"]: row for row in body["write_endpoints"]}
+    assert write_endpoints["iam_apply"]["method"] == "POST"
+    assert write_endpoints["iam_apply"]["path"] == "/system/write/v1/iam/apply"
+    assert write_endpoints["iam_verify"]["method"] == "POST"
+    assert write_endpoints["iam_verify"]["path"] == "/system/write/v1/iam/verify"
+    assert write_endpoints["service_permission_apply"]["path"] == (
+        "/system/write/v1/service-permissions/apply"
+    )
+    assert write_endpoints["service_permission_verify"]["method"] == "GET"
+    assert write_endpoints["service_permission_verify"]["path"] == (
+        "/system/write/v1/service-permissions/verify"
+    )
+
+    security = body["security"]
+    assert security["self_description_auth_policy"] == "internal_control_plane"
+    assert security["write_auth_policy"] == "erp_service_client_required"
+    assert security["required_write_caller"] == "erp-service"
+
+    build = body["build"]
+    assert build["app_version"] == "1.1.0"
+    assert "git_sha" in build
+    assert "image_tag" in build
+    assert "build_time" in build
+
+    assert "default_web_path" not in body
+    assert "default_api_path" not in body
+    assert "local_web_url" not in body
+    assert "local_api_url" not in body
+    assert "page_catalog_url" not in body
+    assert "service_capabilities_url" not in body
+    assert "service_dependencies_url" not in body
+    assert "version" not in body
+    assert "build_info" not in body
     assert "is_active" not in body
     assert "is_visible" not in body
     assert "is_published" not in body
@@ -66,3 +112,16 @@ def test_wms_system_app_manifest_is_registered_in_openapi() -> None:
 
     assert "/system/read/v1/app-manifest" in paths
     assert "get" in paths["/system/read/v1/app-manifest"]
+    assert "/health/db" in paths
+    assert "get" in paths["/health/db"]
+
+    schemas = response.json()["components"]["schemas"]
+    manifest_schema = schemas["WmsSystemAppManifestOut"]
+    assert "manifest_contract_version" in manifest_schema["properties"]
+    assert "app" in manifest_schema["properties"]
+    assert "deployment" in manifest_schema["properties"]
+    assert "service_identity" in manifest_schema["properties"]
+    assert "control_endpoints" in manifest_schema["properties"]
+    assert "write_endpoints" in manifest_schema["properties"]
+    assert "security" in manifest_schema["properties"]
+    assert "build" in manifest_schema["properties"]


### PR DESCRIPTION
## Summary
- upgrade WMS /system/read/v1/app-manifest to Manifest V2
- expose app, deployment, service identity, control endpoints, write endpoints, security policy and build metadata
- add /health/db and include db_health in Manifest V2 control endpoints
- align WMS app name with ERP registration naming

## Validation
- make lint
- make test TESTS="tests/api/test_wms_system_app_manifest_api.py tests/api/test_wms_system_page_catalog_api.py tests/api/test_wms_system_service_capabilities_api.py tests/api/test_wms_system_service_dependencies_api.py"
- local /health/db returned ok
- local /system/read/v1/app-manifest returned manifest_contract_version=2.0
- ERP sync-self-description for WMS succeeded
- wms.control.app_registration returned ok