### PR TITLE
feat(sso): add WMS authorization code exchange

### DIFF
--- a/app/router_mount.py
+++ b/app/router_mount.py
@@ -54,6 +54,7 @@ def mount_routers(app: FastAPI) -> None:
     from app.wms.warehouses.routers.warehouses import router as warehouses_router
     from app.wms.system.read_v1.routers import router as wms_system_read_v1_router
     from app.wms.system.write_v1.routers import router as wms_system_write_v1_router
+    from app.wms.system.sso_v1.routers import router as wms_system_sso_v1_router
 
     from app.oms.router import router as oms_router
     from app.pms.router import router as pms_router
@@ -117,6 +118,7 @@ def mount_routers(app: FastAPI) -> None:
     app.include_router(warehouses_router)
     app.include_router(wms_system_read_v1_router)
     app.include_router(wms_system_write_v1_router)
+    app.include_router(wms_system_sso_v1_router)
 
     # PMS 相关：
     # - PMS export 读面先挂，避免与 owner /items/{id} 类路由冲突

--- a/app/wms/system/sso_v1/__init__.py
+++ b/app/wms/system/sso_v1/__init__.py
@@ -1,0 +1,4 @@
+# app/wms/system/sso_v1/__init__.py
+from __future__ import annotations
+
+"""WMS system SSO exchange package."""

--- a/app/wms/system/sso_v1/contracts/__init__.py
+++ b/app/wms/system/sso_v1/contracts/__init__.py
@@ -1,0 +1,14 @@
+# app/wms/system/sso_v1/contracts/__init__.py
+from __future__ import annotations
+
+from app.wms.system.sso_v1.contracts.sso_exchange import (
+    ErpSsoAuthorizationCodeConsumeOut,
+    WmsSsoExchangeIn,
+    WmsSsoExchangeOut,
+)
+
+__all__ = [
+    "ErpSsoAuthorizationCodeConsumeOut",
+    "WmsSsoExchangeIn",
+    "WmsSsoExchangeOut",
+]

--- a/app/wms/system/sso_v1/contracts/sso_exchange.py
+++ b/app/wms/system/sso_v1/contracts/sso_exchange.py
@@ -1,0 +1,38 @@
+# app/wms/system/sso_v1/contracts/sso_exchange.py
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class WmsSsoExchangeIn(_Base):
+    code: str = Field(..., min_length=1, max_length=256)
+    state: str = Field(..., min_length=1, max_length=256)
+
+
+class WmsSsoExchangeOut(_Base):
+    access_token: str
+    token_type: str = "bearer"
+    expires_in: int
+    redirect_path: str = "/"
+
+
+class ErpSsoAuthorizationCodeConsumeOut(_Base):
+    app_code: str
+    sub: str
+    erp_user_id: int
+    username: str
+    full_name: str | None = None
+    email: str | None = None
+    phone: str | None = None
+    redirect_path: str
+
+
+__all__ = [
+    "ErpSsoAuthorizationCodeConsumeOut",
+    "WmsSsoExchangeIn",
+    "WmsSsoExchangeOut",
+]

--- a/app/wms/system/sso_v1/routers/__init__.py
+++ b/app/wms/system/sso_v1/routers/__init__.py
@@ -1,0 +1,11 @@
+# app/wms/system/sso_v1/routers/__init__.py
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.wms.system.sso_v1.routers.exchange import router as exchange_router
+
+router = APIRouter()
+router.include_router(exchange_router)
+
+__all__ = ["router"]

--- a/app/wms/system/sso_v1/routers/exchange.py
+++ b/app/wms/system/sso_v1/routers/exchange.py
@@ -1,0 +1,80 @@
+# app/wms/system/sso_v1/routers/exchange.py
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Cookie, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.wms.system.sso_v1.contracts import WmsSsoExchangeIn, WmsSsoExchangeOut
+from app.wms.system.sso_v1.services import ERP_SSO_BINDING_COOKIE_NAME
+from app.wms.system.sso_v1.services.sso_exchange_service import (
+    WmsSsoAppMismatchError,
+    WmsSsoBindingRequiredError,
+    WmsSsoErpExchangeFailedError,
+    WmsSsoExchangeService,
+    WmsSsoUserInactiveError,
+    WmsSsoUserNotFoundError,
+)
+
+router = APIRouter(prefix="/system/sso/v1", tags=["system-sso-v1"])
+
+DBSessionDep = Annotated[Session, Depends(get_db)]
+BindingCookieDep = Annotated[
+    str | None,
+    Cookie(alias=ERP_SSO_BINDING_COOKIE_NAME),
+]
+
+
+def get_wms_sso_exchange_service(
+    db: DBSessionDep,
+) -> WmsSsoExchangeService:
+    return WmsSsoExchangeService(db)
+
+
+WmsSsoExchangeServiceDep = Annotated[
+    WmsSsoExchangeService,
+    Depends(get_wms_sso_exchange_service),
+]
+
+
+@router.post("/exchange", response_model=WmsSsoExchangeOut)
+async def exchange_wms_sso_authorization_code(
+    body: WmsSsoExchangeIn,
+    service: WmsSsoExchangeServiceDep,
+    binding: BindingCookieDep = None,
+) -> WmsSsoExchangeOut:
+    try:
+        return await service.exchange(body, binding=binding)
+    except WmsSsoBindingRequiredError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="wms_sso_binding_required",
+        ) from exc
+    except WmsSsoErpExchangeFailedError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="wms_sso_erp_exchange_failed",
+        ) from exc
+    except WmsSsoAppMismatchError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="wms_sso_app_mismatch",
+        ) from exc
+    except WmsSsoUserNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="wms_sso_user_not_found",
+        ) from exc
+    except WmsSsoUserInactiveError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="wms_sso_user_inactive",
+        ) from exc
+
+
+__all__ = [
+    "get_wms_sso_exchange_service",
+    "router",
+]

--- a/app/wms/system/sso_v1/services/__init__.py
+++ b/app/wms/system/sso_v1/services/__init__.py
@@ -1,0 +1,34 @@
+# app/wms/system/sso_v1/services/__init__.py
+from __future__ import annotations
+
+from app.wms.system.sso_v1.services.erp_sso_authorization_code_client import (
+    ERP_SSO_AUTHORIZATION_CODE_CONSUME_PATH,
+    ERP_SSO_BINDING_COOKIE_NAME,
+    ERP_SERVICE_CLIENT_HEADER,
+    ErpSsoAuthorizationCodeClient,
+    ErpSsoAuthorizationCodeClientError,
+    WMS_SERVICE_CLIENT_CODE,
+)
+from app.wms.system.sso_v1.services.sso_exchange_service import (
+    WmsSsoAppMismatchError,
+    WmsSsoBindingRequiredError,
+    WmsSsoErpExchangeFailedError,
+    WmsSsoExchangeService,
+    WmsSsoUserInactiveError,
+    WmsSsoUserNotFoundError,
+)
+
+__all__ = [
+    "ERP_SERVICE_CLIENT_HEADER",
+    "ERP_SSO_AUTHORIZATION_CODE_CONSUME_PATH",
+    "ERP_SSO_BINDING_COOKIE_NAME",
+    "ErpSsoAuthorizationCodeClient",
+    "ErpSsoAuthorizationCodeClientError",
+    "WMS_SERVICE_CLIENT_CODE",
+    "WmsSsoAppMismatchError",
+    "WmsSsoBindingRequiredError",
+    "WmsSsoErpExchangeFailedError",
+    "WmsSsoExchangeService",
+    "WmsSsoUserInactiveError",
+    "WmsSsoUserNotFoundError",
+]

--- a/app/wms/system/sso_v1/services/erp_sso_authorization_code_client.py
+++ b/app/wms/system/sso_v1/services/erp_sso_authorization_code_client.py
@@ -1,0 +1,120 @@
+# app/wms/system/sso_v1/services/erp_sso_authorization_code_client.py
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+from app.wms.system.sso_v1.contracts import ErpSsoAuthorizationCodeConsumeOut
+
+ERP_SERVICE_CLIENT_HEADER = "X-Service-Client"
+WMS_SERVICE_CLIENT_CODE = "wms-service"
+ERP_SSO_BINDING_COOKIE_NAME = "ERP_SSO_BINDING"
+ERP_SSO_AUTHORIZATION_CODE_CONSUME_PATH = (
+    "/system/sso/v1/authorization-codes/consume"
+)
+DEFAULT_ERP_API_BASE_URL = "http://127.0.0.1:7990"
+
+
+class ErpSsoAuthorizationCodeClientError(RuntimeError):
+    pass
+
+
+class ErpSsoAuthorizationCodeClient:
+    """
+    WMS -> ERP SSO authorization-code consume client.
+
+    Boundary:
+    - WMS calls ERP as fixed service client: wms-service.
+    - WMS does not read ERP token or ERP localStorage.
+    - ERP returns identity summary only; WMS still signs its own local token.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        timeout_seconds: float = 10.0,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self.base_url = (
+            base_url
+            or os.environ.get("ERP_API_BASE_URL")
+            or DEFAULT_ERP_API_BASE_URL
+        ).rstrip("/")
+        self.timeout_seconds = float(timeout_seconds)
+        self.transport = transport
+
+    async def consume_authorization_code(
+        self,
+        *,
+        code: str,
+        state: str,
+        binding: str,
+    ) -> ErpSsoAuthorizationCodeConsumeOut:
+        url = f"{self.base_url}{ERP_SSO_AUTHORIZATION_CODE_CONSUME_PATH}"
+        headers = {
+            ERP_SERVICE_CLIENT_HEADER: WMS_SERVICE_CLIENT_CODE,
+        }
+        payload: dict[str, str] = {
+            "code": code,
+            "state": state,
+            "binding": binding,
+        }
+
+        async with httpx.AsyncClient(
+            timeout=self.timeout_seconds,
+            transport=self.transport,
+        ) as client:
+            try:
+                response = await client.post(url, json=payload, headers=headers)
+            except httpx.HTTPError as exc:
+                raise ErpSsoAuthorizationCodeClientError(
+                    "erp_sso_consume_request_failed"
+                ) from exc
+
+        if response.status_code >= 400:
+            detail = _response_detail(response)
+            raise ErpSsoAuthorizationCodeClientError(
+                f"erp_sso_consume_failed:{response.status_code}:{detail}"
+            )
+
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise ErpSsoAuthorizationCodeClientError(
+                "erp_sso_consume_invalid_json"
+            ) from exc
+
+        try:
+            return ErpSsoAuthorizationCodeConsumeOut.model_validate(data)
+        except Exception as exc:
+            raise ErpSsoAuthorizationCodeClientError(
+                "erp_sso_consume_invalid_contract"
+            ) from exc
+
+
+def _response_detail(response: httpx.Response) -> str:
+    try:
+        data: Any = response.json()
+    except ValueError:
+        return response.text[:300]
+
+    if isinstance(data, dict):
+        detail = data.get("detail")
+        if detail is not None:
+            return str(detail)[:300]
+
+    return str(data)[:300]
+
+
+__all__ = [
+    "DEFAULT_ERP_API_BASE_URL",
+    "ERP_SERVICE_CLIENT_HEADER",
+    "ERP_SSO_AUTHORIZATION_CODE_CONSUME_PATH",
+    "ERP_SSO_BINDING_COOKIE_NAME",
+    "ErpSsoAuthorizationCodeClient",
+    "ErpSsoAuthorizationCodeClientError",
+    "WMS_SERVICE_CLIENT_CODE",
+]

--- a/app/wms/system/sso_v1/services/sso_exchange_service.py
+++ b/app/wms/system/sso_v1/services/sso_exchange_service.py
@@ -1,0 +1,134 @@
+# app/wms/system/sso_v1/services/sso_exchange_service.py
+from __future__ import annotations
+
+from typing import Protocol
+
+from sqlalchemy.orm import Session
+
+from app.user.helpers.auth import token_expires_in_seconds
+from app.user.models.user import User
+from app.user.services.user_service import UserService
+from app.wms.system.sso_v1.contracts import (
+    ErpSsoAuthorizationCodeConsumeOut,
+    WmsSsoExchangeIn,
+    WmsSsoExchangeOut,
+)
+from app.wms.system.sso_v1.services.erp_sso_authorization_code_client import (
+    ErpSsoAuthorizationCodeClient,
+    ErpSsoAuthorizationCodeClientError,
+)
+
+
+class WmsSsoBindingRequiredError(ValueError):
+    pass
+
+
+class WmsSsoErpExchangeFailedError(ValueError):
+    pass
+
+
+class WmsSsoAppMismatchError(ValueError):
+    pass
+
+
+class WmsSsoUserNotFoundError(ValueError):
+    pass
+
+
+class WmsSsoUserInactiveError(ValueError):
+    pass
+
+
+class ErpSsoAuthorizationCodeClientLike(Protocol):
+    async def consume_authorization_code(
+        self,
+        *,
+        code: str,
+        state: str,
+        binding: str,
+    ) -> ErpSsoAuthorizationCodeConsumeOut:
+        ...
+
+
+class UserServiceLike(Protocol):
+    def get_user_by_username(self, username: str) -> User | None:
+        ...
+
+    def create_token_for_user(self, user: User) -> str:
+        ...
+
+
+class WmsSsoExchangeService:
+    """
+    Exchange ERP SSO authorization code for WMS local token.
+
+    Boundary:
+    - Does not create WMS users.
+    - Does not create WMS permissions.
+    - Does not accept ERP token as WMS token.
+    - WMS local token and local user/permission checks remain authoritative.
+    """
+
+    def __init__(
+        self,
+        db: Session,
+        *,
+        erp_client: ErpSsoAuthorizationCodeClientLike | None = None,
+        user_service: UserServiceLike | None = None,
+    ) -> None:
+        self.erp_client = erp_client or ErpSsoAuthorizationCodeClient()
+        self.user_service = user_service or UserService(db)
+
+    async def exchange(
+        self,
+        payload: WmsSsoExchangeIn,
+        *,
+        binding: str | None,
+    ) -> WmsSsoExchangeOut:
+        normalized_binding = _strip(binding)
+        if not normalized_binding:
+            raise WmsSsoBindingRequiredError("wms_sso_binding_required")
+
+        try:
+            identity = await self.erp_client.consume_authorization_code(
+                code=_strip(payload.code),
+                state=_strip(payload.state),
+                binding=normalized_binding,
+            )
+        except ErpSsoAuthorizationCodeClientError as exc:
+            raise WmsSsoErpExchangeFailedError("wms_sso_erp_exchange_failed") from exc
+
+        if identity.app_code != "wms":
+            raise WmsSsoAppMismatchError("wms_sso_app_mismatch")
+
+        user = self.user_service.get_user_by_username(identity.username)
+        if user is None:
+            raise WmsSsoUserNotFoundError("wms_sso_user_not_found")
+
+        if not bool(getattr(user, "is_active", True)):
+            raise WmsSsoUserInactiveError("wms_sso_user_inactive")
+
+        access_token = self.user_service.create_token_for_user(user)
+
+        return WmsSsoExchangeOut(
+            access_token=access_token,
+            token_type="bearer",
+            expires_in=token_expires_in_seconds(),
+            redirect_path=identity.redirect_path or "/",
+        )
+
+
+def _strip(value: str | None) -> str:
+    return (value or "").strip()
+
+
+__all__ = [
+    "ErpSsoAuthorizationCodeClientLike",
+    "UserServiceLike",
+    "WmsSsoAppMismatchError",
+    "WmsSsoBindingRequiredError",
+    "WmsSsoErpExchangeFailedError",
+    "WmsSsoExchangeService",
+    "WmsSsoUserInactiveError",
+    "WmsSsoUserNotFoundError",
+]

--- a/openapi/_current.json
+++ b/openapi/_current.json
@@ -6198,56 +6198,6 @@
         }
       }
     },
-    "/system/read/v1/iam-snapshot": {
-      "get": {
-        "tags": [
-          "system-read-v1"
-        ],
-        "summary": "Get WMS IAM snapshot",
-        "description": "Return WMS users, user permissions, and page permission catalog for ERP projection sync.\n\nBoundary:\n- Only ERP service client should be granted this capability.\n- This endpoint is read-only.\n- This endpoint never exposes password_hash, tokens, or secrets.\n- This endpoint does not write WMS permissions.\n- This endpoint does not migrate permission execution to ERP.",
-        "operationId": "get_wms_iam_snapshot_system_read_v1_iam_snapshot_get",
-        "parameters": [
-          {
-            "name": "X-Service-Client",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Service-Client"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WmsSystemIamSnapshotOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/system/write/v1/service-permissions/apply": {
       "post": {
         "tags": [
@@ -6363,6 +6313,185 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/WmsSystemServicePermissionVerifyOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/system/write/v1/iam/apply": {
+      "post": {
+        "tags": [
+          "system-write-v1"
+        ],
+        "summary": "Apply WMS IAM desired state",
+        "description": "Apply WMS local user IAM runtime projection from ERP.\n\nBoundary:\n- Only X-Service-Client: erp-service may call this endpoint.\n- Writes only users / user_permissions.\n- Reads permissions only to validate WMS-owned permission codes.\n- Does not create unknown permissions.\n- Does not write page_registry / page_route_prefixes.",
+        "operationId": "apply_wms_iam_system_write_v1_iam_apply_post",
+        "parameters": [
+          {
+            "name": "X-Service-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Service-Client"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WmsSystemIamApplyIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WmsSystemIamApplyOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/system/write/v1/iam/verify": {
+      "post": {
+        "tags": [
+          "system-write-v1"
+        ],
+        "summary": "Verify WMS IAM desired state",
+        "description": "Verify WMS local user IAM runtime projection against ERP desired state.",
+        "operationId": "verify_wms_iam_system_write_v1_iam_verify_post",
+        "parameters": [
+          {
+            "name": "X-Service-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Service-Client"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WmsSystemIamApplyIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WmsSystemIamVerifyOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/system/sso/v1/exchange": {
+      "post": {
+        "tags": [
+          "system-sso-v1"
+        ],
+        "summary": "Exchange Wms Sso Authorization Code",
+        "operationId": "exchange_wms_sso_authorization_code_system_sso_v1_exchange_post",
+        "parameters": [
+          {
+            "name": "ERP_SSO_BINDING",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Erp Sso Binding"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WmsSsoExchangeIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WmsSsoExchangeOut"
                 }
               }
             }
@@ -8531,6 +8660,7 @@
           "admin-users"
         ],
         "summary": "Get User Permission Matrix",
+        "description": "Read-only WMS local IAM runtime projection.\n\nERP is the IAM owner. WMS keeps local users / user_permissions only for\nruntime permission execution and diagnostic visibility.",
         "operationId": "get_user_permission_matrix_admin_users_permission_matrix_get",
         "responses": {
           "200": {
@@ -8551,64 +8681,6 @@
         ]
       }
     },
-    "/admin/users/{user_id}/permission-matrix": {
-      "put": {
-        "tags": [
-          "admin",
-          "admin-users"
-        ],
-        "summary": "Update User Permission Matrix",
-        "operationId": "update_user_permission_matrix_admin_users__user_id__permission_matrix_put",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "user_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "User Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserPermissionMatrixUpdateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PermissionMatrixRowOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/admin/users": {
       "get": {
         "tags": [
@@ -8616,6 +8688,7 @@
           "admin-users"
         ],
         "summary": "List Users",
+        "description": "Read-only WMS local users runtime projection.\n\nUser creation, status changes, password reset, deletion, and permission\nassignment are managed by ERP and applied through /system/write/v1/iam.",
         "operationId": "list_users_admin_users_get",
         "responses": {
           "200": {
@@ -8638,211 +8711,6 @@
             "OAuth2PasswordBearer": []
           }
         ]
-      },
-      "post": {
-        "tags": [
-          "admin",
-          "admin-users"
-        ],
-        "summary": "Create User",
-        "operationId": "create_user_admin_users_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserCreateMulti"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/admin/users/{user_id}": {
-      "patch": {
-        "tags": [
-          "admin",
-          "admin-users"
-        ],
-        "summary": "Update User",
-        "operationId": "update_user_admin_users__user_id__patch",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "user_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "User Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserUpdateMulti"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/users/{user_id}/delete": {
-      "post": {
-        "tags": [
-          "admin",
-          "admin-users"
-        ],
-        "summary": "Delete User",
-        "operationId": "delete_user_admin_users__user_id__delete_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "user_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "User Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/users/{user_id}/reset-password": {
-      "post": {
-        "tags": [
-          "admin",
-          "admin-users"
-        ],
-        "summary": "Reset Password",
-        "operationId": "reset_password_admin_users__user_id__reset_password_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "user_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "User Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PasswordResetIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
       }
     },
     "/stock/ledger/reconcile-v2/summary": {
@@ -10098,6 +9966,26 @@
                   "additionalProperties": true,
                   "type": "object",
                   "title": "Response Healthz Healthz Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health/db": {
+      "get": {
+        "summary": "Health Db",
+        "operationId": "health_db_health_db_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Health Db Health Db Get"
                 }
               }
             }
@@ -22344,22 +22232,6 @@
         ],
         "title": "OutboundSummaryRowOut"
       },
-      "PagePermissionCellIn": {
-        "properties": {
-          "read": {
-            "type": "boolean",
-            "title": "Read",
-            "default": false
-          },
-          "write": {
-            "type": "boolean",
-            "title": "Write",
-            "default": false
-          }
-        },
-        "type": "object",
-        "title": "PagePermissionCellIn"
-      },
       "PagePermissionCellOut": {
         "properties": {
           "read": {
@@ -22393,11 +22265,6 @@
           "new_password"
         ],
         "title": "PasswordChangeIn"
-      },
-      "PasswordResetIn": {
-        "properties": {},
-        "type": "object",
-        "title": "PasswordResetIn"
       },
       "PermissionMatrixPageOut": {
         "properties": {
@@ -27448,64 +27315,6 @@
         ],
         "title": "Token"
       },
-      "UserCreateMulti": {
-        "properties": {
-          "username": {
-            "type": "string",
-            "title": "Username"
-          },
-          "password": {
-            "type": "string",
-            "title": "Password"
-          },
-          "permission_ids": {
-            "items": {
-              "type": "integer"
-            },
-            "type": "array",
-            "title": "Permission Ids"
-          },
-          "full_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Full Name"
-          },
-          "phone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Phone"
-          },
-          "email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Email"
-          }
-        },
-        "type": "object",
-        "required": [
-          "username",
-          "password"
-        ],
-        "title": "UserCreateMulti"
-      },
       "UserLogin": {
         "properties": {
           "username": {
@@ -27611,76 +27420,6 @@
         },
         "type": "object",
         "title": "UserPermissionMatrixOut"
-      },
-      "UserPermissionMatrixUpdateIn": {
-        "properties": {
-          "page_codes": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Page Codes"
-          },
-          "pages": {
-            "additionalProperties": {
-              "$ref": "#/components/schemas/PagePermissionCellIn"
-            },
-            "type": "object",
-            "title": "Pages"
-          }
-        },
-        "type": "object",
-        "title": "UserPermissionMatrixUpdateIn"
-      },
-      "UserUpdateMulti": {
-        "properties": {
-          "full_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Full Name"
-          },
-          "phone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Phone"
-          },
-          "email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Email"
-          },
-          "is_active": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Active"
-          }
-        },
-        "type": "object",
-        "title": "UserUpdateMulti"
       },
       "ValidationError": {
         "properties": {
@@ -28252,17 +27991,176 @@
         "title": "WmsReadWarehouseOut",
         "description": "WMS warehouse read-v1 contract for cross-system consumers.\n\nBoundary:\n- WMS owns warehouse master data.\n- Cross-system consumers only receive stable read fields.\n- This contract intentionally does not expose management fields."
       },
-      "WmsSystemAppManifestBuildInfoOut": {
+      "WmsSsoExchangeIn": {
         "properties": {
-          "environment": {
+          "code": {
             "type": "string",
+            "maxLength": 256,
             "minLength": 1,
-            "title": "Environment"
+            "title": "Code"
+          },
+          "state": {
+            "type": "string",
+            "maxLength": 256,
+            "minLength": 1,
+            "title": "State"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "code",
+          "state"
+        ],
+        "title": "WmsSsoExchangeIn"
+      },
+      "WmsSsoExchangeOut": {
+        "properties": {
+          "access_token": {
+            "type": "string",
+            "title": "Access Token"
+          },
+          "token_type": {
+            "type": "string",
+            "title": "Token Type",
+            "default": "bearer"
+          },
+          "expires_in": {
+            "type": "integer",
+            "title": "Expires In"
+          },
+          "redirect_path": {
+            "type": "string",
+            "title": "Redirect Path",
+            "default": "/"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "access_token",
+          "expires_in"
+        ],
+        "title": "WmsSsoExchangeOut"
+      },
+      "WmsSystemAppInfoOut": {
+        "properties": {
+          "app_code": {
+            "type": "string",
+            "const": "wms",
+            "title": "App Code"
+          },
+          "app_name": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "App Name"
+          },
+          "app_type": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "App Type"
+          },
+          "owner_domain": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Owner Domain"
+          },
+          "status": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Status"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 512,
+            "minLength": 1,
+            "title": "Description"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "app_code",
+          "app_name",
+          "app_type",
+          "owner_domain",
+          "status",
+          "description"
+        ],
+        "title": "WmsSystemAppInfoOut"
+      },
+      "WmsSystemAppManifestOut": {
+        "properties": {
+          "manifest_contract_version": {
+            "type": "string",
+            "const": "2.0",
+            "title": "Manifest Contract Version"
+          },
+          "generated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Generated At"
+          },
+          "app": {
+            "$ref": "#/components/schemas/WmsSystemAppInfoOut"
+          },
+          "deployment": {
+            "$ref": "#/components/schemas/WmsSystemDeploymentOut"
+          },
+          "service_identity": {
+            "$ref": "#/components/schemas/WmsSystemServiceIdentityOut"
+          },
+          "control_endpoints": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemEndpointDescriptorOut"
+            },
+            "type": "array",
+            "title": "Control Endpoints"
+          },
+          "write_endpoints": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemEndpointDescriptorOut"
+            },
+            "type": "array",
+            "title": "Write Endpoints"
+          },
+          "security": {
+            "$ref": "#/components/schemas/WmsSystemSecurityPolicyOut"
+          },
+          "build": {
+            "$ref": "#/components/schemas/WmsSystemBuildInfoOut"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "manifest_contract_version",
+          "generated_at",
+          "app",
+          "deployment",
+          "service_identity",
+          "security",
+          "build"
+        ],
+        "title": "WmsSystemAppManifestOut"
+      },
+      "WmsSystemBuildInfoOut": {
+        "properties": {
+          "app_version": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "App Version"
           },
           "git_sha": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "maxLength": 128
               },
               {
                 "type": "null"
@@ -28270,10 +28168,23 @@
             ],
             "title": "Git Sha"
           },
+          "image_tag": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Tag"
+          },
           "build_time": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "maxLength": 128
               },
               {
                 "type": "null"
@@ -28285,361 +28196,308 @@
         "additionalProperties": false,
         "type": "object",
         "required": [
-          "environment"
+          "app_version"
         ],
-        "title": "WmsSystemAppManifestBuildInfoOut"
+        "title": "WmsSystemBuildInfoOut"
       },
-      "WmsSystemAppManifestOut": {
+      "WmsSystemDeploymentOut": {
         "properties": {
-          "app_code": {
+          "env_code": {
             "type": "string",
-            "const": "wms",
-            "title": "App Code"
-          },
-          "app_name": {
-            "type": "string",
+            "maxLength": 64,
             "minLength": 1,
-            "title": "App Name"
+            "title": "Env Code"
           },
-          "app_type": {
+          "deployment_mode": {
             "type": "string",
+            "maxLength": 64,
             "minLength": 1,
-            "title": "App Type"
+            "title": "Deployment Mode"
           },
-          "status": {
+          "web_path": {
             "type": "string",
+            "maxLength": 255,
             "minLength": 1,
-            "title": "Status"
+            "title": "Web Path"
           },
-          "description": {
+          "api_path": {
             "type": "string",
+            "maxLength": 255,
             "minLength": 1,
-            "title": "Description"
+            "title": "Api Path"
           },
-          "default_web_path": {
+          "control_base_url": {
             "type": "string",
+            "maxLength": 255,
             "minLength": 1,
-            "title": "Default Web Path"
+            "title": "Control Base Url"
           },
-          "default_api_path": {
+          "internal_api_base_url": {
             "type": "string",
+            "maxLength": 255,
             "minLength": 1,
-            "title": "Default Api Path"
+            "title": "Internal Api Base Url"
           },
-          "local_web_url": {
+          "public_web_url": {
             "type": "string",
+            "maxLength": 255,
             "minLength": 1,
-            "title": "Local Web Url"
+            "title": "Public Web Url"
           },
-          "local_api_url": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Local Api Url"
-          },
-          "health_url": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Health Url"
-          },
-          "db_health_url": {
+          "public_api_base_url": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "maxLength": 255
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Db Health Url"
-          },
-          "openapi_url": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Openapi Url"
-          },
-          "page_catalog_url": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Page Catalog Url"
-          },
-          "service_capabilities_url": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Service Capabilities Url"
-          },
-          "service_dependencies_url": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Service Dependencies Url"
-          },
-          "version": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Version"
-          },
-          "build_info": {
-            "$ref": "#/components/schemas/WmsSystemAppManifestBuildInfoOut"
+            "title": "Public Api Base Url"
           }
         },
         "additionalProperties": false,
         "type": "object",
         "required": [
-          "app_code",
-          "app_name",
-          "app_type",
-          "status",
-          "description",
-          "default_web_path",
-          "default_api_path",
-          "local_web_url",
-          "local_api_url",
-          "health_url",
-          "openapi_url",
-          "page_catalog_url",
-          "service_capabilities_url",
-          "service_dependencies_url",
-          "version",
-          "build_info"
+          "env_code",
+          "deployment_mode",
+          "web_path",
+          "api_path",
+          "control_base_url",
+          "internal_api_base_url",
+          "public_web_url"
         ],
-        "title": "WmsSystemAppManifestOut"
+        "title": "WmsSystemDeploymentOut"
       },
-      "WmsSystemIamSnapshotOut": {
+      "WmsSystemEndpointDescriptorOut": {
         "properties": {
-          "app_code": {
+          "code": {
             "type": "string",
-            "const": "wms",
-            "title": "App Code"
-          },
-          "app_name": {
-            "type": "string",
+            "maxLength": 128,
             "minLength": 1,
-            "title": "App Name"
+            "title": "Code"
           },
-          "snapshot_at": {
+          "method": {
             "type": "string",
-            "format": "date-time",
-            "title": "Snapshot At"
+            "enum": [
+              "GET",
+              "POST",
+              "PUT",
+              "PATCH",
+              "DELETE"
+            ],
+            "title": "Method"
           },
+          "path": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Path"
+          },
+          "purpose": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Purpose"
+          },
+          "is_required": {
+            "type": "boolean",
+            "title": "Is Required",
+            "default": true
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active",
+            "default": true
+          },
+          "auth_policy": {
+            "type": "string",
+            "enum": [
+              "internal_control_plane",
+              "erp_service_client_required",
+              "public_health"
+            ],
+            "title": "Auth Policy"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "code",
+          "method",
+          "path",
+          "purpose",
+          "auth_policy"
+        ],
+        "title": "WmsSystemEndpointDescriptorOut"
+      },
+      "WmsSystemIamApplyIn": {
+        "properties": {
           "users": {
             "items": {
-              "$ref": "#/components/schemas/WmsSystemIamSnapshotUserOut"
+              "$ref": "#/components/schemas/WmsSystemIamUserIn"
             },
             "type": "array",
             "title": "Users"
           },
-          "permissions": {
-            "items": {
-              "$ref": "#/components/schemas/WmsSystemIamSnapshotPermissionOut"
-            },
-            "type": "array",
-            "title": "Permissions"
-          },
           "user_permissions": {
             "items": {
-              "$ref": "#/components/schemas/WmsSystemIamSnapshotUserPermissionOut"
+              "$ref": "#/components/schemas/WmsSystemIamUserPermissionIn"
             },
             "type": "array",
             "title": "User Permissions"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "WmsSystemIamApplyIn"
+      },
+      "WmsSystemIamApplyOut": {
+        "properties": {
+          "app_code": {
+            "type": "string",
+            "const": "wms",
+            "title": "App Code"
           },
-          "page_registry": {
+          "verified": {
+            "type": "boolean",
+            "title": "Verified"
+          },
+          "user_count": {
+            "type": "integer",
+            "title": "User Count"
+          },
+          "desired_permission_count": {
+            "type": "integer",
+            "title": "Desired Permission Count"
+          },
+          "missing_users": {
             "items": {
-              "$ref": "#/components/schemas/WmsSystemIamSnapshotPageOut"
+              "type": "string"
             },
             "type": "array",
-            "title": "Page Registry"
+            "title": "Missing Users"
           },
-          "page_route_prefixes": {
+          "missing_permission_codes": {
             "items": {
-              "$ref": "#/components/schemas/WmsSystemIamSnapshotRoutePrefixOut"
+              "type": "string"
             },
             "type": "array",
-            "title": "Page Route Prefixes"
+            "title": "Missing Permission Codes"
+          },
+          "mismatched_users": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemIamUserDiffOut"
+            },
+            "type": "array",
+            "title": "Mismatched Users"
+          },
+          "missing_user_permissions": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemIamPermissionDiffOut"
+            },
+            "type": "array",
+            "title": "Missing User Permissions"
+          },
+          "extra_user_permissions": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemIamPermissionDiffOut"
+            },
+            "type": "array",
+            "title": "Extra User Permissions"
+          },
+          "applied": {
+            "type": "boolean",
+            "title": "Applied"
           }
         },
         "additionalProperties": false,
         "type": "object",
         "required": [
           "app_code",
-          "app_name",
-          "snapshot_at"
+          "verified",
+          "user_count",
+          "desired_permission_count",
+          "applied"
         ],
-        "title": "WmsSystemIamSnapshotOut"
+        "title": "WmsSystemIamApplyOut"
       },
-      "WmsSystemIamSnapshotPageOut": {
+      "WmsSystemIamPermissionDiffOut": {
         "properties": {
-          "page_code": {
+          "username": {
             "type": "string",
-            "maxLength": 64,
-            "minLength": 1,
-            "title": "Page Code"
-          },
-          "page_name": {
-            "type": "string",
-            "maxLength": 64,
-            "minLength": 1,
-            "title": "Page Name"
-          },
-          "parent_page_code": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 64
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Parent Page Code"
-          },
-          "level": {
-            "type": "integer",
-            "maximum": 3.0,
-            "minimum": 1.0,
-            "title": "Level"
-          },
-          "domain_code": {
-            "type": "string",
-            "maxLength": 32,
-            "minLength": 1,
-            "title": "Domain Code"
-          },
-          "show_in_topbar": {
-            "type": "boolean",
-            "title": "Show In Topbar"
-          },
-          "show_in_sidebar": {
-            "type": "boolean",
-            "title": "Show In Sidebar"
-          },
-          "inherit_permissions": {
-            "type": "boolean",
-            "title": "Inherit Permissions"
-          },
-          "read_permission_code": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Read Permission Code"
-          },
-          "write_permission_code": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Write Permission Code"
-          },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order"
-          },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "page_code",
-          "page_name",
-          "level",
-          "domain_code",
-          "show_in_topbar",
-          "show_in_sidebar",
-          "inherit_permissions",
-          "sort_order",
-          "is_active"
-        ],
-        "title": "WmsSystemIamSnapshotPageOut"
-      },
-      "WmsSystemIamSnapshotPermissionOut": {
-        "properties": {
-          "permission_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Permission Id"
+            "title": "Username"
           },
           "permission_code": {
             "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
             "title": "Permission Code"
           }
         },
         "additionalProperties": false,
         "type": "object",
         "required": [
-          "permission_id",
+          "username",
           "permission_code"
         ],
-        "title": "WmsSystemIamSnapshotPermissionOut"
+        "title": "WmsSystemIamPermissionDiffOut"
       },
-      "WmsSystemIamSnapshotRoutePrefixOut": {
+      "WmsSystemIamUserDiffOut": {
         "properties": {
-          "id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Id"
-          },
-          "page_code": {
+          "username": {
             "type": "string",
-            "maxLength": 64,
-            "minLength": 1,
-            "title": "Page Code"
+            "title": "Username"
           },
-          "route_prefix": {
+          "field_name": {
             "type": "string",
-            "maxLength": 255,
-            "minLength": 1,
-            "title": "Route Prefix"
+            "title": "Field Name"
           },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order"
+          "expected": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected"
           },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
+          "actual": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Actual"
           }
         },
         "additionalProperties": false,
         "type": "object",
         "required": [
-          "id",
-          "page_code",
-          "route_prefix",
-          "sort_order",
-          "is_active"
+          "username",
+          "field_name",
+          "expected",
+          "actual"
         ],
-        "title": "WmsSystemIamSnapshotRoutePrefixOut"
+        "title": "WmsSystemIamUserDiffOut"
       },
-      "WmsSystemIamSnapshotUserOut": {
+      "WmsSystemIamUserIn": {
         "properties": {
-          "user_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "User Id"
-          },
           "username": {
             "type": "string",
             "maxLength": 64,
             "minLength": 1,
             "title": "Username"
-          },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
           },
           "full_name": {
             "anyOf": [
@@ -28676,28 +28534,27 @@
               }
             ],
             "title": "Email"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active",
+            "default": true
           }
         },
         "additionalProperties": false,
         "type": "object",
         "required": [
-          "user_id",
-          "username",
-          "is_active"
+          "username"
         ],
-        "title": "WmsSystemIamSnapshotUserOut"
+        "title": "WmsSystemIamUserIn"
       },
-      "WmsSystemIamSnapshotUserPermissionOut": {
+      "WmsSystemIamUserPermissionIn": {
         "properties": {
-          "user_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "User Id"
-          },
-          "permission_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Permission Id"
+          "username": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Username"
           },
           "permission_code": {
             "type": "string",
@@ -28705,21 +28562,84 @@
             "minLength": 1,
             "title": "Permission Code"
           },
-          "granted_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Granted At"
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active",
+            "default": true
           }
         },
         "additionalProperties": false,
         "type": "object",
         "required": [
-          "user_id",
-          "permission_id",
-          "permission_code",
-          "granted_at"
+          "username",
+          "permission_code"
         ],
-        "title": "WmsSystemIamSnapshotUserPermissionOut"
+        "title": "WmsSystemIamUserPermissionIn"
+      },
+      "WmsSystemIamVerifyOut": {
+        "properties": {
+          "app_code": {
+            "type": "string",
+            "const": "wms",
+            "title": "App Code"
+          },
+          "verified": {
+            "type": "boolean",
+            "title": "Verified"
+          },
+          "user_count": {
+            "type": "integer",
+            "title": "User Count"
+          },
+          "desired_permission_count": {
+            "type": "integer",
+            "title": "Desired Permission Count"
+          },
+          "missing_users": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Missing Users"
+          },
+          "missing_permission_codes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Missing Permission Codes"
+          },
+          "mismatched_users": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemIamUserDiffOut"
+            },
+            "type": "array",
+            "title": "Mismatched Users"
+          },
+          "missing_user_permissions": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemIamPermissionDiffOut"
+            },
+            "type": "array",
+            "title": "Missing User Permissions"
+          },
+          "extra_user_permissions": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemIamPermissionDiffOut"
+            },
+            "type": "array",
+            "title": "Extra User Permissions"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "app_code",
+          "verified",
+          "user_count",
+          "desired_permission_count"
+        ],
+        "title": "WmsSystemIamVerifyOut"
       },
       "WmsSystemPageCatalogOut": {
         "properties": {
@@ -28848,6 +28768,33 @@
           "sort_order"
         ],
         "title": "WmsSystemPageCatalogPageOut"
+      },
+      "WmsSystemSecurityPolicyOut": {
+        "properties": {
+          "self_description_auth_policy": {
+            "type": "string",
+            "const": "internal_control_plane",
+            "title": "Self Description Auth Policy"
+          },
+          "write_auth_policy": {
+            "type": "string",
+            "const": "erp_service_client_required",
+            "title": "Write Auth Policy"
+          },
+          "required_write_caller": {
+            "type": "string",
+            "const": "erp-service",
+            "title": "Required Write Caller"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "self_description_auth_policy",
+          "write_auth_policy",
+          "required_write_caller"
+        ],
+        "title": "WmsSystemSecurityPolicyOut"
       },
       "WmsSystemServiceCapabilitiesOut": {
         "properties": {
@@ -29157,6 +29104,27 @@
           "is_active"
         ],
         "title": "WmsSystemServiceDependencyOut"
+      },
+      "WmsSystemServiceIdentityOut": {
+        "properties": {
+          "service_client_code": {
+            "type": "string",
+            "const": "wms-service",
+            "title": "Service Client Code"
+          },
+          "service_client_header": {
+            "type": "string",
+            "const": "X-Service-Client",
+            "title": "Service Client Header"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "service_client_code",
+          "service_client_header"
+        ],
+        "title": "WmsSystemServiceIdentityOut"
       },
       "WmsSystemServicePermissionApplyIn": {
         "properties": {

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -6198,56 +6198,6 @@
         }
       }
     },
-    "/system/read/v1/iam-snapshot": {
-      "get": {
-        "tags": [
-          "system-read-v1"
-        ],
-        "summary": "Get WMS IAM snapshot",
-        "description": "Return WMS users, user permissions, and page permission catalog for ERP projection sync.\n\nBoundary:\n- Only ERP service client should be granted this capability.\n- This endpoint is read-only.\n- This endpoint never exposes password_hash, tokens, or secrets.\n- This endpoint does not write WMS permissions.\n- This endpoint does not migrate permission execution to ERP.",
-        "operationId": "get_wms_iam_snapshot_system_read_v1_iam_snapshot_get",
-        "parameters": [
-          {
-            "name": "X-Service-Client",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Service-Client"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WmsSystemIamSnapshotOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/system/write/v1/service-permissions/apply": {
       "post": {
         "tags": [
@@ -6363,6 +6313,185 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/WmsSystemServicePermissionVerifyOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/system/write/v1/iam/apply": {
+      "post": {
+        "tags": [
+          "system-write-v1"
+        ],
+        "summary": "Apply WMS IAM desired state",
+        "description": "Apply WMS local user IAM runtime projection from ERP.\n\nBoundary:\n- Only X-Service-Client: erp-service may call this endpoint.\n- Writes only users / user_permissions.\n- Reads permissions only to validate WMS-owned permission codes.\n- Does not create unknown permissions.\n- Does not write page_registry / page_route_prefixes.",
+        "operationId": "apply_wms_iam_system_write_v1_iam_apply_post",
+        "parameters": [
+          {
+            "name": "X-Service-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Service-Client"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WmsSystemIamApplyIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WmsSystemIamApplyOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/system/write/v1/iam/verify": {
+      "post": {
+        "tags": [
+          "system-write-v1"
+        ],
+        "summary": "Verify WMS IAM desired state",
+        "description": "Verify WMS local user IAM runtime projection against ERP desired state.",
+        "operationId": "verify_wms_iam_system_write_v1_iam_verify_post",
+        "parameters": [
+          {
+            "name": "X-Service-Client",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Service-Client"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WmsSystemIamApplyIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WmsSystemIamVerifyOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/system/sso/v1/exchange": {
+      "post": {
+        "tags": [
+          "system-sso-v1"
+        ],
+        "summary": "Exchange Wms Sso Authorization Code",
+        "operationId": "exchange_wms_sso_authorization_code_system_sso_v1_exchange_post",
+        "parameters": [
+          {
+            "name": "ERP_SSO_BINDING",
+            "in": "cookie",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Erp Sso Binding"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WmsSsoExchangeIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WmsSsoExchangeOut"
                 }
               }
             }
@@ -8531,6 +8660,7 @@
           "admin-users"
         ],
         "summary": "Get User Permission Matrix",
+        "description": "Read-only WMS local IAM runtime projection.\n\nERP is the IAM owner. WMS keeps local users / user_permissions only for\nruntime permission execution and diagnostic visibility.",
         "operationId": "get_user_permission_matrix_admin_users_permission_matrix_get",
         "responses": {
           "200": {
@@ -8551,64 +8681,6 @@
         ]
       }
     },
-    "/admin/users/{user_id}/permission-matrix": {
-      "put": {
-        "tags": [
-          "admin",
-          "admin-users"
-        ],
-        "summary": "Update User Permission Matrix",
-        "operationId": "update_user_permission_matrix_admin_users__user_id__permission_matrix_put",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "user_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "User Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserPermissionMatrixUpdateIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PermissionMatrixRowOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/admin/users": {
       "get": {
         "tags": [
@@ -8616,6 +8688,7 @@
           "admin-users"
         ],
         "summary": "List Users",
+        "description": "Read-only WMS local users runtime projection.\n\nUser creation, status changes, password reset, deletion, and permission\nassignment are managed by ERP and applied through /system/write/v1/iam.",
         "operationId": "list_users_admin_users_get",
         "responses": {
           "200": {
@@ -8638,211 +8711,6 @@
             "OAuth2PasswordBearer": []
           }
         ]
-      },
-      "post": {
-        "tags": [
-          "admin",
-          "admin-users"
-        ],
-        "summary": "Create User",
-        "operationId": "create_user_admin_users_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserCreateMulti"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
-    "/admin/users/{user_id}": {
-      "patch": {
-        "tags": [
-          "admin",
-          "admin-users"
-        ],
-        "summary": "Update User",
-        "operationId": "update_user_admin_users__user_id__patch",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "user_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "User Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserUpdateMulti"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserOut"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/users/{user_id}/delete": {
-      "post": {
-        "tags": [
-          "admin",
-          "admin-users"
-        ],
-        "summary": "Delete User",
-        "operationId": "delete_user_admin_users__user_id__delete_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "user_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "User Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin/users/{user_id}/reset-password": {
-      "post": {
-        "tags": [
-          "admin",
-          "admin-users"
-        ],
-        "summary": "Reset Password",
-        "operationId": "reset_password_admin_users__user_id__reset_password_post",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "user_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "User Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PasswordResetIn"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
       }
     },
     "/stock/ledger/reconcile-v2/summary": {
@@ -10098,6 +9966,26 @@
                   "additionalProperties": true,
                   "type": "object",
                   "title": "Response Healthz Healthz Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health/db": {
+      "get": {
+        "summary": "Health Db",
+        "operationId": "health_db_health_db_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Health Db Health Db Get"
                 }
               }
             }
@@ -22344,22 +22232,6 @@
         ],
         "title": "OutboundSummaryRowOut"
       },
-      "PagePermissionCellIn": {
-        "properties": {
-          "read": {
-            "type": "boolean",
-            "title": "Read",
-            "default": false
-          },
-          "write": {
-            "type": "boolean",
-            "title": "Write",
-            "default": false
-          }
-        },
-        "type": "object",
-        "title": "PagePermissionCellIn"
-      },
       "PagePermissionCellOut": {
         "properties": {
           "read": {
@@ -22393,11 +22265,6 @@
           "new_password"
         ],
         "title": "PasswordChangeIn"
-      },
-      "PasswordResetIn": {
-        "properties": {},
-        "type": "object",
-        "title": "PasswordResetIn"
       },
       "PermissionMatrixPageOut": {
         "properties": {
@@ -27448,64 +27315,6 @@
         ],
         "title": "Token"
       },
-      "UserCreateMulti": {
-        "properties": {
-          "username": {
-            "type": "string",
-            "title": "Username"
-          },
-          "password": {
-            "type": "string",
-            "title": "Password"
-          },
-          "permission_ids": {
-            "items": {
-              "type": "integer"
-            },
-            "type": "array",
-            "title": "Permission Ids"
-          },
-          "full_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Full Name"
-          },
-          "phone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Phone"
-          },
-          "email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Email"
-          }
-        },
-        "type": "object",
-        "required": [
-          "username",
-          "password"
-        ],
-        "title": "UserCreateMulti"
-      },
       "UserLogin": {
         "properties": {
           "username": {
@@ -27611,76 +27420,6 @@
         },
         "type": "object",
         "title": "UserPermissionMatrixOut"
-      },
-      "UserPermissionMatrixUpdateIn": {
-        "properties": {
-          "page_codes": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Page Codes"
-          },
-          "pages": {
-            "additionalProperties": {
-              "$ref": "#/components/schemas/PagePermissionCellIn"
-            },
-            "type": "object",
-            "title": "Pages"
-          }
-        },
-        "type": "object",
-        "title": "UserPermissionMatrixUpdateIn"
-      },
-      "UserUpdateMulti": {
-        "properties": {
-          "full_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Full Name"
-          },
-          "phone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Phone"
-          },
-          "email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Email"
-          },
-          "is_active": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Active"
-          }
-        },
-        "type": "object",
-        "title": "UserUpdateMulti"
       },
       "ValidationError": {
         "properties": {
@@ -28252,17 +27991,176 @@
         "title": "WmsReadWarehouseOut",
         "description": "WMS warehouse read-v1 contract for cross-system consumers.\n\nBoundary:\n- WMS owns warehouse master data.\n- Cross-system consumers only receive stable read fields.\n- This contract intentionally does not expose management fields."
       },
-      "WmsSystemAppManifestBuildInfoOut": {
+      "WmsSsoExchangeIn": {
         "properties": {
-          "environment": {
+          "code": {
             "type": "string",
+            "maxLength": 256,
             "minLength": 1,
-            "title": "Environment"
+            "title": "Code"
+          },
+          "state": {
+            "type": "string",
+            "maxLength": 256,
+            "minLength": 1,
+            "title": "State"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "code",
+          "state"
+        ],
+        "title": "WmsSsoExchangeIn"
+      },
+      "WmsSsoExchangeOut": {
+        "properties": {
+          "access_token": {
+            "type": "string",
+            "title": "Access Token"
+          },
+          "token_type": {
+            "type": "string",
+            "title": "Token Type",
+            "default": "bearer"
+          },
+          "expires_in": {
+            "type": "integer",
+            "title": "Expires In"
+          },
+          "redirect_path": {
+            "type": "string",
+            "title": "Redirect Path",
+            "default": "/"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "access_token",
+          "expires_in"
+        ],
+        "title": "WmsSsoExchangeOut"
+      },
+      "WmsSystemAppInfoOut": {
+        "properties": {
+          "app_code": {
+            "type": "string",
+            "const": "wms",
+            "title": "App Code"
+          },
+          "app_name": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "App Name"
+          },
+          "app_type": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "App Type"
+          },
+          "owner_domain": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Owner Domain"
+          },
+          "status": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Status"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 512,
+            "minLength": 1,
+            "title": "Description"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "app_code",
+          "app_name",
+          "app_type",
+          "owner_domain",
+          "status",
+          "description"
+        ],
+        "title": "WmsSystemAppInfoOut"
+      },
+      "WmsSystemAppManifestOut": {
+        "properties": {
+          "manifest_contract_version": {
+            "type": "string",
+            "const": "2.0",
+            "title": "Manifest Contract Version"
+          },
+          "generated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Generated At"
+          },
+          "app": {
+            "$ref": "#/components/schemas/WmsSystemAppInfoOut"
+          },
+          "deployment": {
+            "$ref": "#/components/schemas/WmsSystemDeploymentOut"
+          },
+          "service_identity": {
+            "$ref": "#/components/schemas/WmsSystemServiceIdentityOut"
+          },
+          "control_endpoints": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemEndpointDescriptorOut"
+            },
+            "type": "array",
+            "title": "Control Endpoints"
+          },
+          "write_endpoints": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemEndpointDescriptorOut"
+            },
+            "type": "array",
+            "title": "Write Endpoints"
+          },
+          "security": {
+            "$ref": "#/components/schemas/WmsSystemSecurityPolicyOut"
+          },
+          "build": {
+            "$ref": "#/components/schemas/WmsSystemBuildInfoOut"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "manifest_contract_version",
+          "generated_at",
+          "app",
+          "deployment",
+          "service_identity",
+          "security",
+          "build"
+        ],
+        "title": "WmsSystemAppManifestOut"
+      },
+      "WmsSystemBuildInfoOut": {
+        "properties": {
+          "app_version": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "App Version"
           },
           "git_sha": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "maxLength": 128
               },
               {
                 "type": "null"
@@ -28270,10 +28168,23 @@
             ],
             "title": "Git Sha"
           },
+          "image_tag": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Tag"
+          },
           "build_time": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "maxLength": 128
               },
               {
                 "type": "null"
@@ -28285,361 +28196,308 @@
         "additionalProperties": false,
         "type": "object",
         "required": [
-          "environment"
+          "app_version"
         ],
-        "title": "WmsSystemAppManifestBuildInfoOut"
+        "title": "WmsSystemBuildInfoOut"
       },
-      "WmsSystemAppManifestOut": {
+      "WmsSystemDeploymentOut": {
         "properties": {
-          "app_code": {
+          "env_code": {
             "type": "string",
-            "const": "wms",
-            "title": "App Code"
-          },
-          "app_name": {
-            "type": "string",
+            "maxLength": 64,
             "minLength": 1,
-            "title": "App Name"
+            "title": "Env Code"
           },
-          "app_type": {
+          "deployment_mode": {
             "type": "string",
+            "maxLength": 64,
             "minLength": 1,
-            "title": "App Type"
+            "title": "Deployment Mode"
           },
-          "status": {
+          "web_path": {
             "type": "string",
+            "maxLength": 255,
             "minLength": 1,
-            "title": "Status"
+            "title": "Web Path"
           },
-          "description": {
+          "api_path": {
             "type": "string",
+            "maxLength": 255,
             "minLength": 1,
-            "title": "Description"
+            "title": "Api Path"
           },
-          "default_web_path": {
+          "control_base_url": {
             "type": "string",
+            "maxLength": 255,
             "minLength": 1,
-            "title": "Default Web Path"
+            "title": "Control Base Url"
           },
-          "default_api_path": {
+          "internal_api_base_url": {
             "type": "string",
+            "maxLength": 255,
             "minLength": 1,
-            "title": "Default Api Path"
+            "title": "Internal Api Base Url"
           },
-          "local_web_url": {
+          "public_web_url": {
             "type": "string",
+            "maxLength": 255,
             "minLength": 1,
-            "title": "Local Web Url"
+            "title": "Public Web Url"
           },
-          "local_api_url": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Local Api Url"
-          },
-          "health_url": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Health Url"
-          },
-          "db_health_url": {
+          "public_api_base_url": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "maxLength": 255
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Db Health Url"
-          },
-          "openapi_url": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Openapi Url"
-          },
-          "page_catalog_url": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Page Catalog Url"
-          },
-          "service_capabilities_url": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Service Capabilities Url"
-          },
-          "service_dependencies_url": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Service Dependencies Url"
-          },
-          "version": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Version"
-          },
-          "build_info": {
-            "$ref": "#/components/schemas/WmsSystemAppManifestBuildInfoOut"
+            "title": "Public Api Base Url"
           }
         },
         "additionalProperties": false,
         "type": "object",
         "required": [
-          "app_code",
-          "app_name",
-          "app_type",
-          "status",
-          "description",
-          "default_web_path",
-          "default_api_path",
-          "local_web_url",
-          "local_api_url",
-          "health_url",
-          "openapi_url",
-          "page_catalog_url",
-          "service_capabilities_url",
-          "service_dependencies_url",
-          "version",
-          "build_info"
+          "env_code",
+          "deployment_mode",
+          "web_path",
+          "api_path",
+          "control_base_url",
+          "internal_api_base_url",
+          "public_web_url"
         ],
-        "title": "WmsSystemAppManifestOut"
+        "title": "WmsSystemDeploymentOut"
       },
-      "WmsSystemIamSnapshotOut": {
+      "WmsSystemEndpointDescriptorOut": {
         "properties": {
-          "app_code": {
+          "code": {
             "type": "string",
-            "const": "wms",
-            "title": "App Code"
-          },
-          "app_name": {
-            "type": "string",
+            "maxLength": 128,
             "minLength": 1,
-            "title": "App Name"
+            "title": "Code"
           },
-          "snapshot_at": {
+          "method": {
             "type": "string",
-            "format": "date-time",
-            "title": "Snapshot At"
+            "enum": [
+              "GET",
+              "POST",
+              "PUT",
+              "PATCH",
+              "DELETE"
+            ],
+            "title": "Method"
           },
+          "path": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Path"
+          },
+          "purpose": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Purpose"
+          },
+          "is_required": {
+            "type": "boolean",
+            "title": "Is Required",
+            "default": true
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active",
+            "default": true
+          },
+          "auth_policy": {
+            "type": "string",
+            "enum": [
+              "internal_control_plane",
+              "erp_service_client_required",
+              "public_health"
+            ],
+            "title": "Auth Policy"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "code",
+          "method",
+          "path",
+          "purpose",
+          "auth_policy"
+        ],
+        "title": "WmsSystemEndpointDescriptorOut"
+      },
+      "WmsSystemIamApplyIn": {
+        "properties": {
           "users": {
             "items": {
-              "$ref": "#/components/schemas/WmsSystemIamSnapshotUserOut"
+              "$ref": "#/components/schemas/WmsSystemIamUserIn"
             },
             "type": "array",
             "title": "Users"
           },
-          "permissions": {
-            "items": {
-              "$ref": "#/components/schemas/WmsSystemIamSnapshotPermissionOut"
-            },
-            "type": "array",
-            "title": "Permissions"
-          },
           "user_permissions": {
             "items": {
-              "$ref": "#/components/schemas/WmsSystemIamSnapshotUserPermissionOut"
+              "$ref": "#/components/schemas/WmsSystemIamUserPermissionIn"
             },
             "type": "array",
             "title": "User Permissions"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "WmsSystemIamApplyIn"
+      },
+      "WmsSystemIamApplyOut": {
+        "properties": {
+          "app_code": {
+            "type": "string",
+            "const": "wms",
+            "title": "App Code"
           },
-          "page_registry": {
+          "verified": {
+            "type": "boolean",
+            "title": "Verified"
+          },
+          "user_count": {
+            "type": "integer",
+            "title": "User Count"
+          },
+          "desired_permission_count": {
+            "type": "integer",
+            "title": "Desired Permission Count"
+          },
+          "missing_users": {
             "items": {
-              "$ref": "#/components/schemas/WmsSystemIamSnapshotPageOut"
+              "type": "string"
             },
             "type": "array",
-            "title": "Page Registry"
+            "title": "Missing Users"
           },
-          "page_route_prefixes": {
+          "missing_permission_codes": {
             "items": {
-              "$ref": "#/components/schemas/WmsSystemIamSnapshotRoutePrefixOut"
+              "type": "string"
             },
             "type": "array",
-            "title": "Page Route Prefixes"
+            "title": "Missing Permission Codes"
+          },
+          "mismatched_users": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemIamUserDiffOut"
+            },
+            "type": "array",
+            "title": "Mismatched Users"
+          },
+          "missing_user_permissions": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemIamPermissionDiffOut"
+            },
+            "type": "array",
+            "title": "Missing User Permissions"
+          },
+          "extra_user_permissions": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemIamPermissionDiffOut"
+            },
+            "type": "array",
+            "title": "Extra User Permissions"
+          },
+          "applied": {
+            "type": "boolean",
+            "title": "Applied"
           }
         },
         "additionalProperties": false,
         "type": "object",
         "required": [
           "app_code",
-          "app_name",
-          "snapshot_at"
+          "verified",
+          "user_count",
+          "desired_permission_count",
+          "applied"
         ],
-        "title": "WmsSystemIamSnapshotOut"
+        "title": "WmsSystemIamApplyOut"
       },
-      "WmsSystemIamSnapshotPageOut": {
+      "WmsSystemIamPermissionDiffOut": {
         "properties": {
-          "page_code": {
+          "username": {
             "type": "string",
-            "maxLength": 64,
-            "minLength": 1,
-            "title": "Page Code"
-          },
-          "page_name": {
-            "type": "string",
-            "maxLength": 64,
-            "minLength": 1,
-            "title": "Page Name"
-          },
-          "parent_page_code": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 64
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Parent Page Code"
-          },
-          "level": {
-            "type": "integer",
-            "maximum": 3.0,
-            "minimum": 1.0,
-            "title": "Level"
-          },
-          "domain_code": {
-            "type": "string",
-            "maxLength": 32,
-            "minLength": 1,
-            "title": "Domain Code"
-          },
-          "show_in_topbar": {
-            "type": "boolean",
-            "title": "Show In Topbar"
-          },
-          "show_in_sidebar": {
-            "type": "boolean",
-            "title": "Show In Sidebar"
-          },
-          "inherit_permissions": {
-            "type": "boolean",
-            "title": "Inherit Permissions"
-          },
-          "read_permission_code": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Read Permission Code"
-          },
-          "write_permission_code": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Write Permission Code"
-          },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order"
-          },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "page_code",
-          "page_name",
-          "level",
-          "domain_code",
-          "show_in_topbar",
-          "show_in_sidebar",
-          "inherit_permissions",
-          "sort_order",
-          "is_active"
-        ],
-        "title": "WmsSystemIamSnapshotPageOut"
-      },
-      "WmsSystemIamSnapshotPermissionOut": {
-        "properties": {
-          "permission_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Permission Id"
+            "title": "Username"
           },
           "permission_code": {
             "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
             "title": "Permission Code"
           }
         },
         "additionalProperties": false,
         "type": "object",
         "required": [
-          "permission_id",
+          "username",
           "permission_code"
         ],
-        "title": "WmsSystemIamSnapshotPermissionOut"
+        "title": "WmsSystemIamPermissionDiffOut"
       },
-      "WmsSystemIamSnapshotRoutePrefixOut": {
+      "WmsSystemIamUserDiffOut": {
         "properties": {
-          "id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Id"
-          },
-          "page_code": {
+          "username": {
             "type": "string",
-            "maxLength": 64,
-            "minLength": 1,
-            "title": "Page Code"
+            "title": "Username"
           },
-          "route_prefix": {
+          "field_name": {
             "type": "string",
-            "maxLength": 255,
-            "minLength": 1,
-            "title": "Route Prefix"
+            "title": "Field Name"
           },
-          "sort_order": {
-            "type": "integer",
-            "title": "Sort Order"
+          "expected": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected"
           },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
+          "actual": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Actual"
           }
         },
         "additionalProperties": false,
         "type": "object",
         "required": [
-          "id",
-          "page_code",
-          "route_prefix",
-          "sort_order",
-          "is_active"
+          "username",
+          "field_name",
+          "expected",
+          "actual"
         ],
-        "title": "WmsSystemIamSnapshotRoutePrefixOut"
+        "title": "WmsSystemIamUserDiffOut"
       },
-      "WmsSystemIamSnapshotUserOut": {
+      "WmsSystemIamUserIn": {
         "properties": {
-          "user_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "User Id"
-          },
           "username": {
             "type": "string",
             "maxLength": 64,
             "minLength": 1,
             "title": "Username"
-          },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
           },
           "full_name": {
             "anyOf": [
@@ -28676,28 +28534,27 @@
               }
             ],
             "title": "Email"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active",
+            "default": true
           }
         },
         "additionalProperties": false,
         "type": "object",
         "required": [
-          "user_id",
-          "username",
-          "is_active"
+          "username"
         ],
-        "title": "WmsSystemIamSnapshotUserOut"
+        "title": "WmsSystemIamUserIn"
       },
-      "WmsSystemIamSnapshotUserPermissionOut": {
+      "WmsSystemIamUserPermissionIn": {
         "properties": {
-          "user_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "User Id"
-          },
-          "permission_id": {
-            "type": "integer",
-            "minimum": 1.0,
-            "title": "Permission Id"
+          "username": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Username"
           },
           "permission_code": {
             "type": "string",
@@ -28705,21 +28562,84 @@
             "minLength": 1,
             "title": "Permission Code"
           },
-          "granted_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Granted At"
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active",
+            "default": true
           }
         },
         "additionalProperties": false,
         "type": "object",
         "required": [
-          "user_id",
-          "permission_id",
-          "permission_code",
-          "granted_at"
+          "username",
+          "permission_code"
         ],
-        "title": "WmsSystemIamSnapshotUserPermissionOut"
+        "title": "WmsSystemIamUserPermissionIn"
+      },
+      "WmsSystemIamVerifyOut": {
+        "properties": {
+          "app_code": {
+            "type": "string",
+            "const": "wms",
+            "title": "App Code"
+          },
+          "verified": {
+            "type": "boolean",
+            "title": "Verified"
+          },
+          "user_count": {
+            "type": "integer",
+            "title": "User Count"
+          },
+          "desired_permission_count": {
+            "type": "integer",
+            "title": "Desired Permission Count"
+          },
+          "missing_users": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Missing Users"
+          },
+          "missing_permission_codes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Missing Permission Codes"
+          },
+          "mismatched_users": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemIamUserDiffOut"
+            },
+            "type": "array",
+            "title": "Mismatched Users"
+          },
+          "missing_user_permissions": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemIamPermissionDiffOut"
+            },
+            "type": "array",
+            "title": "Missing User Permissions"
+          },
+          "extra_user_permissions": {
+            "items": {
+              "$ref": "#/components/schemas/WmsSystemIamPermissionDiffOut"
+            },
+            "type": "array",
+            "title": "Extra User Permissions"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "app_code",
+          "verified",
+          "user_count",
+          "desired_permission_count"
+        ],
+        "title": "WmsSystemIamVerifyOut"
       },
       "WmsSystemPageCatalogOut": {
         "properties": {
@@ -28848,6 +28768,33 @@
           "sort_order"
         ],
         "title": "WmsSystemPageCatalogPageOut"
+      },
+      "WmsSystemSecurityPolicyOut": {
+        "properties": {
+          "self_description_auth_policy": {
+            "type": "string",
+            "const": "internal_control_plane",
+            "title": "Self Description Auth Policy"
+          },
+          "write_auth_policy": {
+            "type": "string",
+            "const": "erp_service_client_required",
+            "title": "Write Auth Policy"
+          },
+          "required_write_caller": {
+            "type": "string",
+            "const": "erp-service",
+            "title": "Required Write Caller"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "self_description_auth_policy",
+          "write_auth_policy",
+          "required_write_caller"
+        ],
+        "title": "WmsSystemSecurityPolicyOut"
       },
       "WmsSystemServiceCapabilitiesOut": {
         "properties": {
@@ -29157,6 +29104,27 @@
           "is_active"
         ],
         "title": "WmsSystemServiceDependencyOut"
+      },
+      "WmsSystemServiceIdentityOut": {
+        "properties": {
+          "service_client_code": {
+            "type": "string",
+            "const": "wms-service",
+            "title": "Service Client Code"
+          },
+          "service_client_header": {
+            "type": "string",
+            "const": "X-Service-Client",
+            "title": "Service Client Header"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "service_client_code",
+          "service_client_header"
+        ],
+        "title": "WmsSystemServiceIdentityOut"
       },
       "WmsSystemServicePermissionApplyIn": {
         "properties": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ description = "A simple WMS project"
 
 dependencies = [
     "fastapi>=0.110",
+    "httpx>=0.27",
     "uvicorn>=0.29",
     "pydantic-settings>=2.2",
     "APScheduler>=3.10",
@@ -92,6 +93,7 @@ include = ["app*"]
 pg = ["asyncpg>=0.29", "psycopg[binary]>=3.2"]
 dev = [
     "pytest",
+    "pre-commit",
     "pytest-asyncio",
     "pytest-cov",
     "alembic",

--- a/tests/api/test_wms_system_sso_exchange_api.py
+++ b/tests/api/test_wms_system_sso_exchange_api.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.wms.system.sso_v1.contracts import WmsSsoExchangeIn, WmsSsoExchangeOut
+from app.wms.system.sso_v1.routers.exchange import get_wms_sso_exchange_service
+from app.wms.system.sso_v1.services import ERP_SSO_BINDING_COOKIE_NAME
+from app.wms.system.sso_v1.services.sso_exchange_service import (
+    WmsSsoBindingRequiredError,
+)
+
+PATH = "/system/sso/v1/exchange"
+
+
+class FakeExchangeService:
+    def __init__(self) -> None:
+        self.payload: WmsSsoExchangeIn | None = None
+        self.binding: str | None = None
+
+    async def exchange(
+        self,
+        payload: WmsSsoExchangeIn,
+        *,
+        binding: str | None,
+    ) -> WmsSsoExchangeOut:
+        self.payload = payload
+        self.binding = binding
+        if not binding:
+            raise WmsSsoBindingRequiredError("wms_sso_binding_required")
+        return WmsSsoExchangeOut(
+            access_token="wms-local-token",
+            token_type="bearer",
+            expires_in=3600,
+            redirect_path="/",
+        )
+
+
+def test_wms_sso_exchange_route_returns_local_token() -> None:
+    fake = FakeExchangeService()
+    app.dependency_overrides[get_wms_sso_exchange_service] = lambda: fake
+
+    try:
+        client = TestClient(app)
+        client.cookies.set(ERP_SSO_BINDING_COOKIE_NAME, "binding-value")
+        response = client.post(
+            PATH,
+            json={
+                "code": "code-value",
+                "state": "state-value",
+            },
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body == {
+        "access_token": "wms-local-token",
+        "token_type": "bearer",
+        "expires_in": 3600,
+        "redirect_path": "/",
+    }
+    assert fake.payload is not None
+    assert fake.payload.code == "code-value"
+    assert fake.payload.state == "state-value"
+    assert fake.binding == "binding-value"
+
+
+def test_wms_sso_exchange_route_requires_binding_cookie() -> None:
+    fake = FakeExchangeService()
+    app.dependency_overrides[get_wms_sso_exchange_service] = lambda: fake
+
+    try:
+        client = TestClient(app)
+        response = client.post(
+            PATH,
+            json={
+                "code": "code-value",
+                "state": "state-value",
+            },
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 401
+    assert "wms_sso_binding_required" in response.text
+
+
+def test_wms_sso_exchange_route_is_registered_in_openapi() -> None:
+    client = TestClient(app)
+    response = client.get("/openapi.json")
+
+    assert response.status_code == 200, response.text
+    paths = response.json()["paths"]
+    assert PATH in paths
+    assert "post" in paths[PATH]

--- a/tests/services/test_wms_sso_authorization_code_client.py
+++ b/tests/services/test_wms_sso_authorization_code_client.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from app.wms.system.sso_v1.services import (
+    ERP_SERVICE_CLIENT_HEADER,
+    ERP_SSO_AUTHORIZATION_CODE_CONSUME_PATH,
+    WMS_SERVICE_CLIENT_CODE,
+    ErpSsoAuthorizationCodeClient,
+    ErpSsoAuthorizationCodeClientError,
+)
+
+
+@pytest.mark.asyncio
+async def test_erp_sso_authorization_code_client_consumes_with_wms_service_client() -> None:
+    captured: dict[str, object] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["url"] = str(request.url)
+        captured["service_client"] = request.headers.get(ERP_SERVICE_CLIENT_HEADER)
+        captured["json"] = request.read().decode("utf-8")
+        return httpx.Response(
+            200,
+            json={
+                "app_code": "wms",
+                "sub": "erp:user:1",
+                "erp_user_id": 1,
+                "username": "admin",
+                "full_name": "系统管理员",
+                "email": None,
+                "phone": None,
+                "redirect_path": "/",
+            },
+        )
+
+    client = ErpSsoAuthorizationCodeClient(
+        base_url="http://erp-api.test/api/erp",
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = await client.consume_authorization_code(
+        code="code-value",
+        state="state-value",
+        binding="binding-value",
+    )
+
+    assert result.app_code == "wms"
+    assert result.username == "admin"
+    assert captured["method"] == "POST"
+    assert captured["url"] == (
+        "http://erp-api.test/api/erp"
+        f"{ERP_SSO_AUTHORIZATION_CODE_CONSUME_PATH}"
+    )
+    assert captured["service_client"] == WMS_SERVICE_CLIENT_CODE
+    assert '"code":"code-value"' in str(captured["json"])
+    assert '"state":"state-value"' in str(captured["json"])
+    assert '"binding":"binding-value"' in str(captured["json"])
+
+
+@pytest.mark.asyncio
+async def test_erp_sso_authorization_code_client_raises_on_erp_error() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            410,
+            json={
+                "detail": "sso_authorization_code_expired",
+            },
+        )
+
+    client = ErpSsoAuthorizationCodeClient(
+        base_url="http://erp-api.test",
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(ErpSsoAuthorizationCodeClientError):
+        await client.consume_authorization_code(
+            code="code-value",
+            state="state-value",
+            binding="binding-value",
+        )

--- a/tests/services/test_wms_sso_exchange_service.py
+++ b/tests/services/test_wms_sso_exchange_service.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.wms.system.sso_v1.contracts import (
+    ErpSsoAuthorizationCodeConsumeOut,
+    WmsSsoExchangeIn,
+)
+from app.wms.system.sso_v1.services import ErpSsoAuthorizationCodeClientError
+from app.wms.system.sso_v1.services.sso_exchange_service import (
+    WmsSsoAppMismatchError,
+    WmsSsoBindingRequiredError,
+    WmsSsoErpExchangeFailedError,
+    WmsSsoExchangeService,
+    WmsSsoUserInactiveError,
+    WmsSsoUserNotFoundError,
+)
+
+
+class FakeErpClient:
+    def __init__(
+        self,
+        identity: ErpSsoAuthorizationCodeConsumeOut | None = None,
+        *,
+        fail: bool = False,
+    ) -> None:
+        self.identity = identity or ErpSsoAuthorizationCodeConsumeOut(
+            app_code="wms",
+            sub="erp:user:1",
+            erp_user_id=1,
+            username="admin",
+            full_name="系统管理员",
+            email=None,
+            phone=None,
+            redirect_path="/",
+        )
+        self.fail = fail
+        self.seen: dict[str, str] = {}
+
+    async def consume_authorization_code(
+        self,
+        *,
+        code: str,
+        state: str,
+        binding: str,
+    ) -> ErpSsoAuthorizationCodeConsumeOut:
+        if self.fail:
+            raise ErpSsoAuthorizationCodeClientError("erp failed")
+
+        self.seen = {
+            "code": code,
+            "state": state,
+            "binding": binding,
+        }
+        return self.identity
+
+
+class FakeUserService:
+    def __init__(self, user: object | None = None) -> None:
+        self.user = user
+        self.token_user: object | None = None
+
+    def get_user_by_username(self, username: str):
+        if self.user is None:
+            return None
+        if getattr(self.user, "username", None) == username:
+            return self.user
+        return None
+
+    def create_token_for_user(self, user) -> str:
+        self.token_user = user
+        return "wms-local-token"
+
+
+@pytest.mark.asyncio
+async def test_wms_sso_exchange_service_returns_wms_local_token() -> None:
+    erp_client = FakeErpClient()
+    user = SimpleNamespace(id=1, username="admin", is_active=True)
+    user_service = FakeUserService(user)
+    service = WmsSsoExchangeService(
+        SimpleNamespace(),
+        erp_client=erp_client,
+        user_service=user_service,
+    )
+
+    payload = await service.exchange(
+        WmsSsoExchangeIn(code="code-value", state="state-value"),
+        binding="binding-value",
+    )
+
+    assert payload.access_token == "wms-local-token"
+    assert payload.token_type == "bearer"
+    assert payload.expires_in > 0
+    assert payload.redirect_path == "/"
+    assert erp_client.seen == {
+        "code": "code-value",
+        "state": "state-value",
+        "binding": "binding-value",
+    }
+    assert user_service.token_user is user
+
+
+@pytest.mark.asyncio
+async def test_wms_sso_exchange_service_requires_binding() -> None:
+    service = WmsSsoExchangeService(
+        SimpleNamespace(),
+        erp_client=FakeErpClient(),
+        user_service=FakeUserService(SimpleNamespace(username="admin", is_active=True)),
+    )
+
+    with pytest.raises(WmsSsoBindingRequiredError):
+        await service.exchange(
+            WmsSsoExchangeIn(code="code-value", state="state-value"),
+            binding=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_wms_sso_exchange_service_rejects_erp_failure() -> None:
+    service = WmsSsoExchangeService(
+        SimpleNamespace(),
+        erp_client=FakeErpClient(fail=True),
+        user_service=FakeUserService(SimpleNamespace(username="admin", is_active=True)),
+    )
+
+    with pytest.raises(WmsSsoErpExchangeFailedError):
+        await service.exchange(
+            WmsSsoExchangeIn(code="code-value", state="state-value"),
+            binding="binding-value",
+        )
+
+
+@pytest.mark.asyncio
+async def test_wms_sso_exchange_service_rejects_non_wms_identity() -> None:
+    erp_client = FakeErpClient(
+        ErpSsoAuthorizationCodeConsumeOut(
+            app_code="pms",
+            sub="erp:user:1",
+            erp_user_id=1,
+            username="admin",
+            redirect_path="/",
+        )
+    )
+    service = WmsSsoExchangeService(
+        SimpleNamespace(),
+        erp_client=erp_client,
+        user_service=FakeUserService(SimpleNamespace(username="admin", is_active=True)),
+    )
+
+    with pytest.raises(WmsSsoAppMismatchError):
+        await service.exchange(
+            WmsSsoExchangeIn(code="code-value", state="state-value"),
+            binding="binding-value",
+        )
+
+
+@pytest.mark.asyncio
+async def test_wms_sso_exchange_service_rejects_missing_local_user() -> None:
+    service = WmsSsoExchangeService(
+        SimpleNamespace(),
+        erp_client=FakeErpClient(),
+        user_service=FakeUserService(None),
+    )
+
+    with pytest.raises(WmsSsoUserNotFoundError):
+        await service.exchange(
+            WmsSsoExchangeIn(code="code-value", state="state-value"),
+            binding="binding-value",
+        )
+
+
+@pytest.mark.asyncio
+async def test_wms_sso_exchange_service_rejects_inactive_local_user() -> None:
+    user = SimpleNamespace(id=1, username="admin", is_active=False)
+    service = WmsSsoExchangeService(
+        SimpleNamespace(),
+        erp_client=FakeErpClient(),
+        user_service=FakeUserService(user),
+    )
+
+    with pytest.raises(WmsSsoUserInactiveError):
+        await service.exchange(
+            WmsSsoExchangeIn(code="code-value", state="state-value"),
+            binding="binding-value",
+        )


### PR DESCRIPTION
## Summary
- add WMS /system/sso/v1/exchange endpoint
- consume ERP SSO authorization code using X-Service-Client: wms-service
- require ERP_SSO_BINDING cookie for browser binding
- exchange ERP identity summary for WMS local token
- keep WMS local users and permissions authoritative; no user or permission auto-create
- declare httpx runtime dependency and pre-commit dev dependency

## Validation
- make lint
- make openapi
- make alembic-check
- make test TESTS="tests/api/test_wms_system_sso_exchange_api.py tests/services/test_wms_sso_authorization_code_client.py tests/services/test_wms_sso_exchange_service.py"

## Note
- Full local make test is currently blocked by unrelated PMS legacy/package/env failures observed before this targeted commit gate.