### PR TITLE
refactor(pms-projection): split vertical modules

### DIFF
--- a/app/pms/projections/contracts/__init__.py
+++ b/app/pms/projections/contracts/__init__.py
@@ -1,0 +1,66 @@
+# app/pms/projections/contracts/__init__.py
+from app.pms.projections.contracts.barcodes import (
+    PmsBarcodesProjectionCheckOut,
+    PmsBarcodesProjectionListOut,
+    PmsBarcodesProjectionSyncOut,
+)
+from app.pms.projections.contracts.items import (
+    PmsItemsProjectionCheckOut,
+    PmsItemsProjectionListOut,
+    PmsItemsProjectionSyncOut,
+)
+from app.pms.projections.contracts.pms_projection import (
+    PmsProjectionCheckIssueOut,
+    PmsProjectionCheckOut,
+    PmsProjectionListOut,
+    PmsProjectionResourceStatusOut,
+    PmsProjectionStatusOut,
+    PmsProjectionSyncOut,
+    PmsProjectionSyncRunOut,
+    PmsProjectionSyncRunsOut,
+    ProjectionResource,
+    SyncRunStatus,
+)
+from app.pms.projections.contracts.sku_codes import (
+    PmsSkuCodesProjectionCheckOut,
+    PmsSkuCodesProjectionListOut,
+    PmsSkuCodesProjectionSyncOut,
+)
+from app.pms.projections.contracts.suppliers import (
+    PmsSuppliersProjectionCheckOut,
+    PmsSuppliersProjectionListOut,
+    PmsSuppliersProjectionSyncOut,
+)
+from app.pms.projections.contracts.uoms import (
+    PmsUomsProjectionCheckOut,
+    PmsUomsProjectionListOut,
+    PmsUomsProjectionSyncOut,
+)
+
+__all__ = [
+    "PmsBarcodesProjectionCheckOut",
+    "PmsBarcodesProjectionListOut",
+    "PmsBarcodesProjectionSyncOut",
+    "PmsItemsProjectionCheckOut",
+    "PmsItemsProjectionListOut",
+    "PmsItemsProjectionSyncOut",
+    "PmsProjectionCheckIssueOut",
+    "PmsProjectionCheckOut",
+    "PmsProjectionListOut",
+    "PmsProjectionResourceStatusOut",
+    "PmsProjectionStatusOut",
+    "PmsProjectionSyncOut",
+    "PmsProjectionSyncRunOut",
+    "PmsProjectionSyncRunsOut",
+    "PmsSkuCodesProjectionCheckOut",
+    "PmsSkuCodesProjectionListOut",
+    "PmsSkuCodesProjectionSyncOut",
+    "PmsSuppliersProjectionCheckOut",
+    "PmsSuppliersProjectionListOut",
+    "PmsSuppliersProjectionSyncOut",
+    "PmsUomsProjectionCheckOut",
+    "PmsUomsProjectionListOut",
+    "PmsUomsProjectionSyncOut",
+    "ProjectionResource",
+    "SyncRunStatus",
+]

--- a/app/pms/projections/contracts/barcodes.py
+++ b/app/pms/projections/contracts/barcodes.py
@@ -1,0 +1,29 @@
+# app/pms/projections/contracts/barcodes.py
+from __future__ import annotations
+
+from typing import Literal
+
+from app.pms.projections.contracts.pms_projection import (
+    PmsProjectionCheckOut,
+    PmsProjectionListOut,
+    PmsProjectionSyncOut,
+)
+
+
+class PmsBarcodesProjectionListOut(PmsProjectionListOut):
+    resource: Literal["barcodes"]
+
+
+class PmsBarcodesProjectionCheckOut(PmsProjectionCheckOut):
+    resource: Literal["barcodes"]
+
+
+class PmsBarcodesProjectionSyncOut(PmsProjectionSyncOut):
+    pass
+
+
+__all__ = [
+    "PmsBarcodesProjectionCheckOut",
+    "PmsBarcodesProjectionListOut",
+    "PmsBarcodesProjectionSyncOut",
+]

--- a/app/pms/projections/contracts/items.py
+++ b/app/pms/projections/contracts/items.py
@@ -1,0 +1,29 @@
+# app/pms/projections/contracts/items.py
+from __future__ import annotations
+
+from typing import Literal
+
+from app.pms.projections.contracts.pms_projection import (
+    PmsProjectionCheckOut,
+    PmsProjectionListOut,
+    PmsProjectionSyncOut,
+)
+
+
+class PmsItemsProjectionListOut(PmsProjectionListOut):
+    resource: Literal["items"]
+
+
+class PmsItemsProjectionCheckOut(PmsProjectionCheckOut):
+    resource: Literal["items"]
+
+
+class PmsItemsProjectionSyncOut(PmsProjectionSyncOut):
+    pass
+
+
+__all__ = [
+    "PmsItemsProjectionCheckOut",
+    "PmsItemsProjectionListOut",
+    "PmsItemsProjectionSyncOut",
+]

--- a/app/pms/projections/contracts/pms_projection.py
+++ b/app/pms/projections/contracts/pms_projection.py
@@ -80,9 +80,9 @@ class PmsProjectionSyncRunsOut(BaseModel):
 __all__ = [
     "PmsProjectionCheckIssueOut",
     "PmsProjectionCheckOut",
-    "PmsProjectionStatusOut",
     "PmsProjectionListOut",
     "PmsProjectionResourceStatusOut",
+    "PmsProjectionStatusOut",
     "PmsProjectionSyncOut",
     "PmsProjectionSyncRunOut",
     "PmsProjectionSyncRunsOut",

--- a/app/pms/projections/contracts/sku_codes.py
+++ b/app/pms/projections/contracts/sku_codes.py
@@ -1,0 +1,29 @@
+# app/pms/projections/contracts/sku_codes.py
+from __future__ import annotations
+
+from typing import Literal
+
+from app.pms.projections.contracts.pms_projection import (
+    PmsProjectionCheckOut,
+    PmsProjectionListOut,
+    PmsProjectionSyncOut,
+)
+
+
+class PmsSkuCodesProjectionListOut(PmsProjectionListOut):
+    resource: Literal["sku-codes"]
+
+
+class PmsSkuCodesProjectionCheckOut(PmsProjectionCheckOut):
+    resource: Literal["sku-codes"]
+
+
+class PmsSkuCodesProjectionSyncOut(PmsProjectionSyncOut):
+    pass
+
+
+__all__ = [
+    "PmsSkuCodesProjectionCheckOut",
+    "PmsSkuCodesProjectionListOut",
+    "PmsSkuCodesProjectionSyncOut",
+]

--- a/app/pms/projections/contracts/suppliers.py
+++ b/app/pms/projections/contracts/suppliers.py
@@ -1,0 +1,29 @@
+# app/pms/projections/contracts/suppliers.py
+from __future__ import annotations
+
+from typing import Literal
+
+from app.pms.projections.contracts.pms_projection import (
+    PmsProjectionCheckOut,
+    PmsProjectionListOut,
+    PmsProjectionSyncOut,
+)
+
+
+class PmsSuppliersProjectionListOut(PmsProjectionListOut):
+    resource: Literal["suppliers"]
+
+
+class PmsSuppliersProjectionCheckOut(PmsProjectionCheckOut):
+    resource: Literal["suppliers"]
+
+
+class PmsSuppliersProjectionSyncOut(PmsProjectionSyncOut):
+    pass
+
+
+__all__ = [
+    "PmsSuppliersProjectionCheckOut",
+    "PmsSuppliersProjectionListOut",
+    "PmsSuppliersProjectionSyncOut",
+]

--- a/app/pms/projections/contracts/uoms.py
+++ b/app/pms/projections/contracts/uoms.py
@@ -1,0 +1,29 @@
+# app/pms/projections/contracts/uoms.py
+from __future__ import annotations
+
+from typing import Literal
+
+from app.pms.projections.contracts.pms_projection import (
+    PmsProjectionCheckOut,
+    PmsProjectionListOut,
+    PmsProjectionSyncOut,
+)
+
+
+class PmsUomsProjectionListOut(PmsProjectionListOut):
+    resource: Literal["uoms"]
+
+
+class PmsUomsProjectionCheckOut(PmsProjectionCheckOut):
+    resource: Literal["uoms"]
+
+
+class PmsUomsProjectionSyncOut(PmsProjectionSyncOut):
+    pass
+
+
+__all__ = [
+    "PmsUomsProjectionCheckOut",
+    "PmsUomsProjectionListOut",
+    "PmsUomsProjectionSyncOut",
+]

--- a/app/pms/projections/repos/__init__.py
+++ b/app/pms/projections/repos/__init__.py
@@ -1,0 +1,14 @@
+# app/pms/projections/repos/__init__.py
+from app.pms.projections.repos.pms_projection_repo import (
+    PmsProjectionRepo,
+    ProjectionResourceConfig,
+    RESOURCE_CONFIGS,
+    RESOURCE_ORDER,
+)
+
+__all__ = [
+    "PmsProjectionRepo",
+    "ProjectionResourceConfig",
+    "RESOURCE_CONFIGS",
+    "RESOURCE_ORDER",
+]

--- a/app/pms/projections/repos/pms_projection_repo.py
+++ b/app/pms/projections/repos/pms_projection_repo.py
@@ -1,0 +1,657 @@
+# app/pms/projections/repos/pms_projection_repo.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.pms.projections.contracts.pms_projection import ProjectionResource
+
+
+@dataclass(frozen=True)
+class ProjectionResourceConfig:
+    resource: ProjectionResource
+    table_name: str
+    id_column: str
+    columns: tuple[str, ...]
+    searchable_columns: tuple[str, ...]
+    select_expressions: tuple[str, ...] | None = None
+    from_sql: str | None = None
+    order_by_sql: str | None = None
+
+
+RESOURCE_CONFIGS: dict[ProjectionResource, ProjectionResourceConfig] = {
+    "items": ProjectionResourceConfig(
+        resource="items",
+        table_name="wms_pms_item_projection",
+        id_column="item_id",
+        columns=(
+            "item_id",
+            "sku",
+            "name",
+            "spec",
+            "enabled",
+            "supplier_id",
+            "supplier_code",
+            "supplier_name",
+            "brand",
+            "category",
+            "expiry_policy",
+            "shelf_life_value",
+            "shelf_life_unit",
+            "lot_source_policy",
+            "derivation_allowed",
+            "uom_governance_enabled",
+            "pms_updated_at",
+            "source_hash",
+            "sync_version",
+            "synced_at",
+        ),
+        searchable_columns=(
+            "i.sku",
+            "i.name",
+            "i.spec",
+            "i.brand",
+            "i.category",
+            "s.supplier_code",
+            "s.supplier_name",
+        ),
+        select_expressions=(
+            "i.item_id",
+            "i.sku",
+            "i.name",
+            "i.spec",
+            "i.enabled",
+            "i.supplier_id",
+            "s.supplier_code AS supplier_code",
+            "s.supplier_name AS supplier_name",
+            "i.brand",
+            "i.category",
+            "i.expiry_policy",
+            "i.shelf_life_value",
+            "i.shelf_life_unit",
+            "i.lot_source_policy",
+            "i.derivation_allowed",
+            "i.uom_governance_enabled",
+            "i.pms_updated_at",
+            "i.source_hash",
+            "i.sync_version",
+            "i.synced_at",
+        ),
+        from_sql=(
+            "wms_pms_item_projection AS i "
+            "LEFT JOIN wms_pms_supplier_projection AS s "
+            "ON s.supplier_id = i.supplier_id"
+        ),
+        order_by_sql="i.item_id ASC",
+    ),
+    "suppliers": ProjectionResourceConfig(
+        resource="suppliers",
+        table_name="wms_pms_supplier_projection",
+        id_column="supplier_id",
+        columns=(
+            "supplier_id",
+            "supplier_code",
+            "supplier_name",
+            "active",
+            "website",
+            "pms_updated_at",
+            "source_hash",
+            "sync_version",
+            "synced_at",
+        ),
+        searchable_columns=("supplier_code", "supplier_name", "website"),
+    ),
+    "uoms": ProjectionResourceConfig(
+        resource="uoms",
+        table_name="wms_pms_uom_projection",
+        id_column="item_uom_id",
+        columns=(
+            "item_uom_id",
+            "item_id",
+            "uom",
+            "display_name",
+            "uom_name",
+            "ratio_to_base",
+            "net_weight_kg",
+            "is_base",
+            "is_purchase_default",
+            "is_inbound_default",
+            "is_outbound_default",
+            "pms_updated_at",
+            "source_hash",
+            "sync_version",
+            "synced_at",
+        ),
+        searchable_columns=("uom", "display_name", "uom_name"),
+    ),
+    "sku-codes": ProjectionResourceConfig(
+        resource="sku-codes",
+        table_name="wms_pms_sku_code_projection",
+        id_column="sku_code_id",
+        columns=(
+            "sku_code_id",
+            "item_id",
+            "sku_code",
+            "code_type",
+            "is_primary",
+            "is_active",
+            "effective_from",
+            "effective_to",
+            "pms_updated_at",
+            "source_hash",
+            "sync_version",
+            "synced_at",
+        ),
+        searchable_columns=("sku_code", "code_type"),
+    ),
+    "barcodes": ProjectionResourceConfig(
+        resource="barcodes",
+        table_name="wms_pms_barcode_projection",
+        id_column="barcode_id",
+        columns=(
+            "barcode_id",
+            "item_id",
+            "item_uom_id",
+            "barcode",
+            "symbology",
+            "active",
+            "is_primary",
+            "pms_updated_at",
+            "source_hash",
+            "sync_version",
+            "synced_at",
+        ),
+        searchable_columns=("barcode", "symbology"),
+    ),
+}
+
+RESOURCE_ORDER: tuple[ProjectionResource, ...] = (
+    "items",
+    "suppliers",
+    "uoms",
+    "sku-codes",
+    "barcodes",
+)
+
+
+class PmsProjectionRepo:
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    @staticmethod
+    def config(resource: ProjectionResource) -> ProjectionResourceConfig:
+        try:
+            return RESOURCE_CONFIGS[resource]
+        except KeyError as exc:
+            raise ValueError(f"unsupported PMS projection resource: {resource}") from exc
+
+    @staticmethod
+    def jsonable(value: Any) -> Any:
+        if isinstance(value, Decimal):
+            return str(value)
+        return value
+
+    @staticmethod
+    def select_sql(cfg: ProjectionResourceConfig) -> str:
+        return ", ".join(cfg.select_expressions or cfg.columns)
+
+    @staticmethod
+    def from_sql(cfg: ProjectionResourceConfig) -> str:
+        return cfg.from_sql or cfg.table_name
+
+    @staticmethod
+    def order_by_sql(cfg: ProjectionResourceConfig) -> str:
+        return cfg.order_by_sql or f"{cfg.id_column} ASC"
+
+    @staticmethod
+    def sync_run_from_row(row: Any) -> dict[str, Any]:
+        data = dict(row)
+        return {
+            "id": int(data["id"]),
+            "resource": str(data["resource"]),
+            "status": str(data["status"]),
+            "fetched": int(data.get("fetched") or 0),
+            "upserted": int(data.get("upserted") or 0),
+            "pages": int(data.get("pages") or 0),
+            "started_at": data["started_at"],
+            "finished_at": data.get("finished_at"),
+            "duration_ms": (
+                int(data["duration_ms"]) if data.get("duration_ms") is not None else None
+            ),
+            "error_message": data.get("error_message"),
+            "triggered_by_user_id": (
+                int(data["triggered_by_user_id"])
+                if data.get("triggered_by_user_id") is not None
+                else None
+            ),
+            "pms_api_base_url_snapshot": data.get("pms_api_base_url_snapshot"),
+            "sync_version": data.get("sync_version"),
+        }
+
+    def latest_sync_runs(self) -> dict[str, dict[str, Any]]:
+        rows = (
+            self.db.execute(
+                text(
+                    """
+                    SELECT DISTINCT ON (resource)
+                        id,
+                        resource,
+                        status,
+                        fetched,
+                        upserted,
+                        pages,
+                        started_at,
+                        finished_at,
+                        duration_ms,
+                        error_message,
+                        triggered_by_user_id,
+                        pms_api_base_url_snapshot,
+                        sync_version
+                    FROM wms_pms_projection_sync_runs
+                    WHERE resource IN ('items', 'suppliers', 'uoms', 'sku-codes', 'barcodes')
+                    ORDER BY resource, started_at DESC, id DESC
+                    """
+                )
+            )
+            .mappings()
+            .all()
+        )
+        return {str(row["resource"]): self.sync_run_from_row(row) for row in rows}
+
+    def resource_stats(self, cfg: ProjectionResourceConfig) -> dict[str, Any]:
+        row = (
+            self.db.execute(
+                text(
+                    f"""
+                    SELECT
+                        count(*)::bigint AS row_count,
+                        max(synced_at) AS max_synced_at
+                    FROM {cfg.table_name}
+                    """
+                )
+            )
+            .mappings()
+            .one()
+        )
+        return {
+            "row_count": int(row["row_count"] or 0),
+            "max_synced_at": row["max_synced_at"],
+        }
+
+    def list_projection_rows(
+        self,
+        *,
+        cfg: ProjectionResourceConfig,
+        limit: int,
+        offset: int,
+        q: str | None,
+    ) -> dict[str, Any]:
+        where_sql = ""
+        params: dict[str, Any] = {"limit": int(limit), "offset": int(offset)}
+        query_text = (q or "").strip()
+        if query_text and cfg.searchable_columns:
+            where_parts = [
+                f"CAST({column} AS TEXT) ILIKE :q"
+                for column in cfg.searchable_columns
+            ]
+            where_sql = "WHERE " + " OR ".join(where_parts)
+            params["q"] = f"%{query_text}%"
+
+        from_sql = self.from_sql(cfg)
+        total = int(
+            self.db.execute(
+                text(f"SELECT count(*)::bigint FROM {from_sql} {where_sql}"),
+                params,
+            ).scalar_one()
+        )
+
+        rows = (
+            self.db.execute(
+                text(
+                    f"""
+                    SELECT {self.select_sql(cfg)}
+                    FROM {from_sql}
+                    {where_sql}
+                    ORDER BY {self.order_by_sql(cfg)}
+                    LIMIT :limit OFFSET :offset
+                    """
+                ),
+                params,
+            )
+            .mappings()
+            .all()
+        )
+
+        return {
+            "resource": cfg.resource,
+            "table_name": cfg.table_name,
+            "limit": int(limit),
+            "offset": int(offset),
+            "total": total,
+            "columns": list(cfg.columns),
+            "rows": [
+                {key: self.jsonable(value) for key, value in dict(row).items()}
+                for row in rows
+            ],
+        }
+
+    def create_sync_run(
+        self,
+        *,
+        resource: ProjectionResource,
+        triggered_by_user_id: int | None,
+        pms_api_base_url_snapshot: str | None,
+        sync_version: str,
+    ) -> int:
+        row = (
+            self.db.execute(
+                text(
+                    """
+                    INSERT INTO wms_pms_projection_sync_runs (
+                        resource,
+                        status,
+                        fetched,
+                        upserted,
+                        pages,
+                        started_at,
+                        triggered_by_user_id,
+                        pms_api_base_url_snapshot,
+                        sync_version
+                    )
+                    VALUES (
+                        :resource,
+                        'RUNNING',
+                        0,
+                        0,
+                        0,
+                        now(),
+                        :triggered_by_user_id,
+                        :pms_api_base_url_snapshot,
+                        :sync_version
+                    )
+                    RETURNING id
+                    """
+                ),
+                {
+                    "resource": resource,
+                    "triggered_by_user_id": triggered_by_user_id,
+                    "pms_api_base_url_snapshot": pms_api_base_url_snapshot,
+                    "sync_version": sync_version,
+                },
+            )
+            .mappings()
+            .one()
+        )
+        self.db.commit()
+        return int(row["id"])
+
+    def finish_sync_run(
+        self,
+        *,
+        run_id: int,
+        status: str,
+        duration_ms: int,
+        fetched: int = 0,
+        upserted: int = 0,
+        pages: int = 0,
+        error_message: str | None = None,
+    ) -> dict[str, Any]:
+        row = (
+            self.db.execute(
+                text(
+                    """
+                    UPDATE wms_pms_projection_sync_runs
+                       SET status = :status,
+                           fetched = :fetched,
+                           upserted = :upserted,
+                           pages = :pages,
+                           finished_at = now(),
+                           duration_ms = :duration_ms,
+                           error_message = :error_message
+                     WHERE id = :run_id
+                    RETURNING
+                        id,
+                        resource,
+                        status,
+                        fetched,
+                        upserted,
+                        pages,
+                        started_at,
+                        finished_at,
+                        duration_ms,
+                        error_message,
+                        triggered_by_user_id,
+                        pms_api_base_url_snapshot,
+                        sync_version
+                    """
+                ),
+                {
+                    "run_id": int(run_id),
+                    "status": status,
+                    "fetched": int(fetched),
+                    "upserted": int(upserted),
+                    "pages": int(pages),
+                    "duration_ms": int(duration_ms),
+                    "error_message": error_message,
+                },
+            )
+            .mappings()
+            .one()
+        )
+        self.db.commit()
+        return self.sync_run_from_row(row)
+
+    def list_sync_runs(
+        self,
+        *,
+        resource: ProjectionResource | None,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        params: dict[str, Any] = {"limit": int(limit)}
+        where_sql = ""
+        if resource is not None:
+            self.config(resource)
+            where_sql = "WHERE resource = :resource"
+            params["resource"] = resource
+
+        rows = (
+            self.db.execute(
+                text(
+                    f"""
+                    SELECT
+                        id,
+                        resource,
+                        status,
+                        fetched,
+                        upserted,
+                        pages,
+                        started_at,
+                        finished_at,
+                        duration_ms,
+                        error_message,
+                        triggered_by_user_id,
+                        pms_api_base_url_snapshot,
+                        sync_version
+                    FROM wms_pms_projection_sync_runs
+                    {where_sql}
+                    ORDER BY started_at DESC, id DESC
+                    LIMIT :limit
+                    """
+                ),
+                params,
+            )
+            .mappings()
+            .all()
+        )
+        return [self.sync_run_from_row(row) for row in rows]
+
+    def check_items(self, limit: int) -> list[dict[str, Any]]:
+        rows = (
+            self.db.execute(
+                text(
+                    """
+                    SELECT
+                        i.item_id,
+                        i.supplier_id
+                    FROM wms_pms_item_projection AS i
+                    LEFT JOIN wms_pms_supplier_projection AS s
+                      ON s.supplier_id = i.supplier_id
+                    WHERE i.supplier_id IS NOT NULL
+                      AND s.supplier_id IS NULL
+                    ORDER BY i.item_id ASC
+                    LIMIT :limit
+                    """
+                ),
+                {"limit": int(limit)},
+            )
+            .mappings()
+            .all()
+        )
+        return [
+            {
+                "issue_type": "ITEM_SUPPLIER_MISSING_IN_PROJECTION",
+                "resource": "items",
+                "source_id": str(row["item_id"]),
+                "message": "商品投影中的 supplier_id 在供应商投影中不存在",
+                "item_id": int(row["item_id"]),
+                "supplier_id": int(row["supplier_id"]),
+            }
+            for row in rows
+        ]
+
+    def check_suppliers(self, limit: int) -> list[dict[str, Any]]:
+        _ = limit
+        return []
+
+    def check_uoms(self, limit: int) -> list[dict[str, Any]]:
+        rows = (
+            self.db.execute(
+                text(
+                    """
+                    SELECT
+                        u.item_uom_id,
+                        u.item_id
+                    FROM wms_pms_uom_projection AS u
+                    LEFT JOIN wms_pms_item_projection AS i
+                      ON i.item_id = u.item_id
+                    WHERE i.item_id IS NULL
+                    ORDER BY u.item_uom_id ASC
+                    LIMIT :limit
+                    """
+                ),
+                {"limit": int(limit)},
+            )
+            .mappings()
+            .all()
+        )
+        return [
+            {
+                "issue_type": "UOM_ITEM_MISSING_IN_PROJECTION",
+                "resource": "uoms",
+                "source_id": str(row["item_uom_id"]),
+                "message": "包装单位投影中的 item_id 在商品投影中不存在",
+                "item_id": int(row["item_id"]),
+                "item_uom_id": int(row["item_uom_id"]),
+            }
+            for row in rows
+        ]
+
+    def check_sku_codes(self, limit: int) -> list[dict[str, Any]]:
+        rows = (
+            self.db.execute(
+                text(
+                    """
+                    SELECT
+                        s.sku_code_id,
+                        s.item_id
+                    FROM wms_pms_sku_code_projection AS s
+                    LEFT JOIN wms_pms_item_projection AS i
+                      ON i.item_id = s.item_id
+                    WHERE i.item_id IS NULL
+                    ORDER BY s.sku_code_id ASC
+                    LIMIT :limit
+                    """
+                ),
+                {"limit": int(limit)},
+            )
+            .mappings()
+            .all()
+        )
+        return [
+            {
+                "issue_type": "SKU_CODE_ITEM_MISSING_IN_PROJECTION",
+                "resource": "sku-codes",
+                "source_id": str(row["sku_code_id"]),
+                "message": "SKU 编码投影中的 item_id 在商品投影中不存在",
+                "item_id": int(row["item_id"]),
+            }
+            for row in rows
+        ]
+
+    def check_barcodes(self, limit: int) -> list[dict[str, Any]]:
+        rows = (
+            self.db.execute(
+                text(
+                    """
+                    SELECT
+                        b.barcode_id,
+                        b.item_id,
+                        b.item_uom_id,
+                        u.item_id AS projection_item_id,
+                        CASE
+                          WHEN i.item_id IS NULL THEN 'BARCODE_ITEM_MISSING_IN_PROJECTION'
+                          WHEN u.item_uom_id IS NULL THEN 'BARCODE_UOM_MISSING_IN_PROJECTION'
+                          WHEN u.item_id <> b.item_id THEN 'BARCODE_UOM_ITEM_MISMATCH'
+                          ELSE 'OK'
+                        END AS issue_type
+                    FROM wms_pms_barcode_projection AS b
+                    LEFT JOIN wms_pms_item_projection AS i
+                      ON i.item_id = b.item_id
+                    LEFT JOIN wms_pms_uom_projection AS u
+                      ON u.item_uom_id = b.item_uom_id
+                    WHERE i.item_id IS NULL
+                       OR u.item_uom_id IS NULL
+                       OR u.item_id <> b.item_id
+                    ORDER BY b.barcode_id ASC
+                    LIMIT :limit
+                    """
+                ),
+                {"limit": int(limit)},
+            )
+            .mappings()
+            .all()
+        )
+
+        messages = {
+            "BARCODE_ITEM_MISSING_IN_PROJECTION": "条码投影中的 item_id 在商品投影中不存在",
+            "BARCODE_UOM_MISSING_IN_PROJECTION": "条码投影中的 item_uom_id 在包装单位投影中不存在",
+            "BARCODE_UOM_ITEM_MISMATCH": "条码投影中的 item_id 与包装单位投影所属 item_id 不一致",
+        }
+        return [
+            {
+                "issue_type": str(row["issue_type"]),
+                "resource": "barcodes",
+                "source_id": str(row["barcode_id"]),
+                "message": messages.get(str(row["issue_type"]), "条码投影一致性异常"),
+                "item_id": int(row["item_id"]),
+                "item_uom_id": int(row["item_uom_id"]),
+                "projection_item_id": (
+                    int(row["projection_item_id"])
+                    if row["projection_item_id"] is not None
+                    else None
+                ),
+            }
+            for row in rows
+        ]
+
+
+__all__ = [
+    "PmsProjectionRepo",
+    "ProjectionResourceConfig",
+    "RESOURCE_CONFIGS",
+    "RESOURCE_ORDER",
+]

--- a/app/pms/projections/routers/__init__.py
+++ b/app/pms/projections/routers/__init__.py
@@ -1,0 +1,1 @@
+# app/pms/projections/routers/__init__.py

--- a/app/pms/projections/routers/_sync.py
+++ b/app/pms/projections/routers/_sync.py
@@ -1,0 +1,25 @@
+# app/pms/projections/routers/_sync.py
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from fastapi import HTTPException
+
+from app.integrations.pms.projection_sync import PmsProjectionSyncError
+
+
+async def run_pms_projection_sync(
+    sync_call: Callable[[], Awaitable[dict[str, Any]]],
+) -> dict[str, Any]:
+    try:
+        run = await sync_call()
+    except (RuntimeError, PmsProjectionSyncError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"PMS projection sync failed: {exc}") from exc
+
+    return {"run": run}
+
+
+__all__ = ["run_pms_projection_sync"]

--- a/app/pms/projections/routers/barcodes.py
+++ b/app/pms/projections/routers/barcodes.py
@@ -1,0 +1,53 @@
+# app/pms/projections/routers/barcodes.py
+from __future__ import annotations
+
+from fastapi import APIRouter, Query
+
+from app.pms.projections.contracts.barcodes import (
+    PmsBarcodesProjectionCheckOut,
+    PmsBarcodesProjectionListOut,
+    PmsBarcodesProjectionSyncOut,
+)
+from app.pms.projections.routers._sync import run_pms_projection_sync
+from app.pms.projections.routers.deps import (
+    PmsProjectionReadUserDep,
+    PmsProjectionServiceDep,
+    PmsProjectionWriteUserDep,
+)
+
+router = APIRouter()
+
+
+@router.get("/barcodes", response_model=PmsBarcodesProjectionListOut)
+def list_pms_barcode_projection_rows(
+    _: PmsProjectionReadUserDep,
+    service: PmsProjectionServiceDep,
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    q: str | None = Query(default=None),
+):
+    return service.list_barcodes(limit=limit, offset=offset, q=q)
+
+
+@router.post("/barcodes/sync", response_model=PmsBarcodesProjectionSyncOut)
+async def sync_pms_barcode_projection(
+    current_user: PmsProjectionWriteUserDep,
+    service: PmsProjectionServiceDep,
+):
+    return await run_pms_projection_sync(
+        lambda: service.sync_barcodes(
+            triggered_by_user_id=int(getattr(current_user, "id")),
+        )
+    )
+
+
+@router.post("/barcodes/check", response_model=PmsBarcodesProjectionCheckOut)
+def check_pms_barcode_projection(
+    _: PmsProjectionReadUserDep,
+    service: PmsProjectionServiceDep,
+    limit: int = Query(default=200, ge=1, le=1000),
+):
+    return service.check_barcodes(limit=limit)
+
+
+__all__ = ["router"]

--- a/app/pms/projections/routers/deps.py
+++ b/app/pms/projections/routers/deps.py
@@ -1,0 +1,54 @@
+# app/pms/projections/routers/deps.py
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.pms.projections.services.pms_projection_service import PmsProjectionService
+from app.user.deps.auth import get_current_user
+from app.user.services.user_service import UserService
+
+
+def get_pms_projection_service(db: Session = Depends(get_db)) -> PmsProjectionService:
+    return PmsProjectionService(db)
+
+
+def require_pms_projection_read(
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    svc = UserService(db)
+    svc.check_permission(current_user, ["page.pms.read"])
+    return current_user
+
+
+def require_pms_projection_write(
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    svc = UserService(db)
+    svc.check_permission(current_user, ["page.pms.write"])
+    return current_user
+
+
+PmsProjectionServiceDep = Annotated[
+    PmsProjectionService,
+    Depends(get_pms_projection_service),
+]
+PmsProjectionReadUserDep = Annotated[
+    object,
+    Depends(require_pms_projection_read),
+]
+PmsProjectionWriteUserDep = Annotated[
+    object,
+    Depends(require_pms_projection_write),
+]
+
+__all__ = [
+    "PmsProjectionReadUserDep",
+    "PmsProjectionServiceDep",
+    "PmsProjectionWriteUserDep",
+]

--- a/app/pms/projections/routers/items.py
+++ b/app/pms/projections/routers/items.py
@@ -1,0 +1,53 @@
+# app/pms/projections/routers/items.py
+from __future__ import annotations
+
+from fastapi import APIRouter, Query
+
+from app.pms.projections.contracts.items import (
+    PmsItemsProjectionCheckOut,
+    PmsItemsProjectionListOut,
+    PmsItemsProjectionSyncOut,
+)
+from app.pms.projections.routers._sync import run_pms_projection_sync
+from app.pms.projections.routers.deps import (
+    PmsProjectionReadUserDep,
+    PmsProjectionServiceDep,
+    PmsProjectionWriteUserDep,
+)
+
+router = APIRouter()
+
+
+@router.get("/items", response_model=PmsItemsProjectionListOut)
+def list_pms_item_projection_rows(
+    _: PmsProjectionReadUserDep,
+    service: PmsProjectionServiceDep,
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    q: str | None = Query(default=None),
+):
+    return service.list_items(limit=limit, offset=offset, q=q)
+
+
+@router.post("/items/sync", response_model=PmsItemsProjectionSyncOut)
+async def sync_pms_item_projection(
+    current_user: PmsProjectionWriteUserDep,
+    service: PmsProjectionServiceDep,
+):
+    return await run_pms_projection_sync(
+        lambda: service.sync_items(
+            triggered_by_user_id=int(getattr(current_user, "id")),
+        )
+    )
+
+
+@router.post("/items/check", response_model=PmsItemsProjectionCheckOut)
+def check_pms_item_projection(
+    _: PmsProjectionReadUserDep,
+    service: PmsProjectionServiceDep,
+    limit: int = Query(default=200, ge=1, le=1000),
+):
+    return service.check_items(limit=limit)
+
+
+__all__ = ["router"]

--- a/app/pms/projections/routers/pms_projection.py
+++ b/app/pms/projections/routers/pms_projection.py
@@ -1,103 +1,50 @@
 # app/pms/projections/routers/pms_projection.py
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy.orm import Session
+from fastapi import APIRouter, Query
 
 from app.pms.projections.contracts.pms_projection import (
-    PmsProjectionCheckOut,
     PmsProjectionStatusOut,
-    PmsProjectionListOut,
-    PmsProjectionSyncOut,
     PmsProjectionSyncRunsOut,
     ProjectionResource,
 )
-from app.pms.projections.services.pms_projection_service import PmsProjectionService
-from app.db.session import get_db
-from app.integrations.pms.projection_sync import PmsProjectionSyncError
-from app.user.deps.auth import get_current_user
-from app.user.services.user_service import UserService
+from app.pms.projections.routers import (
+    barcodes,
+    items,
+    sku_codes,
+    suppliers,
+    uoms,
+)
+from app.pms.projections.routers.deps import (
+    PmsProjectionReadUserDep,
+    PmsProjectionServiceDep,
+)
 
 router = APIRouter(prefix="/projections", tags=["pms-projections"])
 
 
-def _service(db: Session) -> PmsProjectionService:
-    return PmsProjectionService(db)
-
-
 @router.get("/status", response_model=PmsProjectionStatusOut)
 def get_pms_projection_sync_status(
-    db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    _: PmsProjectionReadUserDep,
+    service: PmsProjectionServiceDep,
 ):
-    svc = UserService(db)
-    svc.check_permission(current_user, ["page.pms.read"])
-    return _service(db).get_status()
+    return service.get_status()
 
 
 @router.get("/sync-runs", response_model=PmsProjectionSyncRunsOut)
 def list_pms_projection_sync_runs(
+    _: PmsProjectionReadUserDep,
+    service: PmsProjectionServiceDep,
     resource: ProjectionResource | None = Query(default=None),
     limit: int = Query(default=20, ge=1, le=100),
-    db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
 ):
-    svc = UserService(db)
-    svc.check_permission(current_user, ["page.pms.read"])
-    return _service(db).list_sync_runs(resource=resource, limit=limit)
+    return service.list_sync_runs(resource=resource, limit=limit)
 
 
-@router.get("/{resource}", response_model=PmsProjectionListOut)
-def list_pms_projection_rows(
-    resource: ProjectionResource,
-    limit: int = Query(default=50, ge=1, le=500),
-    offset: int = Query(default=0, ge=0),
-    q: str | None = Query(default=None),
-    db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
-):
-    svc = UserService(db)
-    svc.check_permission(current_user, ["page.pms.read"])
-    return _service(db).list_projection(
-        resource=resource,
-        limit=limit,
-        offset=offset,
-        q=q,
-    )
-
-
-@router.post("/{resource}/sync", response_model=PmsProjectionSyncOut)
-async def sync_pms_projection_resource(
-    resource: ProjectionResource,
-    db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
-):
-    svc = UserService(db)
-    svc.check_permission(current_user, ["page.pms.write"])
-
-    try:
-        run = await _service(db).sync_resource(
-            resource=resource,
-            triggered_by_user_id=int(getattr(current_user, "id")),
-        )
-    except (RuntimeError, PmsProjectionSyncError, ValueError) as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
-    except Exception as exc:
-        raise HTTPException(status_code=502, detail=f"PMS projection sync failed: {exc}")
-
-    return {"run": run}
-
-
-@router.post("/{resource}/check", response_model=PmsProjectionCheckOut)
-def check_pms_projection_resource(
-    resource: ProjectionResource,
-    limit: int = Query(default=200, ge=1, le=1000),
-    db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
-):
-    svc = UserService(db)
-    svc.check_permission(current_user, ["page.pms.read"])
-    return _service(db).check_projection(resource=resource, limit=limit)
-
+router.include_router(items.router)
+router.include_router(suppliers.router)
+router.include_router(uoms.router)
+router.include_router(sku_codes.router)
+router.include_router(barcodes.router)
 
 __all__ = ["router"]

--- a/app/pms/projections/routers/sku_codes.py
+++ b/app/pms/projections/routers/sku_codes.py
@@ -1,0 +1,53 @@
+# app/pms/projections/routers/sku_codes.py
+from __future__ import annotations
+
+from fastapi import APIRouter, Query
+
+from app.pms.projections.contracts.sku_codes import (
+    PmsSkuCodesProjectionCheckOut,
+    PmsSkuCodesProjectionListOut,
+    PmsSkuCodesProjectionSyncOut,
+)
+from app.pms.projections.routers._sync import run_pms_projection_sync
+from app.pms.projections.routers.deps import (
+    PmsProjectionReadUserDep,
+    PmsProjectionServiceDep,
+    PmsProjectionWriteUserDep,
+)
+
+router = APIRouter()
+
+
+@router.get("/sku-codes", response_model=PmsSkuCodesProjectionListOut)
+def list_pms_sku_code_projection_rows(
+    _: PmsProjectionReadUserDep,
+    service: PmsProjectionServiceDep,
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    q: str | None = Query(default=None),
+):
+    return service.list_sku_codes(limit=limit, offset=offset, q=q)
+
+
+@router.post("/sku-codes/sync", response_model=PmsSkuCodesProjectionSyncOut)
+async def sync_pms_sku_code_projection(
+    current_user: PmsProjectionWriteUserDep,
+    service: PmsProjectionServiceDep,
+):
+    return await run_pms_projection_sync(
+        lambda: service.sync_sku_codes(
+            triggered_by_user_id=int(getattr(current_user, "id")),
+        )
+    )
+
+
+@router.post("/sku-codes/check", response_model=PmsSkuCodesProjectionCheckOut)
+def check_pms_sku_code_projection(
+    _: PmsProjectionReadUserDep,
+    service: PmsProjectionServiceDep,
+    limit: int = Query(default=200, ge=1, le=1000),
+):
+    return service.check_sku_codes(limit=limit)
+
+
+__all__ = ["router"]

--- a/app/pms/projections/routers/suppliers.py
+++ b/app/pms/projections/routers/suppliers.py
@@ -1,0 +1,53 @@
+# app/pms/projections/routers/suppliers.py
+from __future__ import annotations
+
+from fastapi import APIRouter, Query
+
+from app.pms.projections.contracts.suppliers import (
+    PmsSuppliersProjectionCheckOut,
+    PmsSuppliersProjectionListOut,
+    PmsSuppliersProjectionSyncOut,
+)
+from app.pms.projections.routers._sync import run_pms_projection_sync
+from app.pms.projections.routers.deps import (
+    PmsProjectionReadUserDep,
+    PmsProjectionServiceDep,
+    PmsProjectionWriteUserDep,
+)
+
+router = APIRouter()
+
+
+@router.get("/suppliers", response_model=PmsSuppliersProjectionListOut)
+def list_pms_supplier_projection_rows(
+    _: PmsProjectionReadUserDep,
+    service: PmsProjectionServiceDep,
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    q: str | None = Query(default=None),
+):
+    return service.list_suppliers(limit=limit, offset=offset, q=q)
+
+
+@router.post("/suppliers/sync", response_model=PmsSuppliersProjectionSyncOut)
+async def sync_pms_supplier_projection(
+    current_user: PmsProjectionWriteUserDep,
+    service: PmsProjectionServiceDep,
+):
+    return await run_pms_projection_sync(
+        lambda: service.sync_suppliers(
+            triggered_by_user_id=int(getattr(current_user, "id")),
+        )
+    )
+
+
+@router.post("/suppliers/check", response_model=PmsSuppliersProjectionCheckOut)
+def check_pms_supplier_projection(
+    _: PmsProjectionReadUserDep,
+    service: PmsProjectionServiceDep,
+    limit: int = Query(default=200, ge=1, le=1000),
+):
+    return service.check_suppliers(limit=limit)
+
+
+__all__ = ["router"]

--- a/app/pms/projections/routers/uoms.py
+++ b/app/pms/projections/routers/uoms.py
@@ -1,0 +1,53 @@
+# app/pms/projections/routers/uoms.py
+from __future__ import annotations
+
+from fastapi import APIRouter, Query
+
+from app.pms.projections.contracts.uoms import (
+    PmsUomsProjectionCheckOut,
+    PmsUomsProjectionListOut,
+    PmsUomsProjectionSyncOut,
+)
+from app.pms.projections.routers._sync import run_pms_projection_sync
+from app.pms.projections.routers.deps import (
+    PmsProjectionReadUserDep,
+    PmsProjectionServiceDep,
+    PmsProjectionWriteUserDep,
+)
+
+router = APIRouter()
+
+
+@router.get("/uoms", response_model=PmsUomsProjectionListOut)
+def list_pms_uom_projection_rows(
+    _: PmsProjectionReadUserDep,
+    service: PmsProjectionServiceDep,
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    q: str | None = Query(default=None),
+):
+    return service.list_uoms(limit=limit, offset=offset, q=q)
+
+
+@router.post("/uoms/sync", response_model=PmsUomsProjectionSyncOut)
+async def sync_pms_uom_projection(
+    current_user: PmsProjectionWriteUserDep,
+    service: PmsProjectionServiceDep,
+):
+    return await run_pms_projection_sync(
+        lambda: service.sync_uoms(
+            triggered_by_user_id=int(getattr(current_user, "id")),
+        )
+    )
+
+
+@router.post("/uoms/check", response_model=PmsUomsProjectionCheckOut)
+def check_pms_uom_projection(
+    _: PmsProjectionReadUserDep,
+    service: PmsProjectionServiceDep,
+    limit: int = Query(default=200, ge=1, le=1000),
+):
+    return service.check_uoms(limit=limit)
+
+
+__all__ = ["router"]

--- a/app/pms/projections/services/__init__.py
+++ b/app/pms/projections/services/__init__.py
@@ -1,0 +1,4 @@
+# app/pms/projections/services/__init__.py
+from app.pms.projections.services.pms_projection_service import PmsProjectionService
+
+__all__ = ["PmsProjectionService"]

--- a/app/pms/projections/services/pms_projection_service.py
+++ b/app/pms/projections/services/pms_projection_service.py
@@ -4,189 +4,23 @@ from __future__ import annotations
 import os
 import time
 from collections.abc import Callable, Coroutine
-from dataclasses import dataclass
-from decimal import Decimal
 from typing import Any
 
-from sqlalchemy import text
 from sqlalchemy.orm import Session
 
-from app.pms.projections.contracts.pms_projection import ProjectionResource
 from app.db.session import AsyncSessionLocal
 from app.integrations.pms.projection_sync import (
     SYNC_VERSION,
     PmsProjectionSyncResult,
     sync_pms_read_projection_once,
 )
+from app.pms.projections.contracts.pms_projection import ProjectionResource
+from app.pms.projections.repos.pms_projection_repo import (
+    RESOURCE_ORDER,
+    PmsProjectionRepo,
+)
 
 SyncCallable = Callable[..., Coroutine[Any, Any, PmsProjectionSyncResult]]
-
-
-@dataclass(frozen=True)
-class ProjectionResourceConfig:
-    resource: ProjectionResource
-    table_name: str
-    id_column: str
-    columns: tuple[str, ...]
-    searchable_columns: tuple[str, ...]
-    select_expressions: tuple[str, ...] | None = None
-    from_sql: str | None = None
-    order_by_sql: str | None = None
-
-
-RESOURCE_CONFIGS: dict[ProjectionResource, ProjectionResourceConfig] = {
-    "items": ProjectionResourceConfig(
-        resource="items",
-        table_name="wms_pms_item_projection",
-        id_column="item_id",
-        columns=(
-            "item_id",
-            "sku",
-            "name",
-            "spec",
-            "enabled",
-            "supplier_id",
-            "supplier_code",
-            "supplier_name",
-            "brand",
-            "category",
-            "expiry_policy",
-            "shelf_life_value",
-            "shelf_life_unit",
-            "lot_source_policy",
-            "derivation_allowed",
-            "uom_governance_enabled",
-            "pms_updated_at",
-            "source_hash",
-            "sync_version",
-            "synced_at",
-        ),
-        searchable_columns=(
-            "i.sku",
-            "i.name",
-            "i.spec",
-            "i.brand",
-            "i.category",
-            "s.supplier_code",
-            "s.supplier_name",
-        ),
-        select_expressions=(
-            "i.item_id",
-            "i.sku",
-            "i.name",
-            "i.spec",
-            "i.enabled",
-            "i.supplier_id",
-            "s.supplier_code AS supplier_code",
-            "s.supplier_name AS supplier_name",
-            "i.brand",
-            "i.category",
-            "i.expiry_policy",
-            "i.shelf_life_value",
-            "i.shelf_life_unit",
-            "i.lot_source_policy",
-            "i.derivation_allowed",
-            "i.uom_governance_enabled",
-            "i.pms_updated_at",
-            "i.source_hash",
-            "i.sync_version",
-            "i.synced_at",
-        ),
-        from_sql=(
-            "wms_pms_item_projection AS i "
-            "LEFT JOIN wms_pms_supplier_projection AS s "
-            "ON s.supplier_id = i.supplier_id"
-        ),
-        order_by_sql="i.item_id ASC",
-    ),
-    "suppliers": ProjectionResourceConfig(
-        resource="suppliers",
-        table_name="wms_pms_supplier_projection",
-        id_column="supplier_id",
-        columns=(
-            "supplier_id",
-            "supplier_code",
-            "supplier_name",
-            "active",
-            "website",
-            "pms_updated_at",
-            "source_hash",
-            "sync_version",
-            "synced_at",
-        ),
-        searchable_columns=("supplier_code", "supplier_name", "website"),
-    ),
-    "uoms": ProjectionResourceConfig(
-        resource="uoms",
-        table_name="wms_pms_uom_projection",
-        id_column="item_uom_id",
-        columns=(
-            "item_uom_id",
-            "item_id",
-            "uom",
-            "display_name",
-            "uom_name",
-            "ratio_to_base",
-            "net_weight_kg",
-            "is_base",
-            "is_purchase_default",
-            "is_inbound_default",
-            "is_outbound_default",
-            "pms_updated_at",
-            "source_hash",
-            "sync_version",
-            "synced_at",
-        ),
-        searchable_columns=("uom", "display_name", "uom_name"),
-    ),
-    "sku-codes": ProjectionResourceConfig(
-        resource="sku-codes",
-        table_name="wms_pms_sku_code_projection",
-        id_column="sku_code_id",
-        columns=(
-            "sku_code_id",
-            "item_id",
-            "sku_code",
-            "code_type",
-            "is_primary",
-            "is_active",
-            "effective_from",
-            "effective_to",
-            "pms_updated_at",
-            "source_hash",
-            "sync_version",
-            "synced_at",
-        ),
-        searchable_columns=("sku_code", "code_type"),
-    ),
-    "barcodes": ProjectionResourceConfig(
-        resource="barcodes",
-        table_name="wms_pms_barcode_projection",
-        id_column="barcode_id",
-        columns=(
-            "barcode_id",
-            "item_id",
-            "item_uom_id",
-            "barcode",
-            "symbology",
-            "active",
-            "is_primary",
-            "pms_updated_at",
-            "source_hash",
-            "sync_version",
-            "synced_at",
-        ),
-        searchable_columns=("barcode", "symbology"),
-    ),
-}
-
-RESOURCE_ORDER: tuple[ProjectionResource, ...] = (
-    "items",
-    "suppliers",
-    "uoms",
-    "sku-codes",
-    "barcodes",
-)
 
 
 class PmsProjectionService:
@@ -207,14 +41,8 @@ class PmsProjectionService:
         sync_callable: SyncCallable = sync_pms_read_projection_once,
     ) -> None:
         self.db = db
+        self.repo = PmsProjectionRepo(db)
         self._sync_callable = sync_callable
-
-    @staticmethod
-    def _config(resource: ProjectionResource) -> ProjectionResourceConfig:
-        try:
-            return RESOURCE_CONFIGS[resource]
-        except KeyError as exc:
-            raise ValueError(f"unsupported PMS projection resource: {resource}") from exc
 
     @staticmethod
     def _safe_limit(value: int, *, default: int = 50, max_value: int = 500) -> int:
@@ -237,104 +65,19 @@ class PmsProjectionService:
         value = (os.getenv("PMS_API_BASE_URL") or "").strip().rstrip("/")
         return value or None
 
-    @staticmethod
-    def _jsonable(value: Any) -> Any:
-        if isinstance(value, Decimal):
-            return str(value)
-        return value
-
-    @staticmethod
-    def _select_sql(cfg: ProjectionResourceConfig) -> str:
-        return ", ".join(cfg.select_expressions or cfg.columns)
-
-    @staticmethod
-    def _from_sql(cfg: ProjectionResourceConfig) -> str:
-        return cfg.from_sql or cfg.table_name
-
-    @staticmethod
-    def _order_by_sql(cfg: ProjectionResourceConfig) -> str:
-        return cfg.order_by_sql or f"{cfg.id_column} ASC"
-
-    def _sync_run_from_row(self, row: Any) -> dict[str, Any]:
-        data = dict(row)
-        return {
-            "id": int(data["id"]),
-            "resource": str(data["resource"]),
-            "status": str(data["status"]),
-            "fetched": int(data.get("fetched") or 0),
-            "upserted": int(data.get("upserted") or 0),
-            "pages": int(data.get("pages") or 0),
-            "started_at": data["started_at"],
-            "finished_at": data.get("finished_at"),
-            "duration_ms": (
-                int(data["duration_ms"]) if data.get("duration_ms") is not None else None
-            ),
-            "error_message": data.get("error_message"),
-            "triggered_by_user_id": (
-                int(data["triggered_by_user_id"])
-                if data.get("triggered_by_user_id") is not None
-                else None
-            ),
-            "pms_api_base_url_snapshot": data.get("pms_api_base_url_snapshot"),
-            "sync_version": data.get("sync_version"),
-        }
-
-    def _latest_sync_runs(self) -> dict[str, dict[str, Any]]:
-        rows = (
-            self.db.execute(
-                text(
-                    """
-                    SELECT DISTINCT ON (resource)
-                        id,
-                        resource,
-                        status,
-                        fetched,
-                        upserted,
-                        pages,
-                        started_at,
-                        finished_at,
-                        duration_ms,
-                        error_message,
-                        triggered_by_user_id,
-                        pms_api_base_url_snapshot,
-                        sync_version
-                    FROM wms_pms_projection_sync_runs
-                    WHERE resource IN ('items', 'suppliers', 'uoms', 'sku-codes', 'barcodes')
-                    ORDER BY resource, started_at DESC, id DESC
-                    """
-                )
-            )
-            .mappings()
-            .all()
-        )
-        return {str(row["resource"]): self._sync_run_from_row(row) for row in rows}
-
     def get_status(self) -> dict[str, Any]:
-        latest_runs = self._latest_sync_runs()
+        latest_runs = self.repo.latest_sync_runs()
         resources: list[dict[str, Any]] = []
 
         for resource in RESOURCE_ORDER:
-            cfg = self._config(resource)
-            row = (
-                self.db.execute(
-                    text(
-                        f"""
-                        SELECT
-                            count(*)::bigint AS row_count,
-                            max(synced_at) AS max_synced_at
-                        FROM {cfg.table_name}
-                        """
-                    )
-                )
-                .mappings()
-                .one()
-            )
+            cfg = self.repo.config(resource)
+            stats = self.repo.resource_stats(cfg)
             resources.append(
                 {
                     "resource": resource,
                     "table_name": cfg.table_name,
-                    "row_count": int(row["row_count"] or 0),
-                    "max_synced_at": row["max_synced_at"],
+                    "row_count": stats["row_count"],
+                    "max_synced_at": stats["max_synced_at"],
                     "last_sync_run": latest_runs.get(resource),
                 }
             )
@@ -344,7 +87,7 @@ class PmsProjectionService:
             "resources": resources,
         }
 
-    def list_projection(
+    def _list_projection(
         self,
         *,
         resource: ProjectionResource,
@@ -352,175 +95,45 @@ class PmsProjectionService:
         offset: int,
         q: str | None = None,
     ) -> dict[str, Any]:
-        cfg = self._config(resource)
+        cfg = self.repo.config(resource)
         safe_limit = self._safe_limit(limit)
         safe_offset = self._safe_offset(offset)
 
-        where_sql = ""
-        params: dict[str, Any] = {"limit": safe_limit, "offset": safe_offset}
-        query_text = (q or "").strip()
-        if query_text and cfg.searchable_columns:
-            where_parts = [
-                f"CAST({column} AS TEXT) ILIKE :q"
-                for column in cfg.searchable_columns
-            ]
-            where_sql = "WHERE " + " OR ".join(where_parts)
-            params["q"] = f"%{query_text}%"
-
-        from_sql = self._from_sql(cfg)
-        total = int(
-            self.db.execute(
-                text(f"SELECT count(*)::bigint FROM {from_sql} {where_sql}"),
-                params,
-            ).scalar_one()
+        return self.repo.list_projection_rows(
+            cfg=cfg,
+            limit=safe_limit,
+            offset=safe_offset,
+            q=q,
         )
 
-        rows = (
-            self.db.execute(
-                text(
-                    f"""
-                    SELECT {self._select_sql(cfg)}
-                    FROM {from_sql}
-                    {where_sql}
-                    ORDER BY {self._order_by_sql(cfg)}
-                    LIMIT :limit OFFSET :offset
-                    """
-                ),
-                params,
-            )
-            .mappings()
-            .all()
-        )
+    def list_items(self, *, limit: int, offset: int, q: str | None = None) -> dict[str, Any]:
+        return self._list_projection(resource="items", limit=limit, offset=offset, q=q)
 
-        return {
-            "resource": resource,
-            "table_name": cfg.table_name,
-            "limit": safe_limit,
-            "offset": safe_offset,
-            "total": total,
-            "columns": list(cfg.columns),
-            "rows": [
-                {key: self._jsonable(value) for key, value in dict(row).items()}
-                for row in rows
-            ],
-        }
+    def list_suppliers(self, *, limit: int, offset: int, q: str | None = None) -> dict[str, Any]:
+        return self._list_projection(resource="suppliers", limit=limit, offset=offset, q=q)
 
-    def _create_sync_run(
-        self,
-        *,
-        resource: ProjectionResource,
-        triggered_by_user_id: int | None,
-    ) -> int:
-        row = (
-            self.db.execute(
-                text(
-                    """
-                    INSERT INTO wms_pms_projection_sync_runs (
-                        resource,
-                        status,
-                        fetched,
-                        upserted,
-                        pages,
-                        started_at,
-                        triggered_by_user_id,
-                        pms_api_base_url_snapshot,
-                        sync_version
-                    )
-                    VALUES (
-                        :resource,
-                        'RUNNING',
-                        0,
-                        0,
-                        0,
-                        now(),
-                        :triggered_by_user_id,
-                        :pms_api_base_url_snapshot,
-                        :sync_version
-                    )
-                    RETURNING id
-                    """
-                ),
-                {
-                    "resource": resource,
-                    "triggered_by_user_id": triggered_by_user_id,
-                    "pms_api_base_url_snapshot": self._pms_api_base_url_snapshot(),
-                    "sync_version": SYNC_VERSION,
-                },
-            )
-            .mappings()
-            .one()
-        )
-        self.db.commit()
-        return int(row["id"])
+    def list_uoms(self, *, limit: int, offset: int, q: str | None = None) -> dict[str, Any]:
+        return self._list_projection(resource="uoms", limit=limit, offset=offset, q=q)
 
-    def _finish_sync_run(
-        self,
-        *,
-        run_id: int,
-        status: str,
-        started_monotonic: float,
-        fetched: int = 0,
-        upserted: int = 0,
-        pages: int = 0,
-        error_message: str | None = None,
-    ) -> dict[str, Any]:
-        duration_ms = int((time.monotonic() - started_monotonic) * 1000)
-        row = (
-            self.db.execute(
-                text(
-                    """
-                    UPDATE wms_pms_projection_sync_runs
-                       SET status = :status,
-                           fetched = :fetched,
-                           upserted = :upserted,
-                           pages = :pages,
-                           finished_at = now(),
-                           duration_ms = :duration_ms,
-                           error_message = :error_message
-                     WHERE id = :run_id
-                    RETURNING
-                        id,
-                        resource,
-                        status,
-                        fetched,
-                        upserted,
-                        pages,
-                        started_at,
-                        finished_at,
-                        duration_ms,
-                        error_message,
-                        triggered_by_user_id,
-                        pms_api_base_url_snapshot,
-                        sync_version
-                    """
-                ),
-                {
-                    "run_id": int(run_id),
-                    "status": status,
-                    "fetched": int(fetched),
-                    "upserted": int(upserted),
-                    "pages": int(pages),
-                    "duration_ms": duration_ms,
-                    "error_message": error_message,
-                },
-            )
-            .mappings()
-            .one()
-        )
-        self.db.commit()
-        return self._sync_run_from_row(row)
+    def list_sku_codes(self, *, limit: int, offset: int, q: str | None = None) -> dict[str, Any]:
+        return self._list_projection(resource="sku-codes", limit=limit, offset=offset, q=q)
 
-    async def sync_resource(
+    def list_barcodes(self, *, limit: int, offset: int, q: str | None = None) -> dict[str, Any]:
+        return self._list_projection(resource="barcodes", limit=limit, offset=offset, q=q)
+
+    async def _sync_resource(
         self,
         *,
         resource: ProjectionResource,
         triggered_by_user_id: int | None,
     ) -> dict[str, Any]:
-        self._config(resource)
+        self.repo.config(resource)
         started_monotonic = time.monotonic()
-        run_id = self._create_sync_run(
+        run_id = self.repo.create_sync_run(
             resource=resource,
             triggered_by_user_id=triggered_by_user_id,
+            pms_api_base_url_snapshot=self._pms_api_base_url_snapshot(),
+            sync_version=SYNC_VERSION,
         )
 
         try:
@@ -532,23 +145,55 @@ class PmsProjectionService:
                 await async_session.commit()
 
             resource_result = result.resources[resource]
-            return self._finish_sync_run(
+            duration_ms = int((time.monotonic() - started_monotonic) * 1000)
+            return self.repo.finish_sync_run(
                 run_id=run_id,
                 status="SUCCESS",
-                started_monotonic=started_monotonic,
+                duration_ms=duration_ms,
                 fetched=resource_result.fetched,
                 upserted=resource_result.upserted,
                 pages=resource_result.pages,
                 error_message=None,
             )
         except Exception as exc:
-            self._finish_sync_run(
+            duration_ms = int((time.monotonic() - started_monotonic) * 1000)
+            self.repo.finish_sync_run(
                 run_id=run_id,
                 status="FAILED",
-                started_monotonic=started_monotonic,
+                duration_ms=duration_ms,
                 error_message=str(exc),
             )
             raise
+
+    async def sync_items(self, *, triggered_by_user_id: int | None) -> dict[str, Any]:
+        return await self._sync_resource(
+            resource="items",
+            triggered_by_user_id=triggered_by_user_id,
+        )
+
+    async def sync_suppliers(self, *, triggered_by_user_id: int | None) -> dict[str, Any]:
+        return await self._sync_resource(
+            resource="suppliers",
+            triggered_by_user_id=triggered_by_user_id,
+        )
+
+    async def sync_uoms(self, *, triggered_by_user_id: int | None) -> dict[str, Any]:
+        return await self._sync_resource(
+            resource="uoms",
+            triggered_by_user_id=triggered_by_user_id,
+        )
+
+    async def sync_sku_codes(self, *, triggered_by_user_id: int | None) -> dict[str, Any]:
+        return await self._sync_resource(
+            resource="sku-codes",
+            triggered_by_user_id=triggered_by_user_id,
+        )
+
+    async def sync_barcodes(self, *, triggered_by_user_id: int | None) -> dict[str, Any]:
+        return await self._sync_resource(
+            resource="barcodes",
+            triggered_by_user_id=triggered_by_user_id,
+        )
 
     def list_sync_runs(
         self,
@@ -557,70 +202,36 @@ class PmsProjectionService:
         limit: int,
     ) -> dict[str, Any]:
         safe_limit = self._safe_limit(limit, default=20, max_value=100)
-        params: dict[str, Any] = {"limit": safe_limit}
-        where_sql = ""
         if resource is not None:
-            self._config(resource)
-            where_sql = "WHERE resource = :resource"
-            params["resource"] = resource
-
-        rows = (
-            self.db.execute(
-                text(
-                    f"""
-                    SELECT
-                        id,
-                        resource,
-                        status,
-                        fetched,
-                        upserted,
-                        pages,
-                        started_at,
-                        finished_at,
-                        duration_ms,
-                        error_message,
-                        triggered_by_user_id,
-                        pms_api_base_url_snapshot,
-                        sync_version
-                    FROM wms_pms_projection_sync_runs
-                    {where_sql}
-                    ORDER BY started_at DESC, id DESC
-                    LIMIT :limit
-                    """
-                ),
-                params,
-            )
-            .mappings()
-            .all()
-        )
+            self.repo.config(resource)
 
         return {
             "resource": resource,
             "limit": safe_limit,
-            "runs": [self._sync_run_from_row(row) for row in rows],
+            "runs": self.repo.list_sync_runs(resource=resource, limit=safe_limit),
         }
 
-    def check_projection(
+    def _check_projection(
         self,
         *,
         resource: ProjectionResource,
         limit: int = 200,
     ) -> dict[str, Any]:
-        self._config(resource)
+        self.repo.config(resource)
         safe_limit = self._safe_limit(limit, default=200, max_value=1000)
 
         if resource == "items":
-            rows = self._check_items(safe_limit)
+            rows = self.repo.check_items(safe_limit)
         elif resource == "suppliers":
-            rows = []
+            rows = self.repo.check_suppliers(safe_limit)
         elif resource == "uoms":
-            rows = self._check_uoms(safe_limit)
+            rows = self.repo.check_uoms(safe_limit)
         elif resource == "sku-codes":
-            rows = self._check_sku_codes(safe_limit)
+            rows = self.repo.check_sku_codes(safe_limit)
         elif resource == "barcodes":
-            rows = self._check_barcodes(safe_limit)
+            rows = self.repo.check_barcodes(safe_limit)
         else:
-            raise ValueError(f"unsupported PMS projection resource: {resource}")
+            raise ValueError("unsupported PMS projection resource: " + str(resource))
 
         return {
             "resource": resource,
@@ -629,164 +240,20 @@ class PmsProjectionService:
             "issues": rows,
         }
 
-    def _check_items(self, limit: int) -> list[dict[str, Any]]:
-        rows = (
-            self.db.execute(
-                text(
-                    """
-                    SELECT
-                        i.item_id,
-                        i.supplier_id
-                    FROM wms_pms_item_projection AS i
-                    LEFT JOIN wms_pms_supplier_projection AS s
-                      ON s.supplier_id = i.supplier_id
-                    WHERE i.supplier_id IS NOT NULL
-                      AND s.supplier_id IS NULL
-                    ORDER BY i.item_id ASC
-                    LIMIT :limit
-                    """
-                ),
-                {"limit": int(limit)},
-            )
-            .mappings()
-            .all()
-        )
-        return [
-            {
-                "issue_type": "ITEM_SUPPLIER_MISSING_IN_PROJECTION",
-                "resource": "items",
-                "source_id": str(row["item_id"]),
-                "message": "商品投影中的 supplier_id 在供应商投影中不存在",
-                "item_id": int(row["item_id"]),
-                "supplier_id": int(row["supplier_id"]),
-            }
-            for row in rows
-        ]
+    def check_items(self, *, limit: int = 200) -> dict[str, Any]:
+        return self._check_projection(resource="items", limit=limit)
 
-    def _check_uoms(self, limit: int) -> list[dict[str, Any]]:
-        rows = (
-            self.db.execute(
-                text(
-                    """
-                    SELECT
-                        u.item_uom_id,
-                        u.item_id
-                    FROM wms_pms_uom_projection AS u
-                    LEFT JOIN wms_pms_item_projection AS i
-                      ON i.item_id = u.item_id
-                    WHERE i.item_id IS NULL
-                    ORDER BY u.item_uom_id ASC
-                    LIMIT :limit
-                    """
-                ),
-                {"limit": int(limit)},
-            )
-            .mappings()
-            .all()
-        )
-        return [
-            {
-                "issue_type": "UOM_ITEM_MISSING_IN_PROJECTION",
-                "resource": "uoms",
-                "source_id": str(row["item_uom_id"]),
-                "message": "包装单位投影中的 item_id 在商品投影中不存在",
-                "item_id": int(row["item_id"]),
-                "item_uom_id": int(row["item_uom_id"]),
-            }
-            for row in rows
-        ]
+    def check_suppliers(self, *, limit: int = 200) -> dict[str, Any]:
+        return self._check_projection(resource="suppliers", limit=limit)
 
-    def _check_sku_codes(self, limit: int) -> list[dict[str, Any]]:
-        rows = (
-            self.db.execute(
-                text(
-                    """
-                    SELECT
-                        s.sku_code_id,
-                        s.item_id
-                    FROM wms_pms_sku_code_projection AS s
-                    LEFT JOIN wms_pms_item_projection AS i
-                      ON i.item_id = s.item_id
-                    WHERE i.item_id IS NULL
-                    ORDER BY s.sku_code_id ASC
-                    LIMIT :limit
-                    """
-                ),
-                {"limit": int(limit)},
-            )
-            .mappings()
-            .all()
-        )
-        return [
-            {
-                "issue_type": "SKU_CODE_ITEM_MISSING_IN_PROJECTION",
-                "resource": "sku-codes",
-                "source_id": str(row["sku_code_id"]),
-                "message": "SKU 编码投影中的 item_id 在商品投影中不存在",
-                "item_id": int(row["item_id"]),
-            }
-            for row in rows
-        ]
+    def check_uoms(self, *, limit: int = 200) -> dict[str, Any]:
+        return self._check_projection(resource="uoms", limit=limit)
 
-    def _check_barcodes(self, limit: int) -> list[dict[str, Any]]:
-        rows = (
-            self.db.execute(
-                text(
-                    """
-                    SELECT
-                        b.barcode_id,
-                        b.item_id,
-                        b.item_uom_id,
-                        u.item_id AS projection_item_id,
-                        CASE
-                          WHEN i.item_id IS NULL THEN 'BARCODE_ITEM_MISSING_IN_PROJECTION'
-                          WHEN u.item_uom_id IS NULL THEN 'BARCODE_UOM_MISSING_IN_PROJECTION'
-                          WHEN u.item_id <> b.item_id THEN 'BARCODE_UOM_ITEM_MISMATCH'
-                          ELSE 'OK'
-                        END AS issue_type
-                    FROM wms_pms_barcode_projection AS b
-                    LEFT JOIN wms_pms_item_projection AS i
-                      ON i.item_id = b.item_id
-                    LEFT JOIN wms_pms_uom_projection AS u
-                      ON u.item_uom_id = b.item_uom_id
-                    WHERE i.item_id IS NULL
-                       OR u.item_uom_id IS NULL
-                       OR u.item_id <> b.item_id
-                    ORDER BY b.barcode_id ASC
-                    LIMIT :limit
-                    """
-                ),
-                {"limit": int(limit)},
-            )
-            .mappings()
-            .all()
-        )
+    def check_sku_codes(self, *, limit: int = 200) -> dict[str, Any]:
+        return self._check_projection(resource="sku-codes", limit=limit)
 
-        messages = {
-            "BARCODE_ITEM_MISSING_IN_PROJECTION": "条码投影中的 item_id 在商品投影中不存在",
-            "BARCODE_UOM_MISSING_IN_PROJECTION": "条码投影中的 item_uom_id 在包装单位投影中不存在",
-            "BARCODE_UOM_ITEM_MISMATCH": "条码投影中的 item_id 与包装单位投影所属 item_id 不一致",
-        }
-        return [
-            {
-                "issue_type": str(row["issue_type"]),
-                "resource": "barcodes",
-                "source_id": str(row["barcode_id"]),
-                "message": messages.get(str(row["issue_type"]), "条码投影一致性异常"),
-                "item_id": int(row["item_id"]),
-                "item_uom_id": int(row["item_uom_id"]),
-                "projection_item_id": (
-                    int(row["projection_item_id"])
-                    if row["projection_item_id"] is not None
-                    else None
-                ),
-            }
-            for row in rows
-        ]
+    def check_barcodes(self, *, limit: int = 200) -> dict[str, Any]:
+        return self._check_projection(resource="barcodes", limit=limit)
 
 
-__all__ = [
-    "PmsProjectionService",
-    "RESOURCE_CONFIGS",
-    "RESOURCE_ORDER",
-]
+__all__ = ["PmsProjectionService"]

--- a/tests/ci/test_wms_pms_projection_ops_boundary.py
+++ b/tests/ci/test_wms_pms_projection_ops_boundary.py
@@ -16,8 +16,35 @@ FORBIDDEN_OWNER_SQL_RE = re.compile(
 )
 
 
-def test_pms_projection_service_uses_projection_tables_only() -> None:
-    text = (ROOT / "app/pms/projections/services/pms_projection_service.py").read_text(encoding="utf-8")
+def test_pms_projection_module_uses_wms_directory_style() -> None:
+    base = ROOT / "app/pms/projections"
+
+    for relative in [
+        "contracts/pms_projection.py",
+        "contracts/items.py",
+        "contracts/suppliers.py",
+        "contracts/uoms.py",
+        "contracts/sku_codes.py",
+        "contracts/barcodes.py",
+        "repos/pms_projection_repo.py",
+        "services/pms_projection_service.py",
+        "routers/pms_projection.py",
+        "routers/deps.py",
+        "routers/items.py",
+        "routers/suppliers.py",
+        "routers/uoms.py",
+        "routers/sku_codes.py",
+        "routers/barcodes.py",
+    ]:
+        assert (base / relative).is_file(), relative
+
+    assert not (base / "contracts.py").exists()
+    assert not (base / "service.py").exists()
+    assert not (base / "router.py").exists()
+
+
+def test_pms_projection_repo_uses_projection_tables_only() -> None:
+    text = (ROOT / "app/pms/projections/repos/pms_projection_repo.py").read_text(encoding="utf-8")
 
     assert "wms_pms_item_projection" in text
     assert "wms_pms_supplier_projection" in text
@@ -28,26 +55,52 @@ def test_pms_projection_service_uses_projection_tables_only() -> None:
     assert FORBIDDEN_OWNER_SQL_RE.search(text) is None
 
 
+def test_pms_projection_service_is_not_sql_repo() -> None:
+    text = (ROOT / "app/pms/projections/services/pms_projection_service.py").read_text(encoding="utf-8")
+
+    assert "PmsProjectionRepo" in text
+    assert "RESOURCE_CONFIGS" not in text
+    assert "ProjectionResourceConfig" not in text
+    assert "SELECT " not in text
+    assert "INSERT INTO wms_pms_" not in text
+    assert "UPDATE wms_pms_" not in text
+    assert "DELETE FROM wms_pms_" not in text
+
+
 def test_pms_projection_router_uses_pms_permissions_and_business_prefix() -> None:
-    text = (ROOT / "app/pms/projections/routers/pms_projection.py").read_text(encoding="utf-8")
+    router_text = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in sorted((ROOT / "app/pms/projections/routers").glob("*.py"))
+    )
 
-    assert 'prefix="/projections"' in text
-    assert "page.pms.read" in text
-    assert "page.pms.write" in text
-    assert '"/projections/{resource}"' not in text
-    assert '"/projections/{resource}/sync"' not in text
-    assert '"/projections/{resource}/check"' not in text
+    assert 'prefix="/projections"' in router_text
+    assert "page.pms.read" in router_text
+    assert "page.pms.write" in router_text
 
-    assert "page.admin.read" not in text
-    assert "page.admin.write" not in text
-    assert "/admin" not in text
-    assert "/items" not in text
-    assert "/item-uoms" not in text
-    assert "/item-barcodes" not in text
-    assert "/pms/brands" not in text
-    assert "/pms/categories" not in text
-    assert "/pms/item-attribute-defs" not in text
-    assert "/connection" not in text
+    for path in [
+        '"/items"',
+        '"/items/sync"',
+        '"/items/check"',
+        '"/suppliers"',
+        '"/suppliers/sync"',
+        '"/suppliers/check"',
+        '"/uoms"',
+        '"/uoms/sync"',
+        '"/uoms/check"',
+        '"/sku-codes"',
+        '"/sku-codes/sync"',
+        '"/sku-codes/check"',
+        '"/barcodes"',
+        '"/barcodes/sync"',
+        '"/barcodes/check"',
+    ]:
+        assert path in router_text
+
+    assert "{resource}" not in router_text
+    assert "/admin" not in router_text
+    assert "page.admin.read" not in router_text
+    assert "page.admin.write" not in router_text
+    assert "/connection" not in router_text
 
 
 def test_pms_projection_router_is_not_mounted_under_admin() -> None:


### PR DESCRIPTION
## Summary
- Split WMS PMS projection runtime into explicit resource routers.
- Add per-resource contracts for item, supplier, UOM, SKU code, and barcode projections.
- Move SQL/config-driven projection operations from service into repo layer.
- Keep PMS read-v1 projection sync executor unchanged.
- Retire dynamic PMS projection {resource} runtime routes.

## Verification
- Explicit PMS projection route extraction
- Boundary grep: no dynamic resource route in routers
- Boundary grep: service no longer contains SQL/config table details
- make test TESTS="tests/api/test_pms_projection_ops_api.py tests/ci/test_wms_pms_projection_ops_boundary.py tests/ci/test_wms_pms_projection_sync_boundary.py tests/ci/test_wms_pms_read_projection_boundary.py tests/services/test_pms_projection_sync.py tests/services/test_pms_projection_reconciliation.py tests/services/test_pms_supplier_projection_reconciliation.py"
- make test TESTS="tests/api/test_user_navigation_api.py tests/api/test_pms_projection_ops_api.py tests/ci/test_wms_pms_projection_ops_boundary.py"
- make lint
- make alembic-check
- make test